### PR TITLE
Audit slice 3: preserve uncertainty across component composition

### DIFF
--- a/docs/11-component-architecture.md
+++ b/docs/11-component-architecture.md
@@ -6,11 +6,13 @@ This document defines Agent Memory as a larger system composed of bounded compon
 
 The doctrine should not collapse every concept into one mega-concept. That would make the architecture sound unified while making implementation worse. A real system needs a shared spine and segmented responsibilities.
 
+Component boundaries must also preserve the difference between uncertain inference and governed consequence. A probabilistic output crossing a component boundary must not quietly become authority because the receiving component forgot what kind of signal it was.
+
 ## Core decision
 
 Agent Memory is one overall architecture made of multiple governed components.
 
-It is not one monolithic product, library, database, score, graph, vault, or protocol.
+It is not one monolithic product, library, database, score, graph, vault, protocol, or model.
 
 ## System shape
 
@@ -32,20 +34,20 @@ Agent Memory System
 
 ## Component map
 
-| Component | Canonical role | Owns | Must not own |
-|---|---|---|---|
-| Identity Substrate | Stable object identity | UOR address, deterministic resolution, exact lookup identity | lifecycle policy, truth, promotion |
-| Evidence and Provenance Substrate | Why something is believed | source records, observations, witnesses, evidence bundles | permanence decisions by itself |
-| Reality Graphs | Domain-specific structured truth | code graph, decision graph, task graph, relation graph | runtime memory authority |
-| Lifecycle Engine | Memory state transitions | transient, observed, linked, candidate, disputed, pruned, crystallized | identity semantics |
-| Saturation and Decay Engine | Persistence pressure | calibrated sigma, decay, pressure, routing candidacy | correctness, certification |
-| Governance and Mutation Authority | Permission to change memory | PAMA outcomes, risk, reversibility, authority | raw scoring |
-| Certification and Crystallization Gate | Durable transition approval | verification, approval, certificate, scope | ongoing truth forever |
-| Runtime Memory Space | Operational use | Vault, Neurospace, context recall, graph traversal | canonical doctrine ownership |
-| Context Assembly Surface | What the agent sees now | prompt context, retrieved memories, active constraints | memory mutation without authority |
-| Correction and Dispute Surface | How memory changes safely | user correction, contradiction, reconciliation | silent overwrite |
-| Conformance and Calibration Harness | System validation | fixtures, reports, trap classes, threshold calibration | product UX |
-| Product and Agent Integrations | Adoption surfaces | COREFORGE, EvolveAI, CodeGenome, FailSafe, Bicameral | redefining canonical terms locally |
+| Component | Canonical role | Owns | Must not own | Typical control character |
+|---|---|---|---|---|
+| Identity Substrate | Stable object identity | UOR address, deterministic resolution, exact lookup identity | lifecycle policy, truth, promotion | deterministic substrate |
+| Evidence and Provenance Substrate | Why something is believed | source records, observations, witnesses, evidence bundles, estimator provenance | permanence decisions by itself | deterministic records + uncertain evidence |
+| Reality Graphs | Domain-specific structured reality | code graph, decision graph, task graph, relation graph | runtime memory authority | deterministic identity + probabilistic relations |
+| Lifecycle Engine | Memory state transitions | transient, observed, linked, candidate, disputed, pruned, crystallized | identity semantics | governed state machine |
+| Saturation and Decay Engine | Persistence pressure | calibrated sigma, decay, pressure, routing candidacy | correctness, certification | probabilistic / heuristic / learned estimates |
+| Governance and Mutation Authority | Permission to change memory | PAMA outcomes, risk, reversibility, authority | raw scoring | deterministic or formally bounded governance envelope |
+| Certification and Crystallization Gate | Durable transition approval | verification, approval, certificate, scope | ongoing truth forever | governed consequence |
+| Runtime Memory Space | Operational use | Vault, Neurospace, context recall, graph traversal | canonical doctrine ownership | hybrid retrieval + enforced scope |
+| Context Assembly Surface | What the agent sees now | prompt context, retrieved memories, active constraints | memory mutation without authority | probabilistic ranking inside governed admission |
+| Correction and Dispute Surface | How memory changes safely | user correction, contradiction, reconciliation | silent overwrite | mixed inference + governed commit |
+| Conformance and Calibration Harness | System validation | fixtures, reports, trap classes, threshold calibration | product UX | measurement and falsification |
+| Product and Agent Integrations | Adoption surfaces | COREFORGE, EvolveAI, CodeGenome, FailSafe, Bicameral | redefining canonical terms locally | implementation-specific within doctrine |
 
 ## Component interaction pipeline
 
@@ -54,15 +56,59 @@ Artifact or experience
   -> Identity Substrate
   -> Evidence and Provenance Substrate
   -> Reality Graph or Memory Unit
-  -> Lifecycle Engine
-  -> Saturation and Decay Engine
+  -> probabilistic / heuristic interpretation
+  -> Lifecycle and Saturation proposal
   -> Governance and Mutation Authority
-  -> Certification and Crystallization Gate
+  -> permitted action set
+  -> Certification and Crystallization Gate when required
+  -> committed state transition
   -> Runtime Memory Space
+  -> recall-time governance
   -> Context Assembly Surface
 ```
 
 Corrections and disputes can re-enter the pipeline at Evidence, Lifecycle, Governance, or Certification depending on severity.
+
+The pipeline describes responsibility and authority flow, not necessarily one synchronous execution order.
+
+## Uncertainty must survive handoff
+
+When a component produces an estimate, the receiving component must be able to distinguish:
+
+```text
+value
+semantic meaning
+estimator or method
+estimator version
+calibration scope when relevant
+uncertainty representation
+source evidence
+validity scope
+```
+
+For example, a CodeGenome relation with confidence `0.82` must not arrive at PAMA as a naked `0.82` with no indication that it is an inferred semantic edge.
+
+Likewise, a sensitivity classifier that reports uncertainty must not be converted into `non_sensitive=true` merely because an API wanted a boolean.
+
+## Proposal, authority, selection, commit
+
+Composition should preserve four different logical stages:
+
+```text
+PROPOSAL
+what an estimator, model, rule, or planner suggests
+
+AUTHORITY ENVELOPE
+what policy permits, blocks, defers, or requires review for
+
+SELECTION
+which permitted action is chosen, deterministically or stochastically
+
+COMMIT
+what state actually changes and what receipt is emitted
+```
+
+A component may implement multiple stages, but it must not make them indistinguishable.
 
 ## Segmentation principle
 
@@ -72,13 +118,31 @@ Examples:
 
 - identity failure means the wrong object is addressed
 - evidence failure means the object lacks support
+- estimator failure means a confidence, relevance, sensitivity, or persistence estimate is miscalibrated or out of scope
 - saturation failure means the system remembers or forgets poorly
 - governance failure means the system changes memory without authority
 - certification failure means an unverified memory becomes durable
 - runtime failure means the agent uses memory incorrectly
+- composition failure means individually valid components combine into unsafe behavior
 - conformance failure means the implementation cannot prove its behavior
 
-If two concepts fail differently, segment them.
+If two concepts fail differently, segment them or expose the internal boundary clearly.
+
+## Composition failure is first-class
+
+Safe components do not automatically create a safe system.
+
+Examples:
+
+```text
+safe retriever + missing tenant filter -> cross-tenant leakage
+accurate sensitivity classifier + stale policy -> unsafe sharing
+calibrated utility estimator + overbroad deletion authority -> irreversible loss
+valid individual memories + unsafe composition -> poisoned context
+valid PAMA outcome + stale state snapshot -> incorrect commit
+```
+
+Therefore conformance must test handoffs and composition, not only isolated component behavior.
 
 ## Unification principle
 
@@ -98,11 +162,44 @@ Examples:
 
 1. Shared doctrine, segmented implementation.
 2. Components may depend on each other, but must not redefine each other.
-3. Every durable memory transition must cross identity, evidence, saturation, authority, and certification boundaries.
+3. Every durable memory transition must cross identity, evidence, authority, and certification boundaries; scoring may propose but not authorize.
 4. Runtime memory may use uncertified memory only with scope and warning semantics.
 5. Domain reality graphs may provide evidence, but do not own permanence.
 6. PAMA may authorize mutation, but does not determine factual truth.
 7. Certification may confirm durability, but does not block later correction.
+8. Probabilistic outputs must preserve semantic type, provenance, and uncertainty across handoffs.
+9. A blocked action must remain blocked even when another component assigns it high confidence or utility.
+10. Stochastic selection may occur only inside a policy-permitted action set.
+11. Commit boundaries must bind to the state and policy snapshot under which authority was granted.
+12. Composition-specific failure modes require composition-specific tests.
+
+## Cross-component handoff contract
+
+A consequential handoff should preserve, where applicable:
+
+```text
+memory_id
+source_component
+target_component
+handoff_reason
+state_snapshot
+estimate_type
+estimate_value
+estimator_ref
+estimator_version
+calibration_ref
+uncertainty_summary
+evidence_refs
+policy_refs
+policy_version
+authority_refs
+permitted_action_set
+certification_refs
+ledger_ref
+timestamp
+```
+
+Not all fields apply to every handoff. Omitted authority-critical fields must not be guessed downstream.
 
 ## Component maturity levels
 
@@ -110,7 +207,9 @@ Examples:
 |---|---|
 | Conceptual | The component is defined in doctrine only |
 | Documented | Interfaces and failure modes are documented |
+| Handoff-documented | Input/output semantics and uncertainty/authority boundaries are documented |
 | Fixture-tested | Component behavior appears in conformance fixtures |
+| Composition-tested | Handoffs and multi-component failure modes are tested |
 | Implemented | One repo implements the component |
 | Enforced | The component blocks unsafe behavior at runtime |
 | Cross-repo adopted | Multiple repos conform to the same boundary |
@@ -121,4 +220,4 @@ This repo owns the overall architecture.
 
 Individual repos own implementation slices.
 
-The shared architecture should stabilize concepts, boundaries, and conformance expectations. It should not force every implementation into one repository or one runtime.
+The shared architecture should stabilize concepts, boundaries, handoff semantics, and conformance expectations. It should not force every implementation into one repository or one runtime.

--- a/docs/12-concept-segmentation-matrix.md
+++ b/docs/12-concept-segmentation-matrix.md
@@ -12,6 +12,8 @@ This matrix decides whether a concept belongs as:
 
 This prevents concept drift by forcing every idea to answer where it belongs before it becomes another half-remembered architecture ghost.
 
+The matrix also prevents probabilistic estimation, authority, and committed state change from being collapsed into one concept simply because one implementation happens to place them in the same service.
+
 ## Placement rules
 
 | Placement | Use when | Example |
@@ -33,20 +35,35 @@ This prevents concept drift by forcing every idea to answer where it belongs bef
 | Observation | Doctrine concept | Evidence and Provenance | agent-memory doctrine | Witnessed artifact or relation |
 | Evidence bundle | Component | Evidence and Provenance | FailSafe, CodeGenome, runtime ledgers | Must survive summarization |
 | Provenance | Doctrine concept | Evidence and Provenance | agent-memory doctrine | Required for durable transitions |
+| Estimator provenance | Doctrine concept | Evidence and Provenance | agent-memory doctrine | Identifies model/method/version behind consequential estimates |
 | Fiber | Doctrine concept | Saturation and Decay | agent-memory doctrine | Durability or relevance dimension |
-| Saturation sigma | Component | Saturation and Decay | PRISM-style lifecycle consumer | Routing signal, not truth |
+| Saturation sigma | Component | Saturation and Decay | PRISM-style lifecycle consumer | Routing signal, not truth or permission |
 | Decay | Component | Saturation and Decay | EvolveAI / lifecycle runtime | Reduces operational weight |
 | CMHL | Implementation detail | Saturation and Decay | EvolveAI | Specific decay implementation |
 | MTS | Implementation detail | Lifecycle routing | EvolveAI | Routing heuristic, not universal doctrine |
 | Confidence fusion | Component | Reality Graphs / Evidence | CodeGenome | Evidence support, not permanence |
 | Noisy-OR fusion | Implementation detail | Reality Graphs | CodeGenome | Specific confidence fusion method |
+| Uncertainty representation | Doctrine concept | Evidence / Scoring / Governance handoff | agent-memory doctrine | Point estimates alone may hide consequential uncertainty |
+| Calibration scope | Doctrine concept plus conformance | Conformance and Calibration Harness | agent-memory doctrine | Defines where an estimator claim is valid |
+| Estimator disagreement | Conformance concern plus doctrine concept | Scoring / Evidence | agent-memory doctrine | Must remain visible when materially consequential |
+| Abstention | Doctrine concept | Governance / Lifecycle | agent-memory doctrine | Legitimate outcome when uncertainty is too high |
+| Hysteresis | Implementation pattern plus conformance concern | Lifecycle / Scoring | implementation-specific | Prevents estimator noise from creating state churn |
 | Lifecycle state machine | Component | Lifecycle Engine | agent-memory doctrine | Shared state vocabulary |
+| Transition proposal | Doctrine concept | Lifecycle Engine | agent-memory doctrine | May be probabilistic or learned; does not mutate state |
+| Transition commit | Doctrine concept | Lifecycle Engine | agent-memory doctrine | Governed state mutation with receipt |
 | Crystallization | Doctrine concept plus component | Certification and Crystallization Gate | agent-memory doctrine | Governed transition to durable state |
 | Certification | Component | Certification and Crystallization Gate | governance layer | Confirmation record for durable transition |
-| PAMA | Component | Governance and Mutation Authority | agent-memory doctrine / PAMA implementation | Permission to mutate, promote, prune, or canonize |
-| Mutation authority | Doctrine concept | Governance and Mutation Authority | PAMA | Capability is not authority |
+| PAMA | Component | Governance and Mutation Authority | agent-memory doctrine / PAMA implementation | Permission to mutate, promote, prune, share, delete, or canonize |
+| Mutation authority | Doctrine concept | Governance and Mutation Authority | PAMA | Capability and confidence are not authority |
+| Authority envelope | Doctrine concept | Governance and Mutation Authority | agent-memory doctrine | Finite permitted / blocked / review-required consequence set |
+| Permitted action set | Doctrine concept | Governance / planner handoff | agent-memory doctrine | Stochastic choice may occur only inside this set |
+| Selection mode | Audit concept | Governance / planner handoff | agent-memory doctrine | deterministic, stochastic, human, or external selection |
+| Decision receipt | Component contract | Governance / Lifecycle ledger | FailSafe / PAMA / runtime ledgers | Reconstructs estimate, policy, allowed actions, selection, and consequence |
+| Policy version | Doctrine concept | Governance | agent-memory doctrine | Must remain distinguishable from estimator version |
+| Estimator version | Doctrine concept | Evidence / Scoring | agent-memory doctrine | Needed for consequential inference replay and drift analysis |
 | Neurospace | Component | Runtime Memory Space | COREFORGE | Operational agent memory space |
 | Vault | Implementation plus component | Runtime Memory Space | COREFORGE | Local encrypted memory container |
+| Recall admission | Doctrine concept plus component | Context Assembly Surface | agent-memory doctrine | Retrieval relevance does not override policy or scope |
 | CodeGenome | Component | Reality Graphs | CodeGenome | Code reality graph, not general runtime memory |
 | Shadow Genome | Component | Correction, Dispute, and Negative Memory | EvolveAI / FailSafe style systems | Stores failure patterns and negative constraints |
 | Bicameral decision continuity | Product plus component | Reality Graphs / Durable Decision Memory | Bicameral | High-risk decision memory and drift detection |
@@ -54,8 +71,33 @@ This prevents concept drift by forcing every idea to answer where it belongs bef
 | Arbiter | Product component | Governance and Mutation Authority | COREFORGE | Runtime policy guardian |
 | Context window assembly | Product surface | Context Assembly Surface | COREFORGE / agent runtime | Operational use, not canonical truth |
 | Correction workflow | Product surface plus component | Correction and Dispute Surface | runtime implementation | Must preserve prior state |
-| Calibration protocol | Conformance concern | Conformance and Calibration Harness | agent-memory doctrine | Determines threshold validity |
-| Trap classes | Conformance concern | Conformance and Calibration Harness | agent-memory doctrine | Access-spam and confidently-wrong cases |
+| Calibration protocol | Conformance concern | Conformance and Calibration Harness | agent-memory doctrine | Determines estimator and threshold validity |
+| Trap classes | Conformance concern | Conformance and Calibration Harness | agent-memory doctrine | Includes access-spam, confident falsehood, jitter, disagreement, scope traps |
+| Composition failure | Conformance concern plus doctrine concept | Cross-component | agent-memory doctrine | Safe components may compose into unsafe behavior |
+| Research challenge ledger | Doctrine maintenance concern | Research / governance | agent-memory doctrine | Preserves supporting and challenging evidence |
+
+## Control-character classification
+
+New concepts that influence memory should also be classified by control character:
+
+```text
+DETERMINISTIC_SUBSTRATE
+exact identity, schema validity, committed ledger semantics
+
+PROBABILISTIC_EPISTEMICS
+confidence, relevance, trust, contradiction, classification, utility, prediction
+
+GOVERNANCE_ENVELOPE
+policy mapping from observations/estimates to permitted consequences
+
+BOUNDED_SELECTION
+choice among already-permitted actions
+
+COMMITTED_CONSEQUENCE
+actual state mutation, sharing, certification, archival, deletion, or scope change
+```
+
+A concept can span more than one class only when its internal boundaries remain explicit.
 
 ## Decision tree
 
@@ -83,6 +125,14 @@ Is it mainly used to prove behavior?
   no -> open a doctrine issue before implementing
 ```
 
+Then ask:
+
+```text
+Is this an estimate, an authority decision, an action selection, or a committed consequence?
+```
+
+If the answer is unclear, the concept is under-segmented.
+
 ## Boundary examples
 
 ### Saturation
@@ -93,18 +143,42 @@ Saturation is a component-level concept because it has its own failure modes:
 - false permanence
 - overfit durability dimensions
 - poor threshold calibration
+- boundary instability
+- out-of-scope calibration reuse
 
-It is also a doctrine concept because every implementation must understand that saturation is routing, not truth.
+It is also a doctrine concept because every implementation must understand that saturation is routing, not truth or permission.
 
 ### PAMA
 
 PAMA is a component because it owns a bounded decision:
 
 ```text
-Is this memory transition allowed?
+What consequences are allowed for this proposed memory transition under this policy and state snapshot?
 ```
 
-It should not be embedded as a small helper inside each memory implementation. That would duplicate authority logic and make policy drift inevitable, because humans apparently enjoy creating three versions of the same mistake.
+It should not be embedded as an untyped helper inside each memory implementation. That would duplicate authority logic and make policy drift inevitable, because humans apparently enjoy creating three versions of the same mistake.
+
+### Conflict classification versus conflict consequence
+
+Conflict detection and ranking may be probabilistic:
+
+```text
+claim A likely contradicts claim B
+source A appears more reliable
+```
+
+The consequence remains governed:
+
+```text
+dispute
+split scope
+request verification
+correct
+retain both
+block canonical use
+```
+
+Do not require uncertain conflict interpretation to become deterministic merely to make the system easier to describe.
 
 ### CodeGenome
 
@@ -120,10 +194,12 @@ It should consume canonical doctrine and enforce runtime boundaries, but it shou
 
 ## Segmentation rule
 
-If a concept controls a transition, it should be a component.
+If a concept controls a transition, it should be a component or explicit governance contract.
 
-If a concept explains a boundary, it should be doctrine.
+If a concept explains a cross-system boundary, it should be doctrine.
 
 If a concept proves behavior, it should be conformance.
 
 If a concept only exists inside one repo, keep it there until it proves it deserves promotion.
+
+If a concept is probabilistic, do not make it authoritative by renaming the output.

--- a/docs/13-system-composition-boundaries.md
+++ b/docs/13-system-composition-boundaries.md
@@ -4,7 +4,9 @@
 
 This document defines how the larger Agent Memory architecture composes from separate systems without collapsing their responsibilities.
 
-The goal is to make the architecture feel like one coherent system while preserving the boundaries that make it implementable.
+The goal is to make the architecture feel like one coherent system while preserving the boundaries that make it implementable, governable, and testable.
+
+Composition is also where uncertainty can become dangerous: an estimate produced safely by one component can become an unauthorized consequence if another component consumes it without preserving meaning, scope, uncertainty, or policy state.
 
 ## Composition model
 
@@ -29,30 +31,31 @@ This is one concept at the architecture level and many components at the impleme
 
 ## System boundary
 
-The system boundary includes any component that participates in governed memory state transition.
+The system boundary includes any component that participates in governed memory state transition or governed memory admission.
 
 A component is inside Agent Memory if it answers at least one of these questions:
 
 1. What is this memory object?
 2. Why is this memory supported?
-3. How should this memory be scored or routed?
-4. What state is this memory in?
-5. Who may mutate this memory?
-6. Can this memory become durable?
-7. How is this memory used by an agent?
-8. How is this memory corrected, disputed, or pruned?
-9. How is memory behavior tested?
+3. What does the system estimate about this memory?
+4. How should this memory be scored or routed?
+5. What state is this memory in?
+6. Who may mutate, share, prune, or delete this memory?
+7. Can this memory become durable?
+8. May this memory enter the current agent context?
+9. How is this memory corrected, disputed, or pruned?
+10. How is memory behavior tested?
 
 ## Outside the system boundary
 
-A tool is outside the core Agent Memory system when it only consumes outputs without influencing memory state.
+A tool is outside the core Agent Memory system when it only consumes outputs without influencing memory state or admission.
 
 Examples:
 
 - a UI that only displays certified memory
 - an analytics dashboard that reads conformance reports
 - a documentation site that mirrors doctrine files
-- an LLM prompt template that consumes retrieved memory but cannot mutate state
+- an LLM prompt template that consumes an already-governed context package and cannot mutate state
 
 These can be integrations, but not core components.
 
@@ -74,9 +77,10 @@ stable identity or address
 
 Guarantees:
 
-- deterministic resolution where possible
+- deterministic resolution where required
 - no lifecycle decision
 - no truth claim
+- no confidence-weighted identity substitution
 
 ### Evidence contract
 
@@ -89,13 +93,14 @@ identity, observation, source reference
 Output:
 
 ```text
-evidence record, provenance, confidence signal
+evidence record, provenance, confidence or uncertainty signal
 ```
 
 Guarantees:
 
 - source traceability
 - witness record
+- estimator/method provenance when evidence is inferred
 - no permanence decision by evidence alone
 
 ### Reality graph contract
@@ -115,7 +120,9 @@ graph nodes, graph edges, relation confidence, provenance
 Guarantees:
 
 - domain structure
+- deterministic and inferred relations remain distinguishable
 - confidence and source separation
+- material disagreement remains visible
 - no mutation authority by graph confidence alone
 
 ### Lifecycle contract
@@ -123,20 +130,22 @@ Guarantees:
 Input:
 
 ```text
-memory unit, event, score, policy signal
+memory unit, event, score, policy signal, transition proposal
 ```
 
 Output:
 
 ```text
-state transition proposal or state transition record
+validated transition proposal or committed state-transition record
 ```
 
 Guarantees:
 
+- proposal and commit remain distinct
 - state machine alignment
 - transition metadata
 - no unauthorized mutation
+- policy and state snapshot can be reconstructed for consequential commits
 
 ### Saturation and decay contract
 
@@ -149,34 +158,58 @@ memory unit, fibers, interaction history, pressure
 Output:
 
 ```text
-sigma, decay profile, candidate routing signal
+sigma, decay profile, candidate routing signal, uncertainty metadata
 ```
 
 Guarantees:
 
-- calibrated scoring where used for durable decisions
+- calibrated scoring where used for consequential routing
+- score semantics are declared
+- calibration scope and version are preserved
 - trap-class resistance
-- no truth claim
+- no truth or permission claim
 
 ### Governance contract
 
 Input:
 
 ```text
-requested mutation, memory state, risk, evidence, actor, reversibility
+requested mutation, memory state, risk, evidence, actor, reversibility, estimator outputs, uncertainty
 ```
 
 Output:
 
 ```text
-PAMA outcome
+PAMA outcome and permitted action set
 ```
 
 Guarantees:
 
-- authority decision
+- finite authority decision
+- deterministic or formally bounded outcome for committed inputs and policy snapshot
 - audit requirement
 - no factual confirmation by authority alone
+- missing authority-critical inputs are not guessed
+
+### Action-selection contract
+
+Input:
+
+```text
+permitted action set, planner state, runtime objective
+```
+
+Output:
+
+```text
+selected permitted action
+```
+
+Guarantees:
+
+- deterministic or stochastic selection is allowed only inside the permitted set
+- blocked actions are not selectable
+- selection mode can be recorded when consequential
 
 ### Certification contract
 
@@ -196,6 +229,7 @@ Guarantees:
 
 - durable transition confirmation
 - scoped certification
+- certificate binds to relevant policy/evidence context
 - correction remains possible
 
 ### Runtime memory contract
@@ -209,12 +243,13 @@ memory units, graph relations, context request, policy constraints
 Output:
 
 ```text
-retrieved memory, assembled context, operational memory view
+retrieval candidates, admitted memory, assembled context, operational memory view
 ```
 
 Guarantees:
 
-- scope-aware recall
+- candidate generation may be probabilistic
+- scope, tenancy, sensitivity, dispute, and policy constraints apply before admission
 - user or agent usable memory
 - no hidden durable mutation
 
@@ -229,11 +264,13 @@ contradiction, user correction, failed verification, expired source
 Output:
 
 ```text
-dispute record, correction record, demotion, reconciliation, or pruning
+dispute proposal, correction proposal, demotion, reconciliation, or pruning action
 ```
 
 Guarantees:
 
+- conflict interpretation may remain probabilistic
+- consequence is governed
 - old state is preserved
 - correction is ledgered
 - disputed memory is blocked from canonical use
@@ -255,27 +292,113 @@ conformance result, calibration metrics, failure report
 Guarantees:
 
 - trap-class checks
-- calibration transparency
-- implementation boundaries are testable
+- uncertainty and calibration transparency
+- component and composition boundaries are testable
+- stochastic systems are judged against invariants, not identical sampled outputs
 
 ## Cross-component handoff record
 
-When one component passes memory to another, the handoff should preserve:
+When one component passes consequential memory information to another, the handoff should preserve where applicable:
 
 ```text
 memory_id
 source_component
 target_component
 handoff_reason
-state_before
-state_after_if_changed
+state_snapshot
+signal_type
+signal_semantics
+signal_value
+estimator_ref
+estimator_version
+calibration_ref
+uncertainty_summary
 evidence_refs
 policy_refs
+policy_version
 authority_refs
+permitted_action_set
 certification_refs
 ledger_ref
 timestamp
 ```
+
+Not every handoff requires every field. A receiving component must not infer omitted authority, scope, or certainty.
+
+## Handoff invariants
+
+Across adapters and service boundaries:
+
+1. identity must not become probabilistic accidentally
+2. confidence must not become certification
+3. relevance must not become access permission
+4. utility must not become deletion authority
+5. saturation must not become factual truth
+6. disagreement must not vanish through undocumented averaging
+7. estimator version must not be confused with policy version
+8. a blocked action must remain blocked downstream
+9. stochastic action selection must remain within the permitted action set
+10. committed consequences must remain auditable after the handoff chain completes
+
+## Composition-specific failure modes
+
+### Semantic type erasure
+
+```text
+confidence=0.92 -> receiving service treats 0.92 as approval probability
+```
+
+Mitigation: preserve score semantics and estimator provenance.
+
+### Boolean coercion of uncertainty
+
+```text
+sensitivity classifier: uncertain -> API field: sensitive=false
+```
+
+Mitigation: support abstention/unknown or enforce a conservative policy state.
+
+### Authority leakage
+
+```text
+retriever recommends delete -> storage service interprets recommendation as authorization
+```
+
+Mitigation: require explicit governance outcome and permitted action set.
+
+### Scope laundering
+
+```text
+cross-tenant memory -> summary service removes tenant metadata -> context assembler treats summary as local
+```
+
+Mitigation: scope and provenance must survive synthesis.
+
+### Stale authorization
+
+```text
+PAMA allow at state S1 -> state changes to S2 -> old allow reused for commit
+```
+
+Mitigation: bind authority to state snapshot, policy version, and requested action.
+
+### Unsafe composition
+
+```text
+memory A safe alone
+memory B safe alone
+A + B creates prohibited instruction or inference
+```
+
+Mitigation: apply read-time/composition governance and test multi-memory fixtures.
+
+### Deterministic wrapper fallacy
+
+```text
+probabilistic score -> deterministic threshold -> therefore safe
+```
+
+Mitigation: preserve uncertainty and calibrate the consequential decision boundary.
 
 ## Composition anti-patterns
 
@@ -321,6 +444,20 @@ Correct:
 Sigma is high, therefore propose candidacy and evaluate authority plus certification.
 ```
 
+### Relevance absolutism
+
+Wrong:
+
+```text
+This memory is the best semantic match, therefore inject it.
+```
+
+Correct:
+
+```text
+This memory is a retrieval candidate. Recall-time governance still applies scope, sensitivity, dispute, and policy filters.
+```
+
 ### Product-local doctrine
 
 Wrong:
@@ -337,7 +474,7 @@ Each repo implements its slice while referencing shared doctrine boundaries.
 
 ## Integration posture
 
-Use adapters between components.
+Use typed adapters between components.
 
 Do not use implicit shared assumptions.
 
@@ -346,15 +483,37 @@ Recommended adapters:
 - identity adapter
 - evidence adapter
 - graph adapter
-- lifecycle adapter
-- scoring adapter
+- lifecycle proposal adapter
+- scoring / estimator adapter
 - PAMA adapter
+- action-set adapter
 - certification adapter
 - runtime memory adapter
+- recall-admission adapter
 - conformance adapter
+
+Adapters that carry consequential estimates should document both data schema and semantic contract.
+
+## Composition conformance
+
+At least these end-to-end paths should be tested:
+
+```text
+semantic retrieval -> scope filter -> context admission
+confidence estimator -> PAMA -> transition commit
+saturation estimator -> candidate proposal -> certification
+sensitivity classifier -> sharing policy -> export
+utility estimator -> retention policy -> prune/delete decision
+conflict detector -> dispute policy -> correction/reconciliation
+multi-memory retrieval -> composition policy -> context assembly
+```
+
+Tests should inject uncertainty and disagreement at the seams, not only inside individual components.
 
 ## System rule
 
 Agent Memory is unified by contracts, not by repository location.
 
-The concepts should be segmented by responsibility, then recomposed through governed handoffs.
+The concepts should be segmented by responsibility, then recomposed through governed, typed handoffs.
+
+A safe component is necessary. A safe composition is the actual requirement.

--- a/docs/14-expanded-scope-recommendations.md
+++ b/docs/14-expanded-scope-recommendations.md
@@ -6,24 +6,26 @@ This document records recommended expansion areas beyond the originally stated s
 
 The goal is not to absorb every adjacent idea into Agent Memory. That would recreate the same conceptual sprawl this repo exists to prevent. The goal is to decide which adjacent ideas deserve first-class component treatment, which should remain integrations, and which should stay outside the architecture until they prove necessity.
 
+Expansion proposals must also preserve the governed-uncertainty boundary. Components that classify, infer, rank, predict, or discover may remain probabilistic. Components that authorize durable consequence must expose explicit policy and authority semantics.
+
 ## Recommendation summary
 
-| Recommendation | Placement | Priority | Rationale |
-|---|---|---|---|
-| Source trust and reputation | Component candidate | High | Memory depends on evidence quality over time |
-| Conflict resolution engine | Component candidate | High | Disputes need deterministic handling beyond simple flags |
-| Temporal causality model | Component candidate | High | Memory changes over time and needs causal explanation |
-| Privacy and sensitivity classifier | Component candidate | High | Memory systems must classify what can be stored, recalled, or shared |
-| Memory economics and budget policy | Component candidate | Medium | Agents need cost-aware retention and context assembly |
-| Human correction UX contract | Product plus component | Medium | Durable memory needs user-facing correction pathways |
-| Ontology and schema registry | Component candidate | Medium | Shared memory objects need stable schemas and type evolution |
-| Query planner and recall strategy | Component candidate | Medium | Retrieval needs policy-aware planning, not raw similarity |
-| Multi-agent shared memory protocol | Future subsystem | Medium | Team and org memory require ownership and scope controls |
-| Memory threat model | Conformance plus governance | High | Memory poisoning, access-spam, and unauthorized mutation require explicit treatment |
-| Policy-as-memory | Doctrine concern | Medium | Policies are durable memory but need stronger authority rules |
-| Memory compiler | Future subsystem | Low | Useful later for compiling docs, graphs, traces, and decisions into memory units |
-| Interoperability profile | Future standard | Medium | Needed if multiple implementations claim doctrine conformance |
-| Domain-specific memory packs | Integration pattern | Low | Should not enter core doctrine unless cross-domain behavior emerges |
+| Recommendation | Placement | Priority | Governed-uncertainty posture | Rationale |
+|---|---|---|---|---|
+| Source trust and reputation | Component candidate | High | probabilistic estimate; never authority by itself | Memory depends on evidence quality over time |
+| Conflict resolution engine | Component candidate | High | probabilistic conflict interpretation + governed consequence | Disputes need explicit resolution semantics beyond simple flags |
+| Temporal causality model | Component candidate | High | mixed deterministic timeline + probabilistic causality | Memory changes over time and needs causal explanation |
+| Privacy and sensitivity classifier | Component candidate | High | probabilistic classification feeding strict policy | Memory systems must classify what can be stored, recalled, or shared |
+| Memory economics and budget policy | Component candidate | Medium | utility/cost estimates feeding bounded retention policy | Agents need cost-aware retention and context assembly |
+| Human correction UX contract | Product plus component | Medium | human input enters governed correction path | Durable memory needs user-facing correction pathways |
+| Ontology and schema registry | Component candidate | Medium | deterministic versioning and compatibility rules | Shared memory objects need stable schemas and type evolution |
+| Query planner and recall strategy | Component candidate | Medium | probabilistic planning inside recall policy | Retrieval needs policy-aware planning, not raw similarity |
+| Multi-agent shared memory protocol | Future subsystem | Medium | probabilistic collaboration under explicit ownership/scope rules | Team and org memory require ownership and scope controls |
+| Memory threat model | Conformance plus governance | High | adversarial tests across deterministic and probabilistic boundaries | Poisoning and unauthorized mutation require explicit treatment |
+| Policy-as-memory | Doctrine concern | Medium | policy content may evolve, policy authority must remain explicit | Policies are durable memory but need stronger authority rules |
+| Memory compiler | Future subsystem | Low | probabilistic extraction; governed admission required | Useful later for compiling heterogeneous artifacts into memory units |
+| Interoperability profile | Future standard | Medium | deterministic contract semantics with implementation freedom | Needed if multiple implementations claim doctrine conformance |
+| Domain-specific memory packs | Integration pattern | Low | implementation-specific | Should not enter core doctrine unless cross-domain behavior emerges |
 
 ## Add now
 
@@ -33,7 +35,7 @@ These should be added to the architecture soon because they are foundational and
 
 Memory quality depends on source quality.
 
-The current architecture captures evidence and provenance, but it does not yet define how source reliability changes over time.
+The current architecture captures evidence and provenance, but it does not yet fully define how source reliability changes over time.
 
 Recommended component:
 
@@ -43,11 +45,13 @@ Source Trust and Reputation Layer
 
 Responsibilities:
 
-- track source reliability
+- estimate source reliability
 - weight evidence by source class
+- track source-specific calibration and failure history
 - decay or demote sources that produce contradictions
 - distinguish authoritative, observed, inferred, synthetic, user-provided, and agent-generated sources
 - prevent a noisy source from dominating saturation
+- preserve uncertainty and applicability scope for trust estimates
 
 Failure modes:
 
@@ -55,12 +59,21 @@ Failure modes:
 - stale source remains trusted
 - agent-generated memory recursively cites itself
 - single-source claims become durable without corroboration
+- trust score silently becomes permission to crystallize
+- one domain's trust estimate is reused outside its calibration scope
+
+Governance rule:
+
+```text
+source trust -> evidence weighting
+source trust != mutation authority
+```
 
 ### 2. Conflict resolution engine
 
 Dispute state is necessary but not sufficient.
 
-The system needs a deterministic way to resolve conflicts between memories, sources, policies, and time windows.
+The system needs a governed way to interpret and resolve conflicts between memories, sources, policies, and time windows.
 
 Recommended component:
 
@@ -70,9 +83,10 @@ Conflict Resolution Engine
 
 Responsibilities:
 
-- rank conflicting evidence
-- classify conflict type
-- select correction, split-scope, demotion, or escalation
+- detect and classify conflict
+- rank or compare conflicting evidence
+- estimate whether conflict represents contradiction, supersession, scope mismatch, or uncertainty
+- propose correction, split-scope, demotion, retention of both claims, or escalation
 - preserve minority or historical claims when relevant
 - prevent silent overwrite
 
@@ -85,6 +99,22 @@ Conflict types:
 - source reliability conflict
 - user correction conflict
 - implementation drift
+- estimator disagreement
+
+Control rule:
+
+Conflict detection and evidence ranking may legitimately be probabilistic.
+
+The **resolution consequence** must be governed.
+
+```text
+probabilistic conflict interpretation
+  -> policy-defined options
+  -> permitted action set
+  -> correction / split scope / dispute / escalation / retain both
+```
+
+Do not force uncertain interpretation into deterministic classification merely to make the diagram tidier.
 
 ### 3. Temporal causality model
 
@@ -98,13 +128,23 @@ Temporal Causality Layer
 
 Responsibilities:
 
-- represent event order
+- represent exact event order where known
+- distinguish observed chronology from inferred causality
 - link decisions to causes and consequences
 - distinguish stale from superseded
 - support causal recall
 - preserve timeline of correction and drift
+- attach confidence and provenance to inferred causal relations
 
 This is especially important for decision memory, codebase evolution, organizational memory, and agent self-improvement.
+
+Control rule:
+
+```text
+observed order may be deterministic
+causal attribution may be probabilistic
+policy consequence must not treat inferred causality as certain fact without appropriate evidence
+```
 
 ### 4. Privacy and sensitivity classifier
 
@@ -119,12 +159,22 @@ Privacy and Sensitivity Classifier
 Responsibilities:
 
 - classify memory sensitivity
+- preserve classification uncertainty
 - apply retention boundaries
 - prevent unsafe context assembly
 - enforce local-first and encrypted storage expectations
 - distinguish personal, organizational, security, financial, health, credential, and public data
+- expose confidence, model version, calibration scope, and unknown/abstain state
 
 This component should influence PAMA, Vault, context assembly, and conformance fixtures.
+
+Critical rule:
+
+```text
+classifier uncertain != non-sensitive
+```
+
+For broad sharing, export, or cross-tenant use, uncertainty should trigger stricter handling or review rather than optimistic coercion.
 
 ### 5. Memory threat model
 
@@ -150,6 +200,13 @@ Threat classes:
 - overbroad context assembly
 - malicious correction
 - poisoned code graph evidence
+- unsafe multi-memory composition
+- estimator manipulation
+- calibration drift exploitation
+- policy bypass through stochastic planners
+- authority laundering across component boundaries
+
+The threat model should test both individual components and composition seams.
 
 ## Add soon
 
@@ -159,12 +216,21 @@ These are valuable but should follow the foundational components.
 
 Agent memory has resource costs.
 
-The architecture should model cost, context budget, storage budget, retrieval budget, and cognitive budget.
+The architecture should model cost, context budget, storage budget, retrieval budget, latency budget, and cognitive budget.
 
 Recommended placement:
 
 ```text
-Context Assembly Surface + Saturation and Decay Engine
+Context Assembly Surface + Saturation and Decay Engine + Governance
+```
+
+Utility estimates may be probabilistic.
+
+Retention and deletion consequences remain governed.
+
+```text
+predicted low utility -> prune/archive/delete candidate
+predicted low utility != permanent deletion authority
 ```
 
 This should not become a standalone component yet unless cost policy becomes complex enough to need one.
@@ -186,6 +252,9 @@ Responsibilities:
 - define compatibility rules
 - support migrations
 - prevent implementation-specific fields from corrupting doctrine-level objects
+- define typed representations for uncertainty, policy outcome, action sets, and receipts
+
+Schema compatibility is a deterministic substrate concern even when the data represented by the schema is probabilistic.
 
 ### 8. Query planner and recall strategy
 
@@ -202,10 +271,19 @@ Governed Recall Planner
 Responsibilities:
 
 - choose recall path
+- combine exact, graph, semantic, temporal, and policy-aware retrieval
 - respect certification state
 - avoid disputed canonical use
-- compose graph, vector, exact-address, and policy-aware retrieval
+- obey tenant and sensitivity boundaries
 - produce recall explanations
+- expose stochastic selection mode when relevant
+
+Control rule:
+
+```text
+planner may probabilistically discover candidates
+policy defines admissible candidates and actions
+```
 
 ### 9. Human correction UX contract
 
@@ -222,9 +300,12 @@ The architecture should define what users must be able to see and change:
 - why a memory exists
 - why it was recalled
 - what evidence supports it
+- which parts are inferred
+- how uncertain the system is where material
 - whether it is certified
 - how to dispute it
 - how to correct it
+- what authority the correction carries
 - how correction affects future recall
 
 ## Watch closely
@@ -235,11 +316,20 @@ These are promising but should not enter the core architecture too soon.
 
 Shared memory across agents, teams, or organizations is important, but risky.
 
-It introduces ownership, identity, consent, tenant boundaries, ACLs, role-based recall, and conflicting authority models.
+It introduces ownership, identity, consent, tenant boundaries, ACLs, role-based recall, delegation, source reputation, conflicting authority models, and probabilistic consensus.
 
 Recommendation:
 
 Keep as a future subsystem until single-agent and product-local memory boundaries are stable.
+
+Before admission to core, require conformance cases for:
+
+- conflicting agent estimates
+- delegated authority expiry
+- cross-tenant high relevance
+- shared-memory correction rights
+- source laundering through another agent
+- consensus that is high-confidence but unauthorized
 
 ### 11. Interoperability profile
 
@@ -252,11 +342,12 @@ Potential profiles:
 - Level 3: calibrated saturation
 - Level 4: PAMA authority
 - Level 5: certification and crystallization
-- Level 6: cross-system interoperability
+- Level 6: governed uncertainty
+- Level 7: cross-system interoperability
 
 Recommendation:
 
-Wait until adapter contracts and implementation ownership map exist.
+Wait until adapter contracts, typed handoffs, and implementation ownership maps exist.
 
 ### 12. Memory compiler
 
@@ -264,9 +355,11 @@ A memory compiler could convert docs, traces, issues, PRs, decisions, code graph
 
 This is powerful but dangerous if added too early.
 
+A compiler will almost certainly rely on probabilistic extraction, entity resolution, summarization, and classification. Therefore its output must enter the normal evidence, uncertainty, admission, and governance path.
+
 Recommendation:
 
-Do not add as a component yet. Track as a future subsystem after source trust, conflict resolution, and certification are stronger.
+Do not add as a component yet. Track as a future subsystem after source trust, conflict resolution, sensitivity, and certification are stronger.
 
 ## Keep outside core for now
 
@@ -292,7 +385,7 @@ Agent personality continuity may use memory, but it should not drive memory doct
 
 Recommendation:
 
-Keep personality memory as a runtime/product concern unless it intersects identity, consent, correction, or governance.
+Keep personality memory as a runtime/product concern unless it intersects identity, consent, correction, provenance, or governance.
 
 ### Prompt-template libraries
 
@@ -304,7 +397,7 @@ Keep outside core.
 
 ## Highest-value next additions
 
-The next architecture pass should add:
+The next architecture pass should add or complete:
 
 1. `docs/15-memory-threat-model.md`
 2. `docs/16-source-trust-and-reputation.md`
@@ -312,7 +405,15 @@ The next architecture pass should add:
 4. `docs/18-temporal-causality-layer.md`
 5. `docs/19-privacy-and-sensitivity-classifier.md`
 
-These five expand scope without losing architecture discipline.
+Each should explicitly identify:
+
+```text
+what may be probabilistic
+what must be deterministic or formally bounded
+what authority it does not own
+what uncertainty metadata crosses its boundaries
+what conformance cases can falsify its assumptions
+```
 
 ## Strategic recommendation
 
@@ -324,4 +425,4 @@ That lets EvolveAI, CodeGenome, COREFORGE, UOR, FailSafe, Bicameral, and future 
 
 The long-term wedge is not memory recall.
 
-The wedge is governed memory state transition across identity, evidence, lifecycle, authority, certification, and runtime use.
+The wedge is governed memory state transition and admission across identity, evidence, uncertain inference, lifecycle, authority, certification, forgetting, and runtime use.

--- a/docs/audits/governed-uncertainty/03-component-composition.md
+++ b/docs/audits/governed-uncertainty/03-component-composition.md
@@ -1,0 +1,128 @@
+# Governed Uncertainty Audit: Slice 3
+
+## Scope
+
+This slice audits the architectural-composition documents:
+
+- `11-component-architecture.md`
+- `12-concept-segmentation-matrix.md`
+- `13-system-composition-boundaries.md`
+- `14-expanded-scope-recommendations.md`
+
+The emphasis is not individual component correctness. It is whether uncertainty, authority, scope, and provenance survive composition across component boundaries.
+
+## Baseline
+
+```text
+baseline_main_commit: 880dc1946ad22b6a2ef2208b666653992344bfa1
+baseline_source: merged PR #34 / governed uncertainty audit slice 2
+```
+
+## Baseline scores
+
+| Document | GU-1 | GU-2 | GU-3 | GU-4 | GU-5 | GU-6 | GU-7 | GU-8 | GU-9 | GU-10 | Coverage |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `11-component-architecture.md` | 4 | 2 | 4 | 1 | 3 | 3 | 2 | 0 | 1 | 2 | 55% |
+| `12-concept-segmentation-matrix.md` | 4 | 2 | 4 | 1 | 3 | 2 | 1 | 0 | 1 | 2 | 50% |
+| `13-system-composition-boundaries.md` | 4 | 2 | 4 | 1 | 4 | 3 | 3 | 0 | 1 | 2 | 60% |
+| `14-expanded-scope-recommendations.md` | 2 | 2 | 3 | 1 | 2 | 3 | 1 | 0 | 1 | 2 | 43% |
+
+## Key baseline findings
+
+### Composition lost signal semantics
+
+The existing component and handoff models preserved evidence, policy, authority, and ledger references, but not enough information to distinguish:
+
+- deterministic fact from probabilistic estimate
+- confidence from probability
+- estimator version from policy version
+- uncertain classification from negative classification
+- recommendation from authority
+
+That creates a type-erasure risk at exactly the point components compose.
+
+### Safe components were implicitly treated as sufficient
+
+The architecture described bounded responsibilities well, but did not explicitly model composition failures such as:
+
+- scope laundering through summaries
+- stale authorization after state change
+- cross-tenant high-relevance retrieval
+- unsafe multi-memory composition
+- utility estimates becoming deletion instructions
+- uncertainty being coerced into booleans
+
+### Conflict resolution wording was overly deterministic
+
+`14-expanded-scope-recommendations.md` described the future conflict engine as needing a deterministic conflict-resolution method. That was too broad.
+
+Conflict detection, classification, source comparison, and causal interpretation may remain probabilistic. The governed requirement belongs at the consequence boundary: dispute, correction, split scope, escalation, retention of both claims, or other policy-defined outcomes.
+
+This is recorded as an actual doctrine correction, not merely an expansion.
+
+## Remediation applied
+
+### `11-component-architecture.md`
+
+- classified each component by typical control character
+- added uncertainty-preserving handoffs
+- separated proposal, authority envelope, selection, and commit
+- added composition failure as first-class failure mode
+- added handoff metadata for estimator/version/calibration/policy/action set
+- expanded maturity levels to include handoff and composition testing
+
+### `12-concept-segmentation-matrix.md`
+
+- added estimator provenance, uncertainty representation, calibration scope, abstention, hysteresis, disagreement, action sets, policy/estimator versions, and receipts
+- added control-character classification
+- added explicit question: estimate, authority decision, action selection, or committed consequence?
+- corrected conflict handling to allow probabilistic interpretation with governed consequences
+
+### `13-system-composition-boundaries.md`
+
+- expanded contracts to preserve signal semantics and uncertainty
+- added action-selection contract
+- added recall-admission semantics
+- added handoff invariants
+- added semantic type erasure, boolean coercion, authority leakage, scope laundering, stale authorization, unsafe composition, and deterministic-wrapper failure modes
+- added end-to-end composition conformance paths
+
+### `14-expanded-scope-recommendations.md`
+
+- classified future components by governed-uncertainty posture
+- changed conflict resolution from globally deterministic to probabilistic interpretation plus governed consequence
+- added explicit control rules for source trust, temporal causality, sensitivity, economics, recall planning, multi-agent memory, and memory compiler
+- added new threat classes for estimator manipulation, calibration drift, policy bypass, unsafe composition, and authority laundering
+
+## Post-remediation scores
+
+| Document | GU-1 | GU-2 | GU-3 | GU-4 | GU-5 | GU-6 | GU-7 | GU-8 | GU-9 | GU-10 | Coverage |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `11-component-architecture.md` | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 3 | 4 | 98% |
+| `12-concept-segmentation-matrix.md` | 4 | 4 | 4 | 4 | 4 | 3 | 3 | 4 | 4 | 4 | 95% |
+| `13-system-composition-boundaries.md` | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 100% |
+| `14-expanded-scope-recommendations.md` | 3 | 4 | 4 | 4 | 4 | 4 | 3 | 4 | 4 | 4 | 95% |
+
+## Remaining non-maximal scores
+
+- `11` defines architecture rather than calibration algorithms, so GU-9 is intentionally delegated.
+- `12` is a taxonomy and placement matrix, not the primary owner of consequence-proportionality or full receipts.
+- `14` recommends future work rather than defining exact substrate and replay implementations.
+
+## Verification requirements
+
+- [x] all four documents read before remediation
+- [x] baseline anchored to merged slice 2
+- [x] actual contradictory wording identified and corrected rather than preserved by inertia
+- [x] component handoffs now preserve estimate semantics and authority boundaries
+- [x] composition failure is independently testable
+- [x] bounded stochastic selection is explicit
+- [x] no recommendation grants authority from confidence, trust, relevance, utility, or classification alone
+- [ ] final branch diff reviewed against `main`
+- [ ] PR head verified mergeable
+- [ ] commit status checked
+- [ ] merged using exact verified head SHA
+
+## Next slice
+
+Audit documents `15` through `19` where present. These are high-value because they own threat modeling, source trust, conflict resolution, temporal causality, and privacy/sensitivity, all of which directly determine whether probabilistic memory behavior remains governable.


### PR DESCRIPTION
## Scope

Third incremental governed-uncertainty audit, focused on component composition and cross-component handoffs.

## Baseline

Measured against `main` at `880dc1946ad22b6a2ef2208b666653992344bfa1`, the merged slice 2 state.

## Material correction

This slice corrects an overbroad earlier recommendation that conflict resolution should be deterministic. Conflict detection, classification, evidence ranking, and causal interpretation may remain probabilistic. The governed requirement applies to the consequence boundary: dispute, correction, split scope, escalation, retaining both claims, or another policy-defined outcome.

## Changes

- classifies component control character explicitly
- preserves estimator semantics, version, calibration, uncertainty, and policy state across handoffs
- separates proposal, authority envelope, bounded selection, and committed consequence
- adds composition failure as a first-class failure mode
- adds handoff invariants for relevance, scope, utility, confidence, certification, and policy
- adds composition-specific conformance paths
- refines future components such as source trust, conflict resolution, temporal causality, sensitivity, economics, recall planning, multi-agent memory, and memory compiler under governed uncertainty

## Measurement

Baseline and post-remediation scores are preserved in `docs/audits/governed-uncertainty/03-component-composition.md`.

Post-remediation coverage:

- `11-component-architecture.md`: 98%
- `12-concept-segmentation-matrix.md`: 95%
- `13-system-composition-boundaries.md`: 100%
- `14-expanded-scope-recommendations.md`: 95%

These are documentation-coverage scores, not implementation certification.

## Verification

- branch is 5 commits ahead and 0 behind `main`
- only four doctrine docs plus the slice audit record changed
- no estimator output gains authority through handoff
- stochastic selection is allowed only within the permitted action set
- composition-specific failure modes are now explicit and testable

This PR should merge before auditing docs 15-19.