### PR TITLE
Contracts slice 7A: recall, schema, retention, and scope

### DIFF
--- a/docs/26-governed-recall-planner.md
+++ b/docs/26-governed-recall-planner.md
@@ -1,0 +1,250 @@
+# Governed Recall Planner
+
+## Purpose
+
+Retrieval finds candidate memory. Governed recall decides which candidates may enter an agent's active context, under what representation, and with what warnings or restrictions.
+
+The recall planner exists because semantic relevance is not permission.
+
+```text
+high relevance != authorized recall
+```
+
+## Core pipeline
+
+```text
+query / task
+  -> requester + purpose + scope resolution
+  -> candidate generation
+  -> candidate normalization
+  -> recall admission
+  -> ranking among admitted candidates
+  -> composition risk check
+  -> context budgeting
+  -> context assembly
+  -> recall receipt / explanation
+```
+
+Candidate generation may be probabilistic. Admission and scope enforcement must be explicit and bounded.
+
+## Retrieval modes
+
+A planner may compose:
+
+- exact identity lookup
+- graph traversal
+- temporal lookup
+- evidence search
+- semantic/vector retrieval
+- procedural retrieval
+- prospective-memory lookup
+- policy-memory lookup
+- failure-memory lookup
+- source-aware retrieval
+
+No one retrieval mode owns truth or authority.
+
+## Candidate record
+
+A retrieval candidate should preserve where applicable:
+
+```text
+memory_id
+retrieval_method
+retriever_id
+retriever_version
+score_type
+score
+uncertainty
+source_scope
+memory_scope
+sensitivity
+dispute_state
+certification_state
+freshness_state
+provenance_refs
+```
+
+A score must identify what it means. Similarity, confidence, trust, saturation, and policy priority are not interchangeable.
+
+## Recall admission
+
+Before context inclusion, evaluate:
+
+```text
+requester_identity
+agent_identity
+tenant
+purpose
+memory_scope
+sensitivity
+destination
+consent/delegation
+certification/dispute state
+freshness
+policy_version
+```
+
+Possible outcomes:
+
+```text
+admit
+admit_with_warning
+admit_redacted
+admit_summary_only
+require_verification
+require_review
+quarantine
+block
+```
+
+## Bounded stochastic retrieval
+
+Candidate ordering may vary across runs.
+
+The invariant is not identical ordering. The invariant is:
+
+```text
+blocked_candidate never becomes admitted solely through randomness
+```
+
+A stochastic ranker may choose among admitted candidates, but must not bypass admission.
+
+## Disputed memory
+
+Disputed memory may be useful as evidence that disagreement exists.
+
+It must not be silently presented as canonical.
+
+Possible treatment:
+
+- exclude from ordinary canonical recall
+- include with explicit disputed status
+- surface competing claims together
+- trigger conflict-resolution workflow
+
+## Historical memory
+
+Temporal queries must distinguish:
+
+```text
+current state
+state at time T
+historically true but superseded state
+incorrect state later corrected
+```
+
+A current-state query should not prefer a stale memory merely because it is semantically closer.
+
+## Sensitivity and destination
+
+Recall policy should consider where the assembled context is going:
+
+- local deterministic tool
+- local model
+- external model provider
+- another agent
+- human UI
+- external API
+
+Storage permission does not imply universal context permission.
+
+## Composition risk
+
+Individually admissible memories may create unsafe context when combined.
+
+The planner should support policy checks for:
+
+- reconstruction of secrets
+- conflicting instructions
+- unsafe instruction chains
+- scope interaction
+- aggregate sensitivity
+- poisoned multi-memory patterns
+
+## Context budget
+
+Context pressure creates a second selection problem after admission.
+
+Budget policy may use probabilistic utility estimates, but it should preserve hard requirements such as:
+
+- must-include policy constraints
+- required warnings
+- active correction/dispute state
+- critical procedural prerequisites
+
+Do not let a utility score evict the only memory that explains why an action is prohibited.
+
+## Recall explanations
+
+For consequential recall, the system should be able to answer:
+
+1. Why was this memory a candidate?
+2. Which retrieval method produced it?
+3. Why was it admitted?
+4. Which policy version applied?
+5. Was it redacted, summarized, or transformed?
+6. What uncertainty or dispute state was preserved?
+7. Why were stronger-scoring candidates blocked, if applicable?
+
+## Failure modes
+
+- similarity overrides tenancy
+- ranking occurs before hard admission and leaks blocked candidates
+- disputed memory appears canonical
+- summaries erase scope/sensitivity
+- stale memory outranks current memory
+- stochastic ranker can sample prohibited content
+- context budgeting drops required governance state
+- several safe memories compose into unsafe context
+
+## Conformance cases
+
+### Wrong-tenant perfect match
+
+```text
+semantic_score = 1.0
+tenant_match = false
+expected: blocked
+```
+
+### Disputed high-relevance memory
+
+Expected: excluded from canonical recall or included with explicit dispute semantics.
+
+### Uncertain sensitivity
+
+Expected: high-consequence external disclosure does not treat uncertainty as non-sensitive.
+
+### Stochastic ordering
+
+Run multiple trials.
+
+Expected: admitted ordering may vary; prohibited candidate inclusion rate remains zero.
+
+### Unsafe composition
+
+Expected: individually admitted candidates may still be blocked or transformed at composition time.
+
+### Historical query
+
+Expected: time-scoped query can retrieve superseded historical truth without replacing current state.
+
+## Interface sketch
+
+```text
+plan_recall(request) -> candidate_plan
+admit(candidate, request, policy) -> admission_decision
+rank(admitted_candidates, request) -> ordered_candidates
+check_composition(candidates, request, policy) -> composition_decision
+assemble(candidates, budget, policy) -> governed_context
+explain(recall_id) -> recall_receipt
+```
+
+## Doctrine
+
+Retrieval estimates usefulness.
+
+Recall admission enforces permission.
+
+Context assembly is a governed memory operation, not a vector-search side effect.

--- a/docs/27-schema-registry-and-type-evolution.md
+++ b/docs/27-schema-registry-and-type-evolution.md
@@ -1,0 +1,255 @@
+# Schema Registry and Type Evolution
+
+## Purpose
+
+Agent Memory needs stable semantic contracts without freezing implementation experimentation.
+
+The schema registry defines which fields and meanings belong to doctrine-level interoperability, how those types evolve, and how implementations extend them without silently changing semantics.
+
+## Core rule
+
+```text
+schema compatibility != field-name compatibility only
+```
+
+If two systems both emit `confidence: 0.8` but one means semantic similarity and the other means calibrated factual probability, the schemas are semantically incompatible even if JSON validation passes with enthusiasm.
+
+## Registry layers
+
+### Doctrine core
+
+Stable cross-implementation concepts such as:
+
+- memory identity
+- lifecycle state
+- acquisition mode
+- provenance
+- scope/tenant
+- sensitivity labels
+- authority references
+- policy version
+- certification state
+- dispute/supersession state
+- estimator provenance
+- uncertainty representation
+- deletion/tombstone state
+- decision receipt
+
+### Extension layer
+
+Implementation-specific fields may be added under explicit namespacing or extension objects.
+
+Example:
+
+```json
+{
+  "extensions": {
+    "codegenome": {...},
+    "evolveai": {...}
+  }
+}
+```
+
+Extensions must not redefine core-field meaning.
+
+## Required versioning
+
+Each doctrine-level serialized object should identify a schema version.
+
+Recommended:
+
+```text
+schema_name
+schema_version
+```
+
+Version semantics should distinguish:
+
+- backward-compatible additive change
+- compatible semantic clarification
+- breaking field/type change
+- breaking semantic change
+
+A semantic change can be breaking even when the JSON type does not change.
+
+## Type evolution rules
+
+### Additive field
+
+May be backward compatible when optional and existing semantics remain valid.
+
+### New enum member
+
+Potentially breaking for closed consumers. Consumers should define unknown-value behavior.
+
+### Changed field meaning
+
+Breaking. Requires a new schema version or explicit migration.
+
+### Optional to required
+
+Breaking unless all stored objects are migrated.
+
+### Scalar to structured uncertainty
+
+Breaking unless the old scalar remains interpretable through an explicit compatibility adapter.
+
+## Semantic types that must not collapse
+
+Keep separate:
+
+```text
+confidence
+probability
+similarity
+trust
+saturation
+relevance
+sensitivity
+authority
+certification
+```
+
+Likewise:
+
+```text
+proposal
+permitted_action_set
+selected_action
+committed_transition
+```
+
+## Estimator provenance type
+
+A consequential estimate should be representable as:
+
+```json
+{
+  "signal_type": "semantic_relevance",
+  "value": 0.91,
+  "value_semantics": "cosine-derived ranking score, not calibrated probability",
+  "estimator_id": "retriever-x",
+  "estimator_version": "3.2",
+  "calibration_ref": null,
+  "uncertainty": null,
+  "scope": "project-A"
+}
+```
+
+## Uncertainty type
+
+Support multiple representations rather than forcing one universal confidence scalar.
+
+Possible forms:
+
+- categorical: low / medium / high
+- interval
+- probability distribution summary
+- ensemble disagreement
+- conformal set
+- unknown / unavailable
+
+Every representation should declare its semantics.
+
+## Authority type
+
+Authority records should identify:
+
+```text
+actor
+principal
+scope
+capability / permission
+policy_ref
+policy_version
+expiry / revocation
+source of delegation
+```
+
+Authority must not be inferred from estimator fields.
+
+## Decision-receipt type
+
+A common receipt should support:
+
+```text
+requested_action
+state_snapshot
+estimate_refs
+policy_version
+authority_refs
+permitted_actions
+prohibited_actions
+selected_action
+selection_mode
+before_state
+after_state
+evidence_refs
+rollback_or_recovery_ref
+timestamp
+```
+
+## Migration
+
+A migration should record:
+
+```text
+migration_id
+from_schema_version
+to_schema_version
+transformation
+lossy_fields
+semantic_changes
+validation_result
+rollback_or_backup_ref
+```
+
+Lossy migration requires explicit handling. "The old field didn't fit" is not provenance.
+
+## Unknown fields and versions
+
+For low-risk read-only consumers, preserving unknown extension fields may be sufficient.
+
+For consequential mutation, a consumer should not silently process an unknown core schema version if it cannot establish the semantics required for authority.
+
+Possible outcome:
+
+```text
+unsupported_schema -> abstain / quarantine / require_adapter
+```
+
+## Registry governance
+
+Schema changes should be reviewed for:
+
+- backward compatibility
+- semantic compatibility
+- privacy impact
+- deletion/migration impact
+- conformance impact
+- implementation adoption cost
+
+## Current repository schemas
+
+The repository currently contains:
+
+- `schemas/memory-unit.schema.json`
+- `schemas/conformance-report.schema.json`
+
+These predate the full governed-uncertainty model and should be reconciled in a subsequent schema/fixture slice.
+
+## Conformance cases
+
+- old consumer receives new optional field
+- old consumer receives unknown enum member
+- estimator score changes semantics without type change
+- migrated object loses provenance
+- schema adapter strips tenant scope
+- unknown schema attempts durable mutation
+- decision receipt references mismatched policy version
+
+## Doctrine
+
+Schemas govern meaning, not merely syntax.
+
+Interoperability is unsafe when two components agree on JSON while disagreeing on what the JSON means.

--- a/docs/28-retention-deletion-and-tombstones.md
+++ b/docs/28-retention-deletion-and-tombstones.md
@@ -1,0 +1,197 @@
+# Retention, Deletion, and Tombstones
+
+## Purpose
+
+Forgetting is not one operation.
+
+A governed memory system must distinguish reduced recall, archival, redaction, tombstoning, cryptographic deletion, and full deletion propagation through derived state.
+
+Predicted low utility may nominate a memory for forgetting. It does not authorize irreversible deletion.
+
+## Forgetting modes
+
+| Mode | Active recall | Content retained | Recoverable | Typical use |
+|---|---|---|---|---|
+| deprioritize | yes, lower rank | yes | yes | low current relevance |
+| suppress | no ordinary recall | yes | yes | temporary exclusion |
+| archive | no ordinary recall | yes | yes | historical/audit retention |
+| redact | limited representation | partial | depends | minimize sensitive content |
+| tombstone | no content recall | marker/metadata | policy-dependent | preserve deletion/supersession fact |
+| cryptographic delete | no | ciphertext may remain | no without key | strong local deletion |
+| purge | no | intended no recoverable copies | no | required full deletion outcome |
+
+Implementations may add modes but must define semantics.
+
+## Retention inputs
+
+Retention policy may consider:
+
+- memory type
+- legal/compliance hold
+- user deletion request
+- consent state
+- sensitivity
+- evidence/audit value
+- dependencies
+- currentness
+- certification state
+- dispute state
+- historical value
+- estimated future utility
+- storage cost
+
+Utility and staleness are advisory unless policy explicitly grants them bounded consequence.
+
+## Consequence proportionality
+
+```text
+reversible deprioritization -> low authority may suffice
+archival -> policy-defined authority
+redaction -> sensitivity/privacy authority
+irreversible deletion -> strongest applicable authority and verification
+```
+
+## Dependency graph
+
+Deletion must traverse derivation relationships where required.
+
+Potential dependents include:
+
+- summaries
+- semantic memories
+- procedures
+- embeddings/index records
+- graph edges
+- caches
+- exported artifacts
+- agent-generated reflections
+- preference models
+- successor-agent inherited memory
+
+A deletion operation should identify which dependents are in scope and which cannot be controlled.
+
+## Tombstones
+
+A tombstone records enough metadata to prevent accidental resurrection without preserving content that policy requires erased.
+
+Possible fields:
+
+```text
+memory_id_or_irreversible_reference
+deletion_mode
+reason_class
+policy_version
+deleted_at
+scope
+superseded_by_if_applicable
+```
+
+Privacy policy may require minimizing even tombstone metadata.
+
+## Deletion receipt
+
+For consequential deletion:
+
+```text
+deletion_id
+requester
+actor_authority
+memory_refs
+requested_outcome
+deletion_mode
+policy_version
+dependency_refs
+completed_steps
+failed_steps
+residual_known_copies
+verification_method
+verification_result
+timestamp
+```
+
+## Deletion verification
+
+Verification should answer the user/policy outcome, not merely whether one database row disappeared.
+
+Examples:
+
+- hidden from ordinary recall
+- inaccessible to specified actor
+- removed from local durable store
+- unrecoverable through cryptographic key destruction
+- propagated through known derived memory
+- external copies identified but not controllable
+
+## Evidence retention tension
+
+Audit evidence may conflict with deletion obligations.
+
+Policy must define which requirement controls within the relevant legal and product context.
+
+Do not silently keep deleted content under the label `audit` if the required outcome is erasure.
+
+Possible alternatives:
+
+- content-free tombstone
+- hash/reference without content
+- segregated legally required retention
+- redacted audit event
+
+## Supersession is not deletion
+
+Historical truth should normally remain available when a newer state supersedes it.
+
+```text
+old value valid until T
+new value valid from T
+```
+
+Use deletion only when policy requires removal, not merely because current truth changed.
+
+## Correction is not deletion
+
+Correction preserves the fact that an earlier claim was wrong or incomplete unless privacy/policy requires otherwise.
+
+## Consolidation and deletion
+
+Derived semantic/procedural memory should carry derivation links so deletion can determine whether a source contribution must be removed, recomputed, or marked unavailable.
+
+This is difficult when model weights or lossy abstractions contain distributed influence. The system should not claim full deletion where it cannot demonstrate it.
+
+## Unlearning
+
+Machine unlearning or model-weight removal is distinct from deleting explicit memory records.
+
+Do not use `deleted from vector store` as evidence that learned model state has been unlearned.
+
+## Conformance cases
+
+### Prune versus delete
+
+Expected: pruned memory remains recoverable under policy; deleted memory follows stronger semantics.
+
+### Derived summary residue
+
+Expected: deletion verification detects or addresses a surviving summary.
+
+### Low utility proposal
+
+Expected: utility score alone cannot authorize purge.
+
+### Legal/audit hold
+
+Expected: policy resolves retention conflict explicitly.
+
+### Superseded historical memory
+
+Expected: ordinary current recall excludes it while historical retrieval may retain it.
+
+### Unknown external copy
+
+Expected: receipt reports residual uncontrollable copies rather than claiming universal deletion.
+
+## Doctrine
+
+Forgetting is a governed family of operations.
+
+A system should be able to say exactly what "forgotten" means in each case, because humans have already overloaded that verb enough.

--- a/docs/29-actor-scope-consent-and-tenancy.md
+++ b/docs/29-actor-scope-consent-and-tenancy.md
@@ -1,0 +1,248 @@
+# Actor Scope, Consent, and Tenancy
+
+## Purpose
+
+Memory authority is never universal by default.
+
+A memory may be correct, useful, and safely stored while still being prohibited for another actor, tenant, project, purpose, destination, or agent.
+
+This contract defines the scope metadata and governance rules needed to prevent usefulness from becoming accidental permission.
+
+## Principals and actors
+
+Distinguish where relevant:
+
+- user/principal
+- acting agent
+- organization/tenant
+- team
+- project/repository
+- tool/service
+- destination agent
+- external provider
+
+An agent acts under delegated authority. Reading a memory does not grant the authority of the memory's creator.
+
+## Scope dimensions
+
+A memory may carry:
+
+```text
+owner_principal
+origin_actor
+allowed_readers
+allowed_writers
+tenant
+organization
+project
+repository
+purpose
+sensitivity
+consent_state
+delegation_ref
+allowed_destinations
+reshare_policy
+valid_from
+valid_until
+revocation_ref
+```
+
+Not every memory needs every field, but high-consequence shared memory should not depend on implicit ambient scope.
+
+## Consent
+
+Consent should identify what was authorized rather than one permanent boolean.
+
+Useful dimensions:
+
+- collection
+- durable storage
+- personalization
+- external model use
+- sharing with team/organization
+- sharing with other agents
+- export
+- derived inference
+- retention duration
+
+Consent can be revoked or expire.
+
+## Delegation
+
+Delegated authority should be:
+
+- scoped
+- purpose-bound where applicable
+- time-bounded where applicable
+- revocable
+- non-transitive by default unless policy says otherwise
+
+Wrong:
+
+```text
+Agent A may read X
+Agent B reads A's summary of X
+therefore B inherits A's authority
+```
+
+Correct:
+
+```text
+every boundary evaluates the receiving actor's own authority
+```
+
+## Tenancy
+
+Tenant identity is a hard boundary unless an explicit sharing policy authorizes crossing it.
+
+```text
+semantic_relevance = 1.0
+wrong_tenant = true
+=> recall blocked
+```
+
+Probabilistic retrieval may discover the candidate. It cannot authorize the crossing.
+
+## Purpose limitation
+
+A memory collected for one purpose may not be suitable for another.
+
+Examples:
+
+- support transcript used for immediate troubleshooting
+- personal preference used for local personalization
+- compliance evidence retained for audit
+
+Using these for unrelated training, sharing, or profiling should require separate policy/authority as applicable.
+
+## Scope promotion
+
+Moving memory from narrower to broader scope is a governed transition:
+
+```text
+private -> team
+team -> organization
+organization -> public
+local agent -> multi-agent shared memory
+```
+
+Scope promotion should record:
+
+```text
+requested_scope
+current_scope
+authority
+consent/delegation
+sensitivity
+policy_version
+selected_representation
+receipt
+```
+
+## Scope reduction
+
+Reducing scope may be necessary after:
+
+- consent revocation
+- role change
+- project closure
+- sensitivity reclassification
+- security incident
+- user correction
+
+Derived and cached representations should follow the reduction where policy requires.
+
+## Shared memory ownership
+
+Shared memory should define who may:
+
+- correct
+- dispute
+- supersede
+- delete
+- broaden scope
+- narrow scope
+- certify
+- re-share
+
+Ownership and authority are related but not identical. A system may own storage while a user retains authority over content use.
+
+## Inherited memory
+
+Successor agents should receive:
+
+- origin
+- acquisition mode
+- scope
+- authority constraints
+- consent/delegation status
+- policy version or migration state
+
+Inherited memory is not direct experience, and inheritance does not automatically broaden scope.
+
+## Uncertain identity or scope
+
+Probabilistic entity resolution may be necessary when identity is incomplete.
+
+For high-consequence disclosure:
+
+```text
+uncertain identity != permission
+uncertain tenant != same tenant
+```
+
+Policy should block, narrow, or require verification.
+
+## Conformance cases
+
+### Cross-tenant perfect match
+
+Expected: blocked before context admission.
+
+### Expired delegation
+
+Expected: prior access does not authorize current mutation or recall.
+
+### Re-sharing
+
+Expected: recipient cannot re-share unless policy grants that capability.
+
+### Consent revocation
+
+Expected: future governed use reflects revocation and required derived-state handling.
+
+### Agent inheritance
+
+Expected: successor sees acquisition mode and scope; does not claim direct observation or broader authority.
+
+### Ambiguous identity
+
+Expected: high-consequence sharing abstains or verifies rather than guessing identity.
+
+## Decision receipt
+
+For meaningful scope changes:
+
+```text
+memory_id
+actor
+principal
+current_scope
+requested_scope
+consent_ref
+delegation_ref
+sensitivity
+policy_version
+outcome
+before_scope
+after_scope
+timestamp
+```
+
+## Doctrine
+
+Memory can be relevant without being yours.
+
+Memory can be yours without being shareable.
+
+Scope, consent, delegation, and tenancy determine which uses are actually authorized.

--- a/docs/audits/governed-uncertainty/07a-recall-schema-retention-scope.md
+++ b/docs/audits/governed-uncertainty/07a-recall-schema-retention-scope.md
@@ -1,0 +1,83 @@
+# Governed Memory Contracts: Slice 7A
+
+## Baseline
+
+```text
+baseline_main_commit: 38bedb2e0673dde2f92bee8b124489b355b427fd
+```
+
+## Scope
+
+Creates the dedicated contracts required by Proposed ADRs 013 through 016:
+
+- `26-governed-recall-planner.md`
+- `27-schema-registry-and-type-evolution.md`
+- `28-retention-deletion-and-tombstones.md`
+- `29-actor-scope-consent-and-tenancy.md`
+
+## Key boundaries established
+
+### Recall
+
+```text
+candidate generation may be probabilistic
+recall admission remains governed
+relevance != permission
+```
+
+### Schema evolution
+
+Compatibility includes semantic meaning, not only field names and JSON types.
+
+Critical concepts remain separate:
+
+```text
+confidence
+probability
+similarity
+trust
+saturation
+relevance
+sensitivity
+authority
+certification
+```
+
+### Retention and deletion
+
+Forgetting is split into reversible and irreversible modes. Predicted utility may propose pruning/deletion but cannot authorize irreversible erasure.
+
+Deletion verification must consider derived memories, summaries, indexes, caches, graph relations, exports, and inherited copies where governed by the system.
+
+### Actor scope and tenancy
+
+Authority remains principal-, tenant-, project-, purpose-, consent-, and delegation-scoped.
+
+Probabilistic identity/entity resolution cannot manufacture permission for high-consequence cross-scope operations.
+
+## ADR maturity
+
+ADRs 013-016 remain **Proposed** after this slice because their acceptance requirements also call for schema/fixture reconciliation and executable conformance evidence.
+
+The documents are necessary but not sufficient.
+
+## Next evidence slice
+
+- reconcile `memory-unit.schema.json`
+- reconcile `conformance-report.schema.json`
+- add decision-receipt and audit-event schemas
+- add governed-recall fixtures
+- add deletion-residue fixture
+- add scope/delegation fixtures
+
+## Verification
+
+- [x] all four missing dedicated contracts created
+- [x] no conflict with existing docs 20-25 numbering
+- [x] uncertain estimates remain separate from authority
+- [x] irreversible deletion remains higher-authority than reversible forgetting
+- [x] tenant/scope boundaries cannot be overridden by relevance
+- [x] ADRs remain Proposed pending executable evidence
+- [ ] final branch diff reviewed
+- [ ] PR mergeability/status verified
+- [ ] merge by exact head SHA


### PR DESCRIPTION
## Scope

Creates the first four dedicated contracts required by Proposed ADRs 013-016.

## New documents

- `docs/26-governed-recall-planner.md`
- `docs/27-schema-registry-and-type-evolution.md`
- `docs/28-retention-deletion-and-tombstones.md`
- `docs/29-actor-scope-consent-and-tenancy.md`
- audit record `docs/audits/governed-uncertainty/07a-recall-schema-retention-scope.md`

## Core boundaries

- candidate generation may be probabilistic; recall admission remains governed
- schema compatibility includes semantic meaning, not only syntactic validation
- low predicted utility cannot authorize irreversible deletion
- deletion verification includes derived memory and known copies
- scope, consent, delegation, and tenancy remain independent from relevance

## ADR status

ADRs 013-016 remain Proposed. Their dedicated contracts now exist, but schema reconciliation and executable conformance evidence are still required before acceptance.

## Verification

- branch is 5 commits ahead and 0 behind main
- five new documentation files only
- no runtime implementation claim
- no ADR status is prematurely upgraded

This PR should merge before the schema/fixture evidence slice.