### PR TITLE
Add expanded architecture ADR set

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,14 @@ It should be treated as a reference architecture for governed agent memory syste
 │       ├── ADR-004-pama-controls-mutation-authority.md
 │       ├── ADR-005-codegenome-is-code-reality-substrate.md
 │       ├── ADR-006-neurospace-is-runtime-memory-space.md
-│       └── ADR-007-agent-memory-is-component-architecture.md
+│       ├── ADR-007-agent-memory-is-component-architecture.md
+│       ├── ADR-008-memory-threat-model-is-required.md
+│       ├── ADR-009-source-trust-is-a-first-class-signal.md
+│       ├── ADR-010-conflict-resolution-is-a-separate-component.md
+│       ├── ADR-011-temporal-causality-is-required-for-memory-evolution.md
+│       ├── ADR-012-privacy-and-sensitivity-classification-is-required.md
+│       ├── ADR-013-governed-recall-planner-is-required.md
+│       └── ADR-014-schema-registry-and-type-evolution-are-needed.md
 ├── fixtures/
 │   ├── access-spam-junk.json
 │   ├── certified-durable-memory.json

--- a/docs/adr/ADR-008-memory-threat-model-is-required.md
+++ b/docs/adr/ADR-008-memory-threat-model-is-required.md
@@ -1,0 +1,65 @@
+# ADR-008: Memory Threat Model Is Required
+
+## Status
+
+Proposed
+
+## Context
+
+The doctrine already defines trap classes such as access-spam and confidently-wrong memory. Those are necessary, but not sufficient.
+
+A governed memory system also faces broader threats:
+
+- memory poisoning
+- recursive self-citation
+- source spoofing
+- provenance stripping
+- unauthorized mutation
+- stale policy retention
+- cross-user leakage
+- overbroad context assembly
+- malicious correction
+- poisoned code graph evidence
+
+Without a threat model, conformance becomes too narrow and the system can appear safe while failing under adversarial memory pressure.
+
+## Decision
+
+Agent Memory must include a formal memory threat model.
+
+The threat model will define threat classes, affected components, detection strategies, mitigations, and required conformance fixtures.
+
+## Consequences
+
+### Positive
+
+- expands safety beyond current trap classes
+- gives PAMA and certification concrete adversarial cases
+- improves conformance fixture design
+- clarifies memory-specific security risks
+
+### Negative
+
+- adds additional documentation and fixture burden
+- may require implementation repos to expose more audit and provenance data
+
+## Required follow-up
+
+Create and maintain:
+
+```text
+docs/15-memory-threat-model.md
+```
+
+The threat model should link to:
+
+- PAMA governance
+- certification and crystallization
+- source trust and reputation
+- governed recall
+- privacy and sensitivity classification
+- conformance fixtures
+
+## Doctrine
+
+A memory system is not trustworthy unless it defines how memory can be attacked.

--- a/docs/adr/ADR-009-source-trust-is-a-first-class-signal.md
+++ b/docs/adr/ADR-009-source-trust-is-a-first-class-signal.md
@@ -1,0 +1,63 @@
+# ADR-009: Source Trust Is a First-Class Signal
+
+## Status
+
+Proposed
+
+## Context
+
+Evidence and provenance tell the system where memory came from and what supports it. They do not fully answer whether a source remains reliable over time.
+
+A low-quality source can produce high volume. A stale source can remain cited. An agent can recursively cite its own prior claims. A single-source assertion can become over-weighted if the system treats provenance as equivalent to trust.
+
+That is how memory systems develop the confidence of a freshman philosophy major with a search bar. Delightful. Unsafe.
+
+## Decision
+
+Source trust and reputation must be a first-class signal in the architecture.
+
+The system should track source class, reliability, contradiction history, freshness, authority scope, and self-citation risk.
+
+## Consequences
+
+### Positive
+
+- prevents high-volume low-quality sources from dominating saturation
+- improves evidence weighting
+- supports conflict resolution
+- helps detect recursive self-citation
+- makes source reliability visible to certification gates
+
+### Negative
+
+- requires source metadata beyond simple provenance
+- requires policy for source demotion and rehabilitation
+- may complicate conformance fixtures
+
+## Required source classes
+
+At minimum, implementations should distinguish:
+
+- authoritative
+- observed
+- inferred
+- synthetic
+- user-provided
+- agent-generated
+- external
+- code-derived
+- policy-derived
+
+## Required follow-up
+
+Create and maintain:
+
+```text
+docs/16-source-trust-and-reputation.md
+```
+
+## Doctrine
+
+Provenance says where memory came from.
+
+Source trust says how much weight that source deserves now.

--- a/docs/adr/ADR-010-conflict-resolution-is-a-separate-component.md
+++ b/docs/adr/ADR-010-conflict-resolution-is-a-separate-component.md
@@ -1,0 +1,69 @@
+# ADR-010: Conflict Resolution Is a Separate Component
+
+## Status
+
+Proposed
+
+## Context
+
+The lifecycle state machine includes a `disputed` state. That state identifies a problem, but it does not resolve the problem.
+
+Conflicts can arise between:
+
+- facts
+- decisions
+- time windows
+- policies
+- source reliability scores
+- user corrections
+- implementation states
+- code graph evidence
+
+If conflict resolution is embedded ad hoc inside each implementation, the same memory dispute can resolve differently across systems.
+
+## Decision
+
+Conflict resolution must be treated as a separate component.
+
+The component will classify conflict type, rank evidence, determine whether to correct, demote, split scope, escalate, preserve historical minority claims, or prune.
+
+## Consequences
+
+### Positive
+
+- prevents silent overwrite
+- gives disputed memory a deterministic path forward
+- allows temporal supersession without losing historical context
+- supports policy-aware reconciliation
+
+### Negative
+
+- requires conflict taxonomy and rules
+- requires implementations to expose enough evidence for resolution
+- may require human escalation for high-risk disputes
+
+## Required conflict types
+
+At minimum:
+
+- factual contradiction
+- temporal supersession
+- scope mismatch
+- policy conflict
+- source reliability conflict
+- user correction conflict
+- implementation drift
+
+## Required follow-up
+
+Create and maintain:
+
+```text
+docs/17-conflict-resolution-engine.md
+```
+
+## Doctrine
+
+Dispute is a state.
+
+Resolution is a component.

--- a/docs/adr/ADR-011-temporal-causality-is-required-for-memory-evolution.md
+++ b/docs/adr/ADR-011-temporal-causality-is-required-for-memory-evolution.md
@@ -1,0 +1,60 @@
+# ADR-011: Temporal Causality Is Required for Memory Evolution
+
+## Status
+
+Proposed
+
+## Context
+
+Memory changes over time. A memory may become stale, superseded, corrected, disputed, or historically relevant.
+
+Time-based decay alone does not explain why a memory changed. It only says that time passed, which is technically true and architecturally lazy.
+
+Decision memory, code evolution, organizational memory, agent learning, and correction flows all need causal explanation.
+
+## Decision
+
+Agent Memory must include a temporal causality layer.
+
+The layer will represent event order, causal links, supersession, correction history, and causal recall requirements.
+
+## Consequences
+
+### Positive
+
+- distinguishes stale from superseded
+- supports causal recall
+- preserves decision and correction history
+- improves code-evolution memory
+- helps explain why memory changed
+
+### Negative
+
+- requires event and causal-link modeling
+- increases complexity of memory state transitions
+- requires careful treatment of historical claims
+
+## Required distinctions
+
+The architecture must distinguish:
+
+- stale memory
+- superseded memory
+- corrected memory
+- disputed memory
+- historically relevant memory
+- currently canonical memory
+
+## Required follow-up
+
+Create and maintain:
+
+```text
+docs/18-temporal-causality-layer.md
+```
+
+## Doctrine
+
+Memory does not only decay.
+
+Memory evolves through causes, consequences, corrections, and supersession.

--- a/docs/adr/ADR-012-privacy-and-sensitivity-classification-is-required.md
+++ b/docs/adr/ADR-012-privacy-and-sensitivity-classification-is-required.md
@@ -1,0 +1,62 @@
+# ADR-012: Privacy and Sensitivity Classification Is Required
+
+## Status
+
+Proposed
+
+## Context
+
+Agentic memory systems may store or recall personal, organizational, security, financial, health, credential, code, policy, or public information.
+
+A memory system that cannot classify sensitivity cannot reliably decide what may be stored, recalled, summarized, exported, shared, corrected, or deleted.
+
+Local-first storage helps, but it is not enough. A locally stored sensitive memory can still be recalled into the wrong context, shared with the wrong agent, or preserved beyond its intended scope. Humanity, against all odds, continues to invent new ways to mishandle data.
+
+## Decision
+
+Privacy and sensitivity classification must be a first-class component.
+
+The component should influence storage, retention, recall, context assembly, PAMA authority, certification, export, and deletion behavior.
+
+## Consequences
+
+### Positive
+
+- prevents overbroad recall
+- improves PAMA risk classification
+- supports local-first and encrypted memory boundaries
+- enables conformance tests for cross-user leakage and unsafe context assembly
+- makes retention and deletion policy enforceable
+
+### Negative
+
+- requires sensitivity taxonomy
+- may require implementation-specific classifiers
+- may reduce recall convenience when sensitivity is unclear
+
+## Required classes
+
+At minimum, the system should support sensitivity classes for:
+
+- public
+- personal
+- organizational
+- security-sensitive
+- credential or secret
+- financial
+- health or wellbeing
+- code or IP-sensitive
+- policy or compliance
+- restricted or consent-bound
+
+## Required follow-up
+
+Create and maintain:
+
+```text
+docs/19-privacy-and-sensitivity-classifier.md
+```
+
+## Doctrine
+
+A memory cannot be safely recalled until the system knows the sensitivity boundary it belongs to.

--- a/docs/adr/ADR-013-governed-recall-planner-is-required.md
+++ b/docs/adr/ADR-013-governed-recall-planner-is-required.md
@@ -1,0 +1,62 @@
+# ADR-013: Governed Recall Planner Is Required
+
+## Status
+
+Proposed
+
+## Context
+
+Retrieval is not memory.
+
+Agentic systems often treat retrieval as the whole memory problem: search something, stuff it into context, and hope the model behaves. This is convenient in the same way that removing the brakes makes a car simpler.
+
+A governed memory system needs recall planning that respects state, certification, dispute status, sensitivity, source trust, authority, and context boundaries.
+
+## Decision
+
+Agent Memory must include a governed recall planner.
+
+The planner decides how to retrieve memory across exact lookup, graph traversal, evidence search, vector retrieval, policy recall, runtime context recall, and certification-aware recall.
+
+## Consequences
+
+### Positive
+
+- prevents disputed memory from being used as canonical
+- avoids unsafe recall of sensitive memory
+- distinguishes exact lookup from similarity retrieval
+- supports recall explanations
+- makes context assembly policy-aware
+
+### Negative
+
+- adds another planning step before context assembly
+- requires recall metadata from memory units
+- may block convenient but unsafe retrieval
+
+## Required recall paths
+
+At minimum:
+
+- exact identity lookup
+- graph traversal
+- evidence search
+- vector or similarity retrieval
+- policy recall
+- runtime context recall
+- certified memory recall
+- disputed memory recall with warning semantics
+
+## Required follow-up
+
+Create and maintain:
+
+```text
+docs/20-governed-recall-planner.md
+```
+
+## Doctrine
+
+Retrieval finds candidates.
+
+Governed recall decides what may enter context and under what warning, scope, or authority.

--- a/docs/adr/ADR-014-schema-registry-and-type-evolution-are-needed.md
+++ b/docs/adr/ADR-014-schema-registry-and-type-evolution-are-needed.md
@@ -1,0 +1,46 @@
+# ADR-014: Schema Registry and Type Evolution Are Needed
+
+## Status
+
+Proposed
+
+## Context
+
+The repository now contains initial schemas for memory units and conformance reports. As implementations adopt the doctrine, schemas will need to evolve.
+
+Without explicit schema governance, implementation-specific fields can leak into doctrine-level objects, memory units can become incompatible across systems, and migration rules can become oral tradition, which is how software projects summon ghosts.
+
+## Decision
+
+Agent Memory should define a schema registry and type-evolution strategy.
+
+This should remain an architecture component candidate until adapter contracts and implementation ownership are clearer.
+
+## Consequences
+
+### Positive
+
+- prevents schema drift
+- supports cross-repo adoption
+- enables versioned conformance fixtures
+- makes memory-unit migrations explicit
+
+### Negative
+
+- adds governance overhead
+- requires compatibility rules
+- may slow experimentation if applied too early
+
+## Required follow-up
+
+Create an issue to define:
+
+```text
+docs/21-schema-registry-and-type-evolution.md
+```
+
+## Doctrine
+
+Schemas are part of memory governance.
+
+A memory object that cannot evolve safely cannot remain canonical across implementations.


### PR DESCRIPTION
## Summary

Adds ADRs for the expanded architecture recommendations and opens follow-up issues for concepts that should be tracked without being prematurely absorbed into core doctrine.

## Added ADRs

- ADR-008: Memory Threat Model Is Required
- ADR-009: Source Trust Is a First-Class Signal
- ADR-010: Conflict Resolution Is a Separate Component
- ADR-011: Temporal Causality Is Required for Memory Evolution
- ADR-012: Privacy and Sensitivity Classification Is Required
- ADR-013: Governed Recall Planner Is Required
- ADR-014: Schema Registry and Type Evolution Are Needed

## README updates

The README now lists the expanded ADR set in the repo structure.

## Issues opened

- Add schema registry and type evolution strategy
- Define interoperability profiles for doctrine conformance
- Track memory compiler as future subsystem

## Rationale

The added ADRs convert the expanded-scope recommendations into explicit architectural decisions, while the issues keep second-order work visible without turning every adjacent idea into a first-class component too early.