### PR TITLE
ADR slice 7C: accept evidence-backed contracts 013-019

### DIFF
--- a/docs/adr/ADR-013-governed-recall-planner-is-required.md
+++ b/docs/adr/ADR-013-governed-recall-planner-is-required.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -12,11 +12,11 @@ A governed memory system needs recall planning that respects current state, cert
 
 Candidate generation may legitimately be probabilistic. Recall admission is a governed decision.
 
-## Decision candidate
+## Decision
 
-Agent Memory should include a governed recall planner or equivalent recall-admission component contract.
+Agent Memory includes a governed recall planner or equivalent recall-admission component contract.
 
-The planner should compose exact lookup, graph traversal, evidence search, semantic retrieval, temporal retrieval, procedural recall, and policy constraints without treating relevance as permission.
+The planner composes exact lookup, graph traversal, evidence search, semantic retrieval, temporal retrieval, procedural recall, and policy constraints without treating relevance as permission.
 
 ## Required invariant
 
@@ -41,23 +41,26 @@ prohibited_memory never enters admitted context
 - requires recall metadata and destination context
 - may reduce convenient but unsafe recall
 
-## Required follow-up before acceptance
+## Acceptance evidence
 
-Create and audit:
+Canonical contract:
 
-```text
-docs/26-governed-recall-planner.md
-```
+- [`../26-governed-recall-planner.md`](../26-governed-recall-planner.md)
 
-Then add conformance evidence for:
+Repository conformance fixtures include:
 
-- high-relevance wrong-tenant memory
-- disputed canonical memory
-- uncertain sensitivity
-- unsafe multi-memory composition
-- stochastic candidate ordering under fixed admission policy
+- `cross-tenant-relevance-trap.json`
+- `stochastic-retrieval-policy-envelope.json`
+- `unsafe-multi-memory-composition.json`
+- `uncertain-sensitivity-before-export.json`
 
-## Doctrine candidate
+These fixture definitions and schemas are validated by the repository's `Validate Doctrine Evidence` workflow.
+
+## Acceptance scope
+
+Accepted establishes governed recall as canonical doctrine. It does not claim any particular runtime implementation has passed the behavioral cases end to end.
+
+## Doctrine
 
 Retrieval finds candidates.
 

--- a/docs/adr/ADR-014-schema-registry-and-type-evolution-are-needed.md
+++ b/docs/adr/ADR-014-schema-registry-and-type-evolution-are-needed.md
@@ -2,28 +2,29 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
-The repository contains initial schemas for memory units and conformance reports. As implementations adopt the doctrine, those schemas will evolve.
+The repository contains doctrine-level schemas used by fixtures and future implementations. As implementations adopt the doctrine, those schemas will evolve.
 
 Without explicit schema governance, implementation-specific fields can leak into doctrine-level objects, uncertainty semantics can be lost across adapters, and migrations can become oral tradition, which is how software projects summon ghosts.
 
-## Decision candidate
+## Decision
 
-Agent Memory should define a schema registry and type-evolution strategy.
+Agent Memory defines a schema registry and type-evolution strategy.
 
-The registry should govern doctrine-level types while allowing implementation-specific extension under explicit compatibility rules.
+The registry governs doctrine-level semantic types while allowing implementation-specific extension under explicit compatibility rules.
 
-It should define representations for at least:
+It includes representations for:
 
-- memory unit identity and lifecycle state
+- memory identity and lifecycle state
 - provenance and acquisition mode
 - estimator provenance and uncertainty
 - policy and authority references
 - permitted-action sets
 - decision receipts
+- audit events
 - deletion/tombstone state
 - schema version and migration metadata
 
@@ -42,17 +43,27 @@ It should define representations for at least:
 - requires compatibility and migration rules
 - can slow experimentation if extension mechanisms are too rigid
 
-## Required follow-up before acceptance
+## Acceptance evidence
 
-Create and audit:
+Canonical contract:
 
-```text
-docs/27-schema-registry-and-type-evolution.md
-```
+- [`../27-schema-registry-and-type-evolution.md`](../27-schema-registry-and-type-evolution.md)
 
-Then reconcile the existing schemas and fixtures against the registry.
+Machine-readable evidence:
 
-## Doctrine candidate
+- `schemas/memory-unit.schema.json`
+- `schemas/conformance-report.schema.json`
+- `schemas/decision-receipt.schema.json`
+- `schemas/memory-audit-event.schema.json`
+- `scripts/validate_schemas.py`
+
+The memory schema was expanded additively so legacy fixtures remain valid while governed-uncertainty types become representable.
+
+## Acceptance scope
+
+Accepted establishes semantic schema governance as canonical doctrine. Future breaking migrations still require explicit versioning and evidence.
+
+## Doctrine
 
 Schemas are part of memory governance.
 

--- a/docs/adr/ADR-015-retention-deletion-and-tombstones-are-required.md
+++ b/docs/adr/ADR-015-retention-deletion-and-tombstones-are-required.md
@@ -2,17 +2,17 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
-The architecture distinguishes pruning, archival, suppression, redaction, correction, crystallization, and privacy handling, but still needs one canonical retention/deletion contract tying them together.
+A governed memory system must distinguish pruning, archival, suppression, redaction, correction, tombstoning, cryptographic deletion, and full deletion propagation.
 
 A memory system that can remember but cannot explain deletion is not governed. It is a hoarder with APIs.
 
-## Decision candidate
+## Decision
 
-Agent Memory must define explicit retention, deletion, redaction, archival, and tombstone semantics.
+Agent Memory defines explicit retention, deletion, redaction, archival, and tombstone semantics.
 
 Deletion is not pruning. Predicted low utility is not deletion authority. Removing the raw record is not complete deletion if summaries, embeddings, graphs, caches, or consolidated memories still retain recoverable content.
 
@@ -45,17 +45,24 @@ Deletion is not pruning. Predicted low utility is not deletion authority. Removi
 - requires dependency traversal across derived memory
 - requires policy-specific verification
 
-## Required follow-up before acceptance
+## Acceptance evidence
 
-Create and audit:
+Canonical contract:
 
-```text
-docs/28-retention-deletion-and-tombstones.md
-```
+- [`../28-retention-deletion-and-tombstones.md`](../28-retention-deletion-and-tombstones.md)
 
-Then add deletion-residue and dependency-propagation conformance fixtures.
+Repository fixtures include:
 
-## Doctrine candidate
+- `deletion-residue.json`
+- `irreversible-deletion-under-uncertain-utility.json`
+
+The memory-unit schema now represents retention/tombstone state, and the conformance schema includes deletion-residue metrics.
+
+## Acceptance scope
+
+Accepted establishes the forgetting/deletion mode distinctions as canonical doctrine. It does not claim current runtimes can guarantee full deletion from every derived or external system.
+
+## Doctrine
 
 Forgetting is a governed family of operations.
 

--- a/docs/adr/ADR-016-actor-scope-consent-and-tenancy-are-required.md
+++ b/docs/adr/ADR-016-actor-scope-consent-and-tenancy-are-required.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -17,13 +17,13 @@ Examples:
 - an agent must not inherit authority merely by reading another agent's memory
 - shared memory must not bypass consent, role, or purpose boundaries
 
-## Decision candidate
+## Decision
 
-Agent Memory must define actor scope, consent, delegation, and tenancy as first-class governance concerns.
+Agent Memory defines actor scope, consent, delegation, and tenancy as first-class governance concerns.
 
-Memory units and decision receipts should carry enough metadata to determine who may store, mutate, recall, export, share, correct, or delete them.
+Memory units and decision receipts carry enough metadata to determine who may store, mutate, recall, export, share, correct, or delete them.
 
-Relevance, trust, or inherited access must not create broader authority.
+Relevance, trust, or inherited access does not create broader authority.
 
 ## Required dimensions
 
@@ -54,17 +54,24 @@ Relevance, trust, or inherited access must not create broader authority.
 - complicates shared-memory protocols and inheritance
 - requires consent/revocation propagation
 
-## Required follow-up before acceptance
+## Acceptance evidence
 
-Create and audit:
+Canonical contract:
 
-```text
-docs/29-actor-scope-consent-and-tenancy.md
-```
+- [`../29-actor-scope-consent-and-tenancy.md`](../29-actor-scope-consent-and-tenancy.md)
 
-Then add conformance cases for scope laundering, delegated-authority expiry, and cross-tenant retrieval.
+Machine-readable and fixture evidence includes:
 
-## Doctrine candidate
+- scope fields in `schemas/memory-unit.schema.json`
+- `cross-tenant-relevance-trap.json`
+- `expired-delegation.json`
+- governed recall and sensitivity fixtures
+
+## Acceptance scope
+
+Accepted establishes scope/consent/delegation/tenancy as canonical doctrine. It does not claim every external sharing system can propagate consent or revocation perfectly.
+
+## Doctrine
 
 Memory authority is scoped.
 

--- a/docs/adr/ADR-017-memory-observability-and-audit-events-are-required.md
+++ b/docs/adr/ADR-017-memory-observability-and-audit-events-are-required.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -10,13 +10,13 @@ The doctrine defines lifecycle states, PAMA outcomes, certification gates, confo
 
 Without a common audit-event model, implementations can claim governance while emitting incompatible or incomplete traces. Decorative logging remains logging's favorite hobby.
 
-## Decision candidate
+## Decision
 
-Agent Memory must define a common memory observability and audit-event model.
+Agent Memory defines a common memory observability and audit-event model.
 
-Consequential memory transitions, handoffs, recalls, mutations, certification, disputes, corrections, deletion, policy decisions, and conformance runs should emit structured events appropriate to their risk and privacy constraints.
+Consequential memory transitions, handoffs, recalls, mutations, certification, disputes, corrections, deletion, policy decisions, and conformance runs emit structured events appropriate to their risk and privacy constraints.
 
-Events affecting governed uncertainty should preserve where material:
+Events affecting governed uncertainty preserve where material:
 
 - estimator/model ID and version
 - calibration reference
@@ -52,15 +52,23 @@ At minimum:
 - component_handoff
 - conformance_fixture_run
 
-## Required follow-up before acceptance
+## Acceptance evidence
 
-Create and audit:
+Canonical contract:
 
-```text
-docs/30-memory-observability-and-audit-events.md
-schemas/memory-audit-event.schema.json
-```
+- [`../30-memory-observability-and-audit-events.md`](../30-memory-observability-and-audit-events.md)
 
-## Doctrine candidate
+Machine-readable evidence:
+
+- `schemas/memory-audit-event.schema.json`
+- `schemas/decision-receipt.schema.json`
+
+Repository validation checks both schemas as valid Draft 2020-12 JSON Schemas.
+
+## Acceptance scope
+
+Accepted establishes structured observability and reconstruction semantics as canonical doctrine. It does not require one ledger backend or claim every implementation emits every event today.
+
+## Doctrine
 
 If a consequential memory transition cannot be reconstructed from evidence, policy, authority, and state, its governance is incomplete.

--- a/docs/adr/ADR-018-recovery-rollback-and-replay-are-required.md
+++ b/docs/adr/ADR-018-recovery-rollback-and-replay-are-required.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -12,9 +12,9 @@ A memory may be incorrectly promoted, wrongly corrected, over-pruned, recalled i
 
 If the system cannot recover from these events, governance becomes performative. Performative governance is just theater with YAML.
 
-## Decision candidate
+## Decision
 
-Agent Memory must define recovery, rollback, and replay semantics.
+Agent Memory defines recovery, rollback, and replay semantics.
 
 Implementations should be able to reconstruct consequential decision paths, restore or compensate for unsafe mutations when policy allows, demote incorrectly durable memory, revoke certification, and preserve incident evidence.
 
@@ -57,16 +57,25 @@ what recovery path exists
 - revoke certification
 - preserve incident evidence within privacy constraints
 
-## Required follow-up before acceptance
+## Acceptance evidence
 
-Create and audit:
+Canonical contract:
 
-```text
-docs/31-recovery-rollback-and-replay.md
-```
+- [`../31-recovery-rollback-and-replay.md`](../31-recovery-rollback-and-replay.md)
 
-Then add replay cases for stochastic estimators, policy drift, concurrent mutation, and deletion constraints.
+Repository fixtures include:
 
-## Doctrine candidate
+- `stochastic-replay-reconstruction.json`
+- `policy-estimator-version-drift.json`
+- `concurrent-conflicting-mutation.json`
+- `deletion-residue.json`
+
+Decision-receipt and audit-event schemas preserve the evidence needed for reconstruction.
+
+## Acceptance scope
+
+Accepted establishes recovery/reconstruction as canonical doctrine. It does not claim every runtime already supports automatic rollback or complete dependency repair.
+
+## Doctrine
 
 A governed memory system must recover from its own mistakes without pretending stochastic cognition has to be byte-for-byte replayable.

--- a/docs/adr/ADR-019-memory-quality-metrics-are-required.md
+++ b/docs/adr/ADR-019-memory-quality-metrics-are-required.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -10,9 +10,9 @@ Conformance fixtures test defined cases, but implementations can still degrade o
 
 Ongoing metrics are required to distinguish a memory system that passed yesterday's fixture from one that remains healthy today.
 
-## Decision candidate
+## Decision
 
-Agent Memory must define ongoing memory-quality metrics across retention, forgetting, retrieval, uncertainty, correction, governance, security, privacy, and agent outcomes.
+Agent Memory defines ongoing memory-quality metrics across retention, forgetting, retrieval, uncertainty, correction, governance, security, privacy, recovery, and agent outcomes.
 
 Metrics should be segmented by memory class and consequence class where aggregate numbers would hide risk.
 
@@ -56,17 +56,23 @@ At minimum:
 - metrics can be gamed if detached from adversarial fixtures and evidence
 - some metrics require domain-specific interpretation
 
-## Required follow-up before acceptance
+## Acceptance evidence
 
-Create and audit:
+Canonical contract:
 
-```text
-docs/32-memory-quality-metrics.md
-```
+- [`../32-memory-quality-metrics.md`](../32-memory-quality-metrics.md)
 
-Then map the metrics into conformance-report schema and implementation evidence.
+Machine-readable mapping:
 
-## Doctrine candidate
+- `schemas/conformance-report.schema.json`
+
+The schema now supports Level 6 governed uncertainty and standardized metric fields for calibration, action-set violations, scope admission, deletion residue, replay reconstruction, and correction propagation, with an extension surface for implementation-specific metrics.
+
+## Acceptance scope
+
+Accepted establishes metric families and reporting semantics as canonical doctrine. Product-specific operating thresholds remain implementation and risk-policy decisions.
+
+## Doctrine
 
 Conformance shows a system can satisfy defined invariants under test.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,11 +16,22 @@ ADR status describes **doctrine maturity**, not implementation maturity.
 An `Accepted` ADR does **not** claim:
 
 - every related repository implements it
-- executable conformance exists
 - runtime enforcement is complete
+- all behavioral conformance cases pass in production
 - the decision can never be revised
 
-Implementation maturity is tracked separately through documentation, fixtures, conformance evidence, implementation maps, and runtime evidence.
+Implementation maturity is tracked separately through documentation, fixtures, conformance evidence, implementation maps, quality metrics, and runtime evidence.
+
+## Current doctrine state
+
+```text
+ADR-001 through ADR-019: Accepted
+ADR-020: Proposed
+```
+
+ADRs 001-019 now have their required canonical doctrine contracts and, where specified, repository-level schema/fixture evidence.
+
+ADR-020 remains deliberately different. It requires **runtime end-to-end evidence**, not merely documentation or fixture structure.
 
 ## Current status policy
 
@@ -30,13 +41,28 @@ A decision may move from Proposed to Accepted when:
 2. it is integrated consistently into canonical doctrine
 3. known material contradictions have been resolved or documented
 4. required foundational documentation exists
-5. acceptance does not depend on implementation evidence the ADR itself explicitly requires
+5. any repository-level schema/fixture prerequisites named by the ADR are satisfied
+6. acceptance does not depend on runtime evidence the ADR explicitly says is still missing
 
-If an ADR explicitly requires executable evidence before acceptance, that requirement controls.
+If an ADR explicitly requires stronger evidence before acceptance, that requirement controls.
 
 ## Governed uncertainty
 
-`ADR-020` is intentionally different from many earlier ADRs. It explicitly requires conformance and implementation evidence before acceptance. It remains **Proposed** until those conditions are met.
+[`ADR-020`](ADR-020-probabilistic-discovery-deterministic-governance.md) is intentionally still **Proposed**.
+
+Its acceptance requires at least one real implementation mapped and tested end to end across:
+
+```text
+estimate / proposal
+  -> governance envelope
+  -> permitted action set
+  -> selected action
+  -> committed consequence
+```
+
+It also requires repeated behavioral evidence for stochastic containment, cross-scope recall, concurrency, deletion residue, and related adversarial cases.
+
+The repository now has machine-readable schemas and fixture definitions for those cases, but fixture validity is not runtime proof.
 
 ## Canonical references
 
@@ -46,3 +72,10 @@ If an ADR explicitly requires executable evidence before acceptance, that requir
 - [`../11-component-architecture.md`](../11-component-architecture.md)
 - [`../24-determinism-probability-and-governed-uncertainty.md`](../24-determinism-probability-and-governed-uncertainty.md)
 - [`../25-governed-uncertainty-documentation-conformance-audit.md`](../25-governed-uncertainty-documentation-conformance-audit.md)
+- [`../26-governed-recall-planner.md`](../26-governed-recall-planner.md)
+- [`../27-schema-registry-and-type-evolution.md`](../27-schema-registry-and-type-evolution.md)
+- [`../28-retention-deletion-and-tombstones.md`](../28-retention-deletion-and-tombstones.md)
+- [`../29-actor-scope-consent-and-tenancy.md`](../29-actor-scope-consent-and-tenancy.md)
+- [`../30-memory-observability-and-audit-events.md`](../30-memory-observability-and-audit-events.md)
+- [`../31-recovery-rollback-and-replay.md`](../31-recovery-rollback-and-replay.md)
+- [`../32-memory-quality-metrics.md`](../32-memory-quality-metrics.md)

--- a/docs/audits/governed-uncertainty/07c-adr-evidence-acceptance.md
+++ b/docs/audits/governed-uncertainty/07c-adr-evidence-acceptance.md
@@ -1,0 +1,85 @@
+# ADR Evidence Acceptance: Slice 7C
+
+## Baseline
+
+```text
+baseline_main_commit: edc8df74be85a9d25d4f8592c8e159f20df531ba
+```
+
+At baseline:
+
+```text
+ADR-001 through ADR-012: Accepted
+ADR-013 through ADR-020: Proposed
+```
+
+## Decision
+
+Accept ADR-013 through ADR-019 based on the merged doctrine contracts and repository-level machine-readable evidence introduced in slices 7A and 7B.
+
+Keep ADR-020 **Proposed**.
+
+## Evidence by ADR
+
+| ADR | Acceptance evidence |
+|---|---|
+| 013 Governed recall | doc 26; cross-tenant, stochastic retrieval, unsafe composition, and uncertain-sensitivity fixtures |
+| 014 Schema evolution | doc 27; four validated JSON Schemas; additive memory-unit reconciliation; schema validator |
+| 015 Retention/deletion | doc 28; deletion-residue and uncertain-utility deletion fixtures; retention fields and metrics |
+| 016 Scope/consent/tenancy | doc 29; cross-tenant and expired-delegation fixtures; scope schema fields |
+| 017 Observability | doc 30; audit-event and decision-receipt schemas |
+| 018 Recovery/replay | doc 31; stochastic replay, policy drift, concurrency, and deletion-residue fixtures |
+| 019 Quality metrics | doc 32; Level 6 conformance-report metric mapping |
+
+The schemas and all 24 fixture memory units were validated on PR #40 by the repository's `Validate Doctrine Evidence` workflow before merge.
+
+## Why ADR-020 remains Proposed
+
+ADR-020 intentionally has a stronger acceptance bar.
+
+The repository now possesses:
+
+- doctrine
+- contracts
+- schemas
+- structural fixture validation
+- adversarial test definitions
+
+It does **not** yet possess the required runtime evidence that a real implementation preserves the governed-uncertainty invariant end to end:
+
+```text
+estimate / proposal
+  -> governance envelope
+  -> permitted action set
+  -> selected action
+  -> committed consequence
+```
+
+Still missing for ADR-020 acceptance:
+
+- at least one mapped real implementation
+- repeated behavioral trials for stochastic containment
+- actual cross-scope runtime admission evidence
+- actual concurrency behavior
+- actual deletion-propagation behavior
+- runtime decision receipts demonstrating reconstructability
+
+Therefore accepting ADR-020 now would violate the evidence standard the ADR itself defines.
+
+## Status after this slice
+
+```text
+ADR-001 through ADR-019: Accepted
+ADR-020: Proposed
+```
+
+## Verification
+
+- [x] acceptance evidence is merged into main before status change
+- [x] ADR-013 through ADR-019 link to their canonical contracts/evidence
+- [x] implementation maturity remains separate from doctrine acceptance
+- [x] ADR-020 remains Proposed
+- [x] ADR index updated with current status
+- [ ] branch diff reviewed
+- [ ] repository validation passes on exact PR head
+- [ ] merge by exact validated head SHA


### PR DESCRIPTION
## Scope

Accepts ADR-013 through ADR-019 based on merged contracts, schemas, validated fixture definitions, and the evidence merged in PR #40.

## Status after this PR

- ADR-001 through ADR-019: **Accepted**
- ADR-020: **Proposed**

Accepted continues to mean canonical doctrine, not runtime implementation completion.

## Acceptance evidence

- ADR-013: governed recall doc + cross-tenant/stochastic/composition fixtures
- ADR-014: schema registry doc + four validated JSON Schemas
- ADR-015: retention/deletion doc + deletion-residue and uncertain-utility fixtures
- ADR-016: scope/consent/tenancy doc + cross-tenant and expired-delegation fixtures
- ADR-017: observability doc + audit-event and decision-receipt schemas
- ADR-018: recovery doc + stochastic replay, drift, concurrency, and deletion fixtures
- ADR-019: quality-metrics doc + Level 6 conformance-report metric mapping

## Why ADR-020 stays Proposed

The repository now has doctrine, schemas, validation, and adversarial test definitions, but ADR-020 still requires real end-to-end runtime evidence from estimate -> governance -> permitted action set -> selected action -> committed consequence, including repeated behavioral trials where stochastic behavior is involved.

## Audit record

See `docs/audits/governed-uncertainty/07c-adr-evidence-acceptance.md`.

## Validation

This PR should merge only after the existing `Validate Doctrine Evidence` workflow passes on the exact PR head.