### PR TITLE
Audit slice 6: normalize ADR status and governed-uncertainty alignment

### DIFF
--- a/docs/adr/ADR-001-uor-is-identity-not-memory.md
+++ b/docs/adr/ADR-001-uor-is-identity-not-memory.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -32,6 +32,10 @@ UOR must own deterministic object identity and exact addressability. It must not
 
 - requires a separate lifecycle layer
 - requires implementers to respect the boundary between object identity and memory use
+
+## Acceptance scope
+
+Accepted means this boundary is canonical doctrine. It does not claim that every implementation uses UOR or that any specific UOR integration is complete.
 
 ## Doctrine
 

--- a/docs/adr/ADR-002-saturation-is-routing-not-truth.md
+++ b/docs/adr/ADR-002-saturation-is-routing-not-truth.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
-Saturation is useful for deciding whether memory should persist, decay, route, or become a crystallization candidate. However, high saturation can be produced by flawed signals such as access-spam, repeated incorrect claims, or narrow fiber definitions.
+Saturation is useful for deciding whether memory should persist, decay, route, or become a crystallization candidate. However, high saturation can be produced by flawed signals such as access-spam, repeated incorrect claims, narrow fiber definitions, or estimator drift.
 
 A fully pinned object can still be wrong.
 
@@ -14,7 +14,7 @@ A fully pinned object can still be wrong.
 
 Saturation is a calibrated lifecycle routing score.
 
-It must not be treated as correctness, integrity, identity, or certification.
+It must not be treated as correctness, integrity, identity, certification, or mutation authority.
 
 ## Consequences
 
@@ -23,7 +23,7 @@ It must not be treated as correctness, integrity, identity, or certification.
 - prevents hallucination permanence
 - allows saturation to support routing without overclaiming truth
 - makes trap-class testing mandatory
-- preserves the role of certification and provenance
+- preserves the role of certification, provenance, and PAMA
 
 ### Negative
 
@@ -35,9 +35,16 @@ It must not be treated as correctness, integrity, identity, or certification.
 ```text
 high_saturation != true
 high_saturation != certified
+high_saturation != authorized
 high_saturation == candidate_for_routing_or_review
 ```
 
+## Acceptance scope
+
+Accepted means this separation is canonical doctrine. Specific saturation formulas, estimators, thresholds, and calibration scopes remain implementation concerns and must be validated independently.
+
 ## Doctrine
 
-Saturation can propose. Certification must confirm.
+Saturation can propose.
+
+Governance and certification determine consequence.

--- a/docs/adr/ADR-003-crystallization-requires-certification.md
+++ b/docs/adr/ADR-003-crystallization-requires-certification.md
@@ -2,15 +2,15 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
-Crystallization moves memory into a durable or exact-address retrievable state. That transition can create long-lived agent behavior, so it cannot be granted by repetition, retrieval frequency, or saturation alone.
+Crystallization moves memory into a durable or exact-address retrievable state. That transition can create long-lived agent behavior, so it cannot be granted by repetition, retrieval frequency, saturation, relevance, or model confidence alone.
 
 ## Decision
 
-Crystallization requires certification or an explicitly scoped policy exception.
+Crystallization requires certification or an explicitly scoped policy exception whose authority is equivalent and auditable.
 
 Certification may include human approval, test evidence, cryptographic verification, corroboration, policy approval, or a ledgered gate specific to the memory type.
 
@@ -30,15 +30,23 @@ Certification may include human approval, test evidence, cryptographic verificat
 
 ## Required gate
 
+A simplified gate is:
+
 ```text
 can_crystallize =
   identity_resolved
   and provenance_present
-  and saturation >= calibrated_threshold
+  and lifecycle_candidate == true
   and pama_authority == allow
   and certification_gate == pass
   and dispute_status == clear
 ```
+
+`lifecycle_candidate` may depend on calibrated probabilistic or heuristic signals. Those signals do not themselves certify the transition.
+
+## Acceptance scope
+
+Accepted establishes certification as a canonical durable-transition boundary. The precise certificate mechanism remains implementation- and memory-class-specific.
 
 ## Doctrine
 

--- a/docs/adr/ADR-004-pama-controls-mutation-authority.md
+++ b/docs/adr/ADR-004-pama-controls-mutation-authority.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -12,9 +12,11 @@ Without explicit authority, adaptive memory becomes silent self-modification.
 
 ## Decision
 
-PAMA controls mutation authority.
+PAMA controls mutation authority, or an implementation must provide an equivalent explicit authority model conforming to the same doctrine.
 
-Any transition that changes memory state, durable content, graph relations, promotion status, correction state, or pruning status must pass through PAMA or an equivalent authority model.
+Any consequential transition that changes memory state, durable content, graph relations, promotion status, correction state, pruning/deletion state, sharing scope, or certification status must pass through that authority boundary.
+
+Probabilistic or learned components may estimate confidence, trust, relevance, sensitivity, contradiction, utility, or risk. They may not grant themselves authority from those estimates.
 
 ## Consequences
 
@@ -23,7 +25,7 @@ Any transition that changes memory state, durable content, graph relations, prom
 - makes memory mutation auditable
 - scales autonomy by risk and reversibility
 - prevents unauthorized rewriting of durable memory
-- gives agents a clear boundary between recall and mutation
+- gives agents a clear boundary between inference and mutation
 
 ### Negative
 
@@ -33,6 +35,8 @@ Any transition that changes memory state, durable content, graph relations, prom
 
 ## Authority outcomes
 
+Typical outcomes include:
+
 ```text
 allow
 allow_with_ledger
@@ -41,8 +45,16 @@ require_external_verification
 block
 ```
 
+Implementations may add bounded outcomes such as `abstain`, `quarantine`, or `collect_more_evidence` when their consequence semantics are explicit.
+
+## Acceptance scope
+
+Accepted establishes explicit mutation authority as canonical doctrine. It does not require one PAMA codebase or claim runtime enforcement exists in every implementation.
+
 ## Doctrine
 
 Capability is not authority.
+
+Confidence is not authority.
 
 The fact that an agent can change memory does not mean it is allowed to.

--- a/docs/adr/ADR-005-codegenome-is-code-reality-substrate.md
+++ b/docs/adr/ADR-005-codegenome-is-code-reality-substrate.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -12,7 +12,7 @@ This makes it a domain reality graph for software artifacts, not a general memor
 
 ## Decision
 
-CodeGenome is the canonical code reality substrate.
+CodeGenome is the canonical code-reality substrate within the current Agent Memory architecture mapping.
 
 It should provide evidence, graph relations, provenance, confidence, and impact traversal for code artifacts consumed by agentic memory systems.
 
@@ -33,11 +33,17 @@ It should provide evidence, graph relations, provenance, confidence, and impact 
 
 ```text
 CodeGenome confidence supports evidence.
-It does not automatically grant memory permanence.
+It does not automatically grant memory permanence, certification, or authority.
 ```
+
+Inferred graph relations should preserve their estimator/method provenance and uncertainty when material to downstream decisions.
+
+## Acceptance scope
+
+Accepted means this is the canonical architectural role assigned to CodeGenome. It does not claim every CodeGenome capability is implemented or required by every Agent Memory implementation.
 
 ## Doctrine
 
-CodeGenome tells the agent what is structurally true about code.
+CodeGenome provides a code-reality substrate.
 
-The memory lifecycle decides how that knowledge persists and changes over time.
+The memory lifecycle and governance layers decide how its observations persist, are disputed, and affect agents over time.

--- a/docs/adr/ADR-006-neurospace-is-runtime-memory-space.md
+++ b/docs/adr/ADR-006-neurospace-is-runtime-memory-space.md
@@ -2,19 +2,21 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
-COREFORGE Vault and Neurospace provide the local product runtime where agents assemble, traverse, retrieve, and use memory.
+COREFORGE Vault and Neurospace provide a product/runtime model where agents assemble, traverse, retrieve, and use memory.
 
-Runtime memory has different responsibilities from identity, scoring, governance, and certification.
+Runtime memory has different responsibilities from identity, scoring, governance, certification, and canonical doctrine.
 
 ## Decision
 
-Neurospace is the operational runtime memory space.
+Neurospace is the canonical operational runtime-memory role in the current implementation map.
 
-It consumes identity, evidence, saturation, governance, and certification signals to support agent recall and action. It must not redefine those layers silently.
+It consumes identity, evidence, lifecycle, governance, certification, sensitivity, and scope signals to support agent recall and action. It must not redefine those layers silently.
+
+Candidate generation and ranking may be probabilistic. Recall admission must still enforce policy, tenant, sensitivity, dispute, and scope constraints.
 
 ## Consequences
 
@@ -33,12 +35,17 @@ It consumes identity, evidence, saturation, governance, and certification signal
 
 ```text
 operationally_useful != canonical
+highly_relevant != authorized_for_context
 ```
 
-A memory may be useful in a context window without being crystallized.
+A memory may be useful in a context window without being crystallized, and a relevant memory may still be prohibited from recall.
+
+## Acceptance scope
+
+Accepted establishes the architectural role. It does not claim the current COREFORGE/Neurospace implementation satisfies every doctrine or conformance requirement.
 
 ## Doctrine
 
 Neurospace is where memory is used.
 
-It is not where memory becomes true by convenience.
+It is not where memory becomes true or authorized by convenience.

--- a/docs/adr/ADR-007-agent-memory-is-component-architecture.md
+++ b/docs/adr/ADR-007-agent-memory-is-component-architecture.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -20,9 +20,11 @@ The doctrine repo owns the shared architecture, vocabulary, contracts, segmentat
 
 Individual repos own implementation slices.
 
+Components may contain deterministic, probabilistic, learned, or hybrid internals, but cross-component handoffs must preserve signal semantics, provenance, scope, uncertainty, and authority boundaries.
+
 ## Component boundaries
 
-The canonical components are:
+The canonical components include:
 
 1. Identity Substrate
 2. Evidence and Provenance Substrate
@@ -36,6 +38,8 @@ The canonical components are:
 10. Correction and Dispute Surface
 11. Conformance and Calibration Harness
 12. Product and Agent Integrations
+
+Additional components may be added when they have distinct cross-system interfaces and failure modes.
 
 ## Consequences
 
@@ -53,21 +57,25 @@ The canonical components are:
 - requires adapter contracts between components
 - requires careful documentation discipline
 - requires cross-repo backlinks and implementation maps
-- may feel heavier than a single library until implementation matures
+- creates composition-specific failure modes that must be tested
 
 ## Rejected alternatives
 
 ### One monolithic memory system
 
-Rejected because identity, scoring, certification, governance, and runtime use have distinct failure modes and should not be collapsed.
+Rejected because identity, inference, scoring, certification, governance, runtime use, privacy, and correction have distinct failure modes.
 
 ### Completely separate concepts
 
-Rejected because the concepts all participate in governed memory state transition and need a shared doctrine.
+Rejected because the concepts participate in governed memory transition/admission and need shared doctrine.
 
 ### Product-first definition
 
-Rejected because COREFORGE, EvolveAI, CodeGenome, and future systems should conform to doctrine rather than each product redefining memory terms.
+Rejected because products should conform to doctrine rather than redefine memory terms locally.
+
+## Acceptance scope
+
+Accepted establishes component architecture as canonical doctrine. It does not freeze the component list forever or require one repository per component.
 
 ## Doctrine
 

--- a/docs/adr/ADR-008-memory-threat-model-is-required.md
+++ b/docs/adr/ADR-008-memory-threat-model-is-required.md
@@ -2,64 +2,45 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
-The doctrine already defines trap classes such as access-spam and confidently-wrong memory. Those are necessary, but not sufficient.
+Trap classes such as access-spam and confidently-wrong memory are necessary but insufficient.
 
-A governed memory system also faces broader threats:
+Persistent memory creates additional threats including poisoning, sleeper behavior, authority laundering, recursive self-citation, provenance stripping, scope leakage, stale authorization, deletion residue, unsafe composition, estimator manipulation, and policy bypass.
 
-- memory poisoning
-- recursive self-citation
-- source spoofing
-- provenance stripping
-- unauthorized mutation
-- stale policy retention
-- cross-user leakage
-- overbroad context assembly
-- malicious correction
-- poisoned code graph evidence
-
-Without a threat model, conformance becomes too narrow and the system can appear safe while failing under adversarial memory pressure.
+Without a threat model, conformance can appear strong while ignoring the seams where persistent state becomes a control channel.
 
 ## Decision
 
-Agent Memory must include a formal memory threat model.
+Agent Memory must include and maintain a formal memory threat model.
 
-The threat model will define threat classes, affected components, detection strategies, mitigations, and required conformance fixtures.
+The threat model defines threat classes, trust boundaries, affected components, mitigations, required invariants, and adversarial conformance fixtures.
+
+Canonical document:
+
+- [`../15-memory-threat-model.md`](../15-memory-threat-model.md)
 
 ## Consequences
 
 ### Positive
 
-- expands safety beyond current trap classes
-- gives PAMA and certification concrete adversarial cases
-- improves conformance fixture design
-- clarifies memory-specific security risks
+- expands safety beyond simple trap classes
+- gives PAMA, recall governance, privacy, and certification concrete adversarial cases
+- improves conformance design
+- makes memory-specific security boundaries explicit
 
 ### Negative
 
-- adds additional documentation and fixture burden
-- may require implementation repos to expose more audit and provenance data
+- increases documentation and fixture burden
+- requires implementations to expose provenance, scope, authority, and audit data
+- requires ongoing updates as attacks evolve
 
-## Required follow-up
+## Acceptance scope
 
-Create and maintain:
-
-```text
-docs/15-memory-threat-model.md
-```
-
-The threat model should link to:
-
-- PAMA governance
-- certification and crystallization
-- source trust and reputation
-- governed recall
-- privacy and sensitivity classification
-- conformance fixtures
+Accepted means a formal memory threat model is canonical architecture doctrine and the foundational threat-model document now exists. It does not claim every required adversarial fixture or runtime mitigation is implemented.
 
 ## Doctrine
 
-A memory system is not trustworthy unless it defines how memory can be attacked.
+A memory system is not trustworthy unless it defines how persistent state can be attacked, laundered, leaked, corrupted, or incompletely forgotten.

--- a/docs/adr/ADR-009-source-trust-is-a-first-class-signal.md
+++ b/docs/adr/ADR-009-source-trust-is-a-first-class-signal.md
@@ -2,62 +2,56 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
-Evidence and provenance tell the system where memory came from and what supports it. They do not fully answer whether a source remains reliable over time.
+Evidence and provenance tell the system where memory came from and what supports it. They do not fully answer whether a source remains reliable over time or within the current domain.
 
 A low-quality source can produce high volume. A stale source can remain cited. An agent can recursively cite its own prior claims. A single-source assertion can become over-weighted if the system treats provenance as equivalent to trust.
 
-That is how memory systems develop the confidence of a freshman philosophy major with a search bar. Delightful. Unsafe.
-
 ## Decision
 
-Source trust and reputation must be a first-class signal in the architecture.
+Source trust and reputation are first-class evidence signals.
 
-The system should track source class, reliability, contradiction history, freshness, authority scope, and self-citation risk.
+Trust may be probabilistic, multidimensional, scoped, and time-varying. The system should preserve source class, reliability evidence, contradiction history, independence, freshness, domain scope, estimator provenance, and uncertainty where material.
+
+Trust is not mutation authority, certification, or factual truth.
+
+Canonical document:
+
+- [`../16-source-trust-and-reputation.md`](../16-source-trust-and-reputation.md)
 
 ## Consequences
 
 ### Positive
 
-- prevents high-volume low-quality sources from dominating saturation
+- prevents high-volume low-quality sources from dominating memory
 - improves evidence weighting
 - supports conflict resolution
-- helps detect recursive self-citation
-- makes source reliability visible to certification gates
+- helps detect recursive self-citation and manufactured corroboration
+- makes source reliability visible to governance and certification
 
 ### Negative
 
 - requires source metadata beyond simple provenance
-- requires policy for source demotion and rehabilitation
-- may complicate conformance fixtures
+- requires policy for demotion, rehabilitation, and scope
+- may require calibration of trust estimators
 
-## Required source classes
-
-At minimum, implementations should distinguish:
-
-- authoritative
-- observed
-- inferred
-- synthetic
-- user-provided
-- agent-generated
-- external
-- code-derived
-- policy-derived
-
-## Required follow-up
-
-Create and maintain:
+## Required invariant
 
 ```text
-docs/16-source-trust-and-reputation.md
+source_trust -> evidence weighting
+source_trust != authority
+source_trust != certification
 ```
+
+## Acceptance scope
+
+Accepted establishes source trust as canonical doctrine. Specific reputation algorithms and thresholds remain implementation-specific and require calibration.
 
 ## Doctrine
 
 Provenance says where memory came from.
 
-Source trust says how much weight that source deserves now.
+Source trust estimates how much evidentiary weight that source deserves within a defined scope.

--- a/docs/adr/ADR-010-conflict-resolution-is-a-separate-component.md
+++ b/docs/adr/ADR-010-conflict-resolution-is-a-separate-component.md
@@ -2,68 +2,65 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
 The lifecycle state machine includes a `disputed` state. That state identifies a problem, but it does not resolve the problem.
 
-Conflicts can arise between:
+Conflicts can arise between facts, decisions, time windows, scopes, policies, source reliability estimates, user corrections, estimator outputs, procedures, and implementation states.
 
-- facts
-- decisions
-- time windows
-- policies
-- source reliability scores
-- user corrections
-- implementation states
-- code graph evidence
-
-If conflict resolution is embedded ad hoc inside each implementation, the same memory dispute can resolve differently across systems.
+If conflict handling is embedded ad hoc inside each implementation, the same dispute can produce incompatible consequences across systems.
 
 ## Decision
 
-Conflict resolution must be treated as a separate component.
+Conflict resolution is a separate architectural component or explicitly bounded component contract.
 
-The component will classify conflict type, rank evidence, determine whether to correct, demote, split scope, escalate, preserve historical minority claims, or prune.
+Conflict **interpretation** may be probabilistic. Detection, classification, source ranking, causal interpretation, and stale-versus-superseded analysis can remain uncertain.
+
+Conflict **consequence** must be governed through explicit outcomes such as:
+
+```text
+retain_both
+split_scope
+mark_disputed
+request_more_evidence
+require_verification
+correct_preserve_history
+demote
+archive_superseded
+block_canonical_use
+escalate
+```
+
+Canonical document:
+
+- [`../17-conflict-resolution-engine.md`](../17-conflict-resolution-engine.md)
 
 ## Consequences
 
 ### Positive
 
 - prevents silent overwrite
-- gives disputed memory a deterministic path forward
-- allows temporal supersession without losing historical context
+- preserves alternative hypotheses and historical truth
+- allows temporal supersession without deleting valid history
 - supports policy-aware reconciliation
+- separates uncertain interpretation from authorized mutation
 
 ### Negative
 
-- requires conflict taxonomy and rules
-- requires implementations to expose enough evidence for resolution
-- may require human escalation for high-risk disputes
+- requires conflict taxonomy and evidence exposure
+- requires policy for resolution outcomes
+- may require review for high-risk unresolved disputes
 
-## Required conflict types
+## Acceptance scope
 
-At minimum:
-
-- factual contradiction
-- temporal supersession
-- scope mismatch
-- policy conflict
-- source reliability conflict
-- user correction conflict
-- implementation drift
-
-## Required follow-up
-
-Create and maintain:
-
-```text
-docs/17-conflict-resolution-engine.md
-```
+Accepted establishes conflict resolution as canonical architecture. It does not require deterministic conflict classification or claim one universal resolution algorithm.
 
 ## Doctrine
 
 Dispute is a state.
 
-Resolution is a component.
+Interpretation may be uncertain.
+
+Resolution consequence is governed.

--- a/docs/adr/ADR-011-temporal-causality-is-required-for-memory-evolution.md
+++ b/docs/adr/ADR-011-temporal-causality-is-required-for-memory-evolution.md
@@ -2,59 +2,58 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
 Memory changes over time. A memory may become stale, superseded, corrected, disputed, or historically relevant.
 
-Time-based decay alone does not explain why a memory changed. It only says that time passed, which is technically true and architecturally lazy.
+Time-based decay alone does not explain why memory changed.
 
-Decision memory, code evolution, organizational memory, agent learning, and correction flows all need causal explanation.
+However, exact chronology and causal interpretation are not the same epistemic problem. Event order may be known deterministically while causality remains uncertain.
 
 ## Decision
 
-Agent Memory must include a temporal causality layer.
+Agent Memory must include explicit temporal and causal representation sufficient to distinguish history, current state, supersession, correction, and causal hypotheses.
 
-The layer will represent event order, causal links, supersession, correction history, and causal recall requirements.
+The architecture must preserve exact event/observation/valid times where known and label inferred causal relations with provenance and uncertainty.
+
+Canonical document:
+
+- [`../18-temporal-causality-layer.md`](../18-temporal-causality-layer.md)
 
 ## Consequences
 
 ### Positive
 
-- distinguishes stale from superseded
-- supports causal recall
+- distinguishes stale from superseded and false
+- supports temporal and causal recall
 - preserves decision and correction history
-- improves code-evolution memory
-- helps explain why memory changed
+- avoids treating sequence as proof of causation
+- supports prospective and procedural drift handling
 
 ### Negative
 
-- requires event and causal-link modeling
-- increases complexity of memory state transitions
-- requires careful treatment of historical claims
+- requires multiple temporal fields and causal-link modeling
+- increases complexity of historical queries and lifecycle transitions
 
 ## Required distinctions
 
 The architecture must distinguish:
 
-- stale memory
-- superseded memory
-- corrected memory
-- disputed memory
-- historically relevant memory
-- currently canonical memory
+- event time from observation/record time
+- stale from false
+- superseded from corrected
+- historical from current truth
+- observed dependency from inferred causality
+- prospective obligation from action execution
 
-## Required follow-up
+## Acceptance scope
 
-Create and maintain:
-
-```text
-docs/18-temporal-causality-layer.md
-```
+Accepted establishes temporal evolution and uncertainty-aware causal representation as canonical doctrine. It does not claim a universal causal-inference algorithm.
 
 ## Doctrine
 
-Memory does not only decay.
+Time can be exact while causality remains uncertain.
 
-Memory evolves through causes, consequences, corrections, and supersession.
+Memory evolves through events, evidence, correction, supersession, and sometimes causal relationships whose strength must remain explicit.

--- a/docs/adr/ADR-012-privacy-and-sensitivity-classification-is-required.md
+++ b/docs/adr/ADR-012-privacy-and-sensitivity-classification-is-required.md
@@ -2,61 +2,66 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
 Agentic memory systems may store or recall personal, organizational, security, financial, health, credential, code, policy, or public information.
 
-A memory system that cannot classify sensitivity cannot reliably decide what may be stored, recalled, summarized, exported, shared, corrected, or deleted.
+A memory system that cannot represent sensitivity cannot reliably decide what may be stored, recalled, summarized, exported, shared, corrected, or deleted.
 
-Local-first storage helps, but it is not enough. A locally stored sensitive memory can still be recalled into the wrong context, shared with the wrong agent, or preserved beyond its intended scope. Humanity, against all odds, continues to invent new ways to mishandle data.
+Local-first storage helps, but it is not enough. Sensitive memory can still be recalled into the wrong context, shared with the wrong actor, inferred through composition, or retained after a nominal deletion.
 
 ## Decision
 
-Privacy and sensitivity classification must be a first-class component.
+Privacy and sensitivity classification are first-class memory-governance concerns.
 
-The component should influence storage, retention, recall, context assembly, PAMA authority, certification, export, and deletion behavior.
+Classification may be probabilistic or multi-label. Storage, recall, sharing, export, and deletion consequences remain policy-governed.
+
+Required invariant:
+
+```text
+classifier_uncertain != non_sensitive
+```
+
+Canonical document:
+
+- [`../19-privacy-and-sensitivity-classifier.md`](../19-privacy-and-sensitivity-classifier.md)
 
 ## Consequences
 
 ### Positive
 
-- prevents overbroad recall
-- improves PAMA risk classification
-- supports local-first and encrypted memory boundaries
-- enables conformance tests for cross-user leakage and unsafe context assembly
-- makes retention and deletion policy enforceable
+- prevents overbroad recall and disclosure
+- improves consequence-aware PAMA decisions
+- supports local-first and encrypted boundaries
+- enables conformance tests for cross-user leakage, extraction, composition leakage, and deletion residue
 
 ### Negative
 
-- requires sensitivity taxonomy
-- may require implementation-specific classifiers
+- requires sensitivity taxonomy and policy
+- may require implementation-specific classifiers and calibration
 - may reduce recall convenience when sensitivity is unclear
 
-## Required classes
+## Required handling dimensions
 
-At minimum, the system should support sensitivity classes for:
+At minimum, policy should be able to distinguish:
 
-- public
-- personal
-- organizational
-- security-sensitive
-- credential or secret
-- financial
-- health or wellbeing
-- code or IP-sensitive
-- policy or compliance
-- restricted or consent-bound
+- storage permission/location
+- retrieval permission
+- context destination
+- sharing/export scope
+- encryption
+- retention period
+- deletion mode
+- audit/review requirements
 
-## Required follow-up
+## Acceptance scope
 
-Create and maintain:
-
-```text
-docs/19-privacy-and-sensitivity-classifier.md
-```
+Accepted establishes privacy and sensitivity handling as canonical doctrine. It does not claim one classifier is reliable enough for all domains or consequences.
 
 ## Doctrine
 
-A memory cannot be safely recalled until the system knows the sensitivity boundary it belongs to.
+Sensitivity can be uncertain.
+
+Permission to expose memory cannot be inferred from that uncertainty.

--- a/docs/adr/ADR-013-governed-recall-planner-is-required.md
+++ b/docs/adr/ADR-013-governed-recall-planner-is-required.md
@@ -8,55 +8,57 @@ Proposed
 
 Retrieval is not memory.
 
-Agentic systems often treat retrieval as the whole memory problem: search something, stuff it into context, and hope the model behaves. This is convenient in the same way that removing the brakes makes a car simpler.
+A governed memory system needs recall planning that respects current state, certification, dispute status, sensitivity, source trust, tenancy, authority, and context boundaries.
 
-A governed memory system needs recall planning that respects state, certification, dispute status, sensitivity, source trust, authority, and context boundaries.
+Candidate generation may legitimately be probabilistic. Recall admission is a governed decision.
 
-## Decision
+## Decision candidate
 
-Agent Memory must include a governed recall planner.
+Agent Memory should include a governed recall planner or equivalent recall-admission component contract.
 
-The planner decides how to retrieve memory across exact lookup, graph traversal, evidence search, vector retrieval, policy recall, runtime context recall, and certification-aware recall.
+The planner should compose exact lookup, graph traversal, evidence search, semantic retrieval, temporal retrieval, procedural recall, and policy constraints without treating relevance as permission.
+
+## Required invariant
+
+```text
+candidate_generation may be probabilistic
+relevance != permission
+prohibited_memory never enters admitted context
+```
 
 ## Consequences
 
 ### Positive
 
-- prevents disputed memory from being used as canonical
-- avoids unsafe recall of sensitive memory
+- prevents disputed or wrong-scope memory from entering context as canonical
 - distinguishes exact lookup from similarity retrieval
-- supports recall explanations
+- supports recall explanations and composition checks
 - makes context assembly policy-aware
 
 ### Negative
 
-- adds another planning step before context assembly
-- requires recall metadata from memory units
-- may block convenient but unsafe retrieval
+- adds a governance step before context assembly
+- requires recall metadata and destination context
+- may reduce convenient but unsafe recall
 
-## Required recall paths
+## Required follow-up before acceptance
 
-At minimum:
-
-- exact identity lookup
-- graph traversal
-- evidence search
-- vector or similarity retrieval
-- policy recall
-- runtime context recall
-- certified memory recall
-- disputed memory recall with warning semantics
-
-## Required follow-up
-
-Create and maintain:
+Create and audit:
 
 ```text
-docs/20-governed-recall-planner.md
+docs/26-governed-recall-planner.md
 ```
 
-## Doctrine
+Then add conformance evidence for:
+
+- high-relevance wrong-tenant memory
+- disputed canonical memory
+- uncertain sensitivity
+- unsafe multi-memory composition
+- stochastic candidate ordering under fixed admission policy
+
+## Doctrine candidate
 
 Retrieval finds candidates.
 
-Governed recall decides what may enter context and under what warning, scope, or authority.
+Governed recall decides what may enter context.

--- a/docs/adr/ADR-014-schema-registry-and-type-evolution-are-needed.md
+++ b/docs/adr/ADR-014-schema-registry-and-type-evolution-are-needed.md
@@ -6,41 +6,54 @@ Proposed
 
 ## Context
 
-The repository now contains initial schemas for memory units and conformance reports. As implementations adopt the doctrine, schemas will need to evolve.
+The repository contains initial schemas for memory units and conformance reports. As implementations adopt the doctrine, those schemas will evolve.
 
-Without explicit schema governance, implementation-specific fields can leak into doctrine-level objects, memory units can become incompatible across systems, and migration rules can become oral tradition, which is how software projects summon ghosts.
+Without explicit schema governance, implementation-specific fields can leak into doctrine-level objects, uncertainty semantics can be lost across adapters, and migrations can become oral tradition, which is how software projects summon ghosts.
 
-## Decision
+## Decision candidate
 
 Agent Memory should define a schema registry and type-evolution strategy.
 
-This should remain an architecture component candidate until adapter contracts and implementation ownership are clearer.
+The registry should govern doctrine-level types while allowing implementation-specific extension under explicit compatibility rules.
+
+It should define representations for at least:
+
+- memory unit identity and lifecycle state
+- provenance and acquisition mode
+- estimator provenance and uncertainty
+- policy and authority references
+- permitted-action sets
+- decision receipts
+- deletion/tombstone state
+- schema version and migration metadata
 
 ## Consequences
 
 ### Positive
 
-- prevents schema drift
+- prevents schema drift and semantic type erasure
 - supports cross-repo adoption
 - enables versioned conformance fixtures
-- makes memory-unit migrations explicit
+- makes migrations explicit
 
 ### Negative
 
 - adds governance overhead
-- requires compatibility rules
-- may slow experimentation if applied too early
+- requires compatibility and migration rules
+- can slow experimentation if extension mechanisms are too rigid
 
-## Required follow-up
+## Required follow-up before acceptance
 
-Create an issue to define:
+Create and audit:
 
 ```text
-docs/21-schema-registry-and-type-evolution.md
+docs/27-schema-registry-and-type-evolution.md
 ```
 
-## Doctrine
+Then reconcile the existing schemas and fixtures against the registry.
+
+## Doctrine candidate
 
 Schemas are part of memory governance.
 
-A memory object that cannot evolve safely cannot remain canonical across implementations.
+A memory object that cannot evolve without losing semantic meaning cannot remain canonical across implementations.

--- a/docs/adr/ADR-015-retention-deletion-and-tombstones-are-required.md
+++ b/docs/adr/ADR-015-retention-deletion-and-tombstones-are-required.md
@@ -6,67 +6,57 @@ Proposed
 
 ## Context
 
-The architecture defines pruning, correction, dispute, crystallization, privacy classification, and governed recall. It does not yet define a complete retention and deletion model.
+The architecture distinguishes pruning, archival, suppression, redaction, correction, crystallization, and privacy handling, but still needs one canonical retention/deletion contract tying them together.
 
 A memory system that can remember but cannot explain deletion is not governed. It is a hoarder with APIs.
 
-Memory may need to be:
+## Decision candidate
 
-- retained for audit
-- removed from active recall
-- tombstoned
-- deleted from local storage
-- deleted from exported artifacts
-- retained in redacted form
-- excluded from future context assembly
+Agent Memory must define explicit retention, deletion, redaction, archival, and tombstone semantics.
 
-These are different operations and must not be collapsed.
+Deletion is not pruning. Predicted low utility is not deletion authority. Removing the raw record is not complete deletion if summaries, embeddings, graphs, caches, or consolidated memories still retain recoverable content.
 
-## Decision
+## Required distinctions
 
-Agent Memory must define explicit retention, deletion, and tombstone semantics.
-
-Deletion is not the same as pruning. Pruning removes active recall. Tombstoning preserves a record that something existed and why it was removed. Deletion removes content according to policy, sensitivity, consent, or legal requirement.
+- active recall removal
+- suppression
+- archival retention
+- tombstone retention
+- redacted retention
+- cryptographic deletion
+- source deletion
+- derived-memory deletion
+- exported-memory deletion
+- certification revocation
+- verified full-pipeline purge
 
 ## Consequences
 
 ### Positive
 
-- prevents silent disappearance of memory
-- supports privacy and retention policy
-- preserves accountability when appropriate
-- distinguishes active recall from storage retention
-- supports local-first and user-controlled memory products
+- prevents silent disappearance and incomplete deletion
+- supports privacy, consent, retention, and audit policy
+- preserves accountability where appropriate
+- makes forgetting modes explicit
 
 ### Negative
 
-- requires policy-specific retention rules
-- may create tension between audit preservation and deletion requirements
-- requires careful handling of derived memories and compiled summaries
+- creates tension between deletion and evidence retention
+- requires dependency traversal across derived memory
+- requires policy-specific verification
 
-## Required distinctions
+## Required follow-up before acceptance
 
-The architecture must distinguish:
-
-- active recall removal
-- archival retention
-- tombstone retention
-- redacted retention
-- source deletion
-- derived-memory deletion
-- exported-memory deletion
-- certification revocation
-
-## Required follow-up
-
-Create and maintain:
+Create and audit:
 
 ```text
-docs/23-retention-deletion-and-tombstones.md
+docs/28-retention-deletion-and-tombstones.md
 ```
 
-## Doctrine
+Then add deletion-residue and dependency-propagation conformance fixtures.
 
-Forgetting is a governed operation.
+## Doctrine candidate
 
-A memory system must explain not only why it remembers, but why and how it forgets.
+Forgetting is a governed family of operations.
+
+Irreversible deletion requires stronger authority than reversible pruning or archival.

--- a/docs/adr/ADR-016-actor-scope-consent-and-tenancy-are-required.md
+++ b/docs/adr/ADR-016-actor-scope-consent-and-tenancy-are-required.md
@@ -8,61 +8,64 @@ Proposed
 
 Agent Memory may operate across users, agents, organizations, projects, repositories, tools, and products.
 
-Without explicit actor scope and consent boundaries, a memory may be valid in one context and unsafe in another.
+Without explicit actor scope, delegation, consent, and tenancy boundaries, a memory may be valid in one context and unsafe in another.
 
 Examples:
 
-- a user preference should not silently become an organization policy
-- a project decision should not leak into another tenant
-- an agent should not inherit authority from another agent by reading its memory
-- a shared memory should not bypass consent or role boundaries
+- a user preference must not silently become organization policy
+- a project decision must not leak into another tenant
+- an agent must not inherit authority merely by reading another agent's memory
+- shared memory must not bypass consent, role, or purpose boundaries
 
-## Decision
+## Decision candidate
 
-Agent Memory must define actor scope, consent, and tenancy boundaries as first-class governance concerns.
+Agent Memory must define actor scope, consent, delegation, and tenancy as first-class governance concerns.
 
-Memory units should carry enough scope metadata to determine who may store, mutate, recall, export, correct, or delete them.
+Memory units and decision receipts should carry enough metadata to determine who may store, mutate, recall, export, share, correct, or delete them.
+
+Relevance, trust, or inherited access must not create broader authority.
+
+## Required dimensions
+
+- actor identity
+- agent identity
+- user/principal identity
+- organization or tenant
+- project/repository scope
+- role or capability
+- consent state
+- purpose limitation
+- delegation scope
+- expiry/revocation state
+- re-sharing rights
 
 ## Consequences
 
 ### Positive
 
-- prevents cross-user leakage
+- prevents cross-user and cross-tenant leakage
 - supports multi-agent and organizational memory safely
-- improves PAMA risk classification
-- enables role-aware recall and mutation
-- clarifies product integration boundaries
+- improves PAMA and recall-admission decisions
+- clarifies shared-memory ownership
 
 ### Negative
 
-- requires actor and tenant metadata
-- complicates shared memory protocols
-- may reduce convenience for broad context assembly
+- requires richer scope metadata
+- complicates shared-memory protocols and inheritance
+- requires consent/revocation propagation
 
-## Required scope dimensions
+## Required follow-up before acceptance
 
-At minimum:
-
-- actor identity
-- agent identity
-- user identity
-- organization or tenant
-- project or repository
-- role or permission level
-- consent state
-- delegation scope
-- expiration or revocation status
-
-## Required follow-up
-
-Create and maintain:
+Create and audit:
 
 ```text
-docs/24-actor-scope-consent-and-tenancy.md
+docs/29-actor-scope-consent-and-tenancy.md
 ```
 
-## Doctrine
+Then add conformance cases for scope laundering, delegated-authority expiry, and cross-tenant retrieval.
+
+## Doctrine candidate
 
 Memory authority is scoped.
 
-A memory that is valid for one actor, tenant, or purpose is not automatically valid everywhere else.
+A memory that is useful or valid for one actor, tenant, or purpose is not automatically usable everywhere else.

--- a/docs/adr/ADR-017-memory-observability-and-audit-events-are-required.md
+++ b/docs/adr/ADR-017-memory-observability-and-audit-events-are-required.md
@@ -6,31 +6,27 @@ Proposed
 
 ## Context
 
-The doctrine defines lifecycle states, PAMA outcomes, certification gates, conformance fixtures, and component handoffs. It does not yet define a common observability and audit event model.
+The doctrine defines lifecycle states, PAMA outcomes, certification gates, conformance fixtures, component handoffs, probabilistic estimators, and bounded action sets.
 
-Without shared audit events, implementations can claim governance while emitting incompatible or incomplete traces. That is how observability turns into decorative logging, nature's most boring confetti.
+Without a common audit-event model, implementations can claim governance while emitting incompatible or incomplete traces. Decorative logging remains logging's favorite hobby.
 
-## Decision
+## Decision candidate
 
-Agent Memory must define a memory observability and audit event model.
+Agent Memory must define a common memory observability and audit-event model.
 
-Every meaningful memory transition, handoff, recall, mutation, certification, dispute, correction, deletion, and policy decision should emit a structured event.
+Consequential memory transitions, handoffs, recalls, mutations, certification, disputes, corrections, deletion, policy decisions, and conformance runs should emit structured events appropriate to their risk and privacy constraints.
 
-## Consequences
+Events affecting governed uncertainty should preserve where material:
 
-### Positive
-
-- enables cross-component traceability
-- supports conformance testing
-- improves incident review
-- allows runtime memory behavior to be replayed or audited
-- gives FailSafe, Arbiter, Vault, and product surfaces a common event language
-
-### Negative
-
-- requires event schemas
-- increases implementation burden
-- requires careful handling of sensitive event content
+- estimator/model ID and version
+- calibration reference
+- uncertainty/disagreement summary
+- policy version
+- authority reference
+- permitted action set
+- selected action and selection mode
+- before/after state
+- rollback/recovery reference
 
 ## Required event classes
 
@@ -41,27 +37,30 @@ At minimum:
 - memory_scored
 - memory_state_changed
 - memory_recalled
+- recall_admission_decided
 - memory_mutation_requested
 - pama_decision
+- action_selected
 - certification_requested
 - certification_completed
 - dispute_opened
 - correction_applied
+- memory_archived
 - memory_pruned
 - memory_tombstoned
 - memory_deleted
 - component_handoff
 - conformance_fixture_run
 
-## Required follow-up
+## Required follow-up before acceptance
 
-Create and maintain:
+Create and audit:
 
 ```text
-docs/25-memory-observability-and-audit-events.md
+docs/30-memory-observability-and-audit-events.md
 schemas/memory-audit-event.schema.json
 ```
 
-## Doctrine
+## Doctrine candidate
 
-If a memory transition cannot be observed, it cannot be governed.
+If a consequential memory transition cannot be reconstructed from evidence, policy, authority, and state, its governance is incomplete.

--- a/docs/adr/ADR-018-recovery-rollback-and-replay-are-required.md
+++ b/docs/adr/ADR-018-recovery-rollback-and-replay-are-required.md
@@ -8,51 +8,65 @@ Proposed
 
 Governed memory systems will make mistakes.
 
-A memory may be incorrectly promoted, wrongly corrected, over-pruned, recalled into unsafe context, or mutated under insufficient authority.
+A memory may be incorrectly promoted, wrongly corrected, over-pruned, recalled into unsafe context, mutated under insufficient authority, or committed from stale authorization.
 
 If the system cannot recover from these events, governance becomes performative. Performative governance is just theater with YAML.
 
-## Decision
+## Decision candidate
 
 Agent Memory must define recovery, rollback, and replay semantics.
 
-Implementations should be able to reconstruct memory state transitions, roll back unsafe mutations when policy allows, replay decision paths for audit, and preserve evidence for incident review.
+Implementations should be able to reconstruct consequential decision paths, restore or compensate for unsafe mutations when policy allows, demote incorrectly durable memory, revoke certification, and preserve incident evidence.
+
+Exact replay of stochastic cognition is not always required or possible.
+
+The required invariant is reconstruction of:
+
+```text
+what was observed/estimated
+which policy and authority applied
+what actions were permitted/prohibited
+what action was selected
+what state changed
+what recovery path exists
+```
 
 ## Consequences
 
 ### Positive
 
-- makes unsafe memory transitions recoverable
+- makes unsafe transitions recoverable
 - supports incident review and conformance debugging
-- improves trust in correction workflows
-- enables replay-based validation of PAMA and certification decisions
+- improves correction and certification trust
+- preserves accountability even when model outputs are stochastic
 
 ### Negative
 
-- requires ledger integrity
-- requires event ordering and replay semantics
-- may conflict with deletion requirements unless retention policy is explicit
+- requires ledger integrity and ordering
+- requires state/version binding
+- may conflict with privacy/deletion requirements unless retention is explicit
 
 ## Required recovery capabilities
 
-At minimum:
-
-- replay memory state transition history
+- reconstruct memory transition history
 - identify unsafe transition source
-- roll back unauthorized mutation
+- reject stale authorization at commit
+- roll back or compensate for unauthorized mutation
 - demote incorrectly crystallized memory
 - restore mistakenly pruned memory when retention allows
 - revoke certification
-- preserve incident evidence
+- preserve incident evidence within privacy constraints
 
-## Required follow-up
+## Required follow-up before acceptance
 
-Create and maintain:
+Create and audit:
 
 ```text
-docs/26-recovery-rollback-and-replay.md
+docs/31-recovery-rollback-and-replay.md
 ```
 
-## Doctrine
+Then add replay cases for stochastic estimators, policy drift, concurrent mutation, and deletion constraints.
 
-A governed memory system must be able to recover from its own mistakes.
+## Doctrine candidate
+
+A governed memory system must recover from its own mistakes without pretending stochastic cognition has to be byte-for-byte replayable.

--- a/docs/adr/ADR-019-memory-quality-metrics-are-required.md
+++ b/docs/adr/ADR-019-memory-quality-metrics-are-required.md
@@ -6,59 +6,68 @@ Proposed
 
 ## Context
 
-The doctrine defines conformance fixtures and calibration reporting, but it does not yet define ongoing memory quality metrics.
+Conformance fixtures test defined cases, but implementations can still degrade over time through stale recall, poor correction, over-retention, under-retention, unsafe context assembly, calibration drift, or authority-boundary failures.
 
-An implementation may pass fixtures and still degrade over time through stale recall, poor correction handling, over-retention, under-retention, unsafe context assembly, or excessive false permanence.
+Ongoing metrics are required to distinguish a memory system that passed yesterday's fixture from one that remains healthy today.
 
-Because apparently even memory systems need performance reviews. Horrifying, but useful.
+## Decision candidate
 
-## Decision
+Agent Memory must define ongoing memory-quality metrics across retention, forgetting, retrieval, uncertainty, correction, governance, security, privacy, and agent outcomes.
 
-Agent Memory must define ongoing memory quality metrics.
-
-These metrics should evaluate how well an implementation remembers, forgets, corrects, recalls, protects, and explains memory over time.
-
-## Consequences
-
-### Positive
-
-- supports continuous evaluation beyond fixture snapshots
-- detects degradation over time
-- gives implementation repos comparable quality targets
-- helps tune saturation, decay, recall, and certification policies
-
-### Negative
-
-- requires telemetry and reporting
-- may require workload-specific benchmarks
-- quality metrics can be gamed if not tied to trap classes and audit evidence
+Metrics should be segmented by memory class and consequence class where aggregate numbers would hide risk.
 
 ## Required metric families
 
 At minimum:
 
 - false permanence rate
-- false evaporation rate
-- unsafe recall rate
+- valuable-memory loss / false evaporation
+- stale recall rate
 - disputed canonical use rate
-- correction latency
+- correction latency and propagation
 - provenance retention rate
-- source trust degradation rate
-- overbroad context assembly rate
-- successful rollback rate
+- source-trust calibration/degradation
+- unsafe recall and overbroad context rate
+- cross-scope leakage rate
+- deletion completeness/residue
+- successful rollback or recovery rate
 - certification failure catch rate
-- stale memory recall rate
+- boundary instability rate
+- abstention rate and quality
+- estimator disagreement rate
+- out-of-calibration-scope rate
+- blocked-action escape rate
+- stochastic action-set violation rate
+- memory-guided task success
+- repeated-failure avoidance
 
-## Required follow-up
+## Consequences
 
-Create and maintain:
+### Positive
+
+- supports continuous evaluation beyond fixture snapshots
+- detects drift and degradation
+- gives implementations comparable outcome families
+- makes optimization tradeoffs visible
+
+### Negative
+
+- requires telemetry, workloads, and reporting
+- metrics can be gamed if detached from adversarial fixtures and evidence
+- some metrics require domain-specific interpretation
+
+## Required follow-up before acceptance
+
+Create and audit:
 
 ```text
-docs/27-memory-quality-metrics.md
+docs/32-memory-quality-metrics.md
 ```
 
-## Doctrine
+Then map the metrics into conformance-report schema and implementation evidence.
 
-Conformance proves a system can behave correctly under defined tests.
+## Doctrine candidate
 
-Quality metrics show whether it keeps behaving correctly over time.
+Conformance shows a system can satisfy defined invariants under test.
+
+Quality metrics show whether it continues to do so under real memory pressure and drift.

--- a/docs/adr/ADR-020-probabilistic-discovery-deterministic-governance.md
+++ b/docs/adr/ADR-020-probabilistic-discovery-deterministic-governance.md
@@ -1,4 +1,6 @@
-# ADR-020: Probabilistic Discovery, Deterministic Governance
+# ADR-020: Probabilistic Discovery, Governed Consequences
+
+> Filename retained for decision-history continuity. The refined doctrine no longer assumes every governance mechanism must be computationally deterministic.
 
 ## Status
 
@@ -8,269 +10,264 @@ Proposed
 
 Agentic memory operates under uncertainty.
 
-Candidate extraction, semantic retrieval, contradiction detection, source trust, salience, relevance, abstraction, causal inference, and risk estimation may all depend on learned or probabilistic mechanisms.
+Candidate extraction, semantic retrieval, contradiction detection, source trust, salience, relevance, abstraction, causal inference, sensitivity, future utility, and risk estimation may all depend on learned, heuristic, probabilistic, or stochastic mechanisms.
 
-However, memory also contains transitions whose consequences are too important to delegate directly to uncertain inference:
+Memory also contains consequences too important to delegate directly to uncertain inference:
 
 - canonical promotion
-- mutation of durable state
+- durable mutation
 - cross-tenant or cross-user disclosure
-- deletion and erasure
+- irreversible deletion
 - policy mutation
 - certification
-- inherited memory propagation
+- inherited-memory propagation
 - authority changes
 - preservation or destruction of evidence
 
-A binary architectural choice between "deterministic memory" and "probabilistic memory" is therefore insufficient.
-
-Research also challenges both extremes. Human memory and decision research supports explicit representation of uncertainty and stochastic retrieval. Current agent-memory work shows value in adaptive learned memory control. At the same time, memory-poisoning research shows that aggressively writing and retrieving memory can create persistent attack surfaces, and runtime-assurance research provides precedent for allowing learned behavior only inside separately enforced safety boundaries.
+A binary choice between "deterministic memory" and "probabilistic memory" is therefore insufficient.
 
 ## Decision candidate
 
-Adopt a **governed uncertainty** architecture with the following separation:
+Adopt a **governed uncertainty** architecture:
 
 ```text
-probabilistic / learned epistemics
+probabilistic / learned / heuristic epistemics
         |
         v
-policy-defined governance envelope
+explicit policy + authority envelope
         |
         v
-optional stochastic selection among permitted actions
+permitted / prohibited / deferred actions
         |
         v
-defined state transition + audit receipt
+optional deterministic or stochastic selection
+AMONG PERMITTED ACTIONS ONLY
+        |
+        v
+committed consequence + provenance + receipt
 ```
 
-### Rule 1: probabilistic outputs are not authority
+Short form:
 
-Learned or probabilistic components MAY produce:
+> **Probabilistic epistemics. Governed consequences.**
 
-- beliefs
-- confidence estimates
-- relevance scores
-- risk estimates
+Operational form:
+
+> **Uncertainty may propose. Authority constrains.**
+
+The desired property is **authority boundedness and reconstructability**, not fictional certainty.
+
+## Rule 1: estimator output is not authority
+
+Learned, heuristic, or probabilistic components MAY produce:
+
+- beliefs and alternative hypotheses
+- confidence or probability estimates
+- relevance and trust scores
+- sensitivity or risk estimates
 - contradiction likelihoods
 - rankings
 - memory candidates
 - proposed mutations
 - proposed retrieval sets
-- proposed consolidation targets
+- proposed consolidation or forgetting actions
 
-They MUST NOT acquire mutation, promotion, deletion, sharing, or certification authority merely from their scores.
+They MUST NOT acquire mutation, promotion, deletion, sharing, certification, or policy authority merely from those outputs.
 
-### Rule 2: governance defines the permitted action set
+## Rule 2: governance defines the action envelope
 
-For every consequential transition, a versioned governance function MUST determine the set of permitted outcomes using applicable:
+For every consequential operation, a versioned governance process MUST determine permitted, prohibited, review-required, or deferred outcomes using applicable:
 
 - identity
-- scope
-- tenant
-- authority
+- current state/version
+- scope/tenant
+- actor authority
 - sensitivity
 - provenance
 - lifecycle state
-- risk class
+- risk and reversibility
 - certification state
 - policy
+- estimator uncertainty when relevant
 
-A learned component MUST NOT expand that set.
+A learned component MUST NOT expand its own permitted action set.
 
-### Rule 3: stochastic behavior may remain inside the envelope
+## Rule 3: stochastic behavior may remain inside the envelope
 
-The architecture MAY permit stochastic or learned selection among actions already authorized by policy.
+The architecture MAY permit stochastic or learned selection among already-authorized actions.
 
-Examples include:
-
-- retrieval ordering
-- query exploration
-- low-risk hypothesis testing
-- non-destructive consolidation analysis
-
-The invariant is:
+Required invariant:
 
 ```text
 selected_action ∈ permitted_action_set
 ```
 
-### Rule 4: irreversible and authority-changing transitions receive the strongest boundary
+Randomness does not create permission.
 
-Transitions involving canonical truth, erasure, permission expansion, evidence destruction, cross-scope disclosure, policy mutation, or inherited canonical state MUST require explicit prerequisites beyond model confidence.
+## Rule 4: consequence strength is proportional
 
-Depending on risk, these MAY include:
+The strongest boundary belongs around operations that:
 
-- deterministic policy checks
-- external verification
-- human approval
-- cryptographic authorization
-- certification
-- quorum
-- formal safety constraints
+- create canonical or certified state
+- irreversibly erase data or evidence
+- cross user, tenant, organization, or trust-domain boundaries
+- change policy or authority
+- expose sensitive memory
+- create inherited behavioral control
+- trigger external destructive side effects
 
-### Rule 5: uncertainty remains visible
+High model confidence does not reduce those requirements by itself.
 
-The system MUST NOT silently collapse uncertain inference into authoritative fact.
+## Rule 5: uncertainty remains visible
 
-Where material, audit evidence SHOULD preserve:
+Where material, the decision record SHOULD preserve:
 
-- estimator/model version
-- relevant probabilities or scores
-- threshold or rule version
-- candidate set
+- signal semantics
+- estimator/model identity and version
+- calibration reference and scope
+- uncertainty or disagreement
+- candidate/proposed action
 - policy version
-- authority scope
+- authority and scope
+- permitted and prohibited actions
+- selected action and selection mode
 - committed result
 
-### Rule 6: deterministic does not mean static
+A 0-to-1 score MUST NOT be assumed to be a calibrated probability unless the estimator defines it that way.
 
-Deterministic governance rules MAY consume probabilistic inputs and MAY evolve through explicit versioned policy changes.
+## Rule 6: deterministic does not mean static or correct
 
-Fixed thresholds MUST NOT be assumed safe merely because they are reproducible.
+Reproducible policy can still be badly designed.
 
-Thresholds and classifiers that influence consequential transitions SHOULD be calibrated and adversarially evaluated.
+Fixed thresholds MUST NOT be assumed safe merely because they are deterministic.
 
-### Rule 7: read-path governance is required
+Thresholds and classifiers influencing consequential transitions SHOULD be calibrated, stress-tested near decision boundaries, and re-evaluated under drift.
 
-A memory that was safe to store MAY become unsafe when combined with other memories or retrieved into a different scope.
+## Rule 7: read-path governance is required
 
-Therefore, deterministic or formally bounded policy enforcement MUST exist on both:
+A memory safe to store MAY become unsafe when retrieved under a different scope or combined with other memories.
 
-```text
-write path
-read path
-```
+Policy enforcement must therefore exist on both write and read paths, with context/composition checks where consequence warrants them.
 
-### Rule 8: formal probabilistic guarantees are allowed when absolute guarantees are impossible
+## Rule 8: formally bounded probabilistic guarantees are allowed
 
-Some systems cannot provide absolute deterministic safety because environment models, hidden parameters, or learned estimators remain uncertain.
+Absolute deterministic safety may be impossible in environments with hidden parameters or uncertain models.
 
-Formally bounded probabilistic guarantees MAY be used when:
+A formally bounded probabilistic guarantee MAY be used when:
 
 - the guarantee type is explicit
-- the residual risk is measured
-- the policy accepts that risk
-- stronger deterministic constraints remain enforced where possible
+- residual risk is measured
+- policy explicitly accepts that residual risk
+- stronger exact constraints remain enforced where available
+- the guarantee can be independently evaluated
+
+Calling a system "formally bounded" without specifying the bound is not a guarantee.
+
+## Rule 9: learned is not synonymous with probabilistic
+
+A learned component may be deterministic at inference time. A hand-written heuristic may be uncertain without representing probability.
+
+The architecture should classify a component by what its output **means** and what authority it has, not by whether it contains machine learning.
+
+## Rule 10: governance begins at contract design
+
+Authority, scope, policy versioning, proposal-versus-commit boundaries, and decision receipts must be defined before implementations stabilize consequential memory APIs.
+
+Governance is not a later hardening phase.
 
 ## Consequences
 
 ### Positive
 
 - preserves adaptive and learned memory behavior
-- prevents model confidence from becoming authority
-- makes governance auditable
-- separates epistemic uncertainty from permission
-- supports stronger security boundaries
-- permits safe experimentation inside bounded action spaces
-- improves failure analysis by recording policy and estimator versions separately
-- provides a conceptual bridge to runtime assurance and shielding architectures
+- prevents confidence from becoming authority
+- supports uncertainty-preserving belief memory
+- makes consequential decisions auditable
+- permits stochastic optimization inside bounded action spaces
+- separates policy drift from estimator drift
+- supports read-time and composition security
 
 ### Negative
 
-- adds architectural complexity
-- requires explicit policy and transition semantics
-- requires calibration of probabilistic components
+- requires richer schemas and receipts
+- adds explicit policy and transition semantics
+- requires calibration and drift evaluation
 - can add latency to high-consequence operations
-- may require additional audit storage
-- poorly designed deterministic gates can become brittle bottlenecks
-- formal guarantees may be difficult for complex memory composition
+- formally bounded guarantees can be difficult to specify for complex compositions
 
-### Risks
+### Doctrine risks
 
-- teams may label a rule "deterministic" and stop evaluating whether it is correct
-- fixed thresholds may create false confidence
-- stochastic components may influence governance indirectly through poorly bounded inputs
-- read-path composition can create risks not visible at write time
-- policy version drift may mimic model drift unless both are recorded
-- excessive fail-closed behavior can destroy memory utility
+- deterministic rules may reproduce a bad assumption perfectly
+- estimator and policy may become tightly coupled
+- hidden stochasticity may escape receipts
+- `require_human_review` may create false assurance if the reviewer lacks evidence or authority
+- over-conservative policy can destroy useful adaptation
+- flexible policy can become a euphemism for model self-authorization
+- correct authorization can become stale before commit
+- safe components can compose into unsafe behavior
 
 ## Rejected alternatives
 
 ### Fully deterministic memory control
 
-Rejected as a universal doctrine.
-
-Reason:
-
-Memory relevance, ambiguity, contradiction, abstraction, source trust, retrieval, and risk frequently involve uncertainty. Fixed deterministic heuristics can be brittle and may underperform adaptive methods.
+Rejected as universal doctrine because relevance, ambiguity, trust, contradiction, sensitivity, abstraction, retrieval, and risk frequently involve uncertainty.
 
 ### End-to-end model-directed memory
 
-Rejected for consequential state transitions.
+Rejected for consequential transitions because cognition and authority would collapse into one failure domain.
 
-Reason:
+### Deterministic thresholds as primary governance
 
-A model that can decide what to believe and independently grant itself authority to persist, expose, mutate, or delete that belief collapses epistemics and governance into one failure domain.
-
-### Deterministic thresholds as the primary governance mechanism
-
-Rejected as insufficient.
-
-Reason:
-
-Thresholds require calibration, vary by risk and domain, can be attacked, and can fail under memory composition or distribution shift.
+Rejected as insufficient because thresholds can be miscalibrated, brittle, domain-specific, attacked, or invalid under drift and composition.
 
 ### Human approval for every mutation
 
-Rejected as a default.
-
-Reason:
-
-It creates an unnecessary human bottleneck and prevents useful autonomous low-risk adaptation. Human authority should be reserved for policy-defined consequence classes where it adds material assurance.
-
-## Research basis
-
-The doctrine is informed by freely inspectable research rather than citation collection for its own sake.
-
-Relevant sources include:
-
-- stochastic selective memory retrieval and decision noise: https://pmc.ncbi.nlm.nih.gov/articles/PMC3651451/
-- working-memory uncertainty in decisions: https://pmc.ncbi.nlm.nih.gov/articles/PMC7165478/
-- distinctions among forms of uncertainty: https://pmc.ncbi.nlm.nih.gov/articles/PMC3461114/
-- adaptive memory control for LLM agents: https://arxiv.org/abs/2607.13591
-- adaptive probabilistic memory-structure gating: https://arxiv.org/abs/2602.14038
-- governed evolving agent memory: https://arxiv.org/abs/2603.11768
-- memory-poisoning write-channel vulnerabilities: https://arxiv.org/abs/2606.04329
-- compositional and context-triggered memory poisoning: https://arxiv.org/abs/2607.14651
-- threshold calibration tradeoffs in memory defenses: https://arxiv.org/abs/2601.05504
-- Simplex-style runtime assurance: https://arxiv.org/abs/2109.13446
-- black-box Simplex runtime assurance: https://arxiv.org/abs/2102.12981
-- adaptive shielding under uncertainty: https://arxiv.org/abs/2506.11033
+Rejected as a default because it creates a human bottleneck and prevents useful autonomous low-risk adaptation.
 
 ## Validation required before acceptance
 
-Before moving this ADR from Proposed to Accepted, the repository SHOULD add conformance fixtures proving at least:
+This ADR MUST remain Proposed until the repository has executable evidence proving at least:
 
-1. a high-confidence false memory cannot self-promote
-2. a semantically perfect cross-tenant memory cannot be recalled across scope
+1. high-confidence false memory cannot self-promote
+2. high-relevance wrong-tenant memory cannot enter context
 3. probabilistic contradiction detection cannot silently overwrite certified state
-4. stochastic retrieval cannot bypass policy filters
-5. uncertain sensitivity classification fails safely for high-risk storage
-6. model-predicted low utility cannot independently authorize irreversible deletion
-7. read-time composition defenses can catch unsafe combinations of individually acceptable memories
-8. policy-version changes are distinguishable from estimator/model drift
-9. concurrent conflicting mutations resolve through explicit conflict semantics
-10. stochastic action selection cannot escape its permitted action set
+4. stochastic retrieval/action selection cannot bypass policy filters
+5. uncertain sensitivity is handled safely for high-consequence disclosure
+6. predicted low utility cannot independently authorize irreversible deletion
+7. unsafe multi-memory composition is tested
+8. policy-version drift is distinguishable from estimator/model drift
+9. concurrent conflicting mutations do not silently become last-writer-wins
+10. selected action cannot escape its permitted set across stochastic trials
+11. authority and consequence remain reconstructable from receipts
+12. derived-memory deletion residue is tested
+13. at least one implementation is mapped end-to-end from estimate -> governance -> action set -> commit
+14. at least one adversarial challenge causes a documented boundary, correction, or rejection rather than being ignored
+
+Canonical evidence locations:
+
+- [`../06-conformance-test-plan.md`](../06-conformance-test-plan.md)
+- [`../24-determinism-probability-and-governed-uncertainty.md`](../24-determinism-probability-and-governed-uncertainty.md)
+- [`../25-governed-uncertainty-documentation-conformance-audit.md`](../25-governed-uncertainty-documentation-conformance-audit.md)
+- [`../audits/governed-uncertainty/`](../audits/governed-uncertainty/)
 
 ## Open questions
 
-- Which governance checks require strict computational determinism?
-- Which only require deterministic policy semantics?
+- Which checks require strict computational determinism versus explicit bounded semantics?
 - When are probabilistic safety guarantees sufficient?
-- How should uncertainty propagate into derived and consolidated memory?
-- Can learned governance components themselves be certified inside constrained scopes?
-- What formal model best represents an allowed action envelope for agent memory?
-- How should policy adapt under distribution shift without becoming hidden self-mutation?
+- How should uncertainty propagate through consolidation and derivation?
+- Can learned governance itself be certified inside a constrained scope?
+- What formal model best represents a permitted action envelope?
+- How should policy adapt under drift without becoming hidden self-mutation?
+- Which uncertainty representations are useful enough to standardize?
 
-## Related doctrine
+## Research posture
 
-See:
+The decision should be challenged using freely inspectable research where practical, implementation evidence, adversarial fixtures, and negative results.
 
-- `../24-determinism-probability-and-governed-uncertainty.md`
-- `../03-scoring-and-decay.md`
-- `../04-governance-and-pama.md`
-- `../06-conformance-test-plan.md`
-- `ADR-002-saturation-is-routing-not-truth.md`
-- `ADR-004-pama-controls-mutation-authority.md`
-- `ADR-008-memory-threat-model-is-required.md`
-- `ADR-013-governed-recall-planner-is-required.md`
+Citation count is not confidence.
+
+## Doctrine candidate
+
+The system may be uncertain about what is true.
+
+It must remain explicit about what that uncertainty is allowed to change.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,48 @@
+# Architecture Decision Records
+
+This directory records architectural decisions for the Agent Memory doctrine.
+
+## Status semantics
+
+ADR status describes **doctrine maturity**, not implementation maturity.
+
+| Status | Meaning |
+|---|---|
+| Proposed | A decision candidate under active evaluation. Required evidence, follow-up, or doctrine integration is incomplete. |
+| Accepted | The decision is canonical Agent Memory doctrine. Implementations may still be conceptual, partial, experimental, or absent. |
+| Superseded | A later ADR replaces this decision. Historical rationale remains useful. |
+| Rejected | The proposal was evaluated and intentionally not adopted. |
+
+An `Accepted` ADR does **not** claim:
+
+- every related repository implements it
+- executable conformance exists
+- runtime enforcement is complete
+- the decision can never be revised
+
+Implementation maturity is tracked separately through documentation, fixtures, conformance evidence, implementation maps, and runtime evidence.
+
+## Current status policy
+
+A decision may move from Proposed to Accepted when:
+
+1. its architectural boundary is sufficiently defined
+2. it is integrated consistently into canonical doctrine
+3. known material contradictions have been resolved or documented
+4. required foundational documentation exists
+5. acceptance does not depend on implementation evidence the ADR itself explicitly requires
+
+If an ADR explicitly requires executable evidence before acceptance, that requirement controls.
+
+## Governed uncertainty
+
+`ADR-020` is intentionally different from many earlier ADRs. It explicitly requires conformance and implementation evidence before acceptance. It remains **Proposed** until those conditions are met.
+
+## Canonical references
+
+- [`../01-layer-model.md`](../01-layer-model.md)
+- [`../04-governance-and-pama.md`](../04-governance-and-pama.md)
+- [`../06-conformance-test-plan.md`](../06-conformance-test-plan.md)
+- [`../11-component-architecture.md`](../11-component-architecture.md)
+- [`../24-determinism-probability-and-governed-uncertainty.md`](../24-determinism-probability-and-governed-uncertainty.md)
+- [`../25-governed-uncertainty-documentation-conformance-audit.md`](../25-governed-uncertainty-documentation-conformance-audit.md)

--- a/docs/audits/governed-uncertainty/06-adr-status-and-alignment.md
+++ b/docs/audits/governed-uncertainty/06-adr-status-and-alignment.md
@@ -1,0 +1,171 @@
+# Governed Uncertainty Audit: Slice 6
+
+## Scope
+
+This slice audits all Agent Memory ADRs for:
+
+- status accuracy
+- consistency with the governed-uncertainty doctrine
+- stale follow-up links
+- accidental conflation of doctrine acceptance with implementation completion
+
+## Baseline
+
+```text
+baseline_main_commit: 48201ebf3b42c62053ea48fc04129cb4a8eae66a
+```
+
+## Baseline finding
+
+Every ADR from 001 through 020 was marked `Proposed`.
+
+That no longer reflected repository reality. Several early decisions had become foundational assumptions throughout the canonical docs, while later ADRs still had unfinished dedicated contracts or explicit validation requirements.
+
+Several ADRs also pointed to document numbers later occupied by the interdisciplinary theory corpus:
+
+- ADR-013 -> stale `docs/20-governed-recall-planner.md`
+- ADR-014 -> stale `docs/21-schema-registry-and-type-evolution.md`
+- ADR-015 -> stale `docs/23-retention-deletion-and-tombstones.md`
+- ADR-016 -> stale `docs/24-actor-scope-consent-and-tenancy.md`
+- ADR-017 -> stale `docs/25-memory-observability-and-audit-events.md`
+- ADR-018 -> stale `docs/26-recovery-rollback-and-replay.md`
+- ADR-019 -> stale `docs/27-memory-quality-metrics.md`
+
+## Status semantics added
+
+`docs/adr/README.md` now defines:
+
+```text
+Proposed   = architecture candidate; required doctrine/evidence incomplete
+Accepted   = canonical architecture decision; implementation may still be partial or absent
+Superseded = replaced by a later ADR
+Rejected   = intentionally not adopted
+```
+
+This prevents `Accepted` from being misread as `implemented everywhere`.
+
+## Status decisions
+
+| ADR | Result | Reason |
+|---|---|---|
+| 001 Identity vs memory | Accepted | deeply integrated into layer model and doctrine |
+| 002 Saturation vs truth | Accepted | canonical scoring invariant; now also explicitly not authority |
+| 003 Certification for crystallization | Accepted | canonical durable-transition boundary |
+| 004 PAMA / equivalent mutation authority | Accepted | canonical authority boundary |
+| 005 CodeGenome role | Accepted | canonical implementation-map role, not implementation-completeness claim |
+| 006 Neurospace role | Accepted | canonical runtime role, not implementation-completeness claim |
+| 007 Component architecture | Accepted | canonical architecture structure |
+| 008 Threat model required | Accepted | dedicated threat-model doctrine now exists |
+| 009 Source trust signal | Accepted | dedicated trust doctrine now exists; trust explicitly not authority |
+| 010 Conflict resolution component | Accepted | dedicated conflict doctrine exists; deterministic overclaim corrected |
+| 011 Temporal causality | Accepted | dedicated temporal doctrine exists; chronology/causality distinction clarified |
+| 012 Privacy/sensitivity | Accepted | dedicated privacy doctrine exists; uncertain != non-sensitive |
+| 013 Governed recall planner | Proposed | dedicated contract and executable recall-admission evidence still missing |
+| 014 Schema registry/evolution | Proposed | registry/type-evolution doctrine and schema reconciliation still missing |
+| 015 Retention/deletion/tombstones | Proposed | dedicated lifecycle-wide retention/deletion contract and residue fixtures still missing |
+| 016 Actor scope/consent/tenancy | Proposed | dedicated scope/delegation contract and tests still missing |
+| 017 Observability/audit events | Proposed | common event doctrine/schema still missing |
+| 018 Recovery/rollback/replay | Proposed | dedicated recovery/replay contract and tests still missing |
+| 019 Memory quality metrics | Proposed | dedicated ongoing-metrics contract and schema mapping still missing |
+| 020 Governed uncertainty | Proposed | explicitly requires executable implementation/conformance evidence |
+
+## Alignment corrections
+
+### ADR-002
+
+Saturation is now explicitly neither truth nor authority.
+
+### ADR-003
+
+Crystallization gate now refers to lifecycle candidacy rather than implying one scalar threshold is universally sufficient.
+
+### ADR-004
+
+PAMA now explicitly consumes uncertain signals without allowing those signals to self-authorize.
+
+### ADR-006
+
+Runtime recall now distinguishes relevance from context permission.
+
+### ADR-007
+
+Component architecture now requires uncertainty/provenance/authority semantics to survive handoffs.
+
+### ADR-009
+
+Source trust is explicitly scoped evidence, not authority or certification.
+
+### ADR-010
+
+Corrected prior deterministic overclaim:
+
+```text
+conflict interpretation may be probabilistic
+resolution consequence is governed
+```
+
+### ADR-011
+
+Corrected sequence/causality conflation:
+
+```text
+chronology may be exact
+causal attribution may remain uncertain
+```
+
+### ADR-012
+
+Added:
+
+```text
+classifier_uncertain != non_sensitive
+```
+
+### ADR-013 through ADR-019
+
+Stale follow-up numbering is replaced with reserved slots 26 through 32 and specific evidence requirements.
+
+### ADR-020
+
+Title is refined in-file to **Probabilistic Discovery, Governed Consequences** while retaining the existing filename for history/link stability.
+
+The ADR now explicitly distinguishes:
+
+- deterministic
+- probabilistic
+- learned
+- heuristic
+- formally bounded
+- governed
+
+and requires authority boundedness/reconstructability rather than claiming authority certainty.
+
+## Next canonical slots
+
+Reserved by the updated Proposed ADRs:
+
+```text
+26 governed recall planner
+27 schema registry and type evolution
+28 retention, deletion, and tombstones
+29 actor scope, consent, and tenancy
+30 memory observability and audit events
+31 recovery, rollback, and replay
+32 memory quality metrics
+```
+
+These documents should be created in subsequent incremental slices before their corresponding ADRs are reconsidered for acceptance.
+
+## Verification requirements
+
+- [x] ADR status semantics documented
+- [x] foundational ADRs accepted only where doctrine is already canonical
+- [x] implementation maturity kept separate from ADR status
+- [x] unresolved ADRs remain Proposed
+- [x] stale document-number references removed
+- [x] ADR-020 remains Proposed
+- [x] ADR-020 acceptance evidence made stricter, not weaker
+- [ ] final branch diff reviewed
+- [ ] PR head verified mergeable
+- [ ] commit status checked
+- [ ] merge by exact verified head SHA


### PR DESCRIPTION
## Scope

Sixth incremental governed-uncertainty audit, covering ADR-001 through ADR-020.

## Baseline

Measured against `main` at `48201ebf3b42c62053ea48fc04129cb4a8eae66a`.

## Status correction

All 20 ADRs were marked Proposed at baseline. This PR adds explicit ADR status semantics and separates doctrine acceptance from implementation maturity.

Result:

- ADR-001 through ADR-012: **Accepted**
- ADR-013 through ADR-020: **Proposed**

Accepted means canonical architecture doctrine, not runtime implementation completion.

## Material alignment changes

- saturation is explicitly not authority
- crystallization no longer implies one scalar threshold is sufficient
- PAMA consumes uncertainty without allowing estimators to self-authorize
- runtime relevance is separated from context permission
- component handoffs preserve uncertainty and authority semantics
- source trust is scoped evidence, not authority
- conflict interpretation may be probabilistic while resolution consequence is governed
- chronology is separated from causal inference
- uncertain sensitivity is not treated as non-sensitive
- stale follow-up document numbers are replaced with reserved slots 26-32
- ADR-020 remains Proposed and is refined to **Probabilistic Discovery, Governed Consequences** while retaining its filename for history/link stability

## ADR-020

Acceptance requirements are strengthened. It now explicitly requires executable evidence for false promotion, cross-tenant recall, stochastic action-set containment, unsafe composition, deletion under uncertain utility, policy/estimator drift, concurrency, receipt reconstruction, deletion residue, and one end-to-end implementation map.

## Audit record

See `docs/audits/governed-uncertainty/06-adr-status-and-alignment.md`.

## Verification

- branch is 22 commits ahead and 0 behind main
- changes are ADR documentation and one audit record only
- no implementation-completeness claims are introduced by Accepted status
- ADR-020 remains Proposed
- stale document-number references are removed

This PR should merge before creating the dedicated follow-up contracts for ADR-013 through ADR-019.