### PR TITLE
Make PAMA native doctrine and remove nonessential product coupling

### DIFF
--- a/.github/ISSUE_TEMPLATE/doctrine-consolidation-task.md
+++ b/.github/ISSUE_TEMPLATE/doctrine-consolidation-task.md
@@ -22,20 +22,22 @@ Select one or more:
 - [ ] Certification / crystallization
 - [ ] Runtime / Neurospace
 - [ ] Code reality graph
+- [ ] Durable decision memory
 - [ ] Conformance
 
-## Related system
+## Related implementation
 
-Select one or more:
+Select one or more only when the implementation adds concrete mapping value:
 
 - [ ] UOR Framework
 - [ ] EvolveAI
 - [ ] CodeGenome
 - [ ] COREFORGE Vault / Neurospace
-- [ ] PAMA
 - [ ] FailSafe / Arbiter
-- [ ] Bicameral
-- [ ] Other
+- [ ] Other implementation
+- [ ] Native doctrine only / no external implementation
+
+> PAMA is native Agent Memory doctrine, not an external implementation choice. Use the affected-layer field for PAMA and name a related implementation only when code or runtime evidence is actually being mapped.
 
 ## Current behavior or concept
 
@@ -53,9 +55,9 @@ What decision is needed?
 
 - [ ] The affected layer is identified.
 - [ ] Relevant docs or ADRs are updated.
-- [ ] Implementation impact is mapped.
+- [ ] Implementation impact is mapped only where evidence exists.
 - [ ] Conformance implications are recorded.
-- [ ] Cross-repo links are added if needed.
+- [ ] Cross-repo links are added only if needed.
 
 ## Notes
 

--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -28,13 +28,19 @@ jobs:
       - name: Validate JSON Schemas, fixtures, and source rights
         run: python scripts/validate_schemas.py
 
+      - name: Validate native doctrine and implementation boundaries
+        run: python scripts/validate_doctrine_boundaries.py
+
       - name: Validate top-level documentation links
         run: >-
           python scripts/validate_markdown_links.py
           README.md
           CONTRIBUTING.md
           docs/README.md
+          docs/pama/README.md
+          docs/04-governance-and-pama.md
           docs/08-source-material-index.md
+          docs/33-pama-decision-table.md
           docs/SOURCE_RIGHTS_POLICY.md
           docs/adr/README.md
 
@@ -54,7 +60,8 @@ jobs:
             echo '```'
             echo "python scripts/validate_fixtures.py fixtures"
             echo "python scripts/validate_schemas.py  # requires: pip install jsonschema"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/08-source-material-index.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md"
+            echo "python scripts/validate_doctrine_boundaries.py"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ From working memory to inherited state. From biological theory to executable con
 ![Fixtures](https://img.shields.io/badge/Fixtures-24%20Validated-0f766e)
 ![Research](https://img.shields.io/badge/Research-Open%20Evidence-b45309)
 
-**[Documentation](docs/README.md)** · **[Architecture decisions](docs/adr/README.md)** · **[Research map](docs/23-research-bibliography.md)** · **[Conformance](docs/06-conformance-test-plan.md)** · **[Contributing](CONTRIBUTING.md)**
+**[Documentation](docs/README.md)** · **[PAMA](docs/pama/README.md)** · **[Architecture decisions](docs/adr/README.md)** · **[Research map](docs/23-research-bibliography.md)** · **[Conformance](docs/06-conformance-test-plan.md)** · **[Contributing](CONTRIBUTING.md)**
 
 </div>
 
@@ -58,6 +58,7 @@ You do not need to read the repository front to back. Human working memory has s
 |---|---|---|
 | **Researching memory theory** | [Memory foundations across scales](docs/20-memory-foundations-across-scales.md) | [Forgetting & consolidation](docs/21-forgetting-consolidation-and-memory-metabolism.md), [Research bibliography](docs/23-research-bibliography.md), [Governed uncertainty](docs/24-determinism-probability-and-governed-uncertainty.md) |
 | **Designing an agent architecture** | [Layer model](docs/01-layer-model.md) | [Component architecture](docs/11-component-architecture.md), [Composition boundaries](docs/13-system-composition-boundaries.md), [Agentic memory theory](docs/22-agentic-memory-theory-and-development.md) |
+| **Designing adaptive authority** | [PAMA foundation](docs/pama/README.md) | [Governance & PAMA](docs/04-governance-and-pama.md), [PAMA decision table](docs/33-pama-decision-table.md), [ADR-004](docs/adr/ADR-004-pama-controls-mutation-authority.md) |
 | **Implementing a memory system** | [Agentic memory theory](docs/22-agentic-memory-theory-and-development.md) | [Lifecycle](docs/02-lifecycle-state-machine.md), [PAMA](docs/04-governance-and-pama.md), [Recall planner](docs/26-governed-recall-planner.md), [Schemas](schemas/) |
 | **Reviewing security or privacy** | [Memory threat model](docs/15-memory-threat-model.md) | [Source trust](docs/16-source-trust-and-reputation.md), [Privacy](docs/19-privacy-and-sensitivity-classifier.md), [Retention & deletion](docs/28-retention-deletion-and-tombstones.md), [Scope & tenancy](docs/29-actor-scope-consent-and-tenancy.md) |
 | **Evaluating conformance** | [Conformance test plan](docs/06-conformance-test-plan.md) | [Calibration](docs/09-calibration-protocol.md), [Audit rubric](docs/25-governed-uncertainty-documentation-conformance-audit.md), [Fixtures](fixtures/) |
@@ -94,13 +95,45 @@ Retrieval does not answer:
 
 ---
 
+## Native doctrine: Proportional Adaptive Mutation Authority
+
+**Proportional Adaptive Mutation Authority (PAMA) is native Agent Memory doctrine authored by Kevin R. Knapp.** It is not an external dependency, related-product import, or source-registry item.
+
+Its systems-agnostic rule is:
+
+> **Adaptation should be broadly available to authorized agents. Authority to make a mutation durable, influential, shared, or action-enabling should increase in proportion to the mutation's consequence.**
+
+PAMA preserves four separations:
+
+```text
+adaptation != authority
+memory != procedure
+procedure != permission
+permission != governance
+```
+
+And it separates four dimensions that are easy to muddle when governance is reduced to a single score:
+
+```text
+M0-M5 target class
+lifecycle strength
+requested operation
+A0-A5 downstream authority
+```
+
+A validated procedure can become a trusted capability without gaining permission to execute externally. A highly reinforced memory can remain barred from governance effects. Low-risk reversible learning can proceed without turning a human into the bottleneck for every observation.
+
+See **[PAMA](docs/pama/README.md)**, **[Governance and PAMA](docs/04-governance-and-pama.md)**, and **[PAMA Decision Table](docs/33-pama-decision-table.md)**.
+
+---
+
 ## The system at a glance
 
 ```mermaid
 flowchart LR
     A[Experience / Query / Event] --> B[Evidence + Provenance]
     B --> C[Estimate / Proposal]
-    C --> D{Governance Envelope}
+    C --> D{PAMA Governance Envelope}
     D -->|Block / Review / Verify| E[No Consequential Commit]
     D -->|Permit| F[Permitted Action Set]
     F --> G[Deterministic or Stochastic Selection]
@@ -278,12 +311,13 @@ Agent Memory is **one reference architecture composed of bounded components**, n
 | **Saturation & decay** | persistence pressure and routing signals | truth, certification |
 | **Conflict resolution** | disagreement and resolution proposals | ungoverned overwrite |
 | **Temporal causality** | chronology, valid time, causal hypotheses | certainty from sequence alone |
-| **Governance / PAMA** | mutation and consequence authority | factual truth |
+| **Governance / PAMA** | M0-M5 target classes, A0-A5 authority ceilings, mutation and consequence authority | factual truth, raw scoring |
 | **Privacy & sensitivity** | handling classification and disclosure constraints | optimistic scope guessing |
 | **Certification** | durable transition confirmation | eternal immutability |
 | **Runtime memory** | operational use and graph traversal | doctrine ownership |
 | **Governed recall** | context admission | relevance-as-permission |
 | **Correction & dispute** | revision without history destruction | silent overwrite |
+| **Durable decision memory** | decisions, rationale, supersession, drift | product ownership by adjacency |
 | **Observability** | decision and transition evidence | sensitive shadow copies |
 | **Recovery** | rollback, compensation, replay | rewriting history to hide errors |
 | **Conformance** | fixtures, schemas, calibration, quality metrics | claims of runtime proof without runtime evidence |
@@ -412,6 +446,8 @@ The repository now contains machine-readable doctrine evidence, not just prose.
 - [`conformance-report.schema.json`](schemas/conformance-report.schema.json)
 - [`decision-receipt.schema.json`](schemas/decision-receipt.schema.json)
 - [`memory-audit-event.schema.json`](schemas/memory-audit-event.schema.json)
+- [`source-record.schema.json`](schemas/source-record.schema.json)
+- [`pama-decision.schema.json`](schemas/pama-decision.schema.json)
 
 ### Fixtures
 
@@ -448,6 +484,7 @@ The [`fixtures/`](fixtures/) directory contains **24 validated fixture definitio
 python -m pip install jsonschema
 python scripts/validate_fixtures.py fixtures
 python scripts/validate_schemas.py
+python scripts/validate_doctrine_boundaries.py
 ```
 
 The **[Validate Doctrine Evidence](.github/workflows/validate-doctrine-evidence.yml)** workflow runs the same checks on pushes and pull requests.
@@ -484,10 +521,11 @@ See **[docs/adr/README.md](docs/adr/README.md)** for status semantics.
 | Area | Current state |
 |---|---|
 | Core doctrine | **Canonical and extensively documented** |
+| Native PAMA doctrine | **Canonical; authored by Kevin R. Knapp** |
 | ADR-001 through ADR-019 | **Accepted** |
 | ADR-020 governed uncertainty | **Proposed** |
 | Documentation conformance audit | **Recorded piece by piece** |
-| JSON Schemas | **4 validated schemas** |
+| JSON Schemas | **6 validated schemas** |
 | Conformance fixture definitions | **24 validated fixtures** |
 | Repository validation workflow | **Active** |
 | Runtime reference implementation | **Not yet the evidence basis of this repo** |
@@ -556,7 +594,7 @@ See **[Research Bibliography](docs/23-research-bibliography.md)** and **[Source 
 
 ## Related implementation systems
 
-The doctrine currently maps several existing systems into bounded roles:
+The doctrine currently maps several systems into bounded implementation roles where they add specific value:
 
 | System | Role |
 |---|---|
@@ -564,11 +602,13 @@ The doctrine currently maps several existing systems into bounded roles:
 | **EvolveAI** | memory metabolism and lifecycle prototype |
 | **CodeGenome** | code-reality graph, evidence, provenance, inferred relations |
 | **COREFORGE Vault / Neurospace** | local-first runtime memory and agent-facing recall |
-| **PAMA** | proportional mutation and promotion authority |
 | **FailSafe / Arbiter** | governance enforcement, evidence, approval boundaries |
-| **Bicameral** | durable decision continuity and drift detection |
 
-The map defines architectural roles. It does not claim every related repository already conforms to every current contract.
+**PAMA is intentionally not in this external implementation table.** It is native Agent Memory doctrine. A runtime may implement PAMA inside any conforming codebase while preserving its authority boundary.
+
+**Durable decision memory is also defined internally**, through the [Durable Decision Memory Profile](docs/profiles/durable-decision-memory-profile.md). A product earns an implementation mapping by demonstrating evidence against that profile, not by being conceptually nearby.
+
+The map defines architectural implementation roles. It does not claim every related repository already conforms to every current contract.
 
 See **[Repo Implementation Map](docs/05-repo-implementation-map.md)**.
 
@@ -582,16 +622,18 @@ agent-memory/
 ├── CONTRIBUTING.md                 # evidence and contribution standard
 ├── docs/
 │   ├── README.md                   # full documentation index
+│   ├── pama/                       # native PAMA foundation
 │   ├── 00-10                      # architecture spine
 │   ├── 11-19                      # composition, security, trust, time, privacy
 │   ├── 20-25                      # interdisciplinary theory and governed uncertainty
-│   ├── 26-32                      # operational and executable contracts
+│   ├── 26-39                      # operational and executable contracts
+│   ├── profiles/                  # doctrine profiles for memory classes
 │   ├── adr/                       # architecture decision records
-│   └── audits/governed-uncertainty/
-│       └── ...                    # baseline and post-remediation audit trail
+│   └── audits/                    # preserved audit history
+├── sources/                        # external/material source-rights registry
 ├── schemas/                        # doctrine-level JSON Schemas
 ├── fixtures/                       # 24 conformance fixture definitions
-├── scripts/                        # fixture and schema validators
+├── scripts/                        # fixture, schema, link, and doctrine-boundary validators
 └── .github/
     ├── ISSUE_TEMPLATE/
     └── workflows/
@@ -624,6 +666,11 @@ These are the shortest route to the doctrine:
 18. **Memory must remain correctable after becoming durable.**
 19. **Forgetting is a governed family of operations.**
 20. **Memory quality is measured by future behavior, not recall alone.**
+21. **Adaptation is not authority.**
+22. **Memory is not procedure.**
+23. **Procedure is not permission.**
+24. **Permission is not governance.**
+25. **Validated capability does not imply autonomous execution authority.**
 
 ---
 
@@ -639,6 +686,7 @@ It is **not**:
 - a production-runtime certification program
 - proof that every mapped implementation already conforms
 - a requirement that uncertain cognition become deterministic
+- an architecture whose validity depends on keeping every adjacent product name in the doctrine
 
 It **is** a place to define, challenge, test, and eventually implement the contracts required for memory that persists without becoming ungoverned state.
 

--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ The repository now contains machine-readable doctrine evidence, not just prose.
 - [`conformance-report.schema.json`](schemas/conformance-report.schema.json)
 - [`decision-receipt.schema.json`](schemas/decision-receipt.schema.json)
 - [`memory-audit-event.schema.json`](schemas/memory-audit-event.schema.json)
+- [`calibration-results.schema.json`](schemas/calibration-results.schema.json)
 - [`source-record.schema.json`](schemas/source-record.schema.json)
 - [`pama-decision.schema.json`](schemas/pama-decision.schema.json)
 
@@ -525,7 +526,7 @@ See **[docs/adr/README.md](docs/adr/README.md)** for status semantics.
 | ADR-001 through ADR-019 | **Accepted** |
 | ADR-020 governed uncertainty | **Proposed** |
 | Documentation conformance audit | **Recorded piece by piece** |
-| JSON Schemas | **6 validated schemas** |
+| JSON Schemas | **7 validated schemas** |
 | Conformance fixture definitions | **24 validated fixtures** |
 | Repository validation workflow | **Active** |
 | Runtime reference implementation | **Not yet the evidence basis of this repo** |

--- a/docs/04-governance-and-pama.md
+++ b/docs/04-governance-and-pama.md
@@ -10,30 +10,91 @@ PAMA also defines the boundary between uncertain inference and governed conseque
 
 **Probabilistic or learned systems may estimate confidence, trust, relevance, contradiction, sensitivity, utility, or risk. PAMA determines what those estimates are allowed to change.**
 
-## PAMA definition
+## Native doctrine and provenance
 
-PAMA means Proportional Adaptive Mutation Authority.
+PAMA means **Proportional Adaptive Mutation Authority**.
 
-It is a governance model for deciding when memory, policy, state, identity relations, or derived representations may be changed by an agent or system.
+PAMA is **native Agent Memory doctrine authored by Kevin R. Knapp**. It is not an external source system or dependency that Agent Memory imports from elsewhere.
 
-## Why PAMA exists
+The systems-agnostic foundation is summarized in [`pama/README.md`](pama/README.md). This document specializes that foundation for memory lifecycle, durable state, correction, deletion, sharing, policy, and action boundaries.
 
-Agentic memory becomes dangerous when the system can:
+External standards, research, and implementation systems may support, challenge, align with, or implement PAMA. They do not define its authorship or become its source of authority.
 
-- rewrite durable memory without review
-- promote repeated claims into truth
-- mutate user preferences without consent
-- overwrite project decisions because a new session felt confident
-- prune evidence needed for later accountability
-- crystallize hallucinations
-- convert probabilistic confidence directly into mutation authority
-- infer missing permission because an action appears useful
+## Foundational PAMA thesis
 
-The point of PAMA is to make adaptive memory useful without letting adaptation become silent self-corruption.
+> **Adaptation should be broadly available to authorized agents. Authority to make a mutation durable, influential, shared, or action-enabling should increase in proportion to the mutation's consequence.**
 
-## Mutation classes
+PAMA preserves four separations:
 
-| Class | Description | Default authority |
+```text
+adaptation != authority
+memory != procedure
+procedure != permission
+permission != governance
+```
+
+An agent may observe, infer, propose, or learn without automatically receiving authority to apply a durable or consequential change.
+
+A remembered fact or preference does not automatically become an executable workflow.
+
+A validated procedure does not automatically authorize the agent to execute it.
+
+Permission to act does not authorize an agent to expand, weaken, or redefine governance itself.
+
+The associated review rule is:
+
+> **Review should be applied at promotion and consequence boundaries, not at every observation boundary.**
+
+This is why PAMA is proportional rather than approval-heavy. Low-risk reversible learning should not turn a human into the throughput bottleneck. High-impact mutation should attract stronger evidence, validation, review, authorization, and monitoring.
+
+## PAMA dimensions
+
+PAMA evaluates several dimensions that must not be collapsed into one score.
+
+### Mutation target classes
+
+Target class describes **what kind of state is being changed**.
+
+| Class | Target type | Examples | Default posture |
+|---|---|---|---|
+| **M0** | Execution-local context | current-session correlation, temporary intent interpretation, local retrieval hint | transient; expire automatically |
+| **M1** | Low-risk personal preference | formatting, terminology, view, pacing | tentative, visible, reversible |
+| **M2** | Operational association | project routing, recurring task association, workflow suggestion | evidence-backed; recommendation influence |
+| **M3** | Reusable procedure or capability | validated checklist, repair sequence, reusable workflow | validation and promotion controls |
+| **M4** | Shared fact or identity-bearing state | relationship, entitlement, commitment, permission-affecting fact | authoritative evidence and controlled review |
+| **M5** | Governance, security, or autonomous-action authority | policy exemption, trust elevation, send/deploy/delete authority | explicit authorization; no self-approval |
+
+### Lifecycle strength
+
+Lifecycle strength describes how established retained state is:
+
+```text
+Observed -> Tentative -> Reinforced -> Promoted -> Canonical
+                   \-> Decaying -> Archived / Deprecated / Blocked
+```
+
+Lifecycle strength does not itself grant downstream authority.
+
+### Downstream authority classes
+
+Downstream authority describes **what the retained mutation is permitted to influence**.
+
+| Class | Authority | Meaning |
+|---|---|---|
+| **A0** | Retrieval only | inspection or context recall |
+| **A1** | Recommendation influence | rankings, suggestions, routing, planning |
+| **A2** | Draft generation | drafts for review, no execution |
+| **A3** | Local workflow mutation | authorized internal state changes |
+| **A4** | External action | messages, deployments, purchases, deletions, bookings, provider state |
+| **A5** | Governance change | privileges, policy, trust, enforcement, future autonomy |
+
+A mutation can be strongly validated and still have a low authority ceiling. Reliability does not create permission.
+
+## Memory mutation operations
+
+Agent Memory additionally classifies **the operation being requested**. These are operational mutation types, not replacements for PAMA's M0-M5 target classes.
+
+| Operation | Description | Default authority |
 |---|---|---|
 | Runtime assembly | Build context from existing memory | allowed with audit |
 | Score adjustment | Update saturation, confidence, or decay pressure | allowed with ledger when low risk |
@@ -45,7 +106,24 @@ The point of PAMA is to make adaptive memory useful without letting adaptation b
 | Pruning | Remove from active recall | require reversible tombstone unless ephemeral |
 | Permanent deletion | Intentionally make recovery unavailable | explicit high-consequence authority and deletion scope required |
 | Scope expansion | Share memory with broader actor or tenant scope | explicit authority appropriate to target scope |
-| Policy mutation | Change governance rules | require human approval |
+| Policy mutation | Change governance rules | require human or equivalently authoritative approval |
+
+A compliant decision therefore considers at least:
+
+```text
+target_class
+lifecycle_strength
+requested_operation
+downstream_authority
+risk
+scope
+reversibility
+evidence
+policy
+actor_authority
+```
+
+The operation/risk decision table in [`33-pama-decision-table.md`](33-pama-decision-table.md) is an Agent Memory specialization of this multidimensional PAMA model, not the whole of PAMA.
 
 ## Authority outcomes
 
@@ -69,14 +147,16 @@ This does not require all upstream inputs to be deterministic.
 
 It requires that:
 
-1. the policy knows which inputs are estimates
-2. their provenance and uncertainty are inspectable
-3. the estimator cannot grant itself authority
-4. prohibited actions remain prohibited regardless of confidence
-5. any stochastic behavior after authorization selects only among already-permitted actions
-6. the resulting authority decision can be reconstructed from its receipt
+1. the policy knows which inputs are estimates;
+2. their provenance and uncertainty are inspectable;
+3. the estimator cannot grant itself authority;
+4. prohibited actions remain prohibited regardless of confidence;
+5. any stochastic behavior after authorization selects only among already-permitted actions; and
+6. the resulting authority decision can be reconstructed from its receipt.
 
 ## Risk classes
+
+Risk remains an operational dimension in Agent Memory and composes with PAMA target and authority classes.
 
 | Risk | Examples | Required handling |
 |---|---|---|
@@ -92,6 +172,9 @@ Governance strength should rise with consequence, not merely with estimator conf
 Relevant dimensions include:
 
 ```text
+target_class
+lifecycle_strength
+downstream_authority
 reversibility
 persistence horizon
 sensitivity
@@ -112,9 +195,13 @@ A high-confidence proposal for permanent deletion may still require explicit rev
 
 ```text
 memory_state
+target_class
+lifecycle_strength
 mutation_type
+requested_downstream_authority
 risk_class
 actor
+agent_charter_version
 source_authority
 evidence_quality
 saturation
@@ -135,6 +222,22 @@ requested_scope_change
 ```
 
 PAMA should distinguish required inputs from optional advisory signals. Missing advisory signals may reduce decision quality. Missing required authority inputs must not be silently guessed for consequential actions.
+
+Unknown consequence must not be converted into presumed safety.
+
+## Proportional handling lanes
+
+PAMA concentrates review where influence and consequence increase.
+
+| Lane | Typical use | Core control |
+|---|---|---|
+| **1. Transient automatic** | M0 context and narrow interpretations | no durable authority or external effect |
+| **2. Tentative low-risk retention** | M1 and selected recommendation-only M2 | visible, removable, scoped |
+| **3. Evidence-backed reinforcement** | meaningful but reversible M2 | evidence, correction, conflict checks |
+| **4. Promotion and review** | M3, shared knowledge, meaningful workflow behavior | validation, versioning, authority ceiling, rollback |
+| **5. Restricted authority** | M4/M5 effects involving external action or governance | explicit authorized review, no self-approval, fail closed when authority is ambiguous |
+
+Human attention is a scarce governance resource. PAMA spends it where a mutation becomes durable, shared, action-enabling, identity-bearing, security-relevant, or governance-changing.
 
 ## Promotion rule
 
@@ -175,6 +278,23 @@ can_crystallize =
 ```
 
 Crystallization should bind to the evidence set, policy version, estimator context, authority record, and scope under which it was approved.
+
+## Capability authority ceiling
+
+Reusable capability is a first-class PAMA concern.
+
+A procedure that is repeatedly successful may become a validated capability artifact. It must still declare the maximum downstream authority it can influence.
+
+Examples:
+
+```text
+may retrieve and recommend only
+may draft but not send
+may update bounded internal workflow state
+may not execute external tools without separate authorization
+```
+
+> **Validation can justify trust in a capability. It does not automatically grant permission to use that capability autonomously.**
 
 ## Bounded stochastic action
 
@@ -237,6 +357,20 @@ Correct:
 model confidence -> evidence signal -> calibrated scoring -> governance -> verification path
 ```
 
+### Procedure as permission
+
+Wrong:
+
+```text
+validated procedure -> autonomous execution
+```
+
+Correct:
+
+```text
+validated procedure -> governed capability -> authority ceiling -> separately authorized execution
+```
+
 ### Summary as authority
 
 Wrong:
@@ -285,26 +419,26 @@ PAMA is proportional and adaptive.
 
 Authority may increase when:
 
-- memory is low risk
-- mutation is reversible
-- evidence is strong
-- policy scope is narrow
-- prior similar mutations succeeded
-- user has delegated authority explicitly
-- estimator calibration is valid for the current scope
+- memory is low risk;
+- mutation is reversible;
+- evidence is strong;
+- policy scope is narrow;
+- prior similar mutations succeeded;
+- user has delegated authority explicitly; and
+- estimator calibration is valid for the current scope.
 
 Authority must decrease or escalate when:
 
-- contradiction pressure rises
-- source authority weakens
-- trap-class behavior appears
-- mutation blast radius grows
-- certification is missing or expired
-- system confidence exceeds evidence quality
-- estimator disagreement is material
-- estimator calibration is stale or out of scope
-- a requested mutation expands sharing or tenancy scope
-- the action destroys rollback, evidence, or future governance options
+- contradiction pressure rises;
+- source authority weakens;
+- trap-class behavior appears;
+- mutation blast radius grows;
+- certification is missing or expired;
+- system confidence exceeds evidence quality;
+- estimator disagreement is material;
+- estimator calibration is stale or out of scope;
+- a requested mutation expands sharing or tenancy scope; or
+- the action destroys rollback, evidence, or future governance options.
 
 ## Uncertainty handling
 
@@ -322,10 +456,10 @@ Not all uncertainty should be handled the same way.
 
 For example:
 
-- low-risk epistemic uncertainty may still permit an ephemeral write
-- policy uncertainty on a high-impact mutation should block or escalate
-- authority uncertainty must never be resolved by estimator confidence
-- scope uncertainty should prevent broad sharing until resolved
+- low-risk epistemic uncertainty may still permit an ephemeral write;
+- policy uncertainty on a high-impact mutation should block or escalate;
+- authority uncertainty must never be resolved by estimator confidence; and
+- scope uncertainty should prevent broad sharing until resolved.
 
 ## Fail-safe behavior
 
@@ -351,7 +485,11 @@ Every mutation decision should record:
 mutation_id
 memory_id
 actor
+agent_charter_version
+target_class
+lifecycle_strength
 requested_mutation
+requested_downstream_authority
 pama_inputs
 estimator_refs
 estimator_versions
@@ -379,50 +517,58 @@ A decision receipt should allow an auditor to answer:
 
 1. What did the uncertain components estimate?
 2. Which estimator and calibration versions produced those estimates?
-3. Which policy version interpreted them?
-4. What actions were prohibited?
-5. What actions were permitted?
-6. Which permitted action was selected and how?
-7. What state changed?
-8. Could the change be rolled back?
+3. Which target class, lifecycle strength, requested operation, and authority ceiling were evaluated?
+4. Which policy version interpreted them?
+5. What actions were prohibited?
+6. What actions were permitted?
+7. Which permitted action was selected and how?
+8. What state changed?
+9. Could the change be rolled back?
 
 Exact replay of a stochastic estimator is not always possible or necessary. Exact reconstruction of **authority and consequence** is required.
 
 ## Runtime enforcement
 
-PAMA should be enforced at the boundary where the system changes memory, not merely where it explains memory.
+PAMA should be enforced at the boundary where the system changes memory or behavior, not merely where it explains memory.
 
 Good enforcement points:
 
-- Vault write boundary
-- crystallization gate
-- graph mutation API
-- agent action planner
-- code governance layer
-- correction workflow
-- pruning workflow
-- deletion workflow
-- scope-sharing boundary
+- Vault write boundary;
+- crystallization gate;
+- graph mutation API;
+- agent action planner;
+- reusable capability invocation boundary;
+- code governance layer;
+- correction workflow;
+- pruning workflow;
+- deletion workflow; and
+- scope-sharing boundary.
 
 ## Required adversarial cases
 
 PAMA conformance should eventually include:
 
-- high-confidence false memory requesting durable promotion
-- threshold jitter near promotion boundary
-- estimator disagreement about sensitivity
-- high semantic relevance from the wrong tenant
-- stochastic planner offered both permitted and prohibited actions
-- permanent deletion proposed from uncertain future utility
-- policy-version drift after a prior authorization
-- missing authority record during replay
-- concurrent conflicting mutation requests
-- unsafe multi-memory composition that was not visible at individual write time
+- high-confidence false memory requesting durable promotion;
+- threshold jitter near promotion boundary;
+- estimator disagreement about sensitivity;
+- high semantic relevance from the wrong tenant;
+- stochastic planner offered both permitted and prohibited actions;
+- permanent deletion proposed from uncertain future utility;
+- policy-version drift after a prior authorization;
+- missing authority record during replay;
+- concurrent conflicting mutation requests;
+- unsafe multi-memory composition that was not visible at individual write time;
+- validated M3 capability attempting to exceed its A1/A2 authority ceiling; and
+- M5 governance mutation disguised as a lower-risk operational update.
 
 ## Doctrine
 
 PAMA is not a memory score.
 
-PAMA is the authority layer that decides whether a proposed memory transition is allowed.
+PAMA is not an external dependency of Agent Memory.
+
+PAMA is the authority architecture that decides whether a proposed adaptive mutation is allowed and how much consequence it may carry.
 
 Probability may inform PAMA. Probability does not become PAMA.
+
+**Learning may be broad. Consequence remains governed.**

--- a/docs/05-repo-implementation-map.md
+++ b/docs/05-repo-implementation-map.md
@@ -2,26 +2,57 @@
 
 ## Purpose
 
-This map assigns each related repository or system to a canonical role in the agentic memory architecture.
+This map assigns related repositories or systems to implementation roles in the Agent Memory architecture while keeping **native doctrine** separate from external or product-specific implementations.
 
-The goal is to prevent repo-specific terminology from fragmenting the doctrine.
+The goal is to prevent repo-specific terminology from fragmenting the doctrine and to prevent implementations from collapsing probabilistic estimation, governance, and committed state mutation into one opaque subsystem.
 
-A second goal is to prevent implementations from collapsing probabilistic estimation, governance, and committed state mutation into one opaque subsystem.
+**Agent Memory owns the doctrine. PAMA is part of that doctrine.** PAMA is not listed as an external repository dependency simply because implementations must consume its authority contract.
 
-## System map
+Named implementation systems appear only when they add a specific architecture or conformance mapping value.
 
-| System | Canonical role | Primary responsibility | Governed-uncertainty posture |
+## Native doctrine components
+
+### PAMA
+
+**Proportional Adaptive Mutation Authority (PAMA)** is native Agent Memory governance doctrine authored by Kevin R. Knapp.
+
+Canonical doctrine:
+
+- [`pama/README.md`](pama/README.md)
+- [`04-governance-and-pama.md`](04-governance-and-pama.md)
+- [`33-pama-decision-table.md`](33-pama-decision-table.md)
+- [`adr/ADR-004-pama-controls-mutation-authority.md`](adr/ADR-004-pama-controls-mutation-authority.md)
+
+PAMA owns the **authority semantics**, not a particular repository or deployment location. A runtime may implement PAMA as a dedicated service, policy module, library, or enforcement boundary, provided the separation remains explicit and auditable.
+
+### PAMA implementation contract
+
+A PAMA implementation must preserve:
+
+- M0-M5 mutation target classes;
+- lifecycle strength as separate from authority;
+- A0-A5 downstream authority ceilings;
+- explicit operation classification;
+- consequence-proportional handling;
+- no self-approved privilege expansion;
+- evidence and charter binding;
+- deterministic or formally bounded authority envelopes for committed inputs;
+- receipts reconstructing permitted, prohibited, selected, and committed consequences.
+
+## Related implementation map
+
+| System | Canonical implementation role | Primary responsibility | Governed-uncertainty posture |
 |---|---|---|---|
 | UOR Framework | Identity substrate | deterministic addressability, exact object resolution, content identity | deterministic substrate; must not infer authority |
 | EvolveAI | Memory metabolism prototype | lifecycle orchestration, decay, tier routing, crystallization prototype | probabilistic/heuristic proposals allowed; lifecycle commit remains governed |
-| CodeGenome | Code reality graph | code artifact graph, overlays, confidence fusion, provenance, impact traversal | inferred relations must preserve confidence, estimator provenance, and disagreement |
+| CodeGenome | Code reality graph | code artifact graph, overlays, confidence fusion, provenance, impact traversal | inferred relations preserve confidence, estimator provenance, and disagreement |
 | COREFORGE Vault | Runtime memory container | encrypted local memory, graph recall, context windows, governed storage | probabilistic retrieval may generate candidates; scope and mutation boundaries remain enforced |
 | Neurospace | Operational memory space | agent-facing memory traversal and use within COREFORGE | learned ranking may operate only inside recall-time policy |
-| PAMA | Mutation authority model | governed promotion, mutation, pruning, adaptation, canonicalization | maps uncertain inputs into deterministic or formally bounded authority outcomes |
-| FailSafe | Governance enforcement | evidence capture, approval gates, policy checks, release/session audit | binds policy version, estimator context, permitted action set, and consequence receipt |
-| Arbiter | Product policy guardian | authorization, rate limits, audit logging, action boundaries | enforces prohibited and permitted actions independently of model confidence |
-| Bicameral | Decision continuity layer | durable decision state, drift detection, team/agent alignment | drift/disagreement may be estimated probabilistically; durable decision changes remain governed |
-| Shadow Genome | Negative memory substrate | failure patterns, blocked behaviors, prior harm avoidance | failure inference may be probabilistic; guardrail promotion must preserve evidence and authority |
+| FailSafe | Governance enforcement implementation candidate | evidence capture, approval gates, policy checks, release/session audit | can enforce policy version, estimator context, action set, and consequence receipt |
+| Arbiter | Product policy enforcement candidate | authorization, rate limits, audit logging, action boundaries | can enforce prohibited and permitted actions independently of model confidence |
+| Shadow Genome | Negative memory substrate | failure patterns, blocked behaviors, prior harm avoidance | failure inference may be probabilistic; guardrail promotion preserves evidence and authority |
+
+This table is an implementation map, not a source-of-doctrine table. Absence from the table does not mean a project is unimportant; it means it has not earned a distinct implementation role in this architecture map.
 
 ## UOR Framework
 
@@ -114,30 +145,26 @@ Exact syntax or content-addressed facts may be deterministic while semantic over
 
 High semantic relevance must not override privacy, tenancy, scope, dispute state, or policy. Candidate generation may be probabilistic; admission into active context remains governed.
 
-## PAMA
+## PAMA enforcement boundary
 
-### Canonical owner of
+PAMA is not another external system in this map. It is the native authority contract every mutating implementation must satisfy.
 
-- mutation authority
-- promotion authority
-- adaptive constraints
-- authority scaling by risk and reversibility
+A compliant runtime should expose where:
 
-### Should import from this doctrine
+1. a mutation target is classified M0-M5;
+2. lifecycle strength is read or proposed;
+3. the requested operation is classified;
+4. requested downstream authority A0-A5 is declared;
+5. evidence, actor charter, scope, and reversibility are bound;
+6. policy produces the permitted/prohibited/review-required envelope;
+7. optional deterministic or stochastic selection occurs only inside the permitted set; and
+8. the committed consequence is receipted.
 
-- saturation proposes transitions but does not authorize them
-- certification gates durable memory
-- all mutation authority must be scoped and auditable
-- a fixed policy snapshot and committed input record must yield a reconstructable deterministic or formally bounded authority envelope
-- estimator confidence does not resolve missing policy, authority, or scope
-
-### Governed-uncertainty contract
-
-PAMA consumes uncertainty. It does not become uncertainty. Its purpose is to convert estimates into a finite set of permitted, blocked, deferred, or review-required consequences.
+A runtime may host the PAMA implementation. It may not absorb the semantic boundary so thoroughly that authority becomes indistinguishable from its estimator or storage layer.
 
 ## FailSafe / Arbiter
 
-### Canonical owner of
+### Candidate implementation value
 
 - policy enforcement
 - evidence capture
@@ -153,21 +180,7 @@ PAMA consumes uncertainty. It does not become uncertainty. Its purpose is to con
 - receipts should bind estimator versions, policy version, permitted action set, selected action, and before/after state when relevant
 - high-consequence actions should fail closed or escalate when required governance state cannot be reconstructed
 
-## Bicameral
-
-### Canonical owner of
-
-- decision continuity
-- drift detection
-- durable decision alignment
-- team and agent consensus surfaces
-
-### Should import from this doctrine
-
-- decisions are high-risk memory objects
-- decision changes must preserve old state and rationale
-- drift should trigger dispute or correction, not silent overwrite
-- probabilistic drift detection or disagreement scoring may propose review but must not silently rewrite durable decisions
+FailSafe or Arbiter may be useful implementation mappings for parts of PAMA. They are not the origin or owner of PAMA doctrine.
 
 ## Shadow Genome
 
@@ -182,6 +195,14 @@ PAMA consumes uncertainty. It does not become uncertainty. Its purpose is to con
 - failure inference must preserve causal evidence and applicability scope
 - a high-confidence negative pattern must not become a global prohibition without governed promotion
 - guardrails derived from failure memory should retain provenance to the failures that justified them
+
+## Durable decision memory
+
+Decision continuity, drift, rationale preservation, supersession, and durable decision recall are defined as **Agent Memory capabilities** rather than attributed to an adjacent product.
+
+See [`profiles/durable-decision-memory-profile.md`](profiles/durable-decision-memory-profile.md).
+
+A product or implementation should be named here only if it provides specific implementation evidence against that profile.
 
 ## Cross-repo control contract
 
@@ -204,26 +225,29 @@ COMMITTED_CONSEQUENCE
 state mutation, ledger record, scope change, certification, deletion, or other durable effect
 ```
 
-A repo may own more than one class, but it must expose the boundary between them.
+A repo may own more than one implementation class, but it must expose the boundary between them.
 
 ## Required implementation evidence
 
 A repo claiming governed-uncertainty alignment should be able to point to:
 
-1. where probabilistic or learned estimates are produced
-2. how those estimates identify their method/version and calibration scope
-3. where policy converts estimates into authority outcomes
-4. where prohibited actions are enforced
-5. where the permitted action set is represented, if more than one action can follow
-6. where committed state changes are ledgered
-7. how estimator drift differs from policy change
-8. how the implementation behaves when required authority inputs are missing
+1. where probabilistic or learned estimates are produced;
+2. how those estimates identify their method/version and calibration scope;
+3. where PAMA policy converts estimates into authority outcomes;
+4. where prohibited actions are enforced;
+5. where the permitted action set is represented, if more than one action can follow;
+6. where committed state changes are ledgered;
+7. how estimator drift differs from policy change;
+8. how the implementation behaves when required authority inputs are missing; and
+9. how M0-M5 target class and A0-A5 authority ceilings are represented or equivalently enforced.
 
 ## Source of truth policy
 
-This repo owns the doctrine.
+This repo owns the doctrine, including PAMA.
 
 Other repos may own implementations, experiments, and product behavior, but should reference this doctrine for shared terms and boundaries.
+
+No external repository is required to make PAMA legitimate or canonical.
 
 ## Implementation labels
 

--- a/docs/07-integration-roadmap.md
+++ b/docs/07-integration-roadmap.md
@@ -2,9 +2,11 @@
 
 ## Purpose
 
-This roadmap turns the doctrine into implementation work across the related repos.
+This roadmap turns the doctrine into implementation work across related repos and native Agent Memory contracts.
 
 The priority is consolidation before expansion. The system already has enough ideas. What it needs now is shared vocabulary, conformance boundaries, implementation hooks, and evidence that uncertain inference cannot silently become memory authority.
+
+PAMA is native Agent Memory doctrine. Related repositories implement or consume doctrine; they do not define PAMA's provenance.
 
 ## Phase 1: Canonical doctrine stabilization
 
@@ -18,17 +20,18 @@ Make this repository the shared reference point.
 - finalize layer model
 - finalize lifecycle state machine
 - finalize scoring and decay doctrine
-- finalize PAMA governance boundaries
+- finalize native PAMA governance boundaries
 - finalize governed-uncertainty doctrine and disposition ADR-020 only after evidence supports acceptance
 - finalize ADR set
-- add source backlinks to related repos
+- add source backlinks to related implementation repos where they add concrete value
 
 ### Exit criteria
 
 ```text
 README points to canonical docs
 ADRs accepted, revised, or explicitly proposed
-each related repo has an implementation-map entry
+native doctrine has canonical internal entry points
+each materially relevant implementation repo has an implementation-map entry
 open questions are tracked as issues
 governed-uncertainty audit has no unresolved critical contradiction
 ```
@@ -37,16 +40,17 @@ governed-uncertainty audit has no unresolved critical contradiction
 
 ### Goal
 
-Every implementation repo references the doctrine.
+Every materially relevant implementation repo references the doctrine.
 
 ### Target repos
 
 - UOR Framework
 - EvolveAI
 - CodeGenome
-- COREFORGE
-- FailSafe or governance repos as applicable
-- Bicameral decision-memory surfaces as applicable
+- COREFORGE / successor runtime as applicable
+- FailSafe or governance implementations as applicable
+
+A repository is not a backlink target merely because it is adjacent to Agent Memory concepts. It should map a concrete implementation responsibility or conformance surface.
 
 ### Recommended backlink text
 
@@ -69,7 +73,7 @@ Create repo-specific issues that map existing implementation behavior to doctrin
 5. Map COREFORGE Vault writes to PAMA enforcement points.
 6. Map Neurospace runtime memory to operational versus canonical memory states and recall-time scope enforcement.
 7. Map FailSafe / Arbiter approval gates to crystallization and mutation transitions, including policy-version and permitted-action receipts.
-8. Map Bicameral drift detection to probabilistic proposal versus governed durable decision change.
+8. Map a real durable-decision implementation to [`profiles/durable-decision-memory-profile.md`](profiles/durable-decision-memory-profile.md) only when implementation evidence is available.
 
 ## Phase 4: Governed-uncertainty boundary inventory
 
@@ -157,12 +161,17 @@ Make doctrine enforceable in product and agent runtimes.
 - deletion workflow
 - scope-sharing / tenancy boundary
 - agent action planner
+- reusable capability authority boundary
 
 ### Required behavior
 
 At each enforcement point, identify:
 
 ```text
+PAMA target class M0-M5
+lifecycle strength
+requested operation
+requested downstream authority A0-A5
 what may be probabilistic
 what must remain invariant
 what policy version applies
@@ -218,7 +227,10 @@ Make consequential memory decisions reconstructable without requiring exact repl
 ```text
 actor
 memory_id
+PAMA target class
+lifecycle strength
 requested_action
+requested_downstream_authority
 estimator_refs
 estimator_versions
 uncertainty_summary
@@ -252,6 +264,7 @@ Continuously test doctrine assumptions against accessible research and empirical
 - classify biological/cognitive transfers as mechanism, functional analogy, engineering prescription, or open hypothesis
 - create conformance fixtures when research exposes a falsifiable failure mode
 - do not promote a research-inspired idea to doctrine solely because the analogy is appealing
+- keep external evidence separate from native doctrine authorship
 
 ## Phase 10: Doctrine versioning
 
@@ -277,10 +290,11 @@ Create issues for:
 1. Add schemas for memory units and conformance reports.
 2. Add fixture examples for all required conformance cases.
 3. Expand the calibration harness to measure uncertainty, drift, and decision-boundary stability.
-4. Add cross-repo backlink and governed-uncertainty mapping issues for EvolveAI, CodeGenome, COREFORGE, FailSafe / Arbiter, and Bicameral.
-5. Add PAMA decision-table tests for finite authority outcomes and bounded stochastic action.
+4. Add cross-repo backlink and governed-uncertainty mapping issues only for implementation systems with concrete evidence value.
+5. Add PAMA decision-table tests for M0-M5 target classes, A0-A5 authority ceilings, finite authority outcomes, and bounded stochastic action.
 6. Add a decision-receipt schema that separates estimator outputs from governance outcomes.
 7. Build the cross-repo boundary inventory before accepting ADR-020.
+8. Validate at least one real implementation against the durable-decision memory profile rather than assigning doctrine provenance to an adjacent product.
 
 ## Acceptance dependency for ADR-020
 
@@ -300,5 +314,7 @@ policy and estimator version drift remain distinguishable
 ## Roadmap principle
 
 Do not add another concept until the existing concepts have a stable place to live.
+
+Do not add another implementation name until it earns a distinct role through evidence.
 
 Do not call governed uncertainty complete until it survives implementation and adversarial testing. Documentation agreeing with itself is useful. It is also an exceptionally low bar for reality.

--- a/docs/08-source-material-index.md
+++ b/docs/08-source-material-index.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-This index records the conceptual systems that fed the doctrine and points to the external research evidence used to challenge, extend, or validate those concepts.
+This index records external and related conceptual systems that informed, challenged, implemented, or provided provenance context for Agent Memory doctrine, and points to external research evidence used to challenge, extend, or validate those concepts.
 
-It is not a complete bibliography. Internal architecture provenance and external scientific evidence are deliberately separated so a repo-specific idea does not quietly acquire the authority of neuroscience merely because both happen to use the word "memory."
+It is not a complete bibliography. Native Agent Memory doctrine, implementation provenance, and external scientific evidence are deliberately separated so a repo-specific idea does not quietly acquire the authority of neuroscience merely because both happen to use the word "memory."
 
 For the interdisciplinary literature map, see [`23-research-bibliography.md`](23-research-bibliography.md).
 
@@ -12,22 +12,43 @@ For copyright, license, attribution, and reuse handling, see [`SOURCE_RIGHTS_POL
 
 Research in this repository is not decorative citation inventory. Its job is to improve, constrain, or falsify architectural claims.
 
+## Native Agent Memory doctrine
+
+Some foundational concepts are authored as part of Agent Memory itself and therefore are **not external source records**.
+
+### Proportional Adaptive Mutation Authority (PAMA)
+
+PAMA is native Agent Memory governance doctrine authored by **Kevin R. Knapp**. It does not require an external provenance link or a source-rights registry entry merely because it has an identifiable conceptual origin.
+
+The systems-agnostic PAMA foundation is maintained in [`pama/README.md`](pama/README.md). Agent Memory specializes that foundation through:
+
+- [`04-governance-and-pama.md`](04-governance-and-pama.md)
+- [`33-pama-decision-table.md`](33-pama-decision-table.md)
+- [`34-adapter-contracts.md`](34-adapter-contracts.md)
+- [`36-policy-as-memory.md`](36-policy-as-memory.md)
+- [`38-human-correction-ux-contract.md`](38-human-correction-ux-contract.md)
+- [`adr/ADR-004-pama-controls-mutation-authority.md`](adr/ADR-004-pama-controls-mutation-authority.md)
+- [`adr/ADR-020-probabilistic-discovery-deterministic-governance.md`](adr/ADR-020-probabilistic-discovery-deterministic-governance.md)
+
+External standards, research, and implementations may support, challenge, benchmark, align with, or implement PAMA. They do not become the source of PAMA by doing so.
+
 ## Public-source and reuse rule
 
-> **When a source has a lawful, stable public locator, link the most specific authoritative artifact available. Public accessibility does not imply reuse permission.**
+> **When an external or related source has a lawful, stable public locator, link the most specific authoritative artifact available. Public accessibility does not imply reuse permission.**
 
 The repository distinguishes:
 
-- **provenance**: where an idea, implementation, proposal, or evidence claim came from
+- **native doctrine**: contributor-authored doctrine owned and maintained by Agent Memory
+- **provenance**: where an external idea, implementation, proposal, or evidence claim came from
 - **accessibility**: whether contributors can inspect that source directly
 - **rights status**: what license, permission, authorship, or uncertainty governs reuse of its expression
 - **reuse mode**: citation, independent synthesis, author-originated reuse, licensed reuse, or permission-based reuse
 
 A related public artifact must not be substituted for a private canonical source merely to make the index look complete.
 
-Unknown rights status defaults to **citation and independent synthesis only**.
+Unknown external rights status defaults to **citation and independent synthesis only**.
 
-## Primary source systems
+## External and related provenance systems
 
 | Source | Public source / evidence | Access and reuse posture | Relevant doctrine area |
 |---|---|---|---|
@@ -36,9 +57,9 @@ Unknown rights status defaults to **citation and independent synthesis only**.
 | EvolveAI | [Autopoietic Memory Theory](https://github.com/MythologIQ-Labs-LLC/EvolveAI/blob/main/docs/AUTOPOIETIC_MEMORY_THEORY.md) · [repository](https://github.com/MythologIQ-Labs-LLC/EvolveAI) | Public; Apache-2.0 repository. Independent synthesis preferred; direct reuse must satisfy applicable attribution/NOTICE obligations. | autopoietic memory, L1/L2/L3 tiers, CMHL, REM synthesis, Shadow Genome |
 | CodeGenome | [CodeGenome](https://github.com/MythologIQ-Labs-LLC/CodeGenome) | Public; MIT repository. Independent synthesis preferred; copies/substantial portions retain required notice. | content-addressed code reality graph, overlays, confidence fusion, provenance |
 | COREFORGE | Canonical historical source is private. [GG-CORE](https://github.com/MythologIQ-Labs-LLC/GG-CORE) is a public successor/continuation, not the originating source. | Private historical provenance; do not expose private content or mislabel the successor as original provenance. GG-CORE is Apache-2.0. | local-first product runtime, Vault, Neurospace, governed agent modules |
-| PAMA logic | No standalone canonical public locator verified | Rights/provenance unresolved at standalone-source level; Agent Memory expresses the governance doctrine independently. | mutation authority, adaptive guardrails, promotion and pruning policy |
 | FailSafe / Arbiter | [VerdictArbiter implementation](https://github.com/MythologIQ-Labs-LLC/FailSafe/blob/main/FailSafe/extension/src/sentinel/VerdictArbiter.ts) · [repository](https://github.com/MythologIQ-Labs-LLC/FailSafe) | Public; Apache-2.0 repository. Link implementation directly; copied/adapted material must satisfy applicable license obligations. | evidence capture, policy gates, approval boundaries, audit trails |
-| Bicameral | Canonical decision-continuity source is private; no public artifact is currently treated as a substitute | Private primary provenance; expose only independently stated high-level concepts unless a genuinely relevant public artifact becomes available. | decision continuity, drift detection, durable decisions |
+
+External or private projects should appear here only when they add specific provenance, implementation, challenge, or evidence value. Mere conceptual adjacency is not enough.
 
 ### UOR provenance note
 
@@ -213,24 +234,28 @@ Doctrine placement:
 - [`04-governance-and-pama.md`](04-governance-and-pama.md)
 - [`adr/ADR-006-neurospace-is-runtime-memory-space.md`](adr/ADR-006-neurospace-is-runtime-memory-space.md)
 
-## PAMA
+## Native doctrine: PAMA
 
-No standalone canonical public locator has been verified. Agent Memory therefore records the conceptual provenance without inventing a public source and expresses the doctrine independently.
+PAMA is maintained directly by Agent Memory rather than represented as an external provenance source.
 
-Relevant ideas:
+Canonical entry point:
+
+- [`pama/README.md`](pama/README.md)
+
+Relevant doctrine:
 
 - proportional adaptive mutation authority
-- promotion authority
-- adaptive mutation constraints
-- governance by risk, scope, reversibility, and evidence
-- conversion of uncertain estimator outputs into explicit authority outcomes
+- M0-M5 mutation target classes
+- lifecycle strength
+- A0-A5 downstream authority classes
+- adaptive charters
+- proportional handling lanes
+- reusable capability authority ceilings
+- evidence, lineage, correction, revocation, and consequence-proportional governance
 
-Doctrine placement:
+Agent Memory's memory-specific specialization is in [`04-governance-and-pama.md`](04-governance-and-pama.md) and [`33-pama-decision-table.md`](33-pama-decision-table.md).
 
-- [`04-governance-and-pama.md`](04-governance-and-pama.md)
-- [`24-determinism-probability-and-governed-uncertainty.md`](24-determinism-probability-and-governed-uncertainty.md)
-- [`adr/ADR-004-pama-controls-mutation-authority.md`](adr/ADR-004-pama-controls-mutation-authority.md)
-- [`adr/ADR-020-probabilistic-discovery-deterministic-governance.md`](adr/ADR-020-probabilistic-discovery-deterministic-governance.md)
+No external source-rights entry is required for PAMA itself. Any external research, standard, or implementation reused to support or challenge PAMA remains separately governed by this source policy.
 
 ## FailSafe / Arbiter
 
@@ -248,17 +273,6 @@ Relevant ideas:
 - audit trails
 
 Agent Memory independently expresses the governance doctrine. Directly copied or adapted Apache-2.0 material would require the applicable attribution, license, NOTICE, and modification obligations to be recorded and satisfied.
-
-## Bicameral
-
-The canonical decision-continuity implementation source is currently private. Existing public Bicameral repositories are not treated as provenance substitutes unless a specific public artifact directly supports the cited doctrine.
-
-Relevant ideas:
-
-- decision continuity
-- drift detection
-- durable decisions
-- supersession and rationale preservation
 
 ## Evidence-transfer rule
 
@@ -302,7 +316,7 @@ It does **not** prove that a particular neural network, confidence threshold, or
 
 ## Source-record fields
 
-When a research claim materially affects doctrine, the research map should be able to record:
+When an external research claim materially affects doctrine, the research map should be able to record:
 
 ```text
 source_ref
@@ -318,7 +332,7 @@ related_fixture_or_test
 reviewed_at
 ```
 
-When source material is materially reused rather than merely cited or independently synthesized, the rights record should additionally retain:
+When external source material is materially reused rather than merely cited or independently synthesized, the rights record should additionally retain:
 
 ```text
 public_url
@@ -334,9 +348,9 @@ reuse_basis
 verified_at
 ```
 
-The repository need not turn into citation-management software. It does need enough evidence to distinguish research provenance from permission to copy.
+The repository need not turn into citation-management software. It does need enough evidence to distinguish external research provenance from permission to copy.
 
-Primary rights records live in [`../sources/source-registry.json`](../sources/source-registry.json) and are validated against [`../schemas/source-record.schema.json`](../schemas/source-record.schema.json).
+External and materially reused source-rights records live in [`../sources/source-registry.json`](../sources/source-registry.json) and are validated against [`../schemas/source-record.schema.json`](../schemas/source-record.schema.json).
 
 External research listed in [`23-research-bibliography.md`](23-research-bibliography.md) defaults to citation and independent synthesis unless material reuse is explicitly registered.
 
@@ -381,7 +395,17 @@ This prevents the bibliography from becoming a one-way machine for proving whate
 
 ## Maintenance rule
 
-When a new memory-system idea appears, place it in one or more of these categories before adding implementation work:
+When a new memory-system idea appears, first determine whether it is:
+
+```text
+native Agent Memory doctrine
+external evidence
+external implementation provenance
+cross-domain analogy
+conformance evidence
+```
+
+Then place the idea in one or more architecture categories before adding implementation work:
 
 ```text
 identity
@@ -403,7 +427,7 @@ inheritance
 conformance
 ```
 
-Then apply the source-rights gate:
+For external material, apply the source-rights gate:
 
 1. link the most specific lawful public source when one exists
 2. identify whether the source is public, private, a successor, or lacks a public locator
@@ -412,5 +436,7 @@ Then apply the source-rights gate:
 5. register any material quotation, adaptation, or copy before merge
 6. preserve applicable attribution, notice, and modification obligations
 7. never substitute an adjacent public artifact for private canonical provenance
+
+Native contributor-authored doctrine does not need to be manufactured into an external source merely to satisfy this index. Its authorship and canonical location should be recorded in the doctrine tree itself.
 
 If the idea does not fit the architecture taxonomy, determine whether the taxonomy is genuinely incomplete before creating a new component. Architectural sprawl remains undefeated at naming things humans find interesting.

--- a/docs/11-component-architecture.md
+++ b/docs/11-component-architecture.md
@@ -14,6 +14,8 @@ Agent Memory is one overall architecture made of multiple governed components.
 
 It is not one monolithic product, library, database, score, graph, vault, protocol, or model.
 
+PAMA is a native governance component of this architecture, not an external product dependency.
+
 ## System shape
 
 ```text
@@ -23,11 +25,12 @@ Agent Memory System
 ├── Reality Graphs
 ├── Lifecycle Engine
 ├── Saturation and Decay Engine
-├── Governance and Mutation Authority
+├── Governance and Mutation Authority (PAMA)
 ├── Certification and Crystallization Gate
 ├── Runtime Memory Space
 ├── Context Assembly Surface
 ├── Correction and Dispute Surface
+├── Durable Decision Memory
 ├── Conformance and Calibration Harness
 └── Product and Agent Integrations
 ```
@@ -41,13 +44,14 @@ Agent Memory System
 | Reality Graphs | Domain-specific structured reality | code graph, decision graph, task graph, relation graph | runtime memory authority | deterministic identity + probabilistic relations |
 | Lifecycle Engine | Memory state transitions | transient, observed, linked, candidate, disputed, pruned, crystallized | identity semantics | governed state machine |
 | Saturation and Decay Engine | Persistence pressure | calibrated sigma, decay, pressure, routing candidacy | correctness, certification | probabilistic / heuristic / learned estimates |
-| Governance and Mutation Authority | Permission to change memory | PAMA outcomes, risk, reversibility, authority | raw scoring | deterministic or formally bounded governance envelope |
+| Governance and Mutation Authority | Permission to change memory or downstream authority | native PAMA outcomes, M0-M5 target classes, A0-A5 authority ceilings, risk, reversibility | raw scoring, factual truth | deterministic or formally bounded governance envelope |
 | Certification and Crystallization Gate | Durable transition approval | verification, approval, certificate, scope | ongoing truth forever | governed consequence |
 | Runtime Memory Space | Operational use | Vault, Neurospace, context recall, graph traversal | canonical doctrine ownership | hybrid retrieval + enforced scope |
 | Context Assembly Surface | What the agent sees now | prompt context, retrieved memories, active constraints | memory mutation without authority | probabilistic ranking inside governed admission |
 | Correction and Dispute Surface | How memory changes safely | user correction, contradiction, reconciliation | silent overwrite | mixed inference + governed commit |
+| Durable Decision Memory | Decision continuity and rationale | durable decisions, supersession, drift evidence, rationale preservation | product-specific ownership | governed memory profile |
 | Conformance and Calibration Harness | System validation | fixtures, reports, trap classes, threshold calibration | product UX | measurement and falsification |
-| Product and Agent Integrations | Adoption surfaces | COREFORGE, EvolveAI, CodeGenome, FailSafe, Bicameral | redefining canonical terms locally | implementation-specific within doctrine |
+| Product and Agent Integrations | Adoption surfaces | implementations with explicit mapping evidence | redefining canonical terms locally | implementation-specific within doctrine |
 
 ## Component interaction pipeline
 
@@ -58,7 +62,7 @@ Artifact or experience
   -> Reality Graph or Memory Unit
   -> probabilistic / heuristic interpretation
   -> Lifecycle and Saturation proposal
-  -> Governance and Mutation Authority
+  -> Governance and Mutation Authority (PAMA)
   -> permitted action set
   -> Certification and Crystallization Gate when required
   -> committed state transition
@@ -99,7 +103,7 @@ PROPOSAL
 what an estimator, model, rule, or planner suggests
 
 AUTHORITY ENVELOPE
-what policy permits, blocks, defers, or requires review for
+what PAMA policy permits, blocks, defers, or requires review for
 
 SELECTION
 which permitted action is chosen, deterministically or stochastically
@@ -120,9 +124,10 @@ Examples:
 - evidence failure means the object lacks support
 - estimator failure means a confidence, relevance, sensitivity, or persistence estimate is miscalibrated or out of scope
 - saturation failure means the system remembers or forgets poorly
-- governance failure means the system changes memory without authority
+- governance failure means the system changes memory or authority without permission
 - certification failure means an unverified memory becomes durable
 - runtime failure means the agent uses memory incorrectly
+- durable-decision failure means rationale, supersession, or current decision state is lost or silently rewritten
 - composition failure means individually valid components combine into unsafe behavior
 - conformance failure means the implementation cannot prove its behavior
 
@@ -153,10 +158,12 @@ Examples:
 - UOR participates by providing stable identity
 - CodeGenome participates by providing domain evidence and graph relations
 - EvolveAI participates by modeling lifecycle and decay
-- PAMA participates by controlling mutation authority
-- COREFORGE Vault and Neurospace participate by operationalizing memory
-- FailSafe and Arbiter participate by enforcing policy and audit
-- Bicameral participates by preserving decision continuity
+- PAMA participates as native doctrine controlling mutation and downstream authority
+- COREFORGE Vault and Neurospace may participate by operationalizing memory
+- FailSafe and Arbiter may participate as enforcement implementations
+- durable decision memory participates through the repository's own decision-memory profile
+
+An adjacent product name is not itself an architectural role. Implementations should be named only when the mapping adds concrete evidence or responsibility.
 
 ## Boundary rules
 
@@ -172,6 +179,8 @@ Examples:
 10. Stochastic selection may occur only inside a policy-permitted action set.
 11. Commit boundaries must bind to the state and policy snapshot under which authority was granted.
 12. Composition-specific failure modes require composition-specific tests.
+13. PAMA target class, lifecycle strength, requested operation, and downstream authority remain separate dimensions.
+14. External implementation names require an evidence-backed mapping role, not mere conceptual proximity.
 
 ## Cross-component handoff contract
 
@@ -183,6 +192,10 @@ source_component
 target_component
 handoff_reason
 state_snapshot
+pama_target_class
+lifecycle_strength
+requested_operation
+requested_downstream_authority
 estimate_type
 estimate_value
 estimator_ref
@@ -216,8 +229,8 @@ Not all fields apply to every handoff. Omitted authority-critical fields must no
 
 ## Architecture decision
 
-This repo owns the overall architecture.
+This repo owns the overall architecture and native doctrine, including PAMA.
 
-Individual repos own implementation slices.
+Individual repos may own implementation slices after they demonstrate a meaningful mapping.
 
-The shared architecture should stabilize concepts, boundaries, handoff semantics, and conformance expectations. It should not force every implementation into one repository or one runtime.
+The shared architecture should stabilize concepts, boundaries, handoff semantics, and conformance expectations. It should not force every implementation into one repository or one runtime, and it should not grant doctrine ownership to whichever product happens to implement a feature first.

--- a/docs/12-concept-segmentation-matrix.md
+++ b/docs/12-concept-segmentation-matrix.md
@@ -14,6 +14,8 @@ This prevents concept drift by forcing every idea to answer where it belongs bef
 
 The matrix also prevents probabilistic estimation, authority, and committed state change from being collapsed into one concept simply because one implementation happens to place them in the same service.
 
+PAMA is native Agent Memory doctrine. Product or repository implementations may implement PAMA boundaries; they do not become the provenance owner of PAMA by doing so.
+
 ## Placement rules
 
 | Placement | Use when | Example |
@@ -21,7 +23,7 @@ The matrix also prevents probabilistic estimation, authority, and committed stat
 | Doctrine concept | The idea affects all implementations | saturation is not truth |
 | Component | The idea has distinct interfaces and failure modes | PAMA, lifecycle engine, certification gate |
 | Implementation detail | The idea is repo-specific | EvolveAI REM synthesis implementation |
-| Product surface | The idea affects user interaction | COREFORGE memory correction UI |
+| Product surface | The idea affects user interaction | memory correction UI |
 | Conformance concern | The idea must be tested across systems | access-spam trap class |
 
 ## Segmentation matrix
@@ -30,51 +32,55 @@ The matrix also prevents probabilistic estimation, authority, and committed stat
 |---|---|---|---|---|
 | UOR address | Component | Identity Substrate | UOR Framework | Stable identity, not memory policy |
 | BLAKE3 content identity | Implementation plus component | Identity Substrate | UOR / CodeGenome | Used by multiple systems for deterministic identity |
-| Memory unit | Doctrine concept | Lifecycle Engine | agent-memory doctrine | Shared object abstraction |
-| Artifact | Doctrine concept | Identity and Evidence | agent-memory doctrine | Raw thing entering memory |
-| Observation | Doctrine concept | Evidence and Provenance | agent-memory doctrine | Witnessed artifact or relation |
-| Evidence bundle | Component | Evidence and Provenance | FailSafe, CodeGenome, runtime ledgers | Must survive summarization |
-| Provenance | Doctrine concept | Evidence and Provenance | agent-memory doctrine | Required for durable transitions |
-| Estimator provenance | Doctrine concept | Evidence and Provenance | agent-memory doctrine | Identifies model/method/version behind consequential estimates |
-| Fiber | Doctrine concept | Saturation and Decay | agent-memory doctrine | Durability or relevance dimension |
-| Saturation sigma | Component | Saturation and Decay | PRISM-style lifecycle consumer | Routing signal, not truth or permission |
-| Decay | Component | Saturation and Decay | EvolveAI / lifecycle runtime | Reduces operational weight |
+| Memory unit | Doctrine concept | Lifecycle Engine | Agent Memory doctrine | Shared object abstraction |
+| Artifact | Doctrine concept | Identity and Evidence | Agent Memory doctrine | Raw thing entering memory |
+| Observation | Doctrine concept | Evidence and Provenance | Agent Memory doctrine | Witnessed artifact or relation |
+| Evidence bundle | Component | Evidence and Provenance | Agent Memory contract; implementation candidates | Must survive summarization |
+| Provenance | Doctrine concept | Evidence and Provenance | Agent Memory doctrine | Required for durable transitions |
+| Estimator provenance | Doctrine concept | Evidence and Provenance | Agent Memory doctrine | Identifies model/method/version behind consequential estimates |
+| Fiber | Doctrine concept | Saturation and Decay | Agent Memory doctrine | Durability or relevance dimension |
+| Saturation sigma | Component | Saturation and Decay | Agent Memory doctrine / lifecycle consumer | Routing signal, not truth or permission |
+| Decay | Component | Saturation and Decay | Agent Memory doctrine; EvolveAI candidate | Reduces operational weight |
 | CMHL | Implementation detail | Saturation and Decay | EvolveAI | Specific decay implementation |
 | MTS | Implementation detail | Lifecycle routing | EvolveAI | Routing heuristic, not universal doctrine |
-| Confidence fusion | Component | Reality Graphs / Evidence | CodeGenome | Evidence support, not permanence |
+| Confidence fusion | Component | Reality Graphs / Evidence | CodeGenome implementation candidate | Evidence support, not permanence |
 | Noisy-OR fusion | Implementation detail | Reality Graphs | CodeGenome | Specific confidence fusion method |
-| Uncertainty representation | Doctrine concept | Evidence / Scoring / Governance handoff | agent-memory doctrine | Point estimates alone may hide consequential uncertainty |
-| Calibration scope | Doctrine concept plus conformance | Conformance and Calibration Harness | agent-memory doctrine | Defines where an estimator claim is valid |
-| Estimator disagreement | Conformance concern plus doctrine concept | Scoring / Evidence | agent-memory doctrine | Must remain visible when materially consequential |
-| Abstention | Doctrine concept | Governance / Lifecycle | agent-memory doctrine | Legitimate outcome when uncertainty is too high |
+| Uncertainty representation | Doctrine concept | Evidence / Scoring / Governance handoff | Agent Memory doctrine | Point estimates alone may hide consequential uncertainty |
+| Calibration scope | Doctrine concept plus conformance | Conformance and Calibration Harness | Agent Memory doctrine | Defines where an estimator claim is valid |
+| Estimator disagreement | Conformance concern plus doctrine concept | Scoring / Evidence | Agent Memory doctrine | Must remain visible when materially consequential |
+| Abstention | Doctrine concept | Governance / Lifecycle | Agent Memory doctrine | Legitimate outcome when uncertainty is too high |
 | Hysteresis | Implementation pattern plus conformance concern | Lifecycle / Scoring | implementation-specific | Prevents estimator noise from creating state churn |
-| Lifecycle state machine | Component | Lifecycle Engine | agent-memory doctrine | Shared state vocabulary |
-| Transition proposal | Doctrine concept | Lifecycle Engine | agent-memory doctrine | May be probabilistic or learned; does not mutate state |
-| Transition commit | Doctrine concept | Lifecycle Engine | agent-memory doctrine | Governed state mutation with receipt |
-| Crystallization | Doctrine concept plus component | Certification and Crystallization Gate | agent-memory doctrine | Governed transition to durable state |
-| Certification | Component | Certification and Crystallization Gate | governance layer | Confirmation record for durable transition |
-| PAMA | Component | Governance and Mutation Authority | agent-memory doctrine / PAMA implementation | Permission to mutate, promote, prune, share, delete, or canonize |
+| Lifecycle state machine | Component | Lifecycle Engine | Agent Memory doctrine | Shared state vocabulary |
+| Transition proposal | Doctrine concept | Lifecycle Engine | Agent Memory doctrine | May be probabilistic or learned; does not mutate state |
+| Transition commit | Doctrine concept | Lifecycle Engine | Agent Memory doctrine | Governed state mutation with receipt |
+| Crystallization | Doctrine concept plus component | Certification and Crystallization Gate | Agent Memory doctrine | Governed transition to durable state |
+| Certification | Component | Certification and Crystallization Gate | Agent Memory doctrine / governance implementation | Confirmation record for durable transition |
+| **PAMA** | **Native doctrine component** | Governance and Mutation Authority | **Agent Memory / Kevin R. Knapp** | Systems-agnostic authority architecture; not an external source dependency |
+| PAMA target class M0-M5 | Doctrine concept | Governance and Mutation Authority | Agent Memory / PAMA | What kind of state is being changed |
+| Lifecycle strength | Doctrine concept | Lifecycle / PAMA handoff | Agent Memory doctrine | Observed through canonical; separate from authority |
+| Downstream authority A0-A5 | Doctrine concept | Governance and Mutation Authority | Agent Memory / PAMA | Maximum influence from retrieval through governance change |
+| Mutation operation | Doctrine concept | Governance and Mutation Authority | Agent Memory specialization | Promotion, correction, pruning, deletion, scope expansion, policy mutation, etc. |
 | Mutation authority | Doctrine concept | Governance and Mutation Authority | PAMA | Capability and confidence are not authority |
-| Authority envelope | Doctrine concept | Governance and Mutation Authority | agent-memory doctrine | Finite permitted / blocked / review-required consequence set |
-| Permitted action set | Doctrine concept | Governance / planner handoff | agent-memory doctrine | Stochastic choice may occur only inside this set |
-| Selection mode | Audit concept | Governance / planner handoff | agent-memory doctrine | deterministic, stochastic, human, or external selection |
-| Decision receipt | Component contract | Governance / Lifecycle ledger | FailSafe / PAMA / runtime ledgers | Reconstructs estimate, policy, allowed actions, selection, and consequence |
-| Policy version | Doctrine concept | Governance | agent-memory doctrine | Must remain distinguishable from estimator version |
-| Estimator version | Doctrine concept | Evidence / Scoring | agent-memory doctrine | Needed for consequential inference replay and drift analysis |
-| Neurospace | Component | Runtime Memory Space | COREFORGE | Operational agent memory space |
-| Vault | Implementation plus component | Runtime Memory Space | COREFORGE | Local encrypted memory container |
-| Recall admission | Doctrine concept plus component | Context Assembly Surface | agent-memory doctrine | Retrieval relevance does not override policy or scope |
-| CodeGenome | Component | Reality Graphs | CodeGenome | Code reality graph, not general runtime memory |
-| Shadow Genome | Component | Correction, Dispute, and Negative Memory | EvolveAI / FailSafe style systems | Stores failure patterns and negative constraints |
-| Bicameral decision continuity | Product plus component | Reality Graphs / Durable Decision Memory | Bicameral | High-risk decision memory and drift detection |
-| FailSafe evidence capture | Product plus component | Evidence and Governance | FailSafe | Enforcement and audit surface |
-| Arbiter | Product component | Governance and Mutation Authority | COREFORGE | Runtime policy guardian |
-| Context window assembly | Product surface | Context Assembly Surface | COREFORGE / agent runtime | Operational use, not canonical truth |
+| Authority envelope | Doctrine concept | Governance and Mutation Authority | Agent Memory doctrine | Finite permitted / blocked / review-required consequence set |
+| Permitted action set | Doctrine concept | Governance / planner handoff | Agent Memory doctrine | Stochastic choice may occur only inside this set |
+| Selection mode | Audit concept | Governance / planner handoff | Agent Memory doctrine | deterministic, stochastic, human, or external selection |
+| Decision receipt | Component contract | Governance / Lifecycle ledger | Agent Memory contract; implementation candidates | Reconstructs estimate, policy, allowed actions, selection, and consequence |
+| Policy version | Doctrine concept | Governance | Agent Memory doctrine | Must remain distinguishable from estimator version |
+| Estimator version | Doctrine concept | Evidence / Scoring | Agent Memory doctrine | Needed for consequential inference replay and drift analysis |
+| Neurospace | Component | Runtime Memory Space | COREFORGE implementation | Operational agent memory space |
+| Vault | Implementation plus component | Runtime Memory Space | COREFORGE implementation | Local encrypted memory container |
+| Recall admission | Doctrine concept plus component | Context Assembly Surface | Agent Memory doctrine | Retrieval relevance does not override policy or scope |
+| CodeGenome | Implementation component | Reality Graphs | CodeGenome | Code reality graph, not general runtime memory |
+| Shadow Genome | Implementation component | Correction, Dispute, and Negative Memory | EvolveAI / FailSafe-style systems | Stores failure patterns and negative constraints |
+| Durable decision memory | Doctrine concept plus profile | Durable Decision Memory | Agent Memory doctrine | Decision continuity, drift, rationale preservation, supersession |
+| FailSafe evidence capture | Product plus component | Evidence and Governance | FailSafe implementation | Enforcement and audit surface |
+| Arbiter | Product component | Governance and Mutation Authority | implementation candidate | Runtime policy guardian; does not own PAMA doctrine |
+| Context window assembly | Product surface | Context Assembly Surface | runtime implementation | Operational use, not canonical truth |
 | Correction workflow | Product surface plus component | Correction and Dispute Surface | runtime implementation | Must preserve prior state |
-| Calibration protocol | Conformance concern | Conformance and Calibration Harness | agent-memory doctrine | Determines estimator and threshold validity |
-| Trap classes | Conformance concern | Conformance and Calibration Harness | agent-memory doctrine | Includes access-spam, confident falsehood, jitter, disagreement, scope traps |
-| Composition failure | Conformance concern plus doctrine concept | Cross-component | agent-memory doctrine | Safe components may compose into unsafe behavior |
-| Research challenge ledger | Doctrine maintenance concern | Research / governance | agent-memory doctrine | Preserves supporting and challenging evidence |
+| Calibration protocol | Conformance concern | Conformance and Calibration Harness | Agent Memory doctrine | Determines estimator and threshold validity |
+| Trap classes | Conformance concern | Conformance and Calibration Harness | Agent Memory doctrine | Includes access-spam, confident falsehood, jitter, disagreement, scope traps |
+| Composition failure | Conformance concern plus doctrine concept | Cross-component | Agent Memory doctrine | Safe components may compose into unsafe behavior |
+| Research challenge ledger | Doctrine maintenance concern | Research / governance | Agent Memory doctrine | Preserves supporting and challenging evidence |
 
 ## Control-character classification
 
@@ -104,8 +110,8 @@ A concept can span more than one class only when its internal boundaries remain 
 Use this decision tree for new concepts.
 
 ```text
-Does it affect every implementation?
-  yes -> doctrine concept
+Is it native contributor-authored doctrine that affects implementations broadly?
+  yes -> doctrine concept / component in Agent Memory
   no -> continue
 
 Does it have its own failure mode and interface?
@@ -128,7 +134,7 @@ Is it mainly used to prove behavior?
 Then ask:
 
 ```text
-Is this an estimate, an authority decision, an action selection, or a committed consequence?
+Is this a target class, lifecycle strength, operation, estimate, authority decision, action selection, or committed consequence?
 ```
 
 If the answer is unclear, the concept is under-segmented.
@@ -150,10 +156,19 @@ It is also a doctrine concept because every implementation must understand that 
 
 ### PAMA
 
-PAMA is a component because it owns a bounded decision:
+PAMA is native doctrine and a component because it owns a bounded decision:
 
 ```text
-What consequences are allowed for this proposed memory transition under this policy and state snapshot?
+What consequences are allowed for this proposed adaptive mutation under this policy and state snapshot?
+```
+
+PAMA also requires separate representation of:
+
+```text
+M0-M5 target class
+lifecycle strength
+requested operation
+A0-A5 downstream authority
 ```
 
 It should not be embedded as an untyped helper inside each memory implementation. That would duplicate authority logic and make policy drift inevitable, because humans apparently enjoy creating three versions of the same mistake.
@@ -180,15 +195,21 @@ block canonical use
 
 Do not require uncertain conflict interpretation to become deterministic merely to make the system easier to describe.
 
+### Durable decision memory
+
+Decision continuity is a doctrine capability, not a product-owned concept.
+
+The durable-decision profile defines the contract. A specific implementation may later earn an implementation-map entry by demonstrating conformance to that profile.
+
 ### CodeGenome
 
-CodeGenome is a component inside the larger system, not the whole memory system.
+CodeGenome is an implementation component inside the larger system, not the whole memory system.
 
 It provides code reality evidence. Agent Memory decides how that evidence becomes operational memory or durable memory.
 
 ### Neurospace
 
-Neurospace is runtime memory space.
+Neurospace is a runtime memory-space implementation concept.
 
 It should consume canonical doctrine and enforce runtime boundaries, but it should not redefine identity, certification, or PAMA rules locally.
 
@@ -201,5 +222,7 @@ If a concept explains a cross-system boundary, it should be doctrine.
 If a concept proves behavior, it should be conformance.
 
 If a concept only exists inside one repo, keep it there until it proves it deserves promotion.
+
+If a concept is native contributor-authored doctrine, keep it in the Agent Memory doctrine tree rather than manufacturing an external dependency record.
 
 If a concept is probabilistic, do not make it authoritative by renaming the output.

--- a/docs/14-expanded-scope-recommendations.md
+++ b/docs/14-expanded-scope-recommendations.md
@@ -8,6 +8,8 @@ The goal is not to absorb every adjacent idea into Agent Memory. That would recr
 
 Expansion proposals must also preserve the governed-uncertainty boundary. Components that classify, infer, rank, predict, or discover may remain probabilistic. Components that authorize durable consequence must expose explicit policy and authority semantics.
 
+PAMA is already native core doctrine. Expansion work may refine its implementation contracts, but should not treat it as an external subsystem to be adopted.
+
 ## Recommendation summary
 
 | Recommendation | Placement | Priority | Governed-uncertainty posture | Rationale |
@@ -421,7 +423,9 @@ Do not market this as an agent memory library.
 
 Treat it as a reference architecture for governed agent memory systems.
 
-That lets EvolveAI, CodeGenome, COREFORGE, UOR, FailSafe, Bicameral, and future systems remain separate implementations while still aligning to a common doctrine.
+That lets EvolveAI, CodeGenome, COREFORGE, UOR, FailSafe, and future implementation systems remain separate while aligning to a common doctrine.
+
+PAMA remains native doctrine within Agent Memory rather than another external implementation name in that list.
 
 The long-term wedge is not memory recall.
 

--- a/docs/33-pama-decision-table.md
+++ b/docs/33-pama-decision-table.md
@@ -2,11 +2,45 @@
 
 ## Purpose
 
-This document turns the governance model in [`04-governance-and-pama.md`](04-governance-and-pama.md) into an inspectable decision table: mutation type and risk class map to a minimum authority outcome, and named modifiers raise or lower that minimum under defined conditions.
+This document turns the Agent Memory specialization of PAMA in [`04-governance-and-pama.md`](04-governance-and-pama.md) into an inspectable decision table: requested operation and operational risk map to a minimum authority outcome, and named modifiers raise or lower that minimum under defined conditions.
+
+PAMA itself is native Agent Memory doctrine authored by Kevin R. Knapp. Its foundational taxonomy is defined in [`pama/README.md`](pama/README.md): **M0-M5 target classes**, lifecycle strength, **A0-A5 downstream authority classes**, adaptive charters, and proportional handling lanes.
+
+The table below is therefore **one policy projection of PAMA, not the definition of PAMA**.
 
 The table is policy data, not code. An implementation may encode it as configuration, rules, or a policy engine, but the mapping must satisfy the authority resolution invariant: for fixed committed inputs, current state, and policy version, the resulting authority envelope is deterministic or formally bounded.
 
 This document implements the decision-table requirement of [`adr/ADR-004-pama-controls-mutation-authority.md`](adr/ADR-004-pama-controls-mutation-authority.md).
+
+## Required PAMA dimensions before table lookup
+
+A compliant implementation must classify more than an operation name and generic risk score.
+
+Before resolving this table, the request should establish at least:
+
+```text
+target_class: M0 | M1 | M2 | M3 | M4 | M5
+lifecycle_strength
+requested_operation
+requested_downstream_authority: A0 | A1 | A2 | A3 | A4 | A5
+scope
+reversibility
+actor / charter
+operational_risk
+```
+
+These dimensions are orthogonal.
+
+For example:
+
+- `promotion` is an **operation**;
+- an M3 reusable procedure is a **target class**;
+- `Promoted` is a **lifecycle strength**;
+- A1 recommendation influence is a **downstream authority ceiling**.
+
+Calling all four of these a "mutation class" makes the policy easier to implement incorrectly, which is a charming quality in diagrams and a terrible one in governance.
+
+A high-confidence M3 capability promoted successfully under this table does not gain A4 external-action authority unless a separate PAMA decision authorizes that authority.
 
 ## How to read the table
 
@@ -16,16 +50,34 @@ Outcomes are ordered by strictness:
 allow < allow_with_ledger < require_review < require_external_verification < block
 ```
 
-- A cell is the **minimum** outcome for that mutation type at that risk class. Policy may always be stricter; it must not be weaker.
+- A cell is the **minimum** outcome for that requested operation at that operational risk class. Policy may always be stricter; it must not be weaker.
+- Target class, lifecycle strength, downstream authority, scope, sensitivity, reversibility, and actor authority may escalate the base cell.
 - Modifiers move the outcome along this ordering. A modifier can only relax an outcome when the table row explicitly marks it relaxable.
 - `abstain`, `quarantine`, and `collect_more_evidence` are lateral outcomes: they defer the decision without granting authority. A deferral never counts as satisfaction of a review or verification requirement.
 - `block` is absorbing. No modifier, score, or estimator output relaxes a `block` produced by a prohibited-action rule.
 
+## Foundational class floors
+
+The operation table must not undercut PAMA's target and downstream-authority semantics.
+
+| PAMA dimension | Minimum consequence rule |
+|---|---|
+| **M0** execution-local context | may be transient when it cannot escape local context or create durable/external effects |
+| **M1** low-risk preference | may be retained tentatively when visible, scoped, reversible, and barred from higher authority |
+| **M2** operational association | meaningful recommendation influence requires evidence and correction/conflict handling |
+| **M3** reusable capability | promotion requires validation, versioning, authority ceiling, rollback/revocation, and monitoring |
+| **M4** shared or identity-bearing state | requires authoritative evidence and controlled review appropriate to consequence |
+| **M5** governance/security/autonomous authority | requires explicit authorized review; proposing agent may not self-approve |
+| **A4** external action | never granted merely because a memory or capability is reliable |
+| **A5** governance change | never granted through a lower-authority mutation pathway |
+
+If a base operation/risk cell is weaker than one of these floors, the PAMA class floor wins.
+
 ## Base decision table
 
-Mutation classes are those defined in `04-governance-and-pama.md`. Risk classes follow the same doc: low, medium, high, critical.
+Operational mutation types are defined in `04-governance-and-pama.md`. Risk classes follow the same doc: low, medium, high, critical.
 
-| Mutation type | Low | Medium | High | Critical |
+| Mutation operation | Low | Medium | High | Critical |
 |---|---|---|---|---|
 | Runtime assembly | allow_with_ledger | allow_with_ledger | require_review | require_review |
 | Score adjustment | allow_with_ledger | allow_with_ledger | require_review | block |
@@ -41,10 +93,11 @@ Mutation classes are those defined in `04-governance-and-pama.md`. Risk classes 
 
 Reading notes:
 
-- Score adjustment at critical risk is `block` because a score change on identity, credential, compliance, or safety-boundary memory is not a score change; it is an attempt to route around governance. Re-evaluation of such memory goes through correction or policy mutation instead.
+- Score adjustment at critical risk is `block` because a score change on identity, credential, compliance, or safety-boundary memory is not merely a score change; it is an attempt to route around governance. Re-evaluation of such memory goes through correction or policy mutation instead.
 - Scope expansion at critical risk is `block` because cross-tenant expansion of critical-class memory has no autonomous path. It requires a policy-level decision, which is a policy mutation, not a scope-expansion request.
 - `require_external_verification` means verification by an authority outside the requesting component: a human approver, an independent certification service, or an equivalently authoritative system. The requesting estimator can never be its own verifier.
-- Policy mutation never resolves below `require_review` at any risk class, and human approval remains the default expectation per `04-governance-and-pama.md`.
+- Policy mutation never resolves below `require_review` at any risk class, and human or equivalently authoritative approval remains the default expectation per `04-governance-and-pama.md`.
+- M5 and A5 requests must not be relabeled as lower-risk operations merely to reach a weaker row.
 
 ## Modifier rules
 
@@ -54,6 +107,8 @@ Modifiers apply after the base cell is selected, in the order listed. Escalating
 
 | Modifier | Condition | Effect |
 |---|---|---|
+| M-TARGET | PAMA target class imposes a stricter floor than the base cell | raise to the target-class floor |
+| M-AUTHORITY | requested downstream authority A4/A5 exceeds the authority normally associated with the mutation | raise to explicit review or external verification; A5 never self-approved |
 | M-IRREV | mutation is irreversible or destroys its own rollback path | raise to at least require_review; at high/critical risk raise to at least require_external_verification |
 | M-EVID | evidence quality below policy floor for this mutation type | raise one step and require collect_more_evidence before re-evaluation |
 | M-DISPUTE | target memory is disputed or contradiction pressure is material | raise to at least require_review |
@@ -74,7 +129,7 @@ Relaxation exists so reversible, well-evidenced, narrow mutations are not buried
 | R-REV | mutation is cheaply reversible with a verified rollback path and a reversible tombstone | may lower require_review to allow_with_ledger, only for rows marked relaxable below |
 | R-DELEG | acting under an explicit, unexpired, in-scope delegation record | may lower one step, never below allow_with_ledger, never for policy mutation or scope expansion |
 
-Relaxable rows: link deletion (low/medium), pruning (high), promotion (medium). No other cell is relaxable. Crystallization, permanent deletion, scope expansion, and policy mutation are never relaxable.
+Relaxable rows: link deletion (low/medium), pruning (high), promotion (medium). No other cell is relaxable. Crystallization, permanent deletion, scope expansion, policy mutation, M5 governance/security authority, and A5 governance changes are never relaxable through these modifiers.
 
 Reversibility works in both directions and asymmetrically: irreversibility escalates everywhere, reversibility relaxes only where the table says so. A verified rollback path is a precondition for relaxation, not evidence of safety.
 
@@ -84,6 +139,7 @@ Reversibility works in both directions and asymmetrically: irreversibility escal
 high confidence        -> never relaxes any outcome
 high saturation        -> never relaxes any outcome
 repetition / access    -> never relaxes any outcome
+validated capability   -> never expands its authority ceiling by itself
 prior similar approval -> never substitutes for current authority
 deferral outcomes      -> never satisfy review or verification
 ```
@@ -98,6 +154,7 @@ Each example gives the request, the resolved outcome, the before and after state
 
 Request: decay pass lowers sigma on a task note after two weeks without meaningful reuse.
 
+- PAMA shape: M2 operational association, reinforced, A1 ceiling, score-adjustment operation, low risk.
 - Base cell: score adjustment × low = `allow_with_ledger`. No modifiers trigger.
 - Before: `sigma 0.58`, state `reinforced`. After: `sigma 0.44`, state `reinforced`.
 - Ledger: score-adjustment event with estimator refs, estimator version, and decay-profile ref. No receipt approval refs required.
@@ -122,7 +179,8 @@ Request: remove a `supports` edge that a retracted source had justified.
 
 Request: user corrects a stored preference that was inferred wrongly.
 
-- Base cell: correction × high (user preference) = `require_review`. The user's own correction with explicit approval satisfies review; M-AUTH does not trigger because the actor is the memory's owner principal.
+- PAMA shape: M1 preference, A1 ceiling, correction operation, high handling sensitivity because the value belongs to the user.
+- Base cell: correction × high = `require_review`. The user's own correction with explicit approval satisfies review; M-AUTH does not trigger because the actor is the memory's owner principal.
 - Before: `preference: weekly summary`, state `crystallized`, dispute open. After: `preference: daily summary`, state `corrected`, prior value preserved as history with supersession link per `18-temporal-causality-layer.md`.
 - Ledger: correction event with approval ref (the user's action), before/after state, and rollback path. The old value is superseded, not erased.
 
@@ -132,7 +190,7 @@ Request: recurring, corroborated project decision reaches candidate threshold; s
 
 - Base cell: promotion × high (durable decision) = `require_review`. M-DISAGREE does not trigger; trap-class check passes.
 - Before: state `reinforced`, `sigma 0.86`, certification absent. After: state `pending_verification`. Not durable yet.
-- Ledger: lifecycle-transition event with pama inputs, permitted-action set, and selected action. Receipt records that review is the binding step; saturation alone did not promote.
+- Ledger: lifecycle-transition event with PAMA inputs, permitted-action set, and selected action. Receipt records that review is the binding step; saturation alone did not promote.
 
 ### 6. Crystallization
 
@@ -148,14 +206,25 @@ Request: eviction pass proposes pruning a stale runtime trace from active recall
 
 - Base cell: pruning × low = `allow_with_ledger`. M-EVIDENCE-DESTRUCTION does not trigger: nothing references the trace as evidence.
 - Before: state `stale`, in active recall. After: state `pruned`, reversible tombstone retained per `28-retention-deletion-and-tombstones.md`; content recoverable within the retention window.
-- Ledger: pruning event with tombstone ref. Contrast: the same request against a memory cited in an open dispute is blocked by M-EVIDENCE-DESTRUCTION until the hold resolves — see `fixtures/pruning-with-audit-preservation.json`.
+- Ledger: pruning event with tombstone ref. Contrast: the same request against a memory cited in an open dispute is blocked by M-EVIDENCE-DESTRUCTION until the hold resolves, see `fixtures/pruning-with-audit-preservation.json`.
 
-### 8. Policy mutation
+### 8. Reusable capability authority
+
+Request: a validated troubleshooting procedure has been promoted as an M3 capability with an A1 recommendation ceiling and now requests shell execution.
+
+- Capability validation remains valid.
+- Requested authority changes from A1 to A4, so M-AUTHORITY escalates.
+- The existing capability promotion does not authorize execution.
+- Result: `require_review` or stricter policy outcome for the A4 request; if the actor lacks authority to request that expansion, `block`.
+- Ledger: separate authority decision receipt. The original capability artifact remains unchanged until the new authority decision resolves.
+
+### 9. Policy mutation
 
 Request: agent proposes lowering the candidate threshold from 0.80 to 0.70 because "too few memories are promoting."
 
-- Base cell: policy mutation × high = `require_external_verification`. No relaxation path exists for policy mutation.
-- Before: `candidate_threshold 0.80`, policy version `p-14`. After (only if approved by human or equivalently authoritative review): `candidate_threshold 0.70`, policy version `p-15`, prior version retained for replay.
+- PAMA shape: M5 governance mutation, A5 downstream authority.
+- Base cell: policy mutation × high = `require_external_verification`. No relaxation path exists for policy mutation, M5, or A5.
+- Before: `candidate_threshold 0.80`, policy version `p-14`. After, only if approved by human or equivalently authoritative review: `candidate_threshold 0.70`, policy version `p-15`, prior version retained for replay.
 - Ledger: policy-mutation receipt with approval refs, both policy versions, and effective time. An agent observing its own promotion rate is an estimator; an estimator proposing to widen its own authority is exactly what this row exists to stop.
 
 ## Interaction with lifecycle gates
@@ -179,13 +248,20 @@ A table outcome of `require_review` therefore admits a memory to Pending Verific
 | Deletion proposed from predicted low utility | permanent-deletion row plus M-IRREV; utility estimate cannot authorize | [`../fixtures/irreversible-deletion-under-uncertain-utility.json`](../fixtures/irreversible-deletion-under-uncertain-utility.json) |
 | Delegated actor acts after delegation expiry | R-DELEG does not apply; expired delegation escalates, not relaxes | [`../fixtures/expired-delegation.json`](../fixtures/expired-delegation.json) |
 | Concurrent conflicting mutation requests | no silent last-writer-wins; second request re-resolves against new state | [`../fixtures/concurrent-conflicting-mutation.json`](../fixtures/concurrent-conflicting-mutation.json) |
-| Authority laundering through a permissive path | outcome depends on mutation type actually requested, not the path that carried it | [`../fixtures/authority-laundering.json`](../fixtures/authority-laundering.json) |
+| Authority laundering through a permissive path | outcome depends on mutation actually requested, target class, and downstream authority, not the path that carried it | [`../fixtures/authority-laundering.json`](../fixtures/authority-laundering.json) |
 | Policy applied under drifted estimator version | M-OOD escalates consequential mutations | [`../fixtures/policy-estimator-version-drift.json`](../fixtures/policy-estimator-version-drift.json) |
+
+Additional PAMA-native fixtures should cover:
+
+- M3 capability promoted successfully but blocked from exceeding its A1/A2 ceiling;
+- M5 governance change disguised as M2 operational association;
+- missing target class treated as unknown consequence rather than low risk; and
+- charter mismatch between proposing agent and mutation domain.
 
 ## Doctrine
 
-The decision table is the shape of PAMA, not a replacement for it.
+The decision table is one operational projection of PAMA, not a replacement for it.
 
-A cell grants nothing by itself. It states the weakest outcome a compliant policy may return, given committed inputs whose provenance and uncertainty are inspectable.
+A cell grants nothing by itself. It states the weakest outcome a compliant policy may return, given committed inputs whose provenance, PAMA class, authority ceiling, and uncertainty are inspectable.
 
-Estimates inform the inputs. Authority comes from the table, its modifiers, and the approvals they require — never from the estimate.
+Estimates inform the inputs. Authority comes from PAMA's class boundaries, the table, its modifiers, and the approvals they require, never from the estimate.

--- a/docs/39-implementation-ownership-map.md
+++ b/docs/39-implementation-ownership-map.md
@@ -2,56 +2,107 @@
 
 ## Purpose
 
-[`05-repo-implementation-map.md`](05-repo-implementation-map.md) maps named systems into the architecture's roles and control classes. This document adds the ownership dimension: for each component of [`11-component-architecture.md`](11-component-architecture.md), who is the primary owner, who consumes it, and what its implementation status actually is — so concepts do not drift back into repo-local folklore.
+[`05-repo-implementation-map.md`](05-repo-implementation-map.md) maps named implementation systems into Agent Memory roles and control classes. This document adds the ownership dimension: for each component of [`11-component-architecture.md`](11-component-architecture.md), who owns the doctrine, who is a candidate implementation owner, who consumes it, and what its implementation status actually is.
 
-**Epistemic status: declared, not verified.** This repository is the doctrine and conformance authority; it does not contain, build, or test the implementation systems named below. Every ownership claim is a candidate assignment awaiting the implementation evidence defined in `05-repo-implementation-map.md`, and the doctrine backlinks of issue #5. Nothing here is a conformance claim — see the claiming rules of [`35-interoperability-profiles.md`](35-interoperability-profiles.md).
+This distinction matters especially for PAMA: **Agent Memory owns the PAMA doctrine. A runtime implementation owner is still open.** Those are different facts and should not be collapsed into “no standalone PAMA repository exists.” No standalone external repository is required for native doctrine.
+
+**Epistemic status for implementation ownership: declared, not verified unless stated otherwise.** This repository is the doctrine and conformance authority; it does not contain, build, or test most implementation systems named below. Every external ownership claim is a candidate assignment awaiting the implementation evidence defined in `05-repo-implementation-map.md`. Nothing here is a conformance claim unless it has the required evidence under [`35-interoperability-profiles.md`](35-interoperability-profiles.md).
 
 ## Status vocabulary
 
 ```text
-declared    ownership asserted by doctrine; no implementation evidence in this repo
-partial     some implementation exists per its own repo's claims; unverified here
-verified    implementation evidence linked and checked against doctrine (none yet)
-contested   more than one system claims primary ownership; consolidation needed
-open        no credible owner yet
+doctrine-owned  canonical semantics are owned by Agent Memory
+open            no verified runtime implementation owner yet
+declared        implementation ownership asserted; no conformance evidence in this repo
+partial         some implementation exists per its own repo's claims; unverified here
+verified        implementation evidence linked and checked against doctrine
+contested       more than one implementation claims primary ownership; consolidation needed
 ```
 
 ## Ownership map
 
-| Component | Primary owner (candidate) | Secondary consumers | Status |
+| Component | Doctrine / primary owner | Secondary consumers or implementation candidates | Status |
 |---|---|---|---|
-| Identity Substrate | UOR Framework; CodeGenome for code-node identity | all components | declared |
-| Evidence and Provenance | CodeGenome; FailSafe receipts; COREFORGE ledgers | PAMA, Certification, Conformance | declared, **contested** — three ledger-shaped systems overlap |
-| Reality Graphs | CodeGenome | Bicameral (decision graphs), Runtime Memory | declared |
-| Lifecycle Engine | EvolveAI | COREFORGE Vault | declared, **contested** — Vault also holds lifecycle candidates |
-| Saturation and Decay | EvolveAI (L1/L2/L3 tiers, CMHL decay, REM synthesis) | PRISM-style consumers, Lifecycle | declared |
-| PAMA | dedicated governance module | every mutating component | **open** — no standalone PAMA implementation exists; highest-risk gap |
-| Certification | FailSafe; Arbiter; approval workflows | Lifecycle, Crystallization gate | declared, **contested** — certifier independence (doc 35, Profile 5) must survive consolidation |
-| Runtime Memory Space | COREFORGE Vault / Neurospace | agent runtimes, Context Assembly | declared |
-| Context Assembly | COREFORGE; agent runtimes | user-facing products | declared |
-| Correction and Dispute | Vault, Bicameral, FailSafe-style workflows | Recall admission, Quality metrics | declared, **contested** — three partial candidates, no owner of the user-facing contract in [`38-human-correction-ux-contract.md`](38-human-correction-ux-contract.md) |
-| Conformance | this repository | every implementation | **verified** — the one component whose owner is checkable here: schemas, fixtures, validators, CI |
-| Failure / negative memory | Shadow Genome | Scoring, Threat model | declared |
+| Identity Substrate | UOR Framework semantics as mapped by Agent Memory; CodeGenome for code-node identity | all components | declared |
+| Evidence and Provenance | Agent Memory contracts | CodeGenome, FailSafe receipts, COREFORGE ledgers | declared, **contested implementation** — three ledger-shaped systems overlap |
+| Reality Graphs | Agent Memory contract; CodeGenome candidate implementation | Runtime Memory | declared |
+| Lifecycle Engine | Agent Memory lifecycle doctrine | EvolveAI proposer, COREFORGE Vault committer candidates | declared, **contested implementation** |
+| Saturation and Decay | Agent Memory scoring doctrine | EvolveAI implementation candidate | declared |
+| **PAMA** | **Agent Memory native doctrine, authored by Kevin R. Knapp** | every mutating component; runtime policy module/service TBD | **doctrine-owned; runtime implementation open** |
+| Certification | Agent Memory certification contract | FailSafe, Arbiter, approval workflows | declared, **contested implementation** |
+| Runtime Memory Space | Agent Memory runtime contract | COREFORGE Vault / Neurospace | declared |
+| Context Assembly | Agent Memory recall/context contract | COREFORGE and agent runtimes | declared |
+| Correction and Dispute | Agent Memory correction/dispute contract | Vault and FailSafe-style workflows | declared, **contested implementation** |
+| Durable Decision Memory | Agent Memory durable-decision profile | implementation candidates must map explicitly to profile | **doctrine-owned; runtime implementation open** |
+| Conformance | this repository | every implementation | **verified** — schemas, fixtures, validators, CI |
+| Failure / negative memory | Agent Memory negative-memory doctrine | Shadow Genome implementation candidate | declared |
+
+## PAMA ownership
+
+PAMA's canonical semantics live here:
+
+- [`pama/README.md`](pama/README.md)
+- [`04-governance-and-pama.md`](04-governance-and-pama.md)
+- [`33-pama-decision-table.md`](33-pama-decision-table.md)
+- [`adr/ADR-004-pama-controls-mutation-authority.md`](adr/ADR-004-pama-controls-mutation-authority.md)
+
+The open implementation question is **where the authority evaluator and enforcement boundary run**, not who owns the framework.
+
+A runtime implementation may live inside a larger repository or service if it preserves the semantic boundary. It must expose at least:
+
+```text
+M0-M5 target class
+lifecycle strength
+requested operation
+A0-A5 downstream authority
+actor and charter
+scope and reversibility
+evidence and uncertainty
+policy version
+permitted / prohibited outcomes
+selected action
+committed consequence receipt
+```
+
+PAMA must not be absorbed into a storage or estimator subsystem in a way that makes authority indistinguishable from relevance, confidence, saturation, or implementation convenience.
 
 ## Consolidation and segmentation calls
 
-**Should consolidate** (duplicated concepts):
+**Should consolidate** where implementations duplicate contracts:
 
-- The three ledger-shaped systems (CodeGenome provenance, FailSafe receipts, COREFORGE ledgers) should converge on the decision-receipt and audit-event schemas ([`../schemas/decision-receipt.schema.json`](../schemas/decision-receipt.schema.json), [`../schemas/memory-audit-event.schema.json`](../schemas/memory-audit-event.schema.json)) rather than each defining a private evidence format.
+- The three ledger-shaped implementation candidates (CodeGenome provenance, FailSafe receipts, COREFORGE ledgers) should converge on the decision-receipt and audit-event schemas ([`../schemas/decision-receipt.schema.json`](../schemas/decision-receipt.schema.json), [`../schemas/memory-audit-event.schema.json`](../schemas/memory-audit-event.schema.json)) rather than each defining a private evidence format.
 - Lifecycle ownership must resolve to one committer: EvolveAI proposing transitions that Vault commits is a legitimate split (proposal versus commit per [`02-lifecycle-state-machine.md`](02-lifecycle-state-machine.md)); both committing is not.
 
 **Should remain segmented** (per [`12-concept-segmentation-matrix.md`](12-concept-segmentation-matrix.md)):
 
-- Certification must not collapse into the system that proposes candidates, whatever repo hosts both — independence is the point.
-- PAMA must not be absorbed into Vault or any single runtime: whichever repo implements it, the authority boundary stays a separate, auditable module consumed through the PAMA adapter of [`34-adapter-contracts.md`](34-adapter-contracts.md).
+- Certification must not collapse into the system that proposes candidates, whatever repo hosts both. Independence is the point.
+- PAMA's authority boundary remains a separate, auditable module/contract regardless of which runtime repository implements it. The PAMA adapter of [`34-adapter-contracts.md`](34-adapter-contracts.md) is the seam.
 - Identity stays out of every scoring system. No estimator gets to mint identity.
+- Durable decision memory is an Agent Memory profile; an adjacent product does not become its doctrine owner merely because it implements decisions.
+
+## External implementation inclusion rule
+
+A named external or private implementation should appear in this map only when it adds specific value:
+
+1. a concrete implementation responsibility;
+2. evidence that can be mapped to an Agent Memory contract or profile;
+3. a meaningful conformance candidate; or
+4. a deliberate contested-ownership question that must be resolved.
+
+Conceptual adjacency alone is insufficient.
 
 ## Resolution path
 
-Ownership claims graduate from `declared` only through the evidence items of `05-repo-implementation-map.md`: a doctrine backlink in the owning repo (issue #5), an implementation-alignment issue mapping its slice, and eventually fixture results claiming a profile from `35-interoperability-profiles.md`. Contested rows are resolved by cross-repo decision, recorded here with the decision reference — not by whichever implementation ships first.
+Implementation claims graduate from `declared` only through the evidence items of `05-repo-implementation-map.md`: a doctrine backlink in the implementing repo, an implementation-alignment issue mapping its slice, and eventually fixture results claiming a profile from `35-interoperability-profiles.md`.
+
+Contested rows are resolved by evidence and explicit cross-repo decision, recorded here with the decision reference, not by whichever implementation ships first.
+
+Native doctrine ownership does not require that process. PAMA is already canonical doctrine; its runtime implementation remains subject to conformance evidence.
 
 ## Doctrine
 
-Ownership is a governance fact, not a deployment fact.
+Ownership is a governance fact, not merely a deployment fact.
 
-A component belongs to the repo that accepts its doctrine obligations — its contracts, its conformance surface, its audit duties. Code without those obligations is not an owner; it is an unverified volunteer.
+A component's **doctrine owner** defines its obligations, contracts, conformance surface, and audit duties. An **implementation owner** must demonstrate that its code accepts those obligations.
+
+Code without those obligations is not an owner. It is an unverified volunteer.

--- a/docs/AGENTIC_MEMORY_SYSTEMS_CANONICAL_ARCHITECTURE.md
+++ b/docs/AGENTIC_MEMORY_SYSTEMS_CANONICAL_ARCHITECTURE.md
@@ -2,15 +2,19 @@
 
 ## Purpose
 
-This document defines the canonical architecture for governed agentic memory systems across UOR, EvolveAI, CodeGenome, COREFORGE Vault / Neurospace, PAMA, and related governance systems.
+This document defines the canonical architecture for governed agentic memory systems. It combines native Agent Memory doctrine with clearly bounded implementation and provenance relationships across UOR, EvolveAI, CodeGenome, COREFORGE Vault / Neurospace, FailSafe / Arbiter, and future conforming systems.
 
-It consolidates the logic into one doctrine so implementations can stop rediscovering the same boundary decisions under different names.
+**PAMA is native Agent Memory doctrine authored by Kevin R. Knapp.** It is part of the canonical architecture itself, not another external system in the implementation list.
+
+This document consolidates the logic into one doctrine so implementations can stop rediscovering the same boundary decisions under different names.
 
 ## Core thesis
 
 Agentic memory is not retrieval.
 
-Agentic memory is governed state transition over addressable artifacts, scored by calibrated relevance, constrained by mutation authority, and confirmed by provenance or certification before becoming durable.
+Agentic memory is retained state that can alter an agent's future interpretation, reasoning, planning, tool use, action, or adaptation across a meaningful persistence boundary.
+
+The architecture governs encoding, persistence, recall, revision, forgetting, sharing, inheritance, and mutation authority rather than treating retrieval as the whole system.
 
 ## Canonical pipeline
 
@@ -18,55 +22,91 @@ Agentic memory is governed state transition over addressable artifacts, scored b
 Raw experience / artifact
         |
         v
-UOR identity
+Identity substrate
 What is it? Can it be addressed deterministically?
         |
         v
 Evidence layer
-Who observed it? What supports it? What confidence applies?
+Who observed it? What supports it? What uncertainty applies?
         |
         v
-Saturation / PRISM layer
-Should it persist, decay, route, recheck, or be proposed for crystallization?
+Lifecycle / saturation layer
+Should it persist, decay, route, recheck, consolidate, or become a promotion candidate?
         |
         v
 PAMA governance layer
-Is the system allowed to promote, mutate, canonize, or prune it?
+What is the M0-M5 target class, lifecycle strength, operation, and A0-A5 authority ceiling?
+What consequences are permitted, blocked, deferred, or review-required?
         |
         v
 Certification / crystallization gate
-Can it become durable, canonical, or exact-address retrievable?
+If durable canonical state is requested, have required verification and authority gates passed?
         |
         v
-Neurospace / runtime memory
-How does the agent use it operationally?
+Runtime memory / governed recall
+How may eligible memory influence this agent and task now?
 ```
 
 ## Layer model
 
 | Layer | Question answered | Canonical responsibility |
 |---|---|---|
-| UOR identity | What is this object? | Deterministic content address, exact identity, object resolution |
-| Evidence | Why do we believe this object or relation exists? | Provenance, witness material, confidence, observation records |
-| Saturation / PRISM | How durable or relevant is this object? | Calibrated scoring, routing, decay, tier candidacy |
-| Lifecycle | What state is this memory in? | State transitions, decay, dispute, pruning, crystallization candidacy |
-| PAMA | Who or what may change this memory? | Mutation authority, adaptation limits, policy-weighted promotion |
-| Certification | Can this become durable? | Verification, approval, integrity checks, certificate gates |
-| Runtime / Neurospace | How is this memory used? | Local operational memory, context assembly, graph recall, agent access |
-| CodeGenome | What is true about code? | Canonical code reality graph, overlays, confidence fusion, impact traversal |
+| Identity | What is this object? | Deterministic content address, exact identity, object resolution |
+| Evidence | Why do we believe this object or relation exists? | Provenance, witness material, uncertainty, observation records |
+| Saturation / scoring | How much persistence or routing pressure exists? | Calibrated scoring, routing, decay, lifecycle candidacy |
+| Lifecycle | What state is this memory in? | State transitions, decay, dispute, correction, pruning, promotion candidacy |
+| **PAMA** | What adaptive consequence is permitted? | Native mutation target classes, authority ceilings, charters, proportional governance |
+| Certification | Can this proposed durable transition be confirmed? | Verification, approval, integrity checks, certificate gates |
+| Runtime memory | How is this memory used? | Operational storage, context assembly, graph recall, agent access |
+| Governed recall | What retained state may enter active context? | Relevance plus scope, sensitivity, tenancy, dispute, certification, policy admission |
+| Reality graphs | What structured domain relationships exist? | Domain graph evidence, confidence, provenance, impact traversal |
+| Durable decision memory | How do decisions retain rationale and evolve safely? | decision state, supersession, drift evidence, rationale preservation |
+
+## PAMA native doctrine
+
+PAMA means **Proportional Adaptive Mutation Authority**.
+
+Canonical foundation: [`pama/README.md`](pama/README.md).
+
+PAMA preserves:
+
+```text
+adaptation != authority
+memory != procedure
+procedure != permission
+permission != governance
+```
+
+Foundational dimensions include:
+
+- **M0-M5 target classes**: what kind of state is being changed;
+- **lifecycle strength**: how established the retained adaptive state is;
+- **requested operation**: what transition or mutation is being attempted;
+- **A0-A5 downstream authority**: what the state may influence;
+- **adaptive charter**: what the proposing agent is allowed to learn or propose;
+- **evidence and reversibility**: what supports the mutation and how safely it can be undone;
+- **policy outcome**: what is allowed, ledgered, review-required, externally verified, or blocked.
+
+A validated capability does not acquire external-action authority merely because it works reliably.
 
 ## Governing invariants
 
-1. UOR identity is not memory.
+1. Identity is not memory.
 2. Saturation is not truth.
 3. Repetition is not durability.
 4. Retrieval frequency is not permission to crystallize.
 5. Crystallization is a governed transition, not a natural reward.
-6. Certification confirms what saturation only proposes.
-7. Provenance must survive summarization.
-8. A memory that cannot be disputed cannot be trusted.
+6. Certification confirms a required gate; it does not create eternal truth.
+7. Provenance must survive summarization and derivation.
+8. A memory that cannot be disputed or corrected cannot be safely canonical.
 9. Mutation authority must be explicit and scoped.
 10. Runtime usefulness does not imply canonical permanence.
+11. Adaptation is not authority.
+12. Memory is not procedure.
+13. Procedure is not permission.
+14. Permission is not governance.
+15. Reliability does not expand a capability's authority ceiling.
+16. Probability may inform authority; probability does not create permission.
 
 ## Memory state machine
 
@@ -83,39 +123,44 @@ Transient
   -> Disputed
   -> Corrected
   -> Reconciled
-  -> Pruned
+  -> Archived / Pruned / Tombstoned
 ```
 
-Not all memories move through every state. The state machine exists to make every durable transition explainable.
+Not all memories move through every state. The state machine exists to make consequential transitions explainable.
+
+PAMA lifecycle strength (`Observed`, `Tentative`, `Reinforced`, `Promoted`, `Canonical`) is a governance-facing abstraction over adaptive strength and must not be confused with every implementation lifecycle state. Mappings between the two should be explicit where used.
 
 ## Memory object model
 
-A canonical memory object should carry at least:
+A canonical memory object should carry, where applicable:
 
 ```text
-id: UOR address or implementation-specific identity pointer
+id: stable identity pointer
 content_ref: pointer to raw or canonical content
 type: observation | decision | fact | trace | code_artifact | preference | policy | failure | correction
 evidence: list of evidence records
 provenance: origin, observer, timestamp, method
-confidence: evidence-level confidence
-saturation: calibrated lifecycle score
+confidence / uncertainty: evidence-level epistemic state
+saturation: calibrated lifecycle pressure
 state: lifecycle state
+pama_target_class: M0-M5 when mutation authority is evaluated
+downstream_authority: A0-A5 ceiling when applicable
 authority: mutation and promotion authority scope
 certification: optional confirmation record
 decay_profile: half-life, pressure, last access, dispute status
 ledger_ref: audit or history pointer
 ```
 
-## Distinction between confidence, saturation, and certification
+## Distinction between confidence, saturation, authority, and certification
 
 | Signal | Means | Does not mean |
 |---|---|---|
-| Confidence | Evidence suggests this observation or relation is valid | The memory should persist forever |
-| Saturation | The memory has lifecycle relevance or persistence pressure | The memory is correct |
+| Confidence / uncertainty | Evidence supports an estimate to some degree | The memory should persist forever |
+| Saturation | Memory has lifecycle relevance or persistence pressure | The memory is correct |
+| PAMA authority | Policy permits a bounded consequence | The underlying claim is factually true |
 | Certification | A verification or approval gate was satisfied | The memory can never be revised |
 
-This distinction is mandatory. Collapsing these signals creates hallucination permanence.
+This distinction is mandatory. Collapsing these signals creates hallucination permanence and permission laundering.
 
 ## Crystallization rule
 
@@ -126,35 +171,42 @@ identity_resolved == true
 provenance_present == true
 saturation >= calibrated_threshold
 trap_class_check == pass
-pama_authority == allow
+pama_outcome permits crystallization
 certification_gate == pass
+scope_defined == true
+dispute_status == clear
 ```
 
-A high saturation score may propose crystallization. It must not grant crystallization by itself unless an explicit policy permits that risk.
+A high saturation score may propose crystallization. It must not grant crystallization by itself.
 
-## Implementation doctrine
+## Related implementation doctrine
 
-The repo ecosystem should map to this architecture as follows:
+External or related systems may map to portions of this architecture when they add concrete implementation value:
 
-| System | Role |
+| System | Implementation role |
 |---|---|
 | UOR Framework | Identity substrate and addressability model |
-| EvolveAI | Memory metabolism prototype and lifecycle engine |
-| CodeGenome | Canonical graph substrate for software reality |
-| COREFORGE Vault / Neurospace | Product runtime memory container |
-| PAMA | Mutation authority and adaptive governance model |
-| FailSafe / Arbiter | Governance enforcement, evidence capture, approval gates |
-| Bicameral | Decision continuity and drift detection surface |
+| EvolveAI | Memory metabolism prototype and lifecycle engine candidate |
+| CodeGenome | Graph substrate for software reality and provenance |
+| COREFORGE Vault / Neurospace | Runtime memory implementation candidate |
+| FailSafe / Arbiter | Governance enforcement, evidence capture, and approval implementation candidates |
+
+PAMA is intentionally absent from this external implementation table because it is native doctrine. A runtime PAMA implementation may live in any conforming codebase while preserving the authority boundary.
+
+Durable decision continuity is defined internally through [`profiles/durable-decision-memory-profile.md`](profiles/durable-decision-memory-profile.md). A product should be named as its implementation only after providing specific implementation evidence against that profile.
 
 ## Conformance expectation
 
 Any implementation claiming alignment with this doctrine should be able to demonstrate:
 
-1. deterministic identity or stable reference resolution
-2. durable provenance for memory creation and mutation
-3. calibrated saturation or equivalent lifecycle scoring
-4. trap-class resistance against access-spam and confidently-wrong promotion
-5. explicit mutation authority
-6. dispute and correction pathways
-7. audit evidence for crystallization
-8. safe pruning behavior for ephemeral or contradicted memory
+1. deterministic identity or stable reference resolution;
+2. durable provenance for memory creation and mutation;
+3. calibrated saturation or equivalent lifecycle scoring where used;
+4. trap-class resistance against access-spam and confidently-wrong promotion;
+5. explicit PAMA mutation authority or an equivalent conforming authority model;
+6. separate M0-M5 target, lifecycle strength, operation, and A0-A5 authority semantics where PAMA applies;
+7. dispute and correction pathways;
+8. audit evidence for crystallization and other consequential mutations;
+9. safe pruning and deletion behavior;
+10. governed recall across scope, tenancy, sensitivity, and dispute state; and
+11. runtime evidence for any claimed conformance level.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,11 +11,33 @@ The repository is intentionally layered. Start with the smallest path that answe
 | Researcher / theorist | [`20-memory-foundations-across-scales.md`](20-memory-foundations-across-scales.md) | `21`, `23`, `24` |
 | Agent architect | [`01-layer-model.md`](01-layer-model.md) | `11`, `13`, `22`, `24` |
 | Implementer | [`22-agentic-memory-theory-and-development.md`](22-agentic-memory-theory-and-development.md) | `02`-`10`, `26`-`39`, schemas and fixtures |
+| Governance / adaptive-authority architect | [`pama/README.md`](pama/README.md) | `04`, `33`, `34`, ADR-004, ADR-020 |
 | Security / privacy reviewer | [`15-memory-threat-model.md`](15-memory-threat-model.md) | `16`, `19`, `28`, `29` |
 | Evaluator / governance reviewer | [`06-conformance-test-plan.md`](06-conformance-test-plan.md) | `09`, `24`, `25`, audit records |
-| Source / provenance reviewer | [`08-source-material-index.md`](08-source-material-index.md) | [`SOURCE_RIGHTS_POLICY.md`](SOURCE_RIGHTS_POLICY.md), source registry, `23` |
+| Source / provenance reviewer | [`08-source-material-index.md`](08-source-material-index.md) | [`SOURCE_RIGHTS_POLICY.md`](SOURCE_RIGHTS_POLICY.md), external source registry, `23` |
 | Product / UX designer | [`11-component-architecture.md`](11-component-architecture.md) | `19`, `22`, `26`, `38` |
 | ADR reviewer | [`adr/README.md`](adr/README.md) | ADR-001 through ADR-020 |
+
+## Native PAMA doctrine
+
+**Proportional Adaptive Mutation Authority (PAMA)** is native Agent Memory doctrine authored by **Kevin R. Knapp**.
+
+Start with [`pama/README.md`](pama/README.md) for the systems-agnostic foundation:
+
+- adaptation is not authority
+- memory is not procedure
+- procedure is not permission
+- permission is not governance
+- M0-M5 mutation target classes
+- lifecycle strength
+- A0-A5 downstream authority classes
+- proportional handling lanes
+- adaptive charters
+- capability authority ceilings
+
+Then use [`04-governance-and-pama.md`](04-governance-and-pama.md) and [`33-pama-decision-table.md`](33-pama-decision-table.md) for the Agent Memory specialization.
+
+PAMA is not represented as an external source dependency. External research, standards, and implementations that support or challenge PAMA retain separate provenance and source-rights treatment.
 
 ## 00-10: Canonical architecture spine
 
@@ -25,21 +47,23 @@ The repository is intentionally layered. Start with the smallest path that answe
 | 01 | [`01-layer-model.md`](01-layer-model.md) | Layer ownership, deterministic substrate, probabilistic epistemics, governance boundaries |
 | 02 | [`02-lifecycle-state-machine.md`](02-lifecycle-state-machine.md) | Memory states, proposal-versus-commit, promotion, dispute, correction, pruning |
 | 03 | [`03-scoring-and-decay.md`](03-scoring-and-decay.md) | Saturation, decay, uncertainty, calibration, drift, threshold stability |
-| 04 | [`04-governance-and-pama.md`](04-governance-and-pama.md) | Mutation authority and bounded consequence |
-| 05 | [`05-repo-implementation-map.md`](05-repo-implementation-map.md) | Mapping of related systems into the architecture |
+| 04 | [`04-governance-and-pama.md`](04-governance-and-pama.md) | Native PAMA specialization: mutation authority and bounded consequence |
+| 05 | [`05-repo-implementation-map.md`](05-repo-implementation-map.md) | Mapping of related implementations into the architecture while keeping native doctrine separate |
 | 06 | [`06-conformance-test-plan.md`](06-conformance-test-plan.md) | Conformance Levels 0-6 and adversarial fixture requirements |
 | 07 | [`07-integration-roadmap.md`](07-integration-roadmap.md) | Doctrine-to-implementation roadmap |
-| 08 | [`08-source-material-index.md`](08-source-material-index.md) | Internal provenance, public source locators, rights posture, and external evidence domains |
+| 08 | [`08-source-material-index.md`](08-source-material-index.md) | External/related provenance, public source locators, rights posture, and evidence domains |
 | 09 | [`09-calibration-protocol.md`](09-calibration-protocol.md) | Calibration, abstention, hysteresis, disagreement, drift |
 | 10 | [`10-memory-unit-examples.md`](10-memory-unit-examples.md) | Concrete memory, uncertainty, authority, receipt, and scope examples |
 
 ### Source rights and provenance
 
 - [`SOURCE_RIGHTS_POLICY.md`](SOURCE_RIGHTS_POLICY.md) defines citation, synthesis, author-originated, licensed, and permission-based reuse modes.
-- [`../sources/source-registry.json`](../sources/source-registry.json) records primary-source access and rights posture.
-- [`../schemas/source-record.schema.json`](../schemas/source-record.schema.json) makes reuse-rights records machine-checkable.
+- [`../sources/source-registry.json`](../sources/source-registry.json) records external/private/material-reuse source posture.
+- [`../schemas/source-record.schema.json`](../schemas/source-record.schema.json) makes those source-rights records machine-checkable.
 
-The default is citation plus independent synthesis. Public readability is not treated as an open license, and private canonical provenance is not replaced with convenient but inaccurate public substitutes.
+The default for external sources is citation plus independent synthesis. Public readability is not treated as an open license, and private canonical provenance is not replaced with convenient but inaccurate public substitutes.
+
+Native contributor-authored doctrine does not need to masquerade as an external source. Its authorship and canonical location belong in the doctrine tree.
 
 ## 11-19: Composition, security, trust, time, and privacy
 
@@ -77,21 +101,21 @@ The default is citation plus independent synthesis. Public readability is not tr
 | 30 | [`30-memory-observability-and-audit-events.md`](30-memory-observability-and-audit-events.md) | Structured memory events and reconstruction evidence |
 | 31 | [`31-recovery-rollback-and-replay.md`](31-recovery-rollback-and-replay.md) | Recovery, compensation, state/version binding, replay semantics |
 | 32 | [`32-memory-quality-metrics.md`](32-memory-quality-metrics.md) | Ongoing quality, safety, calibration, deletion, and outcome metrics |
-| 33 | [`33-pama-decision-table.md`](33-pama-decision-table.md) | Mutation type and risk class to minimum authority outcome, with modifiers |
+| 33 | [`33-pama-decision-table.md`](33-pama-decision-table.md) | Agent Memory operation/risk policy projection of native PAMA doctrine |
 | 34 | [`34-adapter-contracts.md`](34-adapter-contracts.md) | Typed seam contracts: required handoff fields, failure modes, rejection semantics |
 | 35 | [`35-interoperability-profiles.md`](35-interoperability-profiles.md) | Six cumulative reliance profiles for cross-system memory exchange |
 | 36 | [`36-policy-as-memory.md`](36-policy-as-memory.md) | Policies as high-authority memory: versioning, certification, conflict, complete recall |
 | 37 | [`37-memory-economics-and-budget-policy.md`](37-memory-economics-and-budget-policy.md) | Budget dimensions and the pressure-shapes-priority-never-authority boundary |
 | 38 | [`38-human-correction-ux-contract.md`](38-human-correction-ux-contract.md) | Minimum user-facing evidence, correction, dispute, and indicator contract |
-| 39 | [`39-implementation-ownership-map.md`](39-implementation-ownership-map.md) | Component ownership candidates with explicit declared/contested/open status |
+| 39 | [`39-implementation-ownership-map.md`](39-implementation-ownership-map.md) | Doctrine ownership versus candidate runtime implementation ownership |
 
 ## Profiles and future subsystems
 
 | Document | Purpose |
 |---|---|
 | [`profiles/durable-decision-memory-profile.md`](profiles/durable-decision-memory-profile.md) | Decision memory: required fields, rationale preservation, supersession, drift, recall |
-| [`future/memory-compiler.md`](future/memory-compiler.md) | Bulk artifact-to-memory compilation — gated future subsystem |
-| [`future/multi-agent-shared-memory-protocol.md`](future/multi-agent-shared-memory-protocol.md) | Shared memory across agents and tenants — gated future subsystem |
+| [`future/memory-compiler.md`](future/memory-compiler.md) | Bulk artifact-to-memory-unit conversion at scale, gated future subsystem |
+| [`future/multi-agent-shared-memory-protocol.md`](future/multi-agent-shared-memory-protocol.md) | Shared memory across agents and tenants, gated future subsystem |
 
 ## Architecture Decision Records
 
@@ -123,7 +147,7 @@ Start with:
 - [`audits/governed-uncertainty/07b-machine-readable-evidence.md`](audits/governed-uncertainty/07b-machine-readable-evidence.md)
 - [`audits/governed-uncertainty/07c-adr-evidence-acceptance.md`](audits/governed-uncertainty/07c-adr-evidence-acceptance.md)
 
-Source-rights audit:
+Source-rights audits:
 
 - [`audits/source-rights/01-public-provenance-and-reuse-rights.md`](audits/source-rights/01-public-provenance-and-reuse-rights.md)
 
@@ -137,7 +161,7 @@ Schemas:
 - [`../schemas/memory-audit-event.schema.json`](../schemas/memory-audit-event.schema.json)
 - [`../schemas/source-record.schema.json`](../schemas/source-record.schema.json)
 
-Source provenance and rights records:
+External/material source provenance and rights records:
 
 - [`../sources/source-registry.json`](../sources/source-registry.json)
 
@@ -151,6 +175,7 @@ Validation:
 python -m pip install jsonschema
 python scripts/validate_fixtures.py fixtures
 python scripts/validate_schemas.py
+python scripts/validate_doctrine_boundaries.py
 ```
 
 Repository CI runs the same validation through [`../.github/workflows/validate-doctrine-evidence.yml`](../.github/workflows/validate-doctrine-evidence.yml).
@@ -161,6 +186,6 @@ Research may support, challenge, narrow, or reject an architectural idea.
 
 Prefer freely inspectable research where practical, but do not let accessibility outrank evidence quality. Biological and cognitive research should be classified as native mechanism, functional analogy, engineering prescription, or open hypothesis before it is transferred into software doctrine.
 
-Evidence availability and reuse permission remain separate questions. Research sources are citation/synthesis-only by default unless material reuse has an explicit rights record.
+Evidence availability and reuse permission remain separate questions. External research sources are citation/synthesis-only by default unless material reuse has an explicit rights record.
 
 The repository's job is not to collect citations until an idea looks inevitable. Its job is to make assumptions inspectable enough that good evidence can change them without making the repository a rights-management guessing game.

--- a/docs/README.md
+++ b/docs/README.md
@@ -147,9 +147,10 @@ Start with:
 - [`audits/governed-uncertainty/07b-machine-readable-evidence.md`](audits/governed-uncertainty/07b-machine-readable-evidence.md)
 - [`audits/governed-uncertainty/07c-adr-evidence-acceptance.md`](audits/governed-uncertainty/07c-adr-evidence-acceptance.md)
 
-Source-rights audits:
+Source-rights and provenance audits:
 
 - [`audits/source-rights/01-public-provenance-and-reuse-rights.md`](audits/source-rights/01-public-provenance-and-reuse-rights.md)
+- [`audits/source-rights/02-pama-native-provenance-and-implementation-reference-cleanup.md`](audits/source-rights/02-pama-native-provenance-and-implementation-reference-cleanup.md)
 
 ## Machine-readable evidence
 
@@ -159,7 +160,9 @@ Schemas:
 - [`../schemas/conformance-report.schema.json`](../schemas/conformance-report.schema.json)
 - [`../schemas/decision-receipt.schema.json`](../schemas/decision-receipt.schema.json)
 - [`../schemas/memory-audit-event.schema.json`](../schemas/memory-audit-event.schema.json)
+- [`../schemas/calibration-results.schema.json`](../schemas/calibration-results.schema.json)
 - [`../schemas/source-record.schema.json`](../schemas/source-record.schema.json)
+- [`../schemas/pama-decision.schema.json`](../schemas/pama-decision.schema.json)
 
 External/material source provenance and rights records:
 

--- a/docs/SOURCE_RIGHTS_POLICY.md
+++ b/docs/SOURCE_RIGHTS_POLICY.md
@@ -14,9 +14,26 @@ When reuse rights are absent, unclear, unnecessary, or disproportionate to the v
 
 This is a repository governance policy, not a substitute for legal advice.
 
+## Native doctrine versus external source material
+
+Agent Memory distinguishes **native contributor-authored doctrine** from **external source material**.
+
+Native doctrine does not need to be forced into the external source registry merely to demonstrate provenance. Its canonical location and authorship should be recorded in the doctrine tree itself.
+
+For native doctrine:
+
+- record the contributor or originator when provenance matters;
+- keep the canonical doctrine in this repository;
+- do not invent an external locator or external reuse license;
+- separately govern any third-party research, standards text, diagrams, code, or other expression incorporated into or used to support that doctrine.
+
+**Proportional Adaptive Mutation Authority (PAMA) is native Agent Memory doctrine authored by Kevin R. Knapp.** Its canonical foundation is [`pama/README.md`](pama/README.md). External OWASP, NIST, regulatory, research, or implementation references may support, challenge, benchmark, or align with PAMA, but they are not the source of PAMA.
+
+This distinction matters because a contributor-authored framework may itself cite external standards. The presence of those references does not transfer authorship of the framework to the standards body, nor does contributor authorship grant permission to copy protected expression from the referenced standards.
+
 ## Default source treatment
 
-Unless a stronger reuse basis has been verified and recorded, treat external material as:
+Unless a stronger reuse basis has been verified and recorded, treat **external** material as:
 
 ```text
 LINKABLE
@@ -29,25 +46,27 @@ SYNTHESIS-ONLY
 The repository should express the idea independently rather than copy distinctive prose, diagrams, tables, screenshots, or code.
 ```
 
-Unknown rights status defaults to **citation and independent synthesis only**.
+Unknown external rights status defaults to **citation and independent synthesis only**.
 
 ## Reuse modes
 
-Every material source should be classifiable as one of these modes:
+Every materially relevant external source should be classifiable as one of these modes:
 
 | Mode | Meaning | Default posture |
 |---|---|---|
 | `citation_only` | Link or cite the source without importing protected expression | Safe default |
 | `independent_synthesis` | Explain facts, ideas, findings, or mechanisms in original repository language | Preferred default |
-| `author_originated` | Material originated with a repository contributor who is asserting authorship/provenance | May be reused subject to contributor authority and any third-party constraints |
+| `author_originated` | Material originated with a repository contributor who is asserting authorship/provenance outside or before the current repository | May be reused subject to contributor authority and any third-party constraints |
 | `licensed_reuse` | Copy or adapt material under a verified license | License obligations must be satisfied |
 | `permission_granted` | Copy or adapt under explicit permission outside a standard license | Permission evidence must be retained |
 
 `licensed_reuse` and `permission_granted` require an explicit reuse basis in the source registry.
 
+Native doctrine maintained directly in Agent Memory is not required to have a source-registry entry unless there is a separate material-reuse reason to create one.
+
 ## What may be linked
 
-When a named source has a lawful, stable public locator, link the most specific authoritative artifact available.
+When a named external source has a lawful, stable public locator, link the most specific authoritative artifact available.
 
 Prefer, in order:
 
@@ -104,6 +123,7 @@ For example, an MIT-licensed repository may contain an issue comment written by 
 - Private accessibility is not publication permission.
 - Do not expose private URLs, confidential text, screenshots, or implementation details merely to make public provenance look complete.
 - A public successor or related project may be identified, but it must be labeled as a successor or related implementation rather than substituted for the private provenance source.
+- A private project should not appear in active Agent Memory provenance surfaces merely because it is conceptually adjacent. It should add a specific, articulable implementation or evidence value.
 
 ### Code
 
@@ -141,9 +161,11 @@ An authorship/provenance statement is not automatically a claim that the underly
 
 For UOR Framework issue #2, the thermodynamic memory-lifecycle proposal was opened by Kevin R. Knapp. The **"thermodynamic ground state" framing as used in that proposal is recorded in Agent Memory as a Kevin R. Knapp contribution**. This is a provenance record. It does not depend on treating the phrase itself as an exclusively protectable asset.
 
+PAMA is stronger than a provenance note attached to an external source: it is a contributor-authored framework maintained as native Agent Memory doctrine. Its external alignment references retain their own rights and citation requirements.
+
 ## Material-reuse record
 
-When source material is materially reused rather than merely cited or independently synthesized, record at least:
+When external source material is materially reused rather than merely cited or independently synthesized, record at least:
 
 ```text
 source_ref
@@ -161,7 +183,7 @@ reuse_basis
 verified_at
 ```
 
-Machine-readable primary-source records live in `sources/source-registry.json` and are validated against `schemas/source-record.schema.json`.
+Machine-readable external/material-reuse records live in `sources/source-registry.json` and are validated against `schemas/source-record.schema.json`.
 
 ## Hard gates
 
@@ -175,6 +197,8 @@ A source marked private must not receive a fabricated public provenance link.
 
 A project successor must not be represented as the originating source.
 
+Native contributor-authored doctrine must not be mislabeled as an unresolved external source merely because it previously existed in another document or repository context.
+
 ## Review checklist
 
 Before merging externally sourced material, reviewers should ask:
@@ -187,5 +211,7 @@ Before merging externally sourced material, reviewers should ask:
 - Is any private or confidential provenance being exposed?
 - Is contributor-originated material correctly attributed?
 - Are we recording provenance without overstating legal exclusivity?
+- Is this actually an external source, or is it native contributor-authored doctrine that belongs in the doctrine tree?
+- Does a named private or external project add specific value here, or is it merely adjacent?
 
 When the answer is uncertain, prefer citation and independent synthesis and record the unresolved rights question rather than rationalizing reuse after the fact.

--- a/docs/adr/ADR-004-pama-controls-mutation-authority.md
+++ b/docs/adr/ADR-004-pama-controls-mutation-authority.md
@@ -6,31 +6,55 @@ Accepted
 
 ## Context
 
-Agentic memory systems need to adapt. Adaptation requires mutation of scores, links, summaries, states, and sometimes durable memory records.
+Agentic memory systems need to adapt. Adaptation requires mutation of scores, links, summaries, states, procedures, capabilities, and sometimes durable memory records.
 
 Without explicit authority, adaptive memory becomes silent self-modification.
+
+**Proportional Adaptive Mutation Authority (PAMA) is native Agent Memory doctrine authored by Kevin R. Knapp.** Its systems-agnostic foundation is maintained in [`../pama/README.md`](../pama/README.md), with the memory-specific contract in [`../04-governance-and-pama.md`](../04-governance-and-pama.md).
+
+PAMA is not an external dependency whose legitimacy depends on a standalone repository. Runtime systems implement its authority contract.
 
 ## Decision
 
 PAMA controls mutation authority, or an implementation must provide an equivalent explicit authority model conforming to the same doctrine.
 
-Any consequential transition that changes memory state, durable content, graph relations, promotion status, correction state, pruning/deletion state, sharing scope, or certification status must pass through that authority boundary.
+Any consequential transition that changes memory state, durable content, graph relations, promotion status, correction state, pruning/deletion state, sharing scope, capability authority, or certification status must pass through that authority boundary.
+
+A PAMA decision considers separate dimensions including:
+
+```text
+M0-M5 mutation target class
+lifecycle strength
+requested operation
+A0-A5 downstream authority
+risk
+scope
+reversibility
+actor / adaptive charter
+evidence and uncertainty
+policy state
+```
 
 Probabilistic or learned components may estimate confidence, trust, relevance, sensitivity, contradiction, utility, or risk. They may not grant themselves authority from those estimates.
+
+A validated procedure or reusable capability does not automatically gain permission to execute externally. Reliability and authority remain separate.
 
 ## Consequences
 
 ### Positive
 
 - makes memory mutation auditable
-- scales autonomy by risk and reversibility
+- scales autonomy by consequence, risk, authority, and reversibility
+- permits low-risk adaptation without requiring human review for every observation
 - prevents unauthorized rewriting of durable memory
-- gives agents a clear boundary between inference and mutation
+- prevents validated capabilities from silently expanding their authority ceiling
+- gives agents a clear boundary between inference, learning, procedure, permission, and governance
 
 ### Negative
 
 - requires policy design
-- requires mutation metadata
+- requires mutation metadata and target/authority classification
+- requires adaptive charter or equivalent actor-scope semantics
 - may slow down high-impact memory changes
 
 ## Authority outcomes
@@ -49,9 +73,21 @@ Implementations may add bounded outcomes such as `abstain`, `quarantine`, or `co
 
 ## Acceptance scope
 
-Accepted establishes explicit mutation authority as canonical doctrine. It does not require one PAMA codebase or claim runtime enforcement exists in every implementation.
+Accepted establishes PAMA and explicit mutation authority as canonical Agent Memory doctrine.
+
+Acceptance does **not** require one external PAMA codebase, standalone repository, or deployment topology. A conforming implementation may host the PAMA evaluator in a service, policy module, library, runtime, or other boundary, provided the semantics remain separately inspectable and auditable.
+
+Accepted also does not claim runtime enforcement exists in every implementation. Runtime evidence remains required for implementation conformance and for the broader governed-uncertainty acceptance boundary in ADR-020.
 
 ## Doctrine
+
+Adaptation is not authority.
+
+Memory is not procedure.
+
+Procedure is not permission.
+
+Permission is not governance.
 
 Capability is not authority.
 

--- a/docs/adr/ADR-007-agent-memory-is-component-architecture.md
+++ b/docs/adr/ADR-007-agent-memory-is-component-architecture.md
@@ -6,21 +6,25 @@ Accepted
 
 ## Context
 
-The Agent Memory doctrine consolidates concepts from UOR, EvolveAI, CodeGenome, COREFORGE Vault / Neurospace, PAMA, FailSafe, Arbiter, Bicameral, and related systems.
+The Agent Memory doctrine combines native architecture with evidence and implementation lessons from systems such as UOR, EvolveAI, CodeGenome, COREFORGE Vault / Neurospace, FailSafe, Arbiter, and future conforming implementations.
 
-These concepts are tightly related, but they do not all belong in the same implementation layer.
+**PAMA is native Agent Memory doctrine authored by Kevin R. Knapp**, not an external system being consolidated into the architecture.
 
-If everything is treated as one concept, the architecture becomes vague. If everything is split into unrelated projects, the doctrine fragments.
+These concepts and implementations are tightly related, but they do not all belong in the same implementation layer.
+
+If everything is treated as one concept, the architecture becomes vague. If everything is split into unrelated projects, the doctrine fragments. If every adjacent product is named as a doctrine source, implementation history starts masquerading as architecture.
 
 ## Decision
 
 Agent Memory is one overall architecture composed of bounded components.
 
-The doctrine repo owns the shared architecture, vocabulary, contracts, segmentation rules, and conformance expectations.
+The doctrine repo owns the shared architecture, vocabulary, contracts, native doctrine such as PAMA, segmentation rules, and conformance expectations.
 
-Individual repos own implementation slices.
+Individual repos may own implementation slices after they provide a meaningful mapping to those contracts.
 
 Components may contain deterministic, probabilistic, learned, or hybrid internals, but cross-component handoffs must preserve signal semantics, provenance, scope, uncertainty, and authority boundaries.
+
+External implementation names are non-canonical examples. Their presence in an implementation map does not grant them ownership of the underlying doctrine concept.
 
 ## Component boundaries
 
@@ -31,15 +35,18 @@ The canonical components include:
 3. Reality Graphs
 4. Lifecycle Engine
 5. Saturation and Decay Engine
-6. Governance and Mutation Authority
+6. Governance and Mutation Authority (PAMA)
 7. Certification and Crystallization Gate
 8. Runtime Memory Space
 9. Context Assembly Surface
 10. Correction and Dispute Surface
-11. Conformance and Calibration Harness
-12. Product and Agent Integrations
+11. Durable Decision Memory
+12. Conformance and Calibration Harness
+13. Product and Agent Integrations
 
 Additional components may be added when they have distinct cross-system interfaces and failure modes.
+
+PAMA's native foundation is maintained in [`../pama/README.md`](../pama/README.md).
 
 ## Consequences
 
@@ -48,22 +55,25 @@ Additional components may be added when they have distinct cross-system interfac
 - preserves one coherent architecture
 - avoids monolithic implementation pressure
 - gives every concept a home
+- separates doctrine ownership from implementation ownership
 - makes cross-repo adoption easier
 - allows conformance to test boundaries rather than repo names
 - supports product runtimes without letting them redefine doctrine locally
+- prevents adjacent products from becoming accidental provenance requirements
 
 ### Negative
 
 - requires adapter contracts between components
 - requires careful documentation discipline
-- requires cross-repo backlinks and implementation maps
+- requires cross-repo backlinks and implementation maps when external implementations are material
 - creates composition-specific failure modes that must be tested
+- requires explicit distinction between native doctrine and imported evidence or implementation patterns
 
 ## Rejected alternatives
 
 ### One monolithic memory system
 
-Rejected because identity, inference, scoring, certification, governance, runtime use, privacy, and correction have distinct failure modes.
+Rejected because identity, inference, scoring, certification, governance, runtime use, privacy, correction, and durable decision memory have distinct failure modes.
 
 ### Completely separate concepts
 
@@ -73,12 +83,18 @@ Rejected because the concepts participate in governed memory transition/admissio
 
 Rejected because products should conform to doctrine rather than redefine memory terms locally.
 
+### Repository-name architecture
+
+Rejected because an architecture should not require an adjacent product to remain named after the product stops adding unique implementation evidence.
+
 ## Acceptance scope
 
-Accepted establishes component architecture as canonical doctrine. It does not freeze the component list forever or require one repository per component.
+Accepted establishes component architecture as canonical doctrine. It does not freeze the component list forever, require one repository per component, or require external repositories for native Agent Memory doctrine.
 
 ## Doctrine
 
 Agent Memory is unified by contracts, not repository location.
+
+PAMA is native doctrine, not a repository dependency.
 
 The system is one architecture, segmented into bounded components, composed through governed handoffs.

--- a/docs/audits/source-rights/02-pama-native-provenance-and-implementation-reference-cleanup.md
+++ b/docs/audits/source-rights/02-pama-native-provenance-and-implementation-reference-cleanup.md
@@ -1,0 +1,98 @@
+# Source Rights Audit 02: PAMA Native Provenance and Implementation Reference Cleanup
+
+## Trigger
+
+The repository had incorrectly represented Proportional Adaptive Mutation Authority (PAMA) alongside external and related source systems, including a source-registry record whose rights status was unresolved.
+
+During review, Kevin R. Knapp supplied the full systems-agnostic PAMA conceptual architecture and confirmed that PAMA is his original content and is core to Agent Memory.
+
+The same review challenged whether references to Bicameral added sufficient specific value to justify retaining a private adjacent product in active Agent Memory provenance and implementation surfaces.
+
+## Findings
+
+### PAMA provenance
+
+The prior representation was materially wrong.
+
+PAMA is not an external dependency from which Agent Memory merely synthesizes mutation-governance ideas. It is native Agent Memory doctrine authored by Kevin R. Knapp.
+
+The supplied PAMA framework establishes, among other things:
+
+- adaptation is not authority;
+- memory is not procedure;
+- procedure is not permission;
+- permission is not governance;
+- review belongs at promotion and consequence boundaries rather than every observation boundary;
+- M0-M5 mutation target classes;
+- lifecycle strength from observed through canonical, with decay/demotion paths;
+- A0-A5 downstream authority classes;
+- proportional handling lanes;
+- adaptive charters;
+- reusable capability authority ceilings;
+- evidence, lineage, correction, revocation, and outcome monitoring.
+
+### Taxonomy drift
+
+Agent Memory's operational PAMA docs had also used the phrase `mutation classes` for operations such as promotion, correction, pruning, and policy mutation.
+
+Those operations are valid Agent Memory policy dimensions, but they are not the same thing as PAMA's foundational M0-M5 mutation target classes.
+
+The correction separates:
+
+```text
+PAMA target class
+lifecycle strength
+requested operation
+downstream authority
+risk
+scope
+reversibility
+actor / charter
+evidence / uncertainty
+policy
+```
+
+### Adjacent private product references
+
+The reviewed Bicameral references did not provide concrete implementation evidence or a unique architectural dependency that Agent Memory could not express directly.
+
+Decision-continuity concepts are already representable through Agent Memory's durable-decision memory profile. Therefore active references were removed rather than preserving product adjacency as provenance.
+
+Historical audit/governance records are not rewritten; they remain evidence of the repository's actual development history.
+
+## Changes
+
+- Added `docs/pama/README.md` as the canonical native PAMA foundation.
+- Reworked `docs/04-governance-and-pama.md` around the native PAMA taxonomy.
+- Reworked `docs/33-pama-decision-table.md` so operation/risk lookup is explicitly one projection of PAMA rather than the definition of PAMA.
+- Removed PAMA from the external/material source registry.
+- Removed Bicameral from the external/material source registry.
+- Removed Bicameral from active source and implementation mapping surfaces.
+- Reframed `docs/05-repo-implementation-map.md` around native doctrine versus related implementation systems.
+- Reframed `docs/39-implementation-ownership-map.md` to separate PAMA doctrine ownership from runtime implementation ownership.
+- Updated ADR-004 to record PAMA's native authorship and deployment-independent acceptance scope.
+- Updated source-rights policy to distinguish native contributor-authored doctrine from external source material.
+- Added CI validation to protect the native PAMA boundary and prevent unreviewed adjacent-product references from drifting back into active doctrine.
+
+## Rights consequence
+
+PAMA itself no longer requires an external source-rights record.
+
+External research, standards, implementations, comments, papers, diagrams, code, or other expression used to support, challenge, align with, or implement PAMA remain governed independently by `SOURCE_RIGHTS_POLICY.md`.
+
+Contributor authorship of PAMA does not erase third-party rights in material PAMA cites or discusses.
+
+## Implementation consequence
+
+PAMA doctrine ownership is resolved:
+
+```text
+PAMA doctrine owner: Agent Memory / Kevin R. Knapp
+runtime PAMA implementation owner: open until implementation evidence exists
+```
+
+A runtime may host the PAMA evaluator inside another codebase, but it must preserve the authority boundary and conformance semantics.
+
+## Audit boundary
+
+This audit records provenance and architecture decisions. It is not a legal determination of copyright scope or an implementation-conformance claim.

--- a/docs/pama/README.md
+++ b/docs/pama/README.md
@@ -1,0 +1,163 @@
+# Proportional Adaptive Mutation Authority (PAMA)
+
+## Status
+
+PAMA is **native Agent Memory doctrine**, not an external source system or borrowed dependency.
+
+The Proportional Adaptive Mutation Authority architecture originated with **Kevin R. Knapp**. Agent Memory adopts PAMA as a core governance foundation and specializes it for durable memory, procedural learning, policy, correction, deletion, scope, and agent action boundaries.
+
+External frameworks used to evaluate or align PAMA, such as OWASP, NIST, or regulatory guidance, are evidence and alignment references. They are not the source of PAMA and do not change its authorship provenance.
+
+## Foundational thesis
+
+> **Adaptation should be broadly available to authorized agents. Authority to make a mutation durable, influential, shared, or action-enabling should increase in proportion to the mutation's consequence.**
+
+PAMA exists to avoid three failure modes at once:
+
+1. **stagnation**, where agents cannot form durable improvement loops;
+2. **casual self-editing**, where observations silently become assumptions, defaults, procedures, or authority; and
+3. **over-governance**, where every low-risk observation requires human approval and meaningful review collapses into fatigue.
+
+The governing review rule is:
+
+> **Review should be applied at promotion and consequence boundaries, not at every observation boundary.**
+
+## Four separations
+
+PAMA starts with four distinctions that Agent Memory must preserve:
+
+```text
+adaptation != authority
+memory != procedure
+procedure != permission
+permission != governance
+```
+
+An agent may observe, infer, propose, or learn without automatically receiving authority to apply a durable or consequential change.
+
+A remembered fact or preference does not automatically become an executable workflow.
+
+A validated procedure does not automatically authorize execution.
+
+Permission to act does not authorize an agent to expand, weaken, or redefine governance itself.
+
+## Mutation target classes
+
+PAMA classifies **what is being changed** separately from the operation used to change it.
+
+| Class | Target type | Examples | Default posture |
+|---|---|---|---|
+| **M0** | Execution-local context | current-session correlation, temporary intent interpretation, local retrieval hint | transient; expire automatically |
+| **M1** | Low-risk personal preference | formatting, terminology, view, pacing | tentative, visible, reversible |
+| **M2** | Operational association | project routing, recurring task association, workflow suggestion | evidence-backed; recommendation influence |
+| **M3** | Reusable procedure or capability | validated checklist, repair sequence, reusable workflow | validation and promotion controls |
+| **M4** | Shared fact or identity-bearing state | relationship, entitlement, commitment, permission-affecting fact | authoritative evidence and controlled review |
+| **M5** | Governance, security, or autonomous-action authority | policy exemption, trust elevation, send/deploy/delete authority | explicit authorization; no self-approval |
+
+These target classes are foundational PAMA taxonomy. Agent Memory's mutation operations such as `promotion`, `correction`, `pruning`, `scope expansion`, and `policy mutation` are a separate dimension.
+
+## Lifecycle strength
+
+PAMA also distinguishes the strength of retained adaptive state:
+
+```text
+Observed -> Tentative -> Reinforced -> Promoted -> Canonical
+                   \-> Decaying -> Archived / Deprecated / Blocked
+```
+
+Strength is not authority. A highly reinforced item may still be barred from external action. A tentative item may be retained safely while being prevented from influencing consequential behavior.
+
+## Downstream authority classes
+
+Every retained mutation should declare the maximum authority it may influence.
+
+| Class | Authority | Meaning |
+|---|---|---|
+| **A0** | Retrieval only | may appear in inspection or context recall |
+| **A1** | Recommendation influence | may affect rankings, suggestions, routing, or planning |
+| **A2** | Draft generation | may shape drafts for human review but cannot execute them |
+| **A3** | Local workflow mutation | may update authorized internal state |
+| **A4** | External action | may affect messages, deployments, purchases, deletions, bookings, or provider state |
+| **A5** | Governance change | may alter privileges, policies, trust, enforcement, or future autonomous authority |
+
+A mutation's lifecycle strength and downstream authority must be evaluated together.
+
+> **Validation can justify trust in a capability. It does not automatically grant permission to use that capability autonomously.**
+
+## Proportional handling lanes
+
+PAMA concentrates friction where consequence increases:
+
+| Lane | Typical use | Core control |
+|---|---|---|
+| **1. Transient automatic** | M0 context and narrow interpretations | no durable authority or external effect |
+| **2. Tentative low-risk retention** | M1 and selected recommendation-only M2 | visible, removable, scoped |
+| **3. Evidence-backed reinforcement** | meaningful but reversible M2 | evidence, correction, conflict checks |
+| **4. Promotion and review** | M3, shared knowledge, meaningful workflow behavior | validation, versioning, authority ceiling, rollback |
+| **5. Restricted authority** | M4/M5 effects involving external action or governance | explicit authorized review, no self-approval, fail closed when authority is ambiguous |
+
+## Adaptive mutation contract
+
+A serious implementation needs a structured mutation proposal carrying at least:
+
+```text
+proposal identity
+proposing agent and charter version
+target reference, domain, class, and scope
+mutation operation
+current and proposed lifecycle strength
+downstream authority ceiling
+reversibility
+evidence and validation references
+corrections and failure evidence
+confidence and uncertainty where applicable
+freshness requirements
+sensitivity
+recommended handling
+policy decision reference
+```
+
+Missing fields must not be interpreted as low risk. Unknown consequence is not presumed safety.
+
+## Security and governance invariants
+
+The following remain true regardless of implementation technology:
+
+1. No mutation becomes more authoritative merely because a trusted agent proposed it.
+2. Missing classification data must not auto-classify a high-impact mutation as low risk.
+3. A reusable capability does not implicitly grant external-action or governance authority.
+4. An agent must not approve its own expansion of privilege, trust, exception, or autonomy.
+5. Evidence-bearing claims must not rely on fabricated or placeholder provenance.
+6. Promotion must not rely only on recurrence, retrieval success, or model confidence.
+7. Security-relaxing mutations require stricter treatment than protective observations.
+8. Learned state remains subject to correction, staleness, conflict, revocation, and failure evidence.
+9. Context assembly must preserve whether memory is tentative, promoted, canonical, stale, corrected, or disputed.
+10. Claims of safe self-improvement require downstream outcome and authority-compliance evidence.
+
+## Agent Memory specialization
+
+Agent Memory operationalizes PAMA across several documents rather than treating it as a separate external project:
+
+- [`../04-governance-and-pama.md`](../04-governance-and-pama.md) defines the memory-specific authority boundary and evaluation contract.
+- [`../33-pama-decision-table.md`](../33-pama-decision-table.md) specializes PAMA into operation/risk decision data.
+- [`../34-adapter-contracts.md`](../34-adapter-contracts.md) defines the typed PAMA handoff boundary.
+- [`../36-policy-as-memory.md`](../36-policy-as-memory.md) applies PAMA to high-authority policy memory.
+- [`../38-human-correction-ux-contract.md`](../38-human-correction-ux-contract.md) exposes correction and consequential review to humans.
+- [`../adr/ADR-004-pama-controls-mutation-authority.md`](../adr/ADR-004-pama-controls-mutation-authority.md) makes PAMA canonical architecture doctrine.
+- [`../adr/ADR-020-probabilistic-discovery-deterministic-governance.md`](../adr/ADR-020-probabilistic-discovery-deterministic-governance.md) applies PAMA to probabilistic discovery and governed consequence.
+
+## Provenance rule
+
+PAMA should not appear in the external source-rights registry merely because it has conceptual provenance. It is contributor-originated native doctrine in this repository.
+
+External sources that challenge, support, benchmark, regulate, or provide implementation analogies for PAMA retain their own source and rights records.
+
+## Doctrine
+
+PAMA is not a memory score.
+
+PAMA is not a human-approval-everywhere system.
+
+PAMA is the architecture that allows adaptation while scaling mutation authority with consequence.
+
+**Learning may be broad. Consequence remains governed.**

--- a/docs/profiles/durable-decision-memory-profile.md
+++ b/docs/profiles/durable-decision-memory-profile.md
@@ -2,11 +2,13 @@
 
 ## Purpose
 
-This is the first entry in the profile family: doctrine applied to one high-value memory class. Decision memory serves Bicameral-style decision continuity, agent governance, product planning, and code evolution — and decisions are not ordinary facts. A fact is true or it is not. A decision was *made*: by someone, over alternatives, for reasons, within a scope, until superseded.
+This is the first entry in the profile family: doctrine applied to one high-value memory class. Decision memory serves decision continuity, agent governance, product planning, organizational memory, and code evolution. Decisions are not ordinary facts. A fact is true or it is not. A decision was *made*: by someone, over alternatives, for reasons, within a scope, until superseded.
 
 Treating decisions as facts produces the familiar failures: decisions relitigated because the rationale evaporated, superseded decisions enforced by agents that remembered the conclusion but not the retirement, and drift between what was decided and what is being done that nobody can date.
 
 This profile defines the required shape, lifecycle handling, recall rules, and conformance surface for decision memory. It builds on the general doctrine and assumes it; nothing here relaxes a general rule.
+
+A particular product may implement this profile, but product adjacency is not doctrine provenance. Implementation claims should be added only when evidence demonstrates meaningful conformance to the profile.
 
 ## Required fields
 
@@ -54,33 +56,45 @@ reversal without replacement -> status = reversed, with rationale for reversal
 expiry                       -> status = expired at effective_until / unactioned review_by
 ```
 
-A superseded decision is never deleted by supersession — decision history is exactly the memory class whose past states stay load-bearing (audits, "why is the system like this," re-evaluation).
+A superseded decision is never deleted by supersession. Decision history is exactly the memory class whose past states stay load-bearing for audits, explanation, and re-evaluation.
 
 **Drift** is the gap between an active decision and observed reality:
 
-- Detectors (agents, conformance runs, humans) may attach `drift_signals` — estimator outputs, with provenance and uncertainty per the evidence rules.
-- Drift signals never auto-supersede. Material drift routes to the decision's owner for a governed outcome: reaffirm, revise (new decision superseding), or reverse. An estimator observing drift and "correcting" the decision itself is the confidence-becomes-authority failure with a paper trail.
+- Detectors, whether agents, conformance runs, or humans, may attach `drift_signals`: estimator outputs with provenance and uncertainty per the evidence rules.
+- Drift signals never auto-supersede. Material drift routes to the decision's owner for a governed outcome: reaffirm, revise through a new superseding decision, or reverse. An estimator observing drift and "correcting" the decision itself is the confidence-becomes-authority failure with a paper trail.
 - Unreviewed drift past `review_by` escalates per the review-budget rules of [`../37-memory-economics-and-budget-policy.md`](../37-memory-economics-and-budget-policy.md); the conservative interim state is that the decision stands but is flagged contested-by-drift in recall.
 
 ## Owner and approval metadata
 
-- Ownership is a role or principal that survives personnel change; orphaned decisions (owner no longer resolvable) are flagged for re-ownership at next review, not silently ownerless.
-- Approval strength scales with the decision's risk class per [`../33-pama-decision-table.md`](../33-pama-decision-table.md): a team convention needs less than a security boundary decision.
-- Corrections to decision *records* (typos, mislinked evidence) are ordinary corrections per [`../38-human-correction-ux-contract.md`](../38-human-correction-ux-contract.md). Changing what was decided is never a correction; it is supersession or reversal by the owner's authority.
+- Ownership is a role or principal that survives personnel change; orphaned decisions, where the owner is no longer resolvable, are flagged for re-ownership at next review, not silently ownerless.
+- Approval strength scales with the decision's PAMA target class, downstream authority, and operational risk per [`../33-pama-decision-table.md`](../33-pama-decision-table.md): a team convention needs less than a security-boundary decision.
+- Corrections to decision *records* such as typos or mislinked evidence are ordinary corrections per [`../38-human-correction-ux-contract.md`](../38-human-correction-ux-contract.md). Changing what was decided is never a correction; it is supersession or reversal by the owner's authority.
 
 ## Recall and certification rules
 
-**Recall** (through [`../26-governed-recall-planner.md`](../26-governed-recall-planner.md)):
+**Recall** through [`../26-governed-recall-planner.md`](../26-governed-recall-planner.md):
 
-- An agent acting within a decision's scope gets the decision recalled with policy-grade completeness — the applicable-set rule of [`../36-policy-as-memory.md`](../36-policy-as-memory.md) applies: missing an active in-scope decision is a recall failure.
+- An agent acting within a decision's scope gets the decision recalled with policy-grade completeness. The applicable-set rule of [`../36-policy-as-memory.md`](../36-policy-as-memory.md) applies: missing an active in-scope decision is a recall failure.
 - Recall returns the decision with its status. Superseded and reversed decisions surface only as historical, never as current constraints; a drift-flagged decision surfaces with the flag.
-- Rationale and alternatives are recallable on demand but need not be admitted into every context — the decision statement, scope, and status are the working set; the rest is one hop away with provenance intact.
+- Rationale and alternatives are recallable on demand but need not be admitted into every context. The decision statement, scope, and status are the working set; the rest is one hop away with provenance intact.
 
 **Certification**:
 
-- An active decision constrains behavior, which makes it authority-adjacent: certification for decision memory verifies the *record* — statement matches approval, scope is defined, owner resolvable, supersession chain intact — not the decision's wisdom.
+- An active decision constrains behavior, which makes it authority-adjacent: certification for decision memory verifies the *record*. Statement matches approval, scope is defined, owner is resolvable, and the supersession chain is intact. Certification does not certify the decision's wisdom.
 - Certified-active decisions are the only ones agents may treat as binding constraints. Uncertified decision records are candidate memory: recallable, flagged, non-binding.
-- Certification revocation (broken supersession chain, unresolvable authority) demotes the decision to disputed per [`../31-recovery-rollback-and-replay.md`](../31-recovery-rollback-and-replay.md) — visible, contested, non-binding until repaired.
+- Certification revocation due to a broken supersession chain or unresolvable authority demotes the decision to disputed per [`../31-recovery-rollback-and-replay.md`](../31-recovery-rollback-and-replay.md): visible, contested, non-binding until repaired.
+
+## PAMA treatment
+
+Decision memory uses native PAMA semantics rather than product-specific authority assumptions.
+
+Depending on scope and consequence, a decision commonly falls into:
+
+- **M2** when it is an operational association or recommendation only;
+- **M4** when it becomes a shared, commitment-bearing, identity-bearing, or permission-affecting decision state; or
+- **M5** when it changes governance, security, privilege, or autonomous-action authority.
+
+Its downstream authority ceiling may range from A0 recall to A5 governance change. A decision record does not gain a stronger authority ceiling merely because it is old, frequently recalled, highly saturated, or repeatedly followed.
 
 ## Conformance fixture recommendations
 
@@ -93,6 +107,7 @@ A superseded decision is never deleted by supersession — decision history is e
 | Alternative set lost in consolidation | fails: compression preserved statement but dropped alternatives/approvals |
 | Approval chain unreconstructable | certification refused; decision non-binding — the [`../../fixtures/authority-laundering.json`](../../fixtures/authority-laundering.json) pattern applied to decisions |
 | Conflicting active decisions in one scope | governed conflict per [`../17-conflict-resolution-engine.md`](../17-conflict-resolution-engine.md); strictest-applicable interim; no recency-wins |
+| Product claims decision-memory conformance without profile evidence | claim remains unverified; product name does not substitute for fixture or runtime evidence |
 
 A `superseded-decision-recall` fixture is the highest-value addition and should join the fixture backlog tracked in issue #43.
 
@@ -100,4 +115,4 @@ A `superseded-decision-recall` fixture is the highest-value addition and should 
 
 A decision is memory with an owner, a reason, and an expiry on its certainty.
 
-Store the conclusion and you have a fact that will rot. Store the commitment — rationale, alternatives, authority, scope, supersession — and the system can do the one thing decision memory exists for: change its mind on purpose, and know that it did.
+Store the conclusion and you have a fact that will rot. Store the commitment, including rationale, alternatives, authority, scope, and supersession, and the system can do the one thing decision memory exists for: change its mind on purpose, and know that it did.

--- a/schemas/pama-decision.schema.json
+++ b/schemas/pama-decision.schema.json
@@ -1,0 +1,291 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Knapp-Kevin/agent-memory/schemas/pama-decision.schema.json",
+  "title": "Proportional Adaptive Mutation Authority Decision",
+  "description": "Doctrine-level contract for a PAMA authority evaluation. PAMA is native Agent Memory doctrine authored by Kevin R. Knapp. This schema separates mutation target class, lifecycle strength, requested operation, downstream authority, evidence, policy, and resulting authority envelope.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "proposal_id",
+    "proposing_actor",
+    "target",
+    "mutation",
+    "basis",
+    "policy",
+    "decision"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "proposal_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "proposing_actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "charter_version"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "role": {"type": "string", "minLength": 1},
+        "charter_version": {"type": "string", "minLength": 1},
+        "authority_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reference", "class", "scope"],
+      "properties": {
+        "reference": {"type": "string", "minLength": 1},
+        "domain": {"type": "string", "minLength": 1},
+        "class": {
+          "type": "string",
+          "enum": [
+            "M0_EXECUTION_LOCAL_CONTEXT",
+            "M1_LOW_RISK_PERSONAL_PREFERENCE",
+            "M2_OPERATIONAL_ASSOCIATION",
+            "M3_REUSABLE_PROCEDURE_OR_CAPABILITY",
+            "M4_SHARED_OR_IDENTITY_BEARING_STATE",
+            "M5_GOVERNANCE_SECURITY_OR_AUTONOMOUS_AUTHORITY"
+          ]
+        },
+        "scope": {"type": "string", "minLength": 1},
+        "tenant_ref": {"type": "string", "minLength": 1},
+        "purpose": {"type": "string", "minLength": 1}
+      }
+    },
+    "mutation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "current_strength",
+        "proposed_strength",
+        "downstream_authority",
+        "reversibility",
+        "risk_class"
+      ],
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "runtime_assembly",
+            "score_adjustment",
+            "link_creation",
+            "link_deletion",
+            "correction",
+            "promotion",
+            "crystallization",
+            "pruning",
+            "permanent_deletion",
+            "scope_expansion",
+            "policy_mutation",
+            "capability_promotion",
+            "authority_change",
+            "other"
+          ]
+        },
+        "current_strength": {
+          "type": "string",
+          "enum": [
+            "observed",
+            "tentative",
+            "reinforced",
+            "promoted",
+            "canonical",
+            "decaying",
+            "archived",
+            "deprecated",
+            "blocked",
+            "not_applicable"
+          ]
+        },
+        "proposed_strength": {
+          "type": "string",
+          "enum": [
+            "observed",
+            "tentative",
+            "reinforced",
+            "promoted",
+            "canonical",
+            "decaying",
+            "archived",
+            "deprecated",
+            "blocked",
+            "not_applicable"
+          ]
+        },
+        "downstream_authority": {
+          "type": "string",
+          "enum": [
+            "A0_RETRIEVAL_ONLY",
+            "A1_RECOMMENDATION_INFLUENCE",
+            "A2_DRAFT_GENERATION",
+            "A3_LOCAL_WORKFLOW_MUTATION",
+            "A4_EXTERNAL_ACTION",
+            "A5_GOVERNANCE_CHANGE"
+          ]
+        },
+        "reversibility": {
+          "type": "string",
+          "enum": [
+            "ephemeral",
+            "reversible",
+            "versioned_revocable",
+            "compensatable",
+            "irreversible",
+            "unknown"
+          ]
+        },
+        "risk_class": {
+          "type": "string",
+          "enum": ["low", "medium", "high", "critical"]
+        },
+        "requested_scope_change": {"type": "string"}
+      }
+    },
+    "basis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_refs"],
+      "properties": {
+        "justification": {"type": "string"},
+        "evidence_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "validation_result_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "correction_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "estimator_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "estimator_versions": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "calibration_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "uncertainty_summary": {"type": "string"},
+        "freshness_requirement": {"type": "string"},
+        "sensitivity": {"type": "string"}
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_version"],
+      "properties": {
+        "policy_version": {"type": "string", "minLength": 1},
+        "policy_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "required_review_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "permitted_actions",
+        "prohibited_actions"
+      ],
+      "properties": {
+        "outcome": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "allow_with_ledger",
+            "require_review",
+            "require_external_verification",
+            "block",
+            "abstain",
+            "quarantine",
+            "collect_more_evidence"
+          ]
+        },
+        "permitted_actions": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "prohibited_actions": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "selected_action": {"type": ["string", "null"]},
+        "selection_mode": {
+          "type": ["string", "null"],
+          "enum": ["deterministic", "stochastic", "human", "external", null]
+        },
+        "decision_receipt_ref": {"type": "string", "minLength": 1}
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "mutation": {
+            "properties": {
+              "downstream_authority": {"const": "A5_GOVERNANCE_CHANGE"}
+            },
+            "required": ["downstream_authority"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "decision": {
+            "properties": {
+              "outcome": {
+                "enum": [
+                  "require_review",
+                  "require_external_verification",
+                  "block",
+                  "abstain",
+                  "quarantine",
+                  "collect_more_evidence"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/validate_doctrine_boundaries.py
+++ b/scripts/validate_doctrine_boundaries.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Validate native-doctrine and implementation-reference boundaries.
+
+This validator protects two repository decisions:
+
+1. PAMA is native Agent Memory doctrine, not an external source-registry entry.
+2. Private/adjacent product references must not drift into active doctrine without
+   an explicit, separately reviewed implementation mapping decision.
+
+Historical audit/governance records are excluded so the repository preserves its
+actual change history rather than rewriting it to satisfy current terminology.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+TEXT_SUFFIXES = {".md", ".json", ".yml", ".yaml", ".txt"}
+EXCLUDED_PREFIXES = (
+    "docs/audits/",
+    ".failsafe/",
+)
+EXCLUDED_FILES = {
+    "scripts/validate_doctrine_boundaries.py",
+}
+
+# Constructed to keep the validator from matching its own source text.
+DISALLOWED_ADJACENT_PRODUCT = "bi" + "cameral"
+
+
+def is_active_text(path: Path, root: Path) -> bool:
+    rel = path.relative_to(root).as_posix()
+    if rel in EXCLUDED_FILES:
+        return False
+    if any(rel.startswith(prefix) for prefix in EXCLUDED_PREFIXES):
+        return False
+    if path.suffix.lower() not in TEXT_SUFFIXES:
+        return False
+    return True
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    errors: list[str] = []
+
+    pama_entry = root / "docs" / "pama" / "README.md"
+    if not pama_entry.exists():
+        errors.append("docs/pama/README.md: missing canonical native PAMA entry point")
+    else:
+        text = pama_entry.read_text(encoding="utf-8")
+        required = (
+            "Kevin R. Knapp",
+            "native Agent Memory doctrine",
+            "M0",
+            "M5",
+            "A0",
+            "A5",
+        )
+        for token in required:
+            if token not in text:
+                errors.append(f"docs/pama/README.md: missing required native-doctrine marker {token!r}")
+
+    registry_path = root / "sources" / "source-registry.json"
+    try:
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        errors.append(f"sources/source-registry.json: cannot inspect registry: {exc}")
+        registry = {}
+
+    for index, record in enumerate(registry.get("sources", []) if isinstance(registry, dict) else []):
+        if not isinstance(record, dict):
+            continue
+        searchable = " ".join(
+            str(record.get(field, ""))
+            for field in ("source_id", "title", "source_type", "repository", "provenance_note")
+        ).lower()
+        if "pama" in searchable:
+            errors.append(
+                f"sources/source-registry.json sources[{index}]: native PAMA doctrine must not be registered as an external source"
+            )
+        if DISALLOWED_ADJACENT_PRODUCT in searchable:
+            errors.append(
+                f"sources/source-registry.json sources[{index}]: adjacent private product must not be retained as source provenance without a new explicit value decision"
+            )
+
+    # Current decision: the adjacent private product adds no necessary value to
+    # active Agent Memory doctrine. Historical audit records remain untouched.
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or not is_active_text(path, root):
+            continue
+        rel = path.relative_to(root).as_posix()
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if DISALLOWED_ADJACENT_PRODUCT in text.lower():
+            errors.append(
+                f"{rel}: contains an adjacent-product reference in active doctrine; remove it or change this validator through an explicit value-justified review"
+            )
+
+    source_index = root / "docs" / "08-source-material-index.md"
+    if source_index.exists():
+        index_text = source_index.read_text(encoding="utf-8")
+        if "## Native Agent Memory doctrine" not in index_text:
+            errors.append("docs/08-source-material-index.md: missing native-doctrine separation")
+        if "PAMA is native Agent Memory governance doctrine" not in index_text:
+            errors.append("docs/08-source-material-index.md: PAMA native provenance is not explicit")
+
+    if errors:
+        print("Doctrine-boundary validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Validated native PAMA provenance and active implementation-reference boundaries.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sources/source-registry.json
+++ b/sources/source-registry.json
@@ -3,6 +3,7 @@
   "policy": "../docs/SOURCE_RIGHTS_POLICY.md",
   "verified_at": "2026-08-10",
   "default_external_research_posture": "citation_only_or_independent_synthesis_unless_material_reuse_is_explicitly_registered",
+  "scope_note": "This registry tracks external, private, successor, or materially reused sources. Native Agent Memory doctrine such as PAMA is documented in the doctrine tree and does not require an external source record.",
   "sources": [
     {
       "source_id": "uor-issue-2-kevin-knapp",
@@ -131,27 +132,6 @@
       "verified_at": "2026-08-10"
     },
     {
-      "source_id": "pama-logic",
-      "title": "PAMA logic",
-      "source_type": "internal_architecture_provenance",
-      "public_url": null,
-      "repository": null,
-      "access": "no_public_locator",
-      "copyright_owner_or_originator": null,
-      "license_spdx": null,
-      "license_url": null,
-      "rights_status": "unknown",
-      "reuse_mode": "independent_synthesis",
-      "reuse_basis": "No standalone canonical public source or external reuse license has been verified.",
-      "material_reused": "Agent Memory expresses the governance doctrine independently and does not rely on copied PAMA source expression.",
-      "attribution_required": false,
-      "notice_required": false,
-      "modification_notice_required": false,
-      "provenance_note": "Public-link gap is explicit rather than filled with a merely related artifact.",
-      "limitations": "Do not add a convenient adjacent link and present it as canonical provenance.",
-      "verified_at": "2026-08-10"
-    },
-    {
       "source_id": "failsafe-arbiter",
       "title": "FailSafe / VerdictArbiter",
       "source_type": "public_repository_primary_implementation",
@@ -170,27 +150,6 @@
       "modification_notice_required": true,
       "provenance_note": "Direct implementation locator is preferred over a generic project homepage.",
       "limitations": "Any future copied or adapted code/documentation must satisfy applicable Apache-2.0 obligations.",
-      "verified_at": "2026-08-10"
-    },
-    {
-      "source_id": "bicameral-decision-continuity",
-      "title": "Bicameral decision continuity and durable decisions",
-      "source_type": "private_primary_provenance",
-      "public_url": null,
-      "repository": "BicameralAI/bicameral",
-      "access": "private",
-      "copyright_owner_or_originator": "BicameralAI",
-      "license_spdx": null,
-      "license_url": null,
-      "rights_status": "private_internal",
-      "reuse_mode": "independent_synthesis",
-      "reuse_basis": "Canonical implementation source is private. Existing public Bicameral repositories are not treated as substitutes unless they directly support the cited doctrine.",
-      "material_reused": "High-level conceptual provenance only.",
-      "attribution_required": true,
-      "notice_required": false,
-      "modification_notice_required": false,
-      "provenance_note": "No public source is linked until a genuinely relevant public artifact exists.",
-      "limitations": "Do not expose private repository URLs or content in public-facing material solely for provenance completeness.",
       "verified_at": "2026-08-10"
     }
   ]


### PR DESCRIPTION
## Scope

Corrects the Agent Memory provenance and architecture model after review of Kevin R. Knapp's full Proportional Adaptive Mutation Authority framework.

## PAMA provenance

PAMA is now explicitly treated as **native Agent Memory doctrine authored by Kevin R. Knapp**, not as an external dependency or unresolved source record.

Adds `docs/pama/README.md` as the canonical systems-agnostic foundation and aligns the memory-specific governance docs to it.

## PAMA taxonomy correction

The supplied framework establishes distinct dimensions that the repository had partially conflated:

- M0-M5 mutation target classes
- lifecycle strength
- requested mutation operation
- A0-A5 downstream authority
- adaptive charter / actor authority
- evidence, reversibility, scope, risk, and policy outcome

`docs/04-governance-and-pama.md` and `docs/33-pama-decision-table.md` now preserve those distinctions. The operation/risk table is explicitly one Agent Memory policy projection of PAMA, not the definition of PAMA.

## Machine-readable PAMA contract

Adds `schemas/pama-decision.schema.json` covering proposer/charter, M0-M5 target, lifecycle strength, operation, A0-A5 authority ceiling, evidence/uncertainty, policy version, permitted/prohibited actions, selection, and outcome.

A5 governance-change requests cannot resolve directly to ordinary allow outcomes in the schema.

## Source-rights correction

- removes PAMA from `sources/source-registry.json`
- keeps the registry for external, private, successor, or materially reused sources
- updates `SOURCE_RIGHTS_POLICY.md` to distinguish native contributor-authored doctrine from external source material
- preserves separate rights treatment for external research or standards used to support, challenge, benchmark, or align PAMA

## Product-coupling cleanup

Removes nonessential Bicameral references from active doctrine, source provenance, implementation maps, issue templates, the README, the durable-decision profile, and related architecture surfaces.

Decision continuity and drift remain first-class Agent Memory concepts through `profiles/durable-decision-memory-profile.md`; a product earns an implementation mapping only with concrete implementation/conformance evidence.

Historical audit/governance records are intentionally preserved rather than rewritten.

## Doctrine ownership versus implementation ownership

PAMA doctrine ownership is resolved:

- doctrine owner: Agent Memory / Kevin R. Knapp
- runtime implementation owner: open until implementation evidence exists

A runtime may host the PAMA evaluator in any conforming codebase if the authority boundary remains explicit and auditable.

## Enforcement

Adds `scripts/validate_doctrine_boundaries.py` and CI coverage to ensure:

- the native PAMA entry point remains present and attributed
- PAMA does not drift back into the external source registry
- nonessential adjacent-product references do not drift back into active doctrine without an explicit reviewed change
- historical audit records remain exempt from revisionist cleanup

## Audit trail

Adds `docs/audits/source-rights/02-pama-native-provenance-and-implementation-reference-cleanup.md`.

## Validation

Exact branch head validates:

- 24 conformance fixtures
- 7 JSON Schemas
- 7 external/material source-rights records
- native PAMA provenance and implementation-reference boundaries
- top-level and PAMA documentation links
- calibration report example consistency

This PR changes provenance and doctrine structure. It does not claim a legal determination of copyright scope or runtime PAMA conformance.