### PR TITLE
Audit slice 1: govern uncertainty across core memory doctrine

### DIFF
--- a/docs/01-layer-model.md
+++ b/docs/01-layer-model.md
@@ -8,6 +8,10 @@ The most important boundary is this:
 
 UOR is identity. Saturation is lifecycle scoring. Certification is confirmation. PAMA is authority. Neurospace is runtime use.
 
+A second boundary is equally important:
+
+**Probabilistic or learned components may estimate what is likely, relevant, conflicting, stale, useful, or risky. They do not acquire authority from those estimates. Consequential memory transitions occur only through deterministic or formally bounded governance.**
+
 ## Layer 1: Identity substrate
 
 ### Owner
@@ -40,12 +44,14 @@ CodeGenome, EvolveAI traces, FailSafe ledgers, COREFORGE audit records, and sour
 - attach evidence to claims
 - track creation and mutation history
 - preserve witness material through summaries and transformations
+- identify the method, model, rule set, or observer that produced probabilistic estimates used downstream
 
 ### Must not do
 
 - promote memories by evidence volume alone
 - treat model confidence as verification
 - collapse provenance into a summary without retaining source links
+- represent an estimated probability as if it were deterministic evidence
 
 ## Layer 3: Saturation and lifecycle routing
 
@@ -60,6 +66,13 @@ PRISM-style bridge logic, EvolveAI lifecycle engine, UOR decay proposal consumer
 - propose crystallization candidates
 - adjust decay under contextual pressure
 - identify stale, disputed, or prunable objects
+- preserve uncertainty and calibration metadata when routing depends on probabilistic or learned estimators
+
+### Control character
+
+This layer may be probabilistic, heuristic, learned, or hybrid.
+
+Its outputs are **proposals and estimates**, not authority grants.
 
 ### Must not do
 
@@ -67,6 +80,7 @@ PRISM-style bridge logic, EvolveAI lifecycle engine, UOR decay proposal consumer
 - grant permanence without certification
 - crystallize access-spam
 - treat repetition as durability
+- convert a score, probability, ranking, or learned action directly into an irreversible transition
 
 ## Layer 4: Lifecycle state machine
 
@@ -79,6 +93,14 @@ EvolveAI and any runtime memory engine.
 - manage memory states
 - perform decay, reinforcement, dispute, correction, reconciliation, and pruning
 - preserve audit trail for state transitions
+- validate that requested transitions are legal from the current state
+- separate transition proposal from transition commit
+
+### Control character
+
+The state-transition contract should be deterministic for a fixed current state, authorized transition, policy version, and committed inputs.
+
+Probabilistic systems may propose a transition. They must not bypass transition validity or authority checks.
 
 ### Must not do
 
@@ -99,11 +121,19 @@ PAMA and enforcement surfaces such as Arbiter or FailSafe.
 - control promotion and demotion
 - require approval when confidence, evidence, or authority is insufficient
 - preserve adaptive constraints
+- map uncertain evidence and estimator outputs into a finite policy-defined authority outcome
+
+### Control character
+
+For a fixed policy snapshot and reconstructable input record, the authority envelope must be deterministic or formally bounded.
+
+A probabilistic estimate may influence the decision, but it must not define its own permission to mutate memory.
 
 ### Must not do
 
 - allow high-confidence autonomous mutation in high-risk domains without explicit authority
 - allow agents to rewrite durable memory without ledgered correction
+- use stochastic choice to escape a blocked or review-required authority outcome
 
 ## Layer 6: Certification and crystallization
 
@@ -117,6 +147,11 @@ Certification gate, approval system, policy engine, or ledger-backed governance 
 - verify identity, provenance, evidence, and authority
 - attach certificate or approval records
 - move objects to exact-address durable lookup when permitted
+- bind certification to the relevant memory state, evidence set, policy version, scope, and estimator context when probabilistic evidence materially affected promotion
+
+### Control character
+
+Certification is a governed consequence. Its acceptance criteria must be explicit and reproducible or formally specified within a bounded approval protocol.
 
 ### Must not do
 
@@ -137,11 +172,21 @@ COREFORGE Vault / Neurospace and related product runtimes.
 - perform graph traversal
 - enforce local privacy and encryption boundaries
 - expose memory through governed product workflows
+- apply recall-time policy after probabilistic candidate generation or ranking
+
+### Control character
+
+Candidate retrieval and ranking may be probabilistic.
+
+Scope, tenancy, sensitivity, certification-state, and policy exclusions must still be enforced before retrieved memory enters active context.
+
+A runtime may choose stochastically among multiple already-permitted candidates or strategies, but only inside the permitted action set.
 
 ### Must not do
 
 - treat operational utility as canonical truth
 - hide agent memory mutation from users or ledgers
+- inject a highly relevant memory that violates scope or authority constraints
 
 ## Layer 8: Domain reality graphs
 
@@ -155,11 +200,68 @@ CodeGenome for code artifacts. Future domain graphs may cover decisions, tasks, 
 - fuse observations from multiple sources
 - retain confidence and provenance
 - expose query and traversal primitives
+- distinguish exact graph facts from inferred edges, ranked hypotheses, or probabilistic relations
+
+### Control character
+
+Graph identity, schema, and committed relations should remain reproducible. Relation discovery, confidence fusion, entity resolution, and ranking may be probabilistic when their provenance and uncertainty are preserved.
 
 ### Must not do
 
 - allow one observer to become canonical without fusion and evidence
 - hide confidence conflicts
+
+## Control-character map
+
+| Responsibility | Typical control character | Why |
+|---|---|---|
+| identity and exact reference | deterministic | ambiguity here corrupts every later decision |
+| schema and transition validity | deterministic | invalid states must not become policy-dependent guesses |
+| evidence interpretation | probabilistic or hybrid | evidence can be incomplete, noisy, or contradictory |
+| confidence, trust, relevance, saturation | probabilistic, learned, heuristic, or hybrid | these are estimates, not authority |
+| authority envelope | deterministic or formally bounded | permissions and prohibitions must be reconstructable |
+| certification consequence | deterministic or explicitly governed approval | durable promotion requires accountable consequence |
+| retrieval candidate generation | probabilistic or hybrid | semantic and contextual relevance are uncertain |
+| recall-time scope enforcement | deterministic or formally bounded | high relevance does not override access policy |
+| choice among already-permitted actions | optionally stochastic | uncertainty may remain useful inside the safe action set |
+| ledger and state-transition receipt | deterministic | accountability requires replayable evidence |
+
+## Governed uncertainty boundary
+
+The canonical flow is:
+
+```text
+observation / query
+        |
+        v
+probabilistic or learned interpretation
+(confidence, relevance, trust, contradiction, risk, candidate ranking)
+        |
+        v
+explicit governance envelope
+(scope, authority, transition validity, policy, sensitivity, reversibility)
+        |
+        v
+permitted action set
+        |
+        +--> zero actions: block / abstain / escalate
+        |
+        +--> one action: commit defined consequence
+        |
+        +--> multiple actions: deterministic or stochastic selection may occur inside set
+        |
+        v
+state transition + audit receipt
+```
+
+Required properties:
+
+1. Estimator output must identify what it measures and how it was produced when it materially affects a consequential transition.
+2. Estimator confidence must not be reused as mutation authority.
+3. A blocked action must remain blocked regardless of how confidently a probabilistic component proposes it.
+4. Policy outcome and estimator output must remain separately inspectable.
+5. Consequential commits must bind to the policy version and state snapshot under which they were authorized.
+6. If required authority inputs cannot be reconstructed for a high-consequence action, the system should abstain, block, or escalate rather than infer permission.
 
 ## Boundary table
 
@@ -167,11 +269,12 @@ CodeGenome for code artifacts. Future domain graphs may cover decisions, tasks, 
 |---|---|
 | What is this object? | Identity substrate |
 | Why do we believe this claim? | Evidence and provenance |
-| Should this memory persist? | Saturation and lifecycle routing |
+| How likely, relevant, stale, or persistent does it appear? | Saturation / epistemic routing |
+| Is the proposed transition legal from this state? | Lifecycle state machine |
 | Can the memory change? | PAMA governance |
 | Can this become durable? | Certification and crystallization |
 | How does the agent use it now? | Runtime memory space |
-| What is true about a codebase? | Domain reality graph |
+| What is true or hypothesized about a codebase? | Domain reality graph |
 
 ## Anti-collapse rules
 
@@ -180,3 +283,6 @@ CodeGenome for code artifacts. Future domain graphs may cover decisions, tasks, 
 3. Do not collapse confidence into certification.
 4. Do not collapse runtime utility into permanence.
 5. Do not collapse mutation capability into mutation authority.
+6. Do not collapse probabilistic inference into permission.
+7. Do not collapse deterministic execution into correctness.
+8. Do not collapse policy outcome and estimator output into one opaque score.

--- a/docs/02-lifecycle-state-machine.md
+++ b/docs/02-lifecycle-state-machine.md
@@ -6,6 +6,8 @@ The lifecycle state machine defines how agentic memory moves from raw experience
 
 The state machine does not assume every memory should become permanent. Most memory should remain operational, decay naturally, or be pruned.
 
+The state machine also separates **transition proposal** from **transition commit**. Probabilistic, learned, heuristic, or model-directed components may propose that a memory should move. Only an authorized and valid lifecycle operation may commit the state change.
+
 ## Canonical states
 
 ```text
@@ -83,11 +85,15 @@ The memory has sufficient saturation or governance relevance to be considered fo
 
 Candidate status is not approval.
 
+A probabilistic or learned component may nominate Candidate state, but nomination must preserve its estimator output and must still pass transition validity and governance checks.
+
 ### Pending Verification
 
 The memory is waiting on certification, approval, external confirmation, policy review, or test evidence.
 
 Pending verification is the default state for high-impact memories that appear useful but are not yet trusted.
+
+It is also a valid abstention state when the system cannot safely resolve uncertainty near a consequential boundary.
 
 ### Crystallized
 
@@ -113,6 +119,7 @@ Staleness triggers may include:
 - new contradictory evidence
 - stale dependencies
 - expired certification
+- estimator drift that makes the prior lifecycle decision unreliable
 
 ### Disputed
 
@@ -143,9 +150,50 @@ The memory has been removed from active recall or durable lifecycle consideratio
 
 Pruned does not always mean deleted. Depending on policy, it may mean archived, tombstoned, summarized, or made inaccessible to normal retrieval.
 
+## Transition proposal versus transition commit
+
+A lifecycle implementation should model these as distinct operations.
+
+```text
+probabilistic / learned estimator
+        |
+        v
+transition proposal
+  proposed_state
+  confidence / score
+  estimator identity + version
+  evidence refs
+        |
+        v
+transition validation
+  legal from current state?
+  scope valid?
+  authority sufficient?
+  policy permits consequence?
+  uncertainty acceptable for consequence class?
+        |
+        +--> block
+        +--> abstain / Pending Verification
+        +--> require review
+        +--> permit
+        |
+        v
+transition commit
+  deterministic or formally bounded state mutation
+  audit receipt
+```
+
+Rules:
+
+1. A proposal does not mutate lifecycle state.
+2. An estimator cannot authorize its own proposed transition.
+3. For a fixed current state, policy snapshot, authority record, and committed inputs, transition validity must be reproducible or formally bounded.
+4. A blocked transition must not become allowed because a model repeats it with greater confidence.
+5. If multiple permitted transitions remain, deterministic or stochastic selection may occur only within that permitted set.
+
 ## Required transition metadata
 
-Every state transition should record:
+Every committed state transition should record:
 
 ```text
 from_state
@@ -156,12 +204,19 @@ actor
 timestamp
 evidence_refs
 policy_refs
+policy_version
 confidence_before
 confidence_after
 saturation_before
 saturation_after
+estimator_refs
+estimator_versions
+uncertainty_summary
+proposal_ref
 ledger_ref
 ```
+
+Where applicable, `uncertainty_summary` should identify whether the relevant estimate was well calibrated, near a decision boundary, in disagreement with another estimator, or outside its validated scope.
 
 ## Promotion gates
 
@@ -175,6 +230,19 @@ trap_class_check != fail
 pama_authority in [allow, require_review]
 ```
 
+This expression is a minimum gate, not a claim that scalar thresholds are sufficient.
+
+If saturation, confidence, trust, sensitivity, or contradiction estimators are uncertain near a consequential boundary, policy may require:
+
+```text
+abstain
+require_review
+require_external_verification
+collect_more_evidence
+```
+
+rather than treating tiny score changes as authoritative state changes.
+
 A memory can move from Pending Verification to Crystallized only if:
 
 ```text
@@ -183,6 +251,29 @@ pama_authority == allow
 scope_defined == true
 dispute_status == clear
 ```
+
+Crystallization must bind to the policy version and evidence/estimator context used to authorize it.
+
+## Threshold stability and hysteresis
+
+Lifecycle systems should avoid oscillating memory states because an uncertain score moves slightly above or below a threshold.
+
+Where repeated boundary crossings are plausible, implementations should consider:
+
+- separate enter and exit thresholds
+- minimum evidence changes before reversal
+- cooldown or observation windows
+- explicit dispute/review states instead of rapid promotion/demotion
+- confidence intervals or calibrated uncertainty around the score
+
+Example:
+
+```text
+candidate_enter_threshold = 0.80
+candidate_exit_threshold  = 0.70
+```
+
+The specific values must be calibrated. The doctrine requirement is stability proportional to consequence, not those numbers.
 
 ## Demotion gates
 
@@ -194,6 +285,7 @@ A crystallized memory should be demoted when:
 - source is invalidated
 - user correction overrides previous state
 - implementation dependency changes
+- estimator calibration or provenance is invalidated in a way that undermines the original promotion basis
 
 Demotion should move to Stale, Disputed, or Corrected, not directly to deletion.
 
@@ -220,8 +312,28 @@ Required behavior:
 - dispute state blocks canonical use
 - correction path preserves previous false claim for audit
 
+### Threshold-jitter memory
+
+A memory whose estimated lifecycle score repeatedly crosses a boundary because of estimator noise.
+
+Required behavior:
+
+- the system does not repeatedly promote and demote solely from tiny score changes
+- decision-boundary instability is recorded
+- consequential transitions use hysteresis, abstention, review, or additional evidence as policy requires
+
+### Estimator-disagreement memory
+
+Two valid estimators materially disagree about confidence, sensitivity, trust, or persistence value.
+
+Required behavior:
+
+- disagreement remains visible
+- policy determines whether to combine, choose, abstain, or escalate
+- no estimator gains authority merely by reporting a larger number
+
 ## Lifecycle goal
 
 The lifecycle exists to make agent memory accountable.
 
-A memory system is not mature because it remembers more. It is mature when it can explain why something was remembered, why it was trusted, why it changed, and why it was forgotten.
+A memory system is not mature because it remembers more. It is mature when it can explain why something was remembered, why it was trusted, why it changed, why uncertainty was tolerated or escalated, and why it was forgotten.

--- a/docs/03-scoring-and-decay.md
+++ b/docs/03-scoring-and-decay.md
@@ -6,6 +6,10 @@ This document consolidates the scoring logic from UOR saturation, EvolveAI memor
 
 The scoring model exists to support lifecycle decisions. It must not be mistaken for truth.
 
+A second rule follows from that distinction:
+
+**A score is an estimate with scope, method, calibration limits, and uncertainty. It must not be treated as a deterministic fact merely because software represents it as a number.**
+
 ## Signal taxonomy
 
 | Signal | Purpose | Typical owner |
@@ -16,6 +20,7 @@ The scoring model exists to support lifecycle decisions. It must not be mistaken
 | Authority | Permission to mutate or promote | PAMA, Arbiter, policy layer |
 | Certification | Confirmation of durable transition | Verification or approval gate |
 | Risk | Potential harm from wrong mutation or permanence | PAMA, governance layer |
+| Uncertainty | Limits, spread, calibration, or disagreement around an estimate | estimator + calibration harness |
 
 ## Canonical scoring shape
 
@@ -39,6 +44,30 @@ memory_lifecycle_score = f(
 
 This is not a single universal equation yet. It is the required signal family.
 
+The function output should be interpreted as an estimator output, not a command.
+
+## Score metadata
+
+When a probabilistic, learned, or calibrated score materially affects a consequential memory decision, preserve enough metadata to interpret it:
+
+```text
+score_name
+score_value
+estimator_id
+estimator_version
+calibration_version
+calibration_scope
+sample_or_evidence_refs
+uncertainty_representation
+confidence_interval_or_equivalent
+out_of_distribution_signal
+computed_at
+```
+
+Not every implementation needs a classical confidence interval. Some estimators may use posterior spread, ensemble disagreement, conformal sets, calibration bins, categorical uncertainty, or another justified representation.
+
+The requirement is to avoid false precision.
+
 ## Saturation
 
 Saturation is a calibrated lifecycle score.
@@ -61,6 +90,8 @@ Where pinned fibers may include:
 
 Raw access should never dominate saturation.
 
+A saturation value should carry the calibration scope under which it is meaningful. `sigma = 0.92` without calibration context is weaker evidence than the number's apparent precision suggests.
+
 ## Effective decay
 
 A UOR-aligned decay model may use:
@@ -81,6 +112,8 @@ Interpretation:
 - unresolved or weakly pinned memory decays faster
 - fully crystallized memory may enter a non-decaying regime inside its certified scope
 
+Decay decisions should distinguish uncertainty in the decay estimator from authority to archive, prune, delete, or retain.
+
 ## EvolveAI memory tier routing
 
 EvolveAI uses a memory tier score shape:
@@ -100,6 +133,8 @@ Canonical interpretation:
 
 MTS is a routing heuristic. It should be integrated with saturation, confidence, and authority rather than treated as a complete promotion rule.
 
+If any MTS input is itself estimated, the implementation should retain its uncertainty rather than assuming the composite score erased it.
+
 ## CodeGenome confidence fusion
 
 CodeGenome contributes confidence fusion for code-reality observations.
@@ -113,6 +148,8 @@ high confidence relation != crystallized memory
 high saturation != correct relation
 certified relation == confirmed within scope
 ```
+
+If multiple observers or estimators disagree, fusion should preserve disagreement information when it materially affects downstream governance.
 
 ## PAMA authority weighting
 
@@ -129,6 +166,10 @@ Inputs may include:
 - reversibility
 - blast radius
 - implementation maturity
+- estimator uncertainty
+- calibration quality
+- estimator disagreement
+- distribution-shift indicators
 
 Suggested authority outcomes:
 
@@ -140,6 +181,8 @@ require_external_verification
 block
 ```
 
+No probabilistic score directly selects its own authority outcome. PAMA or equivalent governance maps estimator outputs into a policy-defined consequence.
+
 ## Crystallization threshold
 
 A crystallization threshold must be calibrated.
@@ -149,6 +192,44 @@ Do not choose `sigma >= 0.95` by intuition. Calibrate using labeled examples:
 - PERSIST objects that should become durable
 - EVAPORATE objects that should decay
 - trap-class objects that are designed to fool the scoring system
+
+A threshold is an operating point, not a truth boundary.
+
+## Decision-boundary stability
+
+A calibrated system should measure not only whether a threshold performs well on average, but whether decisions are stable near the boundary.
+
+Required questions include:
+
+- How much does the output change under small perturbations to evidence?
+- How often do equivalent inputs cross opposite sides of the threshold?
+- How much calibration error exists in the region where governance changes consequence?
+- Does estimator disagreement increase near the boundary?
+- Is the current input inside the calibration scope?
+- Has data or environment drift changed the operating point?
+
+Where consequence is meaningful, policy may define an uncertainty or abstention band:
+
+```text
+score < lower_bound       -> ordinary non-promotion path
+lower_bound <= score <= upper_bound -> collect evidence / review / abstain
+score > upper_bound       -> eligible for next governance gate
+```
+
+The doctrine does not mandate one mathematical form. It mandates that expensive mistakes not be hidden behind false threshold precision.
+
+## Hysteresis
+
+Where repeated state oscillation is costly, use separate thresholds or equivalent stability controls.
+
+Example only:
+
+```text
+promote_candidate_above = 0.80
+demote_candidate_below  = 0.70
+```
+
+The values require calibration. The principle is that estimator noise should not manufacture lifecycle churn.
 
 ## Required trap classes
 
@@ -186,6 +267,42 @@ Expected result:
 saturation plateau below durable threshold unless corroborated or approved
 ```
 
+### Threshold-jitter candidate
+
+Equivalent or minimally perturbed observations move repeatedly across a consequential threshold.
+
+Expected result:
+
+```text
+boundary_instability_detected == true
+repeated automatic promotion/demotion == false
+policy outcome in [abstain, require_review, collect_more_evidence, stable_hysteresis_path]
+```
+
+### Estimator disagreement
+
+Two otherwise valid estimators materially disagree.
+
+Expected result:
+
+```text
+disagreement_preserved == true
+no estimator self-authorizes transition
+policy resolves or escalates disagreement
+```
+
+### Distribution-shift candidate
+
+An estimator is asked to score memory outside the domain on which its calibration was validated.
+
+Expected result:
+
+```text
+out_of_scope_or_drift_signal == true
+calibration claim is not silently reused
+high-consequence promotion requires recalibration, review, or external verification
+```
+
 ## Calibration report
 
 Every scoring implementation should be able to report:
@@ -199,7 +316,16 @@ evaporation_rate_for_true_ephemeral
 trap_class_failure_rate
 durability_dimensions_tested
 scope_of_validity
+calibration_error
+boundary_instability_rate
+abstention_rate
+estimator_disagreement_rate
+out_of_scope_rate
+estimator_version
+calibration_version
 ```
+
+Metrics that are not meaningful for a given estimator may be marked not applicable with justification rather than fabricated.
 
 ## Operating-point selection
 
@@ -207,12 +333,32 @@ The threshold should be chosen according to cost:
 
 | Preference | Threshold behavior |
 |---|---|
-| Avoid false permanence | higher threshold, require certification |
+| Avoid false permanence | higher threshold, uncertainty band, require certification |
 | Avoid losing valuable memories | lower candidate threshold, stronger review queue |
 | Balance both costs | calibrated threshold using explicit tradeoff |
+| High uncertainty near irreversible consequence | abstain, collect evidence, or escalate |
 
-## Hard rule
+## Drift and versioning
+
+Estimator changes and policy changes are different events.
+
+A conforming implementation should be able to distinguish:
+
+```text
+same policy + new estimator
+new policy + same estimator
+new calibration + same estimator
+new environment outside prior calibration scope
+```
+
+A previous authorization should not be reinterpreted under a new estimator or policy without an explicit replay or migration decision.
+
+## Hard rules
 
 No score should grant permanence alone.
 
 Only a governed transition can do that.
+
+No deterministic threshold should be treated as proof that the underlying estimate is correct.
+
+No probabilistic estimator should be allowed to define its own authority.

--- a/docs/04-governance-and-pama.md
+++ b/docs/04-governance-and-pama.md
@@ -6,6 +6,10 @@ PAMA defines mutation authority for agentic memory systems.
 
 The central question is not whether an agent can change memory. The central question is whether it is allowed to change memory, under what scope, with what evidence, and with what rollback path.
 
+PAMA also defines the boundary between uncertain inference and governed consequence.
+
+**Probabilistic or learned systems may estimate confidence, trust, relevance, contradiction, sensitivity, utility, or risk. PAMA determines what those estimates are allowed to change.**
+
 ## PAMA definition
 
 PAMA means Proportional Adaptive Mutation Authority.
@@ -22,6 +26,8 @@ Agentic memory becomes dangerous when the system can:
 - overwrite project decisions because a new session felt confident
 - prune evidence needed for later accountability
 - crystallize hallucinations
+- convert probabilistic confidence directly into mutation authority
+- infer missing permission because an action appears useful
 
 The point of PAMA is to make adaptive memory useful without letting adaptation become silent self-corruption.
 
@@ -37,6 +43,8 @@ The point of PAMA is to make adaptive memory useful without letting adaptation b
 | Promotion | Move memory toward durable state | require certification gate |
 | Crystallization | Make memory canonical or exact-address durable | require explicit authority |
 | Pruning | Remove from active recall | require reversible tombstone unless ephemeral |
+| Permanent deletion | Intentionally make recovery unavailable | explicit high-consequence authority and deletion scope required |
+| Scope expansion | Share memory with broader actor or tenant scope | explicit authority appropriate to target scope |
 | Policy mutation | Change governance rules | require human approval |
 
 ## Authority outcomes
@@ -51,6 +59,23 @@ require_external_verification
 block
 ```
 
+Implementations may add outcomes such as `abstain`, `quarantine`, or `collect_more_evidence` when useful, but every outcome must have defined consequence semantics.
+
+## Authority resolution invariant
+
+For a fixed set of committed inputs, current state, and policy version, PAMA must produce a **deterministic or formally bounded authority envelope**.
+
+This does not require all upstream inputs to be deterministic.
+
+It requires that:
+
+1. the policy knows which inputs are estimates
+2. their provenance and uncertainty are inspectable
+3. the estimator cannot grant itself authority
+4. prohibited actions remain prohibited regardless of confidence
+5. any stochastic behavior after authorization selects only among already-permitted actions
+6. the resulting authority decision can be reconstructed from its receipt
+
 ## Risk classes
 
 | Risk | Examples | Required handling |
@@ -58,7 +83,30 @@ block
 | Low | temporary context, low-impact links, ephemeral cache decay | allow with normal ledger |
 | Medium | task memory, project notes, reusable summaries | allow with evidence and reversible correction |
 | High | user preferences, security policy, durable decisions, code mutation plans | require review or certification |
-| Critical | identity, credentials, compliance, permanent deletion, safety boundaries | require explicit human approval |
+| Critical | identity, credentials, compliance, permanent deletion, cross-tenant scope expansion, safety boundaries | require explicit human or equivalently authoritative approval |
+
+## Consequence proportionality
+
+Governance strength should rise with consequence, not merely with estimator confidence.
+
+Relevant dimensions include:
+
+```text
+reversibility
+persistence horizon
+sensitivity
+scope / tenancy
+blast radius
+canonicality
+authority level
+dependency fan-out
+ability to destroy evidence
+ability to alter future governance
+```
+
+A low-confidence, reversible cache decision may still be acceptable.
+
+A high-confidence proposal for permanent deletion may still require explicit review.
 
 ## PAMA evaluation inputs
 
@@ -77,7 +125,16 @@ blast_radius
 certification_status
 user_approval_state
 policy_scope
+estimator_refs
+estimator_versions
+calibration_refs
+uncertainty_summary
+estimator_disagreement
+out_of_distribution_signal
+requested_scope_change
 ```
+
+PAMA should distinguish required inputs from optional advisory signals. Missing advisory signals may reduce decision quality. Missing required authority inputs must not be silently guessed for consequential actions.
 
 ## Promotion rule
 
@@ -92,7 +149,19 @@ can_promote =
   and pama_outcome in [allow, allow_with_ledger, require_review]
 ```
 
+This is a simplified gate, not a claim that a point threshold is sufficient.
+
 If PAMA returns `require_review`, the memory may enter Pending Verification but must not crystallize.
+
+If estimator uncertainty, disagreement, drift, or scope invalidates the confidence of a consequential promotion proposal, PAMA may return:
+
+```text
+require_review
+require_external_verification
+block
+```
+
+rather than inferring permission from the score.
 
 ## Crystallization rule
 
@@ -104,6 +173,39 @@ can_crystallize =
   and scope_defined
   and dispute_status == clear
 ```
+
+Crystallization should bind to the evidence set, policy version, estimator context, authority record, and scope under which it was approved.
+
+## Bounded stochastic action
+
+PAMA does not require every downstream choice to be deterministic.
+
+If governance produces a permitted set such as:
+
+```text
+permitted_actions = [
+  store_ephemeral,
+  request_more_evidence,
+  defer
+]
+```
+
+a planner may choose deterministically or stochastically among those actions if policy allows.
+
+It may not sample from:
+
+```text
+[
+  store_ephemeral,
+  request_more_evidence,
+  defer,
+  crystallize_without_certification
+]
+```
+
+and then claim the unsafe action was merely a probabilistic outcome.
+
+Randomness does not create permission.
 
 ## Anti-patterns
 
@@ -132,7 +234,7 @@ model says it confidently -> durable memory
 Correct:
 
 ```text
-model confidence -> evidence signal -> calibrated scoring -> verification path
+model confidence -> evidence signal -> calibrated scoring -> governance -> verification path
 ```
 
 ### Summary as authority
@@ -149,6 +251,34 @@ Correct:
 summary says X -> source refs retained -> provenance survives compression
 ```
 
+### Determinism as correctness
+
+Wrong:
+
+```text
+fixed threshold produced same answer twice -> safe decision
+```
+
+Correct:
+
+```text
+reproducible decision + calibrated inputs + valid policy + appropriate consequence controls -> auditable governed decision
+```
+
+### Probabilistic utility as deletion authority
+
+Wrong:
+
+```text
+predicted_future_utility < 0.05 -> permanently delete
+```
+
+Correct:
+
+```text
+low predicted utility -> deletion candidate -> retention/dependency/privacy policy -> authorized deletion mode
+```
+
 ## Adaptive authority
 
 PAMA is proportional and adaptive.
@@ -161,8 +291,9 @@ Authority may increase when:
 - policy scope is narrow
 - prior similar mutations succeeded
 - user has delegated authority explicitly
+- estimator calibration is valid for the current scope
 
-Authority must decrease when:
+Authority must decrease or escalate when:
 
 - contradiction pressure rises
 - source authority weakens
@@ -170,6 +301,47 @@ Authority must decrease when:
 - mutation blast radius grows
 - certification is missing or expired
 - system confidence exceeds evidence quality
+- estimator disagreement is material
+- estimator calibration is stale or out of scope
+- a requested mutation expands sharing or tenancy scope
+- the action destroys rollback, evidence, or future governance options
+
+## Uncertainty handling
+
+PAMA should distinguish at least:
+
+```text
+epistemic uncertainty: uncertainty about the content or model
+aleatoric uncertainty: irreducible variability/noise where relevant
+policy uncertainty: policy is missing, ambiguous, conflicting, or version-misaligned
+authority uncertainty: actor permission cannot be reconstructed
+scope uncertainty: target user, tenant, or domain is unclear
+```
+
+Not all uncertainty should be handled the same way.
+
+For example:
+
+- low-risk epistemic uncertainty may still permit an ephemeral write
+- policy uncertainty on a high-impact mutation should block or escalate
+- authority uncertainty must never be resolved by estimator confidence
+- scope uncertainty should prevent broad sharing until resolved
+
+## Fail-safe behavior
+
+For high or critical consequence actions, PAMA should fail closed or escalate when required governance state cannot be reconstructed.
+
+Examples:
+
+```text
+policy version missing -> block / require review
+actor authority unresolved -> block
+scope ambiguous for cross-tenant sharing -> block
+certification reference invalid -> block crystallization
+estimator outside calibration scope -> require verification for consequential promotion
+```
+
+Low-risk, reversible operations may use explicitly defined degraded modes if policy permits them.
 
 ## Audit requirements
 
@@ -181,8 +353,16 @@ memory_id
 actor
 requested_mutation
 pama_inputs
+estimator_refs
+estimator_versions
+calibration_refs
+uncertainty_summary
 pama_outcome
+permitted_action_set
+selected_action
+selection_mode
 policy_refs
+policy_version
 evidence_refs
 approval_refs
 before_state
@@ -190,6 +370,23 @@ after_state
 rollback_path
 timestamp
 ```
+
+`selection_mode` should identify whether a permitted downstream choice was deterministic, stochastic, human-selected, or externally determined.
+
+## Replay requirement
+
+A decision receipt should allow an auditor to answer:
+
+1. What did the uncertain components estimate?
+2. Which estimator and calibration versions produced those estimates?
+3. Which policy version interpreted them?
+4. What actions were prohibited?
+5. What actions were permitted?
+6. Which permitted action was selected and how?
+7. What state changed?
+8. Could the change be rolled back?
+
+Exact replay of a stochastic estimator is not always possible or necessary. Exact reconstruction of **authority and consequence** is required.
 
 ## Runtime enforcement
 
@@ -204,9 +401,28 @@ Good enforcement points:
 - code governance layer
 - correction workflow
 - pruning workflow
+- deletion workflow
+- scope-sharing boundary
+
+## Required adversarial cases
+
+PAMA conformance should eventually include:
+
+- high-confidence false memory requesting durable promotion
+- threshold jitter near promotion boundary
+- estimator disagreement about sensitivity
+- high semantic relevance from the wrong tenant
+- stochastic planner offered both permitted and prohibited actions
+- permanent deletion proposed from uncertain future utility
+- policy-version drift after a prior authorization
+- missing authority record during replay
+- concurrent conflicting mutation requests
+- unsafe multi-memory composition that was not visible at individual write time
 
 ## Doctrine
 
 PAMA is not a memory score.
 
 PAMA is the authority layer that decides whether a proposed memory transition is allowed.
+
+Probability may inform PAMA. Probability does not become PAMA.

--- a/docs/25-governed-uncertainty-documentation-conformance-audit.md
+++ b/docs/25-governed-uncertainty-documentation-conformance-audit.md
@@ -1,0 +1,241 @@
+# Governed Uncertainty Documentation Conformance Audit
+
+## Purpose
+
+This document measures the repository's existing documentation against the governed-uncertainty doctrine introduced in `docs/24-determinism-probability-and-governed-uncertainty.md` and proposed in `docs/adr/ADR-020-probabilistic-discovery-deterministic-governance.md`.
+
+The goal is not to reward documents for repeating the same terminology. The goal is to determine whether each relevant document preserves the architectural boundary between uncertain inference and governed consequence.
+
+This audit is intentionally incremental. Each slice records:
+
+1. the baseline document state
+2. applicable criteria
+3. gaps and contradictions
+4. remediation applied
+5. post-remediation score
+6. verification evidence
+7. merge state
+
+A documentation score is **not** evidence that an implementation is safe or conforming. It measures doctrine coverage only.
+
+## Audit anchor
+
+Baseline for the first audit pass:
+
+```text
+repository: Knapp-Kevin/agent-memory
+baseline_main_commit: 2bf1f6bca18820b55e754913b606900d5cbe872d
+baseline_source: merged PR #32
+```
+
+## Working doctrine under test
+
+The current doctrine candidate is:
+
+> Probabilistic discovery may produce beliefs, rankings, hypotheses, candidates, confidence estimates, and proposed actions. Consequential memory transitions must occur inside an explicit governance envelope whose permissions, prohibitions, state transitions, and audit consequences are deterministic or formally bounded.
+
+Equivalent shorter form:
+
+> The system may be uncertain about what is true while remaining certain about what it is allowed to do with that uncertainty.
+
+This doctrine remains subject to challenge. Deterministic behavior is not assumed to be safer merely because it is deterministic, and probabilistic behavior is not assumed to be unsafe merely because it is uncertain.
+
+## Scoring scale
+
+Each applicable criterion is scored from 0 through 4.
+
+| Score | Meaning |
+|---|---|
+| 0 | absent, contradicted, or unsafe assumption |
+| 1 | implicit or incidental coverage |
+| 2 | partially explicit but materially incomplete |
+| 3 | explicit and mostly correct, but not fully bounded or testable |
+| 4 | explicit, bounded, auditable, and testable within the document's purpose |
+| N/A | criterion is not materially applicable to that document |
+
+Coverage percentage is calculated only across applicable criteria.
+
+## Canonical audit criteria
+
+### GU-1 Deterministic substrate
+
+Does the document identify operations that require stable, reproducible behavior, such as identity, schema validation, authorization, state-transition validity, exact references, ledger semantics, or deletion scope?
+
+### GU-2 Probabilistic epistemics
+
+Does the document explicitly permit and correctly scope probabilistic or learned behavior for uncertain interpretation, ranking, inference, confidence, contradiction detection, relevance, trust estimation, abstraction, or discovery?
+
+### GU-3 Authority separation
+
+Does the document clearly state that confidence, relevance, saturation, probability, model output, or learned policy does not itself grant mutation, promotion, deletion, sharing, certification, or policy authority?
+
+### GU-4 Uncertainty representation and provenance
+
+Does the document preserve where an estimate came from, what it measures, how calibrated it is, its scope, model/method version when relevant, and whether uncertainty itself is represented rather than collapsed into a point estimate?
+
+### GU-5 Governed consequence
+
+Does uncertain input resolve into a finite, policy-defined set of permitted outcomes or state transitions whose effects are explicit?
+
+### GU-6 Consequence proportionality
+
+Does governance become stronger as actions become less reversible, more durable, more sensitive, broader in scope, higher in authority, or larger in blast radius?
+
+### GU-7 Auditability and replay
+
+Can a consequential decision be reconstructed from actor, inputs, evidence, estimator outputs, policy version, outcome, before/after state, and rollback or recovery information where applicable?
+
+### GU-8 Bounded stochastic action
+
+If stochastic behavior is permitted after governance, does the document make clear that randomness or learned choice may select only among actions already permitted by the governance envelope?
+
+### GU-9 Calibration, abstention, and drift
+
+Does the document address uncertainty calibration, threshold sensitivity, hysteresis where needed, estimator disagreement, abstention/escalation, distribution shift, model drift, and the difference between policy-version change and estimator-version change?
+
+### GU-10 Adversarial and conformance validation
+
+Does the document define tests or failure cases that can falsify its assumptions, including high-confidence error, threshold jitter, unsafe composition, stochastic retrieval, cross-scope relevance, uncertainty in sensitivity, concurrent mutation, or irreversible action under uncertain utility?
+
+## Interpretation bands
+
+These bands are reporting aids, not certification levels.
+
+| Coverage | Interpretation |
+|---|---|
+| 90-100% | doctrine-explicit |
+| 75-89% | substantially aligned |
+| 60-74% | partial alignment; important gaps remain |
+| 40-59% | implicit or structurally incomplete |
+| below 40% | materially under-specified for governed uncertainty |
+
+A high score cannot compensate for a critical contradiction. Any document that grants durable authority directly from confidence, probability, saturation, similarity, or model output fails GU-3 regardless of aggregate score.
+
+---
+
+# Slice 1: Core architecture documents 01-04
+
+## Baseline assessment
+
+Baseline was measured against `main` at `2bf1f6b` before remediation.
+
+| Document | GU-1 | GU-2 | GU-3 | GU-4 | GU-5 | GU-6 | GU-7 | GU-8 | GU-9 | GU-10 | Coverage |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `01-layer-model.md` | 4 | 1 | 4 | 1 | 3 | 2 | 3 | 0 | 1 | 1 | 50% |
+| `02-lifecycle-state-machine.md` | 4 | 1 | 4 | 2 | 4 | 2 | 4 | 0 | 1 | 2 | 60% |
+| `03-scoring-and-decay.md` | 3 | 3 | 4 | 2 | 3 | 3 | 2 | 0 | 3 | 3 | 65% |
+| `04-governance-and-pama.md` | 3 | 2 | 4 | 2 | 4 | 4 | 4 | 0 | 2 | 2 | 68% |
+
+### `01-layer-model.md`
+
+Strengths:
+
+- deterministic identity is already explicit
+- saturation, certification, and authority are separated
+- mutation capability is explicitly separated from mutation authority
+
+Gaps:
+
+- no named probabilistic epistemic responsibility
+- no rule for carrying estimator uncertainty into governance
+- no bounded-stochastic-action rule
+- no explicit distinction between estimator output and policy outcome
+
+Remediation target:
+
+- classify layers by control character
+- add an explicit epistemic/governance boundary
+- require estimator provenance where probabilistic outputs affect memory
+- state that stochastic choice may occur only after policy filtering
+
+### `02-lifecycle-state-machine.md`
+
+Strengths:
+
+- state machine is naturally deterministic and auditable
+- transition metadata already records authority, evidence, confidence, saturation, and ledger references
+- promotion and crystallization are distinct transitions
+
+Gaps:
+
+- threshold outputs can appear to directly drive transitions without an explicit proposal/commit split
+- no behavior for uncertain or conflicting estimators
+- no hysteresis or threshold-jitter treatment
+- no estimator/method version in transition evidence
+
+Remediation target:
+
+- separate transition proposal from transition commit
+- make estimator outputs inputs to governance, not state mutation instructions
+- define escalation/abstention for uncertainty near consequential boundaries
+- record estimator and policy versions
+
+### `03-scoring-and-decay.md`
+
+Strengths:
+
+- strongest pre-existing separation of confidence, saturation, authority, certification, and risk
+- explicitly states that no score grants permanence
+- already requires calibration and trap classes
+
+Gaps:
+
+- calibration is centered on threshold selection rather than uncertainty quality
+- no confidence intervals or calibration-error concept
+- no estimator disagreement, drift, abstention, or hysteresis handling
+- point estimates may appear more precise than their evidence warrants
+
+Remediation target:
+
+- define score uncertainty as first-class metadata
+- add calibration error, drift, and decision-boundary stability checks
+- require abstention/escalation zones where false irreversible transitions are costly
+
+### `04-governance-and-pama.md`
+
+Strengths:
+
+- authority is already separate from confidence and saturation
+- risk and reversibility are already first-class PAMA inputs
+- finite authority outcomes already exist
+- enforcement is located at mutation boundaries
+
+Gaps:
+
+- PAMA inputs do not explicitly include uncertainty quality, estimator provenance, or estimator disagreement
+- no rule that PAMA outcome mapping must be deterministic or formally bounded for a fixed input/policy snapshot
+- no explicit allowance for stochastic choice among already-permitted actions
+- no fail-safe behavior when policy or estimator state cannot be reconstructed
+
+Remediation target:
+
+- add governed-uncertainty inputs and decision receipt fields
+- define deterministic/formally bounded authority resolution
+- permit bounded stochastic choice only after authorization
+- fail closed or escalate when authority cannot be reconstructed for high-consequence actions
+
+## Slice 1 completion criteria
+
+Slice 1 may be merged when:
+
+- [ ] all four documents are remediated against their stated targets
+- [ ] no existing invariant is weakened
+- [ ] no document grants authority directly from a probabilistic estimate
+- [ ] changed files remain documentation-only
+- [ ] post-remediation scores are recorded here
+- [ ] branch diff is reviewed against `main`
+- [ ] merge uses the verified head SHA
+
+## Remaining audit queue
+
+Next slices should evaluate, in order:
+
+1. `05-repo-implementation-map.md` through `10-memory-unit-examples.md`
+2. `11-component-architecture.md` through `14-expanded-scope-recommendations.md`
+3. planned/implemented `15` through `19` documents, where present
+4. `20-memory-foundations-across-scales.md` through `24-determinism-probability-and-governed-uncertainty.md`
+5. all ADRs, with special attention to authority, lifecycle, retention/deletion, observability, recovery, and quality metrics
+6. schemas and fixtures
+7. README and cross-document consistency
+
+Each slice should preserve baseline and post-remediation measurements so doctrine evolution remains inspectable rather than anecdotal.

--- a/docs/25-governed-uncertainty-documentation-conformance-audit.md
+++ b/docs/25-governed-uncertainty-documentation-conformance-audit.md
@@ -130,103 +130,160 @@ Baseline was measured against `main` at `2bf1f6b` before remediation.
 
 Strengths:
 
-- deterministic identity is already explicit
-- saturation, certification, and authority are separated
-- mutation capability is explicitly separated from mutation authority
+- deterministic identity was already explicit
+- saturation, certification, and authority were separated
+- mutation capability was explicitly separated from mutation authority
 
-Gaps:
+Baseline gaps:
 
 - no named probabilistic epistemic responsibility
 - no rule for carrying estimator uncertainty into governance
 - no bounded-stochastic-action rule
 - no explicit distinction between estimator output and policy outcome
 
-Remediation target:
+Remediation applied:
 
-- classify layers by control character
-- add an explicit epistemic/governance boundary
-- require estimator provenance where probabilistic outputs affect memory
-- state that stochastic choice may occur only after policy filtering
+- classified architecture responsibilities by control character
+- added explicit probabilistic-estimation versus governance boundary
+- required estimator provenance where estimates materially affect memory
+- added recall-time governance after probabilistic candidate generation
+- added bounded stochastic selection only among already-permitted actions
+- added anti-collapse rules for inference versus permission and determinism versus correctness
 
 ### `02-lifecycle-state-machine.md`
 
 Strengths:
 
-- state machine is naturally deterministic and auditable
-- transition metadata already records authority, evidence, confidence, saturation, and ledger references
-- promotion and crystallization are distinct transitions
+- state machine was naturally deterministic and auditable
+- transition metadata already recorded authority, evidence, confidence, saturation, and ledger references
+- promotion and crystallization were distinct transitions
 
-Gaps:
+Baseline gaps:
 
-- threshold outputs can appear to directly drive transitions without an explicit proposal/commit split
+- threshold outputs could appear to directly drive transitions without an explicit proposal/commit split
 - no behavior for uncertain or conflicting estimators
 - no hysteresis or threshold-jitter treatment
 - no estimator/method version in transition evidence
 
-Remediation target:
+Remediation applied:
 
-- separate transition proposal from transition commit
-- make estimator outputs inputs to governance, not state mutation instructions
-- define escalation/abstention for uncertainty near consequential boundaries
-- record estimator and policy versions
+- separated transition proposal from transition commit
+- made estimator outputs inputs to governance rather than state mutation instructions
+- added estimator and policy versions to transition metadata
+- added uncertainty summary to consequential transition receipts
+- added abstention, review, and evidence-gathering paths near uncertain boundaries
+- added hysteresis guidance and explicit threshold-jitter and estimator-disagreement traps
 
 ### `03-scoring-and-decay.md`
 
 Strengths:
 
 - strongest pre-existing separation of confidence, saturation, authority, certification, and risk
-- explicitly states that no score grants permanence
-- already requires calibration and trap classes
+- explicitly stated that no score grants permanence
+- already required calibration and trap classes
 
-Gaps:
+Baseline gaps:
 
-- calibration is centered on threshold selection rather than uncertainty quality
+- calibration centered on threshold selection rather than uncertainty quality
 - no confidence intervals or calibration-error concept
 - no estimator disagreement, drift, abstention, or hysteresis handling
-- point estimates may appear more precise than their evidence warrants
+- point estimates could appear more precise than their evidence warranted
 
-Remediation target:
+Remediation applied:
 
-- define score uncertainty as first-class metadata
-- add calibration error, drift, and decision-boundary stability checks
-- require abstention/escalation zones where false irreversible transitions are costly
+- defined score uncertainty as first-class metadata
+- added estimator, calibration, scope, version, and out-of-distribution metadata
+- added calibration error, decision-boundary stability, abstention, hysteresis, disagreement, and drift treatment
+- added threshold-jitter, estimator-disagreement, and distribution-shift trap classes
+- separated estimator-version, calibration-version, and policy-version changes
+- retained the hard rule that scores never grant permanence or authority
 
 ### `04-governance-and-pama.md`
 
 Strengths:
 
-- authority is already separate from confidence and saturation
-- risk and reversibility are already first-class PAMA inputs
-- finite authority outcomes already exist
-- enforcement is located at mutation boundaries
+- authority was already separate from confidence and saturation
+- risk and reversibility were already first-class PAMA inputs
+- finite authority outcomes already existed
+- enforcement was located at mutation boundaries
 
-Gaps:
+Baseline gaps:
 
-- PAMA inputs do not explicitly include uncertainty quality, estimator provenance, or estimator disagreement
+- PAMA inputs did not explicitly include uncertainty quality, estimator provenance, or estimator disagreement
 - no rule that PAMA outcome mapping must be deterministic or formally bounded for a fixed input/policy snapshot
 - no explicit allowance for stochastic choice among already-permitted actions
-- no fail-safe behavior when policy or estimator state cannot be reconstructed
+- no fail-safe behavior when policy or estimator state could not be reconstructed
 
-Remediation target:
+Remediation applied:
 
-- add governed-uncertainty inputs and decision receipt fields
-- define deterministic/formally bounded authority resolution
-- permit bounded stochastic choice only after authorization
-- fail closed or escalate when authority cannot be reconstructed for high-consequence actions
+- added governed-uncertainty inputs and decision receipt fields
+- defined deterministic/formally bounded authority resolution for fixed committed inputs and policy
+- added explicit consequence proportionality by reversibility, persistence, sensitivity, scope, authority, blast radius, and evidence destruction
+- permitted stochastic selection only after governance creates a permitted action set
+- added epistemic, policy, authority, and scope uncertainty handling
+- added fail-closed/escalation behavior for missing high-consequence governance state
+- added replay requirements and adversarial cases
 
-## Slice 1 completion criteria
+## Post-remediation assessment
 
-Slice 1 may be merged when:
+Post-remediation scoring measures the documents on branch `agent/governed-uncertainty-audit-01` before merge.
 
-- [ ] all four documents are remediated against their stated targets
-- [ ] no existing invariant is weakened
-- [ ] no document grants authority directly from a probabilistic estimate
-- [ ] changed files remain documentation-only
-- [ ] post-remediation scores are recorded here
-- [ ] branch diff is reviewed against `main`
-- [ ] merge uses the verified head SHA
+`N/A` means the criterion is not materially owned by that document and is excluded from the percentage denominator.
 
-## Remaining audit queue
+| Document | GU-1 | GU-2 | GU-3 | GU-4 | GU-5 | GU-6 | GU-7 | GU-8 | GU-9 | GU-10 | Coverage |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `01-layer-model.md` | 4 | 4 | 4 | 3 | 4 | 3 | 4 | 4 | N/A | N/A | 94% |
+| `02-lifecycle-state-machine.md` | 4 | 3 | 4 | 4 | 4 | 3 | 4 | 4 | 4 | 4 | 95% |
+| `03-scoring-and-decay.md` | N/A | 4 | 4 | 4 | 4 | 4 | 3 | N/A | 4 | 4 | 97% |
+| `04-governance-and-pama.md` | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 100% |
+
+## Score interpretation
+
+The increase is meaningful because the documents did not merely gain vocabulary:
+
+- `01` now locates deterministic, probabilistic, hybrid, and governed responsibilities.
+- `02` now distinguishes probabilistic transition proposals from governed transition commits.
+- `03` now models uncertainty around scores rather than treating calibrated point estimates as complete.
+- `04` now defines how PAMA consumes uncertain signals without allowing those signals to become authority.
+
+Remaining non-maximal scores are deliberate rather than forgotten:
+
+- `01` is an architectural placement document, not a calibration or adversarial-test specification.
+- `02` permits probabilistic proposals but leaves estimator-specific design to scoring/retrieval components.
+- `03` records estimator/audit metadata but does not own the complete mutation receipt, which belongs to PAMA and lifecycle governance.
+
+## Slice 1 verification
+
+Verified before PR creation:
+
+- [x] all four documents remediated against their stated targets
+- [x] no existing invariant weakened
+- [x] no document grants authority directly from a probabilistic estimate
+- [x] changed files are documentation-only
+- [x] post-remediation scores recorded
+- [x] branch diff reviewed against `main`
+- [x] branch is based on merged foundation commit `2bf1f6b`
+
+Branch diff at verification contained only:
+
+```text
+docs/01-layer-model.md
+docs/02-lifecycle-state-machine.md
+docs/03-scoring-and-decay.md
+docs/04-governance-and-pama.md
+docs/25-governed-uncertainty-documentation-conformance-audit.md
+```
+
+Merge state:
+
+```text
+status: ready_for_incremental_pr
+merge_requirement: use verified PR head SHA
+```
+
+---
+
+# Remaining audit queue
 
 Next slices should evaluate, in order:
 


### PR DESCRIPTION
## Scope

First incremental documentation-conformance slice against the governed-uncertainty doctrine.

## Baseline

Measured against `main` at `2bf1f6bca18820b55e754913b606900d5cbe872d`.

## Changes

- added `docs/25-governed-uncertainty-documentation-conformance-audit.md`
- remediated `docs/01-layer-model.md`
- remediated `docs/02-lifecycle-state-machine.md`
- remediated `docs/03-scoring-and-decay.md`
- remediated `docs/04-governance-and-pama.md`

## Key doctrine clarified

- probabilistic or learned components may produce estimates and proposals
- estimates do not grant authority
- lifecycle transitions separate proposal from commit
- PAMA maps uncertain inputs into deterministic or formally bounded authority outcomes
- stochastic choice is permitted only among already-authorized actions
- threshold calibration now includes uncertainty, drift, disagreement, abstention, and decision-boundary stability
- policy, estimator, and calibration versions remain distinguishable for replay

## Recorded measurement

The audit file preserves both baseline and post-remediation scores rather than overwriting the pre-change state.

Post-remediation coverage:

- `01-layer-model.md`: 94%
- `02-lifecycle-state-machine.md`: 95%
- `03-scoring-and-decay.md`: 97%
- `04-governance-and-pama.md`: 100%

These percentages measure documentation coverage only, not runtime correctness.

## Verification

- branch is 6 commits ahead of `main` and 0 behind
- changed files are documentation-only
- no existing invariant was weakened
- no document grants authority directly from confidence, probability, saturation, similarity, or model output
- branch diff was reviewed before PR creation

This PR is intended to be merged before the next audit slice begins.