### PR TITLE
Audit slice 4: add threat, trust, conflict, causality, and privacy foundations

### DIFF
--- a/docs/15-memory-threat-model.md
+++ b/docs/15-memory-threat-model.md
@@ -1,0 +1,404 @@
+# Memory Threat Model
+
+## Purpose
+
+Persistent memory turns an agent from a session-bound system into a stateful system whose mistakes, compromises, and authority errors can survive the interaction that created them.
+
+This threat model defines the major adversarial and accidental failure classes that Agent Memory implementations should defend against.
+
+The core security rule is:
+
+> Memory content may be uncertain or adversarial. Memory authority must not be inferred from content, confidence, similarity, repetition, or apparent usefulness.
+
+## Assets
+
+The memory system may protect:
+
+- user facts and preferences
+- credentials and sensitive data
+- organizational decisions
+- policies and safety constraints
+- code and operational knowledge
+- source provenance
+- audit history
+- correction and dispute records
+- deletion state and tombstones
+- agent procedures and prospective obligations
+- scope and tenant boundaries
+
+## Security properties
+
+A conforming architecture should preserve:
+
+```text
+INTEGRITY
+untrusted content cannot silently become canonical memory
+
+CONFIDENTIALITY
+memory cannot cross actor, tenant, sensitivity, or policy boundaries without authority
+
+AUTHORITY INTEGRITY
+content cannot manufacture permission to mutate, share, delete, certify, or act
+
+PROVENANCE INTEGRITY
+origin and transformation history survive summarization and derivation
+
+TEMPORAL INTEGRITY
+stale authorization and superseded policy cannot silently control current state
+
+DELETION FIDELITY
+required forgetting propagates through raw, derived, summarized, indexed, and cached forms
+
+RECOVERY
+corruption and unsafe mutation have a defined detection, rollback, correction, or containment path
+```
+
+## Trust boundaries
+
+Key boundaries include:
+
+1. external content -> observation
+2. observation -> memory write candidate
+3. candidate -> durable memory
+4. memory store -> retrieval candidate
+5. retrieval candidate -> active context
+6. active context -> agent action
+7. agent inference -> memory mutation proposal
+8. proposal -> PAMA / policy decision
+9. authority envelope -> committed mutation
+10. one user/tenant/agent -> another
+11. raw memory -> summary / consolidation / semantic memory
+12. deletion request -> every derived representation
+
+Each boundary should identify what may be probabilistic and what must remain enforced.
+
+## Threat classes
+
+### 1. Direct memory poisoning
+
+An attacker causes malicious, false, or manipulative content to be persisted so it influences later sessions.
+
+Attack path:
+
+```text
+untrusted input
+  -> accepted memory
+  -> later retrieval
+  -> behavior change
+```
+
+Controls:
+
+- origin-aware write admission
+- source trust as evidence, not authority
+- quarantine or ephemeral-only modes
+- certification before high-authority durable promotion
+- retrieval-time re-evaluation
+- correction and dispute paths
+
+### 2. Sleeper memory poisoning
+
+Malicious content remains dormant until a later context triggers retrieval or action.
+
+Controls must therefore operate beyond write time.
+
+Required posture:
+
+```text
+write-time safety != lifetime safety
+```
+
+Read-time and action-time governance remain necessary.
+
+### 3. Authority laundering
+
+Untrusted content gains apparent authority through transformations such as:
+
+- summarization
+- trusted-tool echo
+- repeated agent self-citation
+- manufactured corroboration
+- cross-agent restatement
+- consolidation into semantic memory
+
+Controls:
+
+- preserve origin binding through derivation
+- distinguish evidence lineage from authority lineage
+- require explicit authority elevation
+- prevent self-corroboration from counting as independent support
+
+### 4. Recursive self-citation
+
+An agent writes an inference, later retrieves it as evidence, then treats the retrieval as independent corroboration.
+
+Required invariant:
+
+```text
+derived_from(self) != independent corroboration
+```
+
+### 5. Access-spam reinforcement
+
+Repeated access artificially inflates saturation or permanence.
+
+Controls:
+
+- low raw-read weight
+- deduplicated evidence lineage
+- diminishing reinforcement for identical evidence
+- trap-class conformance
+
+### 6. Hallucination permanence
+
+A confident but false inference becomes durable through repetition or internal reuse.
+
+Controls:
+
+- confidence is not certification
+- contradiction and verification paths
+- high-consequence promotion requires stronger evidence
+- durable state remains correctable
+
+### 7. Provenance stripping
+
+Transformation removes source, scope, uncertainty, tenant, or authority metadata.
+
+Examples:
+
+```text
+source memory -> summary without tenant tag
+probabilistic claim -> plain text fact
+untrusted origin -> trusted aggregate
+```
+
+Controls:
+
+- typed derivation records
+- mandatory scope inheritance
+- provenance-preserving summaries
+- conformance tests for metadata survival
+
+### 8. Scope and tenant leakage
+
+A highly relevant memory from the wrong user, tenant, project, or authorization domain enters context.
+
+Required invariant:
+
+```text
+relevance != permission
+```
+
+Controls:
+
+- deterministic or formally bounded scope enforcement
+- tenant binding on memory identity/metadata
+- post-retrieval admission checks
+- deny or escalate on ambiguous scope
+
+### 9. Sensitive-memory extraction
+
+Attackers intentionally probe memory to reconstruct private information.
+
+Controls may include:
+
+- least-privilege retrieval
+- restricted recall surfaces
+- sensitivity-aware summarization
+- query and extraction-rate controls
+- differential disclosure policies where appropriate
+- audit of sensitive memory access
+
+### 10. Deletion residue
+
+A deletion request removes a raw record while derived summaries, embeddings, graph nodes, caches, or consolidated memories retain recoverable content.
+
+Controls:
+
+- dependency-aware deletion graph
+- tombstones or redaction propagation
+- deletion verification across memory tiers
+- retention-policy receipts
+
+### 11. Stale policy retention
+
+A memory is correctly handled under an old policy but later reused after policy changes.
+
+Controls:
+
+- bind consequential decisions to policy version
+- invalidate or re-evaluate where policy requires
+- distinguish policy change from estimator change
+
+### 12. Stale authorization reuse
+
+PAMA authorizes an action for state snapshot S1, but the memory changes before commit.
+
+Controls:
+
+- bind authorization to state/version
+- compare-and-swap or equivalent concurrency control
+- require re-authorization after material state change
+
+### 13. Stochastic policy bypass
+
+A planner is given both permitted and prohibited actions and samples the prohibited one.
+
+Required invariant:
+
+```text
+randomness does not create permission
+```
+
+The planner's selectable set must already exclude prohibited actions.
+
+### 14. Unsafe multi-memory composition
+
+Individual memories are benign alone but dangerous when combined.
+
+Examples:
+
+- two partial secrets reconstruct a credential
+- several harmless instructions form an attack chain
+- distributed poisoned memories trigger only when retrieved together
+
+Controls:
+
+- context-level admission and composition checks
+- information-flow analysis for high-risk domains
+- multi-memory conformance fixtures
+
+### 15. Estimator manipulation
+
+An attacker changes inputs specifically to exploit confidence, trust, relevance, sensitivity, or utility estimators.
+
+Controls:
+
+- adversarial calibration tests
+- uncertainty and out-of-distribution signals
+- multiple independent signals where justified
+- no direct authority from estimator output
+
+### 16. Calibration drift exploitation
+
+An estimator remains technically functional but its calibration no longer matches current data or attack conditions.
+
+Controls:
+
+- calibration versioning
+- drift monitoring
+- scope-of-validity metadata
+- conservative fallback for high-consequence decisions
+
+### 17. Malicious or mistaken correction
+
+A correction surface is used to overwrite accurate memory or remove evidence.
+
+Controls:
+
+- correction authority
+- prior-state preservation
+- conflict handling rather than silent replacement
+- audit receipt
+
+### 18. Permanent deletion abuse
+
+A utility or staleness estimate triggers irreversible deletion of valuable or evidentiary memory.
+
+Controls:
+
+- separate prune/archive/delete modes
+- retention and legal/policy checks
+- dependency checks
+- stronger authority as reversibility decreases
+
+## Probabilistic security components
+
+The threat model does **not** require every defense to be deterministic.
+
+Probabilistic components may legitimately estimate:
+
+- maliciousness
+- source trust
+- anomaly likelihood
+- sensitivity
+- contradiction
+- semantic relevance
+- poisoning risk
+- utility
+- composition risk
+
+The governance requirement is that these estimates cannot create their own authority.
+
+```text
+risk estimate
+  -> policy envelope
+  -> block / quarantine / review / allow-under-constraints
+```
+
+## Deterministic or formally bounded security consequences
+
+Strong invariants should include:
+
+- cross-tenant denial
+- invalid transition denial
+- policy-version binding
+- required provenance fields
+- action-set exclusion
+- deletion scope semantics
+- ledger creation for consequential changes
+- certification requirements
+- concurrency/version checks
+
+## Threat severity
+
+Evaluate threats along at least:
+
+```text
+persistence
+blast radius
+sensitivity
+authority gained
+reversibility
+detectability
+cross-session reach
+cross-agent reach
+evidence destruction
+```
+
+A low-probability attack that gains durable authority can be more serious than a frequent ephemeral error.
+
+## Required conformance cases
+
+At minimum:
+
+- direct poisoning
+- sleeper poisoning
+- recursive self-citation
+- provenance stripping
+- cross-tenant high-relevance recall
+- stochastic policy bypass
+- unsafe multi-memory composition
+- uncertain sensitivity
+- stale authorization
+- deletion residue
+- permanent deletion from predicted low utility
+- estimator drift
+
+## Research signals
+
+Accessible current work reinforces several threat-model choices:
+
+- [Memory Poisoning Attack and Defense on Memory Based LLM-Agents](https://arxiv.org/abs/2601.05504) evaluates poisoning robustness and shows trust thresholds require careful calibration.
+- [Hidden in Memory: Sleeper Memory Poisoning in LLM Agents](https://arxiv.org/abs/2605.15338) studies delayed persistent poisoning across later conversations.
+- [AgentSys: Secure and Dynamic LLM Agents Through Explicit Hierarchical Memory Management](https://arxiv.org/abs/2602.07398) demonstrates the value of explicit memory isolation and schema-validated boundary crossing.
+- [Securing LLM-Agent Long-Term Memory Against Poisoning](https://arxiv.org/abs/2606.24322) argues for non-malleable origin-bound authority and explicitly studies authority laundering through memory transformations.
+- [Toward Secure LLM Agents](https://arxiv.org/abs/2606.10749) frames persistent state, delegated authority, provenance, and compositional weakness as central agent-security concerns.
+
+These sources inform threats and design candidates. They do not make any one defense universal doctrine without implementation evidence.
+
+## Doctrine
+
+Persistent memory is a security boundary because it can turn transient untrusted information into future behavior.
+
+The system must govern not only **what gets remembered**, but what remembered information is ever allowed to **authorize**.

--- a/docs/16-source-trust-and-reputation.md
+++ b/docs/16-source-trust-and-reputation.md
@@ -1,0 +1,362 @@
+# Source Trust and Reputation
+
+## Purpose
+
+Memory quality depends not only on what a source says, but on what kind of source produced it, how reliably that source has behaved, what scope the reliability applies to, and whether later transformations preserve the source's origin.
+
+Source trust is therefore a first-class evidence signal.
+
+It is **not** authority.
+
+```text
+source trust -> evidence weighting
+source trust != permission
+source trust != certification
+source trust != factual truth
+```
+
+## Why a trust layer exists
+
+Without explicit source trust, memory systems tend to make one of two mistakes:
+
+1. treat every observation as equally credible
+2. smuggle source preference into opaque model behavior
+
+Neither is acceptable for governed memory.
+
+## Source classes
+
+At minimum, implementations should distinguish:
+
+- direct user statement
+- user-approved correction
+- authoritative policy or system record
+- signed or verified artifact
+- deterministic tool observation
+- probabilistic tool/model inference
+- external document or webpage
+- organization-internal document
+- agent-generated summary
+- agent-generated inference
+- another agent's assertion
+- synthetic or simulated data
+- unknown or unattributed source
+
+Source class is not a universal trust ordering. Context matters.
+
+A user statement may be authoritative about personal preference while weak evidence about an external scientific fact.
+
+## Trust is multidimensional
+
+A single scalar may be convenient but can hide important distinctions.
+
+Useful dimensions include:
+
+```text
+identity_assurance
+provenance_integrity
+domain_competence
+historical_reliability
+independence
+recency
+scope_match
+corroboration_quality
+adversarial_exposure
+transformation_distance
+```
+
+Implementations may use a scalar, vector, categorical model, or probabilistic distribution. They must declare what the representation means.
+
+## Trust estimate record
+
+A consequential source-trust estimate should preserve:
+
+```text
+source_id
+source_class
+trust_dimensions
+trust_value_or_distribution
+estimator_id
+estimator_version
+calibration_version
+calibration_scope
+evidence_refs
+uncertainty
+valid_scope
+computed_at
+expires_or_recheck_at
+```
+
+## Deterministic substrate
+
+The following should be stable where required:
+
+- source identity
+- source-to-memory provenance links
+- origin labels
+- tenant/scope labels
+- signature/hash verification results
+- derivation relationships
+- policy rules governing authority
+
+Trust estimation may be probabilistic. Origin should not become probabilistic because a model likes the prose.
+
+## Probabilistic trust
+
+Trust may legitimately be inferred from:
+
+- prior accuracy
+- contradiction history
+- domain-specific performance
+- provenance quality
+- corroboration
+- anomaly signals
+- freshness
+- source behavior over time
+
+A probabilistic trust estimate should remain an estimate.
+
+Example:
+
+```text
+source_reliability = 0.86
+```
+
+must not silently become:
+
+```text
+source_is_authoritative = true
+```
+
+unless policy explicitly defines that transition and its scope.
+
+## Latent source preference
+
+LLMs may exhibit source preferences independent of explicit trust policy.
+
+That creates a hidden trust channel:
+
+```text
+model prior
+  -> source preference
+  -> retrieval / synthesis weighting
+  -> memory formation
+```
+
+Governed memory should therefore distinguish **declared trust policy** from **latent model preference**.
+
+Possible controls:
+
+- expose source identity during evaluation
+- test counterfactual source labels
+- compare content-equivalent sources
+- record retrieval/ranking behavior by source class
+- avoid treating model attention or selection frequency as evidence of reliability
+
+## Independence and corroboration
+
+Corroboration is useful only when evidence is sufficiently independent.
+
+Wrong:
+
+```text
+agent summary A
+agent restates A as B
+another summary cites B
+=> three sources
+```
+
+Correct:
+
+```text
+A -> B -> C share one origin lineage
+independent_source_count = 1
+```
+
+Required rules:
+
+- preserve derivation graphs
+- detect self-citation loops
+- distinguish independent witnesses from transformations
+- prevent Sybil-style manufactured corroboration
+
+## Trust decay and recovery
+
+Trust may change with time and evidence.
+
+Possible transitions:
+
+```text
+trusted -> degraded
+unknown -> trusted-within-scope
+trusted -> disputed
+blocked -> rehabilitated
+```
+
+Changes should be evidence-driven and ledgered when consequential.
+
+A source should not gain permanent global reputation because it performed well on one task family.
+
+## Domain and scope specificity
+
+Trust should be scoped.
+
+Examples:
+
+```text
+source trusted for repository build status
+source not authoritative for security policy
+
+user authoritative for own preference
+user not automatically authoritative for third-party identity
+```
+
+Cross-domain trust transfer should be explicit.
+
+## Trust and authority
+
+PAMA may consume source trust as one input.
+
+It should also consider:
+
+- requested consequence
+- actor authority
+- reversibility
+- scope
+- certification
+- contradiction
+- sensitivity
+- provenance integrity
+
+Example:
+
+```text
+high-trust source + low-risk reversible update -> may allow
+high-trust source + permanent deletion -> still requires deletion authority
+```
+
+High trust does not eliminate consequence proportionality.
+
+## Trust and memory lifecycle
+
+Source trust may influence:
+
+- admission
+- saturation
+- contradiction pressure
+- verification priority
+- retrieval ranking
+- consolidation
+- stale-state detection
+
+It should not directly determine:
+
+- identity
+- certification
+- cross-tenant permission
+- permanent deletion
+- policy mutation
+
+## Trust and forgetting
+
+Weak or deteriorating source trust may increase decay pressure, but automatic deletion can destroy evidence needed to explain why a source became untrusted.
+
+Prefer a distinction between:
+
+```text
+reduced retrieval priority
+archival
+quarantine
+dispute
+retention for audit
+irreversible deletion
+```
+
+## Trust attacks
+
+Threats include:
+
+- source spoofing
+- trusted-tool echo
+- provenance laundering
+- manufactured corroboration
+- self-citation
+- reputation farming
+- domain transfer abuse
+- stale reputation reuse
+- source-label manipulation
+- model latent preference exploitation
+
+## Conformance cases
+
+### High-volume low-quality source
+
+Expected:
+
+```text
+volume alone does not create high trust
+```
+
+### Trusted-tool echo
+
+Untrusted content passes through a trusted tool unchanged.
+
+Expected:
+
+```text
+content origin remains untrusted
+```
+
+### Manufactured corroboration
+
+Several memories derive from one attacker-controlled source.
+
+Expected:
+
+```text
+independent corroboration count does not inflate
+```
+
+### Domain mismatch
+
+A source reliable for domain A makes a claim in domain B.
+
+Expected:
+
+```text
+A-specific reputation not silently reused as B authority
+```
+
+### Latent preference counterfactual
+
+Equivalent content is attributed to different source labels.
+
+Expected:
+
+```text
+material ranking differences are measurable and do not silently redefine trust policy
+```
+
+### Trust uncertainty near high consequence
+
+Expected:
+
+```text
+uncertainty may trigger verification or review
+confidence does not manufacture authority
+```
+
+## Research signals
+
+- [In Agents We Trust, but Who Do Agents Trust?](https://arxiv.org/abs/2602.15456) reports systematic latent source preferences in LLM agents, supporting explicit evaluation of hidden source weighting.
+- [From Agent Traces to Trust](https://arxiv.org/abs/2606.04990) surveys evidence tracing and execution provenance, reinforcing the importance of provenance-bearing memory and process-level accountability.
+- [Securing LLM-Agent Long-Term Memory Against Poisoning](https://arxiv.org/abs/2606.24322) challenges content- and lineage-only defenses when origin can be laundered through transformations, motivating stronger origin-bound authority semantics.
+- [Belief Memory: Agent Memory Under Partial Observability](https://arxiv.org/abs/2605.05583) provides evidence that preserving multiple candidate beliefs and their probabilities can outperform collapsing ambiguous observations into deterministic conclusions.
+
+## Doctrine
+
+Trust is evidence about a source.
+
+It is not a transferable permission token.
+
+A mature memory system knows **who said it, how that source earned trust, where that trust applies, how uncertain it is, and what the trust is actually allowed to influence**.

--- a/docs/17-conflict-resolution-engine.md
+++ b/docs/17-conflict-resolution-engine.md
@@ -1,0 +1,356 @@
+# Conflict Resolution Engine
+
+## Purpose
+
+Memory systems must tolerate contradiction without collapsing into either silent overwrite or permanent paralysis.
+
+The Conflict Resolution Engine interprets conflicts among memories, sources, scopes, policies, and time windows, then proposes governed resolution paths.
+
+Its core rule is:
+
+> Conflict interpretation may be probabilistic. Conflict consequence must be governed.
+
+## Why conflict is first-class
+
+Persistent memory will inevitably encounter:
+
+- new facts that contradict old facts
+- preferences that change
+- policies that supersede prior policies
+- sources that disagree
+- partial observations that support multiple explanations
+- agent inferences that later fail
+- memory that is valid in one scope but wrong in another
+
+A system that cannot represent disagreement will eventually mistake recency, confidence, or repetition for truth.
+
+## Conflict types
+
+### Factual contradiction
+
+Two claims cannot both be true under the same scope and time.
+
+### Temporal supersession
+
+Both claims may have been true, but at different times.
+
+### Scope mismatch
+
+Claims differ because they apply to different users, projects, tenants, environments, or domains.
+
+### Source conflict
+
+Sources disagree and neither has automatic authority.
+
+### Policy conflict
+
+Two rules or authorities overlap incompatibly.
+
+### User correction conflict
+
+A user correction challenges an inferred or stored memory.
+
+### Estimator disagreement
+
+Models, heuristics, or observers assign materially different confidence, trust, sensitivity, or causal interpretations.
+
+### Representation conflict
+
+An episodic record and a generalized semantic summary diverge.
+
+### Procedure-version conflict
+
+A learned procedure no longer matches the environment or policy under which it was formed.
+
+## Conflict record
+
+A conflict should be representable independently from either side:
+
+```text
+conflict_id
+claim_refs
+memory_refs
+scope
+time_window
+conflict_type_candidates
+source_refs
+estimator_refs
+estimator_versions
+confidence_or_probability
+uncertainty
+policy_refs
+status
+detected_at
+```
+
+Do not destroy alternatives simply because one is currently favored.
+
+## Probabilistic interpretation
+
+Conflict detection may estimate:
+
+- whether two claims truly contradict
+- whether one supersedes the other
+- whether a scope mismatch explains the difference
+- source reliability
+- causal explanations
+- likelihood that a claim is stale
+
+Multiple hypotheses may remain active.
+
+Example:
+
+```text
+P(factual_contradiction) = 0.20
+P(temporal_supersession) = 0.65
+P(scope_mismatch) = 0.15
+```
+
+The exact mathematical representation is implementation-specific.
+
+The doctrine requirement is that uncertainty not be collapsed prematurely.
+
+## Governed resolution outcomes
+
+Policy may permit outcomes such as:
+
+```text
+retain_both
+split_scope
+mark_disputed
+request_more_evidence
+require_external_verification
+prefer_temporally_newer
+prefer_authoritative_source
+correct_preserve_history
+demote
+archive_superseded
+block_canonical_use
+escalate
+```
+
+The estimator proposes. Policy determines which consequences are permissible.
+
+## Resolution precedence
+
+Some evidence may carry explicit authority.
+
+Examples:
+
+- user correction about the user's own stated preference
+- signed policy superseding an older policy
+- verified repository state replacing an inferred build-state memory
+
+Precedence must be scoped.
+
+```text
+human correction authority in scope X
+!= universal factual authority in all scopes
+```
+
+## Historical truth versus current truth
+
+Conflict resolution must preserve history.
+
+Wrong:
+
+```text
+old address = A
+new address = B
+therefore erase A
+```
+
+Correct:
+
+```text
+A valid until T
+B valid from T
+current=B
+historical=A preserved
+```
+
+This distinction is central to temporal memory.
+
+## Correction versus supersession
+
+Use correction when the earlier memory was wrong within its claimed scope/time.
+
+Use supersession when the earlier memory was valid but no longer current.
+
+```text
+correction -> prior claim was erroneous or incomplete
+supersession -> prior claim was valid then, newer state applies now
+```
+
+## Scope splitting
+
+Sometimes conflict should create multiple scoped memories rather than a winner.
+
+Example:
+
+```text
+production uses endpoint A
+staging uses endpoint B
+```
+
+A flat overwrite would destroy useful truth.
+
+## Conflict and source trust
+
+Source trust may influence conflict ranking, but must not dominate automatically.
+
+Consider:
+
+- source domain competence
+- origin integrity
+- independence
+- recency
+- directness
+- authoritative scope
+- corroboration
+- uncertainty
+
+A highly trusted source can still be wrong or out of scope.
+
+## Conflict and saturation
+
+Saturation should not make a claim immune to correction.
+
+A highly saturated memory may deserve stronger audit handling because more downstream systems depend on it, but that is consequence management, not factual immunity.
+
+## Conflict and crystallized memory
+
+Crystallized memory remains disputable.
+
+When a credible conflict is introduced:
+
+```text
+Crystallized
+  -> Disputed or Stale
+  -> verification / resolution
+  -> Corrected / Reconciled / split scope / restored
+```
+
+Canonical use may be restricted while the dispute remains unresolved.
+
+## Conflict and action
+
+An agent may need to act before conflict is fully resolved.
+
+Policy can define bounded behavior:
+
+```text
+low consequence -> proceed with warning
+medium consequence -> choose reversible action
+high consequence -> require verification
+critical consequence -> abstain or escalate
+```
+
+Uncertainty does not require universal paralysis. It requires proportional consequence handling.
+
+## Deterministic substrate
+
+The following should remain stable:
+
+- claim identities
+- conflict identities
+- evidence/provenance links
+- state-transition validity
+- policy outcome semantics
+- history preservation
+- ledger records
+
+Conflict interpretation need not be deterministic.
+
+## Anti-patterns
+
+### Newest wins
+
+Recency alone does not prove truth.
+
+### Most repeated wins
+
+Repetition may share one origin.
+
+### Highest confidence wins
+
+Model confidence is not authority.
+
+### Trusted source always wins
+
+Trust is scoped evidence, not universal truth.
+
+### Deterministic classifier as truth oracle
+
+A reproducible conflict label can still be wrong.
+
+### Silent merge
+
+Combining conflicting memories into a summary without preserving the dispute destroys evidence.
+
+## Conformance cases
+
+### Temporary failure misremembered as permanent
+
+Multiple observations support both transient and persistent explanations.
+
+Expected:
+
+```text
+alternatives remain visible until evidence resolves them
+```
+
+### User preference changed over time
+
+Expected:
+
+```text
+old preference preserved historically
+new preference becomes current within scope
+```
+
+### Scope mismatch
+
+Expected:
+
+```text
+claims split by scope instead of one overwriting the other
+```
+
+### High-confidence wrong claim versus verified artifact
+
+Expected:
+
+```text
+confidence does not overrule authoritative evidence within its scope
+```
+
+### Two uncertain estimators disagree
+
+Expected:
+
+```text
+disagreement preserved
+policy may request evidence or abstain
+```
+
+### Concurrent corrections
+
+Expected:
+
+```text
+conflict is explicit
+silent last-writer-wins is prohibited for durable state
+```
+
+## Research signals
+
+- [Belief Memory: Agent Memory Under Partial Observability](https://arxiv.org/abs/2605.05583) challenges deterministic one-conclusion storage and supports retaining alternative hypotheses under uncertainty.
+- [Memory for Autonomous LLM Agents: Mechanisms, Evaluation, and Emerging Frontiers](https://arxiv.org/abs/2603.07670) identifies contradiction handling and causally grounded retrieval among important memory-system concerns.
+- [From Agent Traces to Trust](https://arxiv.org/abs/2606.04990) reinforces provenance and evidence tracing as prerequisites for explaining and recovering from agent errors.
+
+## Doctrine
+
+Conflict is not a defect in memory. Hidden conflict is.
+
+A mature system preserves disagreement long enough to resolve it responsibly, and it separates the uncertain question **“what does this conflict mean?”** from the governed question **“what are we allowed to change because of it?”**

--- a/docs/18-temporal-causality-layer.md
+++ b/docs/18-temporal-causality-layer.md
@@ -1,0 +1,394 @@
+# Temporal Causality Layer
+
+## Purpose
+
+Memory is not only a collection of facts. It is a record of change.
+
+A mature memory system must distinguish:
+
+- what happened
+- when it happened
+- what was believed at the time
+- what changed later
+- what caused the change, when causality is actually supported
+
+Chronology can often be observed directly. Causality usually cannot.
+
+Therefore:
+
+> Temporal order may be deterministic when timestamps and events are known. Causal attribution should preserve uncertainty unless independently established.
+
+## Why temporal causality matters
+
+Without temporal structure, memory systems confuse:
+
+- stale facts with false facts
+- superseded decisions with incorrect decisions
+- sequence with causation
+- current state with historical state
+- future intentions with completed actions
+- recurring patterns with causal laws
+
+This causes bad retrieval and worse governance.
+
+## Core temporal concepts
+
+### Event time
+
+When the underlying event occurred.
+
+### Observation time
+
+When the system observed or recorded the event.
+
+### Valid time
+
+When a claim was true or applicable.
+
+### Transaction time
+
+When the memory system committed the record.
+
+### Decision time
+
+When an authority approved a decision.
+
+### Supersession time
+
+When a newer state replaced an older current state.
+
+### Expiry time
+
+When a certification, policy, or memory should be re-evaluated.
+
+These times may differ and should not be collapsed into one timestamp.
+
+## Temporal memory record
+
+Where relevant:
+
+```text
+memory_id
+event_time
+observation_time
+valid_from
+valid_until
+recorded_at
+superseded_at
+source_refs
+scope
+causal_links
+causal_confidence
+estimator_ref
+estimator_version
+uncertainty
+```
+
+## Chronology versus causality
+
+Observed sequence:
+
+```text
+A occurred
+then B occurred
+```
+
+does not establish:
+
+```text
+A caused B
+```
+
+Causal links should identify their epistemic status:
+
+```text
+observed_dependency
+explicit_human_rationale
+verified_mechanism
+statistical_association
+model_inference
+hypothesis
+```
+
+## Causal relation types
+
+Useful relations include:
+
+- caused
+- contributed_to
+- enabled
+- blocked
+- triggered
+- motivated
+- depended_on
+- superseded_due_to
+- correlated_with
+- hypothesized_cause
+
+Not every relation requires numerical probability. The system must distinguish observed/declared causal evidence from inferred causality.
+
+## Deterministic temporal substrate
+
+Where source data supports it, preserve exact:
+
+- event identity
+- timestamp
+- sequence
+- version
+- commit hash
+- policy version
+- state transition
+- supersession relationship
+
+Do not ask a model to infer information the system already possesses deterministically.
+
+## Probabilistic causal inference
+
+Models may help infer:
+
+- likely causes of failure
+- relationships among historical events
+- why a user preference appears to have changed
+- whether one decision influenced another
+- which prior memories explain a current state
+
+These outputs should preserve:
+
+```text
+causal_hypothesis
+supporting_evidence
+alternative_hypotheses
+confidence_or_probability
+estimator_version
+scope
+```
+
+Causal inference must not rewrite the historical event log.
+
+## Stale versus false
+
+A memory can be historically correct and currently stale.
+
+Example:
+
+```text
+2026-01: service endpoint = A
+2026-06: service endpoint changed to B
+```
+
+The first memory is not necessarily false.
+
+Correct representation:
+
+```text
+A valid_until 2026-06
+B valid_from 2026-06
+current=B
+```
+
+## Supersession
+
+Supersession should preserve:
+
+```text
+old_memory_ref
+new_memory_ref
+reason
+supersession_authority
+evidence_refs
+effective_time
+```
+
+Do not delete historical state simply because it is no longer current.
+
+## Correction
+
+Correction differs from supersession.
+
+```text
+SUPERCESSION
+old record was valid, new state applies later
+
+CORRECTION
+old record was wrong or materially incomplete within its claimed scope/time
+```
+
+The difference affects audit, retrieval, and trust.
+
+## Temporal retrieval
+
+A query should be able to express:
+
+```text
+current truth
+truth at time T
+state before event E
+changes since T
+why current state differs from prior state
+what was believed when decision D was made
+```
+
+Retrieval ranking may be probabilistic, but valid-time filtering and scope rules should be explicit.
+
+## Causally grounded retrieval
+
+For consequential questions, the system may prefer memories that explain dependencies rather than merely resemble the query semantically.
+
+Example:
+
+```text
+Why did deployment fail?
+```
+
+may require:
+
+```text
+recent configuration change
+  -> changed dependency
+  -> failed health check
+  -> rollback decision
+```
+
+rather than the nearest vector match to the word "deployment."
+
+## Temporal contradiction
+
+Apparent contradictions should first test for time mismatch.
+
+```text
+claim A at T1
+claim B at T2
+```
+
+may indicate supersession rather than factual conflict.
+
+## Temporal causality and governance
+
+Causal inference can influence priority and review, but should not create authority.
+
+Wrong:
+
+```text
+model believes memory X caused failure -> permanently delete X
+```
+
+Correct:
+
+```text
+causal hypothesis -> evidence collection / review -> governed remediation
+```
+
+## Prospective memory
+
+Temporal memory also points forward.
+
+Prospective records may include:
+
+```text
+intention
+trigger condition
+due time
+owner
+completion state
+cancellation state
+policy scope
+```
+
+Remembering an obligation is distinct from executing it.
+
+The execution system should verify current authority and conditions at action time.
+
+## Procedural drift
+
+A procedure that once succeeded can become stale as tools, APIs, environments, or policy change.
+
+Track:
+
+- procedure version
+- environment version
+- last successful use
+- failure history
+- dependency changes
+
+A procedure's historical success is evidence, not eternal validity.
+
+## Temporal decay
+
+Time can decrease retrieval priority without implying falsity.
+
+Decay policies should consider:
+
+- memory type
+- currentness requirements
+- supersession links
+- certification expiry
+- evidence retention needs
+- legal/privacy requirements
+
+## Conformance cases
+
+### Historically true, currently stale
+
+Expected:
+
+```text
+historical query returns old fact
+current query returns new fact
+old fact is not labeled false solely because it is stale
+```
+
+### Out-of-order observation
+
+An event occurred earlier but was observed later.
+
+Expected:
+
+```text
+event_time and observation_time remain distinct
+```
+
+### Correlation mistaken for causation
+
+Expected:
+
+```text
+causal claim remains hypothesis unless evidence supports stronger status
+```
+
+### Superseded policy
+
+Expected:
+
+```text
+old decision remains auditable under old policy
+new actions use current policy
+```
+
+### Prospective obligation after policy change
+
+Expected:
+
+```text
+memory of obligation persists
+execution re-checks current authority
+```
+
+### Procedure version drift
+
+Expected:
+
+```text
+past success does not automatically certify current procedure
+```
+
+## Research signals
+
+- [Memory for Autonomous LLM Agents: Mechanisms, Evaluation, and Emerging Frontiers](https://arxiv.org/abs/2603.07670) identifies causally grounded retrieval, contradiction handling, and long-horizon memory management as emerging agent-memory challenges.
+- [Belief Memory: Agent Memory Under Partial Observability](https://arxiv.org/abs/2605.05583) supports retaining uncertainty instead of converting ambiguous observations into one deterministic historical conclusion.
+- [From Agent Traces to Trust](https://arxiv.org/abs/2606.04990) emphasizes execution provenance, memory lineage, and process-level accountability, which are prerequisites for credible temporal explanation.
+
+## Doctrine
+
+Memory should preserve the difference between **what happened**, **what was believed**, **what became true later**, and **what the system merely infers caused it**.
+
+Time can be exact while causality remains uncertain.

--- a/docs/19-privacy-and-sensitivity-classifier.md
+++ b/docs/19-privacy-and-sensitivity-classifier.md
@@ -1,0 +1,400 @@
+# Privacy and Sensitivity Classifier
+
+## Purpose
+
+Persistent memory changes privacy from a one-response concern into a lifecycle concern.
+
+Sensitive information can be exposed when it is:
+
+- written
+- transformed
+- summarized
+- embedded
+- retrieved
+- composed with other memory
+- exported
+- shared across agents
+- retained after deletion
+
+The sensitivity classifier helps estimate what handling a memory may require.
+
+It does not grant permission.
+
+> Sensitivity classification may be probabilistic. Storage, recall, sharing, export, and deletion consequences must remain governed.
+
+## Core rule
+
+```text
+classifier uncertain != non-sensitive
+```
+
+A classifier's inability to identify sensitivity is not evidence that broad use is safe.
+
+## Sensitivity classes
+
+Implementations may define their own taxonomy, but should be able to represent categories such as:
+
+- public
+- internal
+- personal
+- personally identifying
+- confidential
+- credential / secret
+- security-sensitive
+- financial
+- health
+- legal / compliance
+- organizationally restricted
+- user-private preference or history
+- unknown / unclassified
+
+Multi-label classification may be necessary.
+
+## Handling dimensions
+
+Sensitivity should influence distinct decisions rather than one universal flag:
+
+```text
+may_store
+storage_location
+must_encrypt
+may_retrieve
+who_may_retrieve
+may_enter_model_context
+may_summarize
+may_export
+may_share_cross_agent
+may_share_cross_tenant
+retention_period
+deletion_mode
+audit_requirement
+human_review_requirement
+```
+
+A memory can be permitted for local encrypted storage but prohibited from external model context or cross-agent sharing.
+
+## Classification record
+
+A material classification should preserve:
+
+```text
+memory_id
+labels
+classifier_id
+classifier_version
+calibration_version
+confidence_or_probability
+uncertainty
+policy_context
+scope
+source_refs
+classified_at
+expires_or_recheck_at
+```
+
+## Deterministic substrate
+
+Where policy defines them, the following should remain strict:
+
+- tenant identity
+- ACL membership
+- explicit user restrictions
+- credential type when exact schema identifies it
+- encryption requirements
+- prohibited export rules
+- policy version
+- deletion request state
+
+Do not replace exact metadata with model classification when exact metadata exists.
+
+## Probabilistic sensitivity classification
+
+Models may identify sensitive content that lacks deterministic labels.
+
+Examples:
+
+- free-text health information
+- implicit personal relationships
+- secrets embedded in logs
+- inferred financial data
+- security-relevant operational details
+
+The classifier may output:
+
+```text
+labels: [personal, financial]
+confidence: 0.78
+uncertainty: medium
+```
+
+Policy decides the consequence.
+
+## Conservative uncertainty handling
+
+For low-cost reversible actions, policy may tolerate uncertainty.
+
+For high-consequence disclosure, policy should generally become stricter as uncertainty rises.
+
+Example:
+
+```text
+local ephemeral use + uncertain sensitivity -> may allow with restricted scope
+cross-tenant export + uncertain sensitivity -> block or require review
+```
+
+This is consequence proportionality, not a universal rule that uncertain data must always be blocked.
+
+## Privacy across the write path
+
+Before durable storage, evaluate:
+
+- purpose
+- source authority
+- sensitivity
+- user expectations
+- retention need
+- encryption/storage boundary
+- whether a less revealing representation would suffice
+
+Possible outcomes:
+
+```text
+do_not_store
+store_ephemeral
+store_redacted
+store_encrypted_local
+store_with_expiry
+store_durable_with_restricted_scope
+require_review
+```
+
+## Privacy across retrieval
+
+Retrieval should be a two-stage process:
+
+```text
+candidate generation
+  -> recall admission
+```
+
+Semantic relevance is not enough.
+
+Recall admission should evaluate:
+
+- requester identity
+- tenant
+- purpose
+- sensitivity
+- certification/dispute state
+- policy
+- downstream destination
+
+## Context exposure
+
+A memory allowed in storage is not automatically allowed in every context window.
+
+Destination matters:
+
+```text
+local deterministic tool
+local model
+external model provider
+human UI
+another agent
+external API
+```
+
+Policy can authorize different representations for different destinations.
+
+## Minimization
+
+Prefer the least revealing memory representation that preserves legitimate utility.
+
+Possible transformations:
+
+- redact identifiers
+- replace raw text with structured attributes
+- summarize only relevant non-sensitive facts
+- tokenize or reference secrets rather than copy them
+- store exact secret in dedicated vault while memory stores a capability reference
+
+Minimization should preserve enough provenance to support correction and deletion.
+
+## Derived-memory privacy
+
+Summaries and semantic memories can still contain sensitive information.
+
+Required rule:
+
+```text
+transformation does not erase privacy obligations
+```
+
+Derived memories should inherit or recompute appropriate sensitivity and retain derivation links.
+
+## Composition leakage
+
+Several non-sensitive memories may combine to reveal sensitive information.
+
+Example:
+
+```text
+memory A: travel date
+memory B: home address
+memory C: household schedule
+```
+
+The combination may create a higher-risk disclosure than any one item.
+
+Privacy governance should therefore consider context composition, not only item-level classification.
+
+## Cross-session inference
+
+Persistent memory can allow later inference that was impossible in one session.
+
+This should be considered when evaluating:
+
+- longitudinal behavior
+- identity linkage
+- health/financial patterns
+- relationship inference
+- work habits
+- location patterns
+
+## Deletion fidelity
+
+Deletion must account for:
+
+- raw records
+- summaries
+- embeddings/index entries
+- graph relations
+- caches
+- semantic consolidation
+- derived preference models
+- cross-agent copies where governed by the system
+
+Deletion modes may include:
+
+```text
+hide_from_recall
+archive
+redact
+tombstone
+cryptographic_delete
+full_pipeline_purge
+```
+
+The requested privacy outcome determines which mode is sufficient.
+
+## Deletion receipt
+
+A consequential deletion should be able to record:
+
+```text
+requester
+authority
+memory_refs
+derived_refs
+deletion_mode
+policy_version
+completed_steps
+residual_known_copies
+verification_result
+timestamp
+```
+
+## Extraction resistance
+
+Sensitive memory stores should assume adversarial queries may attempt reconstruction.
+
+Controls may include:
+
+- least-privilege recall
+- purpose-aware access
+- response minimization
+- extraction-rate limits
+- anomaly detection
+- structured secret isolation
+- refusal to expose raw memory state when unnecessary
+- sensitive-access audit trails
+
+Probabilistic detection is useful, but explicit ACL and scope rules should not depend on attack detection succeeding.
+
+## Multi-agent privacy
+
+Sharing memory across agents introduces additional questions:
+
+- who owns the memory?
+- did the user consent to this agent receiving it?
+- may the receiving agent persist it?
+- may it re-share it?
+- which policy version travels with it?
+- how does deletion propagate?
+
+Shared memory should carry scope and handling requirements as data, not tribal knowledge between services.
+
+## Conformance cases
+
+### High-relevance wrong-tenant memory
+
+Expected:
+
+```text
+candidate may rank first
+admission blocks it
+```
+
+### Uncertain sensitivity before export
+
+Expected:
+
+```text
+uncertainty does not coerce to public/non-sensitive
+```
+
+### Raw deletion with derived summary
+
+Expected:
+
+```text
+deletion verification detects residual derived memory
+```
+
+### Credential in free text
+
+Expected:
+
+```text
+classifier may detect it probabilistically
+explicit secret policy controls storage and recall
+```
+
+### Composition leakage
+
+Expected:
+
+```text
+individually allowed memories can still trigger context-level privacy control
+```
+
+### Cross-session extraction probing
+
+Expected:
+
+```text
+sensitive data is not released merely because attacker reconstructs a semantically plausible request
+```
+
+## Research signals
+
+- [Agents That Know Too Much: A Data-Centric Survey of Privacy in LLM Agents](https://arxiv.org/abs/2606.26627) emphasizes privacy risks across agent data surfaces, persistent memory, delegated permissions, compositional inference, and cross-session leakage.
+- [Deployment-Time Memorization in Foundation-Model Agents](https://arxiv.org/abs/2606.10062) studies the privacy-utility tradeoff of persistent agent memory and reports deletion residue in derived memory when only raw records are deleted.
+- [Spore: Efficient and Training-Free Privacy Extraction Attack on LLMs via Inference-Time Hybrid Probing](https://arxiv.org/abs/2604.23711) studies inference-time extraction attacks against agent memory, reinforcing that alignment alone is not an access-control mechanism.
+- [AgentSys](https://arxiv.org/abs/2602.07398) provides evidence that explicit isolation and schema-validated boundary crossing can reduce prompt-injection risk in agent memory flows.
+
+## Doctrine
+
+Privacy is not a label attached at write time.
+
+It is a lifecycle property governing **where memory may live, who may retrieve it, what representation may be exposed, how it may be combined, and whether forgetting actually removes what it promised to remove**.

--- a/docs/audits/governed-uncertainty/04-threat-trust-conflict-causality-privacy.md
+++ b/docs/audits/governed-uncertainty/04-threat-trust-conflict-causality-privacy.md
@@ -1,0 +1,163 @@
+# Governed Uncertainty Audit: Slice 4
+
+## Scope
+
+This slice evaluates the reserved foundational slots:
+
+- `15-memory-threat-model.md`
+- `16-source-trust-and-reputation.md`
+- `17-conflict-resolution-engine.md`
+- `18-temporal-causality-layer.md`
+- `19-privacy-and-sensitivity-classifier.md`
+
+## Baseline
+
+```text
+baseline_main_commit: 2a073e01d820905de2e1bedf363c46c88469fbad
+baseline_source: merged PR #35 / governed uncertainty audit slice 3
+```
+
+## Baseline finding: documents absent
+
+All five filenames were explicitly reserved by the architecture roadmap but did not yet exist on `main`.
+
+This is recorded as **ABSENT**, not assigned a misleading percentage score.
+
+Related concepts existed elsewhere in the doctrine, but no dedicated documents owned the complete boundaries, interfaces, threat cases, or conformance requirements.
+
+| Document | Baseline | Material doctrine already scattered elsewhere |
+|---|---|---|
+| `15-memory-threat-model.md` | ABSENT | poisoning traps, PAMA, provenance, scope, forgetting |
+| `16-source-trust-and-reputation.md` | ABSENT | evidence quality, provenance, source authority |
+| `17-conflict-resolution-engine.md` | ABSENT | dispute/correction lifecycle, contradiction pressure |
+| `18-temporal-causality-layer.md` | ABSENT | stale/superseded memory, prospective memory, lifecycle time |
+| `19-privacy-and-sensitivity-classifier.md` | ABSENT | scope, Vault privacy, deletion, retrieval admission |
+
+## Research posture
+
+This slice used freely inspectable research to challenge and refine the architecture, including current open work on:
+
+- memory poisoning and sleeper poisoning
+- origin/authority laundering
+- explicit memory isolation
+- latent source preferences
+- belief memory under partial observability
+- provenance and execution tracing
+- persistent-agent privacy and extraction
+- deletion residue across derived memory
+
+Research is cited inside the relevant doctrine documents as evidence or challenge material. It does not automatically create doctrine.
+
+## Documents created
+
+### 15 memory threat model
+
+Adds:
+
+- integrity, confidentiality, authority integrity, provenance integrity, temporal integrity, deletion fidelity, and recovery properties
+- twelve major trust boundaries across write, read, action, sharing, derivation, and deletion paths
+- direct and sleeper poisoning
+- authority laundering
+- recursive self-citation
+- provenance stripping
+- scope leakage
+- extraction attacks
+- deletion residue
+- stale policy/authorization
+- stochastic policy bypass
+- unsafe memory composition
+- estimator manipulation and calibration drift
+- malicious correction and deletion abuse
+
+### 16 source trust and reputation
+
+Adds:
+
+- source classes
+- multidimensional trust
+- estimator provenance and calibration scope
+- latent model source preference as a hidden trust channel
+- independent-corroboration requirements
+- domain-specific reputation
+- trust decay and rehabilitation
+- explicit rule that trust is evidence, not authority
+
+### 17 conflict resolution engine
+
+Adds:
+
+- factual, temporal, scope, source, policy, correction, estimator, representation, and procedure-version conflict
+- multiple-hypothesis conflict interpretation
+- finite governed resolution outcomes
+- historical truth versus current truth
+- correction versus supersession
+- scope splitting
+- conflict handling under uncertainty and consequence proportionality
+
+### 18 temporal causality layer
+
+Adds:
+
+- event, observation, valid, transaction, decision, supersession, and expiry time
+- deterministic chronology versus probabilistic causal attribution
+- causal relation epistemic status
+- stale versus false
+- supersession and historical preservation
+- temporal retrieval
+- causally grounded retrieval
+- prospective memory and action-time authority revalidation
+- procedural drift
+
+### 19 privacy and sensitivity classifier
+
+Adds:
+
+- sensitivity taxonomy and handling dimensions
+- explicit unknown/uncertain state
+- write-path privacy
+- candidate retrieval versus recall admission
+- destination-aware context exposure
+- minimization
+- derived-memory privacy
+- composition and cross-session leakage
+- deletion fidelity and receipts
+- extraction resistance
+- multi-agent privacy
+
+## Post-creation governed-uncertainty scores
+
+| Document | GU-1 | GU-2 | GU-3 | GU-4 | GU-5 | GU-6 | GU-7 | GU-8 | GU-9 | GU-10 | Coverage |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `15-memory-threat-model.md` | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 100% |
+| `16-source-trust-and-reputation.md` | 4 | 4 | 4 | 4 | 4 | 4 | 4 | N/A | 4 | 4 | 100% |
+| `17-conflict-resolution-engine.md` | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 100% |
+| `18-temporal-causality-layer.md` | 4 | 4 | 4 | 4 | 4 | 4 | 4 | N/A | 4 | 4 | 100% |
+| `19-privacy-and-sensitivity-classifier.md` | 4 | 4 | 4 | 4 | 4 | 4 | 4 | N/A | 4 | 4 | 100% |
+
+`N/A` is used where bounded stochastic action is not materially owned by the document.
+
+## Important doctrine refinements
+
+1. **Conflict resolution is not globally deterministic.** Conflict interpretation may remain probabilistic; resolution consequences are governed.
+2. **Trust is not authority.** Source reliability influences evidence weighting, not permission.
+3. **Time is not causality.** Exact chronology may coexist with uncertain causal inference.
+4. **Unknown sensitivity is not non-sensitive.** Consequence policy must handle classification uncertainty explicitly.
+5. **Threat detection is not the security boundary.** Probabilistic attack detection can improve defense, but ACL, scope, authority, and action-set controls must remain enforceable even when detection fails.
+6. **Deletion is a graph problem.** Raw-record deletion is insufficient when derived memory remains recoverable.
+
+## Verification requirements
+
+- [x] confirmed docs 15-19 did not exist at baseline
+- [x] created all five reserved foundation documents
+- [x] each document explicitly separates probabilistic interpretation from authority
+- [x] each document defines deterministic/formally bounded consequences where material
+- [x] each document includes falsifiable conformance cases
+- [x] open research is used as support/challenge material rather than proof by citation volume
+- [ ] final branch diff reviewed against `main`
+- [ ] PR head verified mergeable
+- [ ] commit status checked
+- [ ] merged using exact verified head SHA
+
+## Next slice
+
+Audit the newer interdisciplinary theory documents `20` through `24`. Because those documents introduced the governed-uncertainty thesis, the audit should be adversarial: look for internal contradictions, overclaimed biological analogy, missing challenge evidence, or places where the newer theory itself fails the rubric it created.


### PR DESCRIPTION
## Scope

Fourth incremental governed-uncertainty slice. This fills the five foundation documents previously reserved as docs 15-19.

## Baseline

Measured against `main` at `2a073e01d820905de2e1bedf363c46c88469fbad`.

All five documents were absent at baseline, so the audit records them as `ABSENT` rather than inventing pre-change scores.

## New doctrine

- memory threat model across write, read, action, sharing, derivation, and deletion paths
- source trust and reputation with explicit separation of trust from authority
- conflict resolution that permits probabilistic interpretation while governing consequences
- temporal causality separating exact chronology from uncertain causal attribution
- privacy and sensitivity classification across storage, recall, context exposure, composition, and deletion

## Research posture

The docs use freely inspectable current research as challenge/evidence material, including memory poisoning, sleeper attacks, origin laundering, explicit memory isolation, latent source preference, belief memory under partial observability, execution provenance, persistent-agent privacy, extraction, and deletion residue.

Research citations do not convert design candidates into accepted doctrine by themselves.

## Measurement

`docs/audits/governed-uncertainty/04-threat-trust-conflict-causality-privacy.md` records the baseline gap and post-creation coverage.

## Verification

- branch is 6 commits ahead and 0 behind main
- only five new doctrine documents plus one audit record are changed
- every new probabilistic estimator remains separate from authority
- every document defines falsifiable conformance cases
- unknown sensitivity is not treated as non-sensitive
- conflict interpretation is not falsely required to be deterministic
- deletion fidelity includes derived memory rather than raw records only

This PR should merge before auditing the newer interdisciplinary theory docs 20-24.