### PR TITLE
Define canonical and derived state semantics for deletion propagation

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -60,6 +60,7 @@ jobs:
           docs/32-memory-quality-metrics.md
           docs/programs/runtime-evidence/README.md
           docs/programs/runtime-evidence/graphiti-conformance.md
+          docs/programs/runtime-evidence/canonical-and-derived-state.md
           reference/README.md
 
       - name: Validate GitHub Wiki source links
@@ -82,7 +83,7 @@ jobs:
             echo "python scripts/validate_fixtures.py fixtures"
             echo "python scripts/validate_schemas.py  # requires: pip install jsonschema"
             echo "python scripts/validate_doctrine_boundaries.py"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md reference/README.md"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md reference/README.md"
             echo "python scripts/validate_wiki_links.py wiki-src"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'

--- a/README.md
+++ b/README.md
@@ -286,7 +286,16 @@ predicted low utility != irreversible deletion authority
 
 Deletion must also account for derived memory such as summaries, indexes, graph edges, caches, exported copies, and consolidated state where the system controls them.
 
-See **[Forgetting, Consolidation, and Memory Metabolism](docs/21-forgetting-consolidation-and-memory-metabolism.md)** and **[Retention, Deletion, and Tombstones](docs/28-retention-deletion-and-tombstones.md)**.
+Derived state fails in a way canonical state cannot — by being out of date — and the two ways it can be out of date are not interchangeable:
+
+```text
+stale     a source changed        content may be wrong
+residual  a source was purged     content may be prohibited
+```
+
+Staleness may be repairable by recomputation. Residue is not, because recomputation cannot un-retain content the deletion was meant to destroy, and because deciding what happens to it is the deletion authority's call rather than an estimator's.
+
+See **[Forgetting, Consolidation, and Memory Metabolism](docs/21-forgetting-consolidation-and-memory-metabolism.md)** and **[Retention, Deletion, and Tombstones](docs/28-retention-deletion-and-tombstones.md)**. The propagation semantics behind that distinction are worked out in **[Canonical and Derived State](docs/programs/runtime-evidence/canonical-and-derived-state.md)**, which is design work rather than adopted doctrine.
 
 ---
 
@@ -527,6 +536,8 @@ estimate / proposal
 with repeated stochastic trials, cross-scope admission tests, actual concurrency behavior, deletion propagation, and reconstructable runtime receipts.
 
 That missing evidence is a feature of the governance process, not an embarrassing footnote to hide below the fold.
+
+Deletion propagation is the slice currently in progress, and beginning it surfaced something worth stating plainly: the requirement was not yet expressible. A claim like *this projection is stale with respect to canonical state* had no defined meaning in this repository, which made it untestable rather than merely unproven. **[Canonical and Derived State](docs/programs/runtime-evidence/canonical-and-derived-state.md)** supplies the missing definitions and fixes the evidence bar before the implementation that has to clear it. It is a design spike — no code, no fixtures, and no claim on the evidence ledger.
 
 ---
 

--- a/docs/28-retention-deletion-and-tombstones.md
+++ b/docs/28-retention-deletion-and-tombstones.md
@@ -72,6 +72,8 @@ Potential dependents include:
 
 A deletion operation should identify which dependents are in scope and which cannot be controlled.
 
+Those dependents are not one kind of thing. Summaries, semantic memories, and procedures are memory units with identity, lifecycle, and derivation links. Embeddings, index records, caches, and graph projections are not, so nothing obliges them to record what they were built from — which is where residue collects. Propagation semantics for both, including how staleness is expressed and what a purge must reach, are developed in [`programs/runtime-evidence/canonical-and-derived-state.md`](programs/runtime-evidence/canonical-and-derived-state.md). That is program design work; nothing in it is doctrine until an ADR adopts it.
+
 ## Tombstones
 
 A tombstone records enough metadata to prevent accidental resurrection without preserving content that policy requires erased.

--- a/docs/31-recovery-rollback-and-replay.md
+++ b/docs/31-recovery-rollback-and-replay.md
@@ -67,6 +67,8 @@ Prevent unsafe memory from entering context while investigation proceeds.
 
 Recompute or dispute derived memories that depended on corrupted state.
 
+Recomputation is itself a governed transition where the derivation involves an estimator, because it commits new content rather than restoring old content. Repair triggered automatically by staleness detection would let an estimator write whenever it can cause a version change. See [`programs/runtime-evidence/canonical-and-derived-state.md`](programs/runtime-evidence/canonical-and-derived-state.md), which is design work rather than adopted doctrine.
+
 ## State/version binding
 
 Authorization should bind to the state version it evaluated.

--- a/docs/programs/runtime-evidence/README.md
+++ b/docs/programs/runtime-evidence/README.md
@@ -73,6 +73,7 @@ Documents are added when their slice is ready to execute, not in advance. A dire
 |---|---|---|
 | [`graphiti-conformance.md`](graphiti-conformance.md) | first substrate capability mapping | documentation-verified, with key findings confirmed by execution |
 | [`../../../reference/README.md`](../../../reference/README.md) | minimal governed adapter | bound and executed against a real substrate |
+| [`canonical-and-derived-state.md`](canonical-and-derived-state.md) | canonical memory versus derived projections | design spike: vocabulary and proposed invariants only, no runtime evidence |
 
 ## Preconditions
 

--- a/docs/programs/runtime-evidence/canonical-and-derived-state.md
+++ b/docs/programs/runtime-evidence/canonical-and-derived-state.md
@@ -1,0 +1,175 @@
+# Canonical and Derived State
+
+> Status: **design spike. Not doctrine, not evidence.** This document defines vocabulary and proposes invariants for the P4 slice of the [runtime evidence program](README.md). It discharges no [ADR-020](../../adr/ADR-020-probabilistic-discovery-deterministic-governance.md) validation item, and nothing here is adopted until an ADR says so. Its purpose is to make the P4 requirements *expressible* — a claim like "this projection is stale with respect to canonical state" currently has no defined meaning in this repository, which makes it untestable rather than merely unproven.
+
+## Why this slice exists
+
+ADR-020 cannot be accepted until item 12, *derived-memory deletion residue is tested*, is discharged. Item 12 is a single line, and underneath it sits the largest unmodelled surface in the architecture.
+
+The doctrine already asserts the requirements. [Doc 28](../../28-retention-deletion-and-tombstones.md) requires deletion to traverse derivation relationships and lists summaries, embeddings, index records, graph edges, caches, and exports as dependents. [Doc 31](../../31-recovery-rollback-and-replay.md) requires dependency repair and names derived-memory deletion residue as a failure case. The [first substrate mapping](graphiti-conformance.md) classifies derived projections as *CONFIGURABLE, weak by default* — embeddings, indices, and communities all exist, and none self-invalidate.
+
+What is missing is not conviction. It is a definition of what derived state *is*, what it must declare, and what "stale" means precisely enough to fail a test.
+
+## Three tiers, not two
+
+The framing "canonical memory versus derived projections" is a useful headline and a misleading model, because it implies one boundary where there are two.
+
+```text
+tier 1   canonical memory units
+         authoritative; wrong only on their own terms
+
+tier 2   derived memory units
+         governed; carry identity, lifecycle, authority, provenance.derived_from
+         wrong on their own terms OR by being out of date with their sources
+
+tier 3   projections
+         indices, embeddings, caches, materialized views, community summaries
+         not memory units; no identity, no lifecycle, no authority, no schema
+```
+
+Tier 2 is already partly modelled: [`memory-unit.schema.json`](../../../schemas/memory-unit.schema.json) carries `provenance.derived_from`, and [`deletion-residue`](../../../fixtures/deletion-residue.json) exercises exactly that shape — a `summary` whose raw source was deleted.
+
+**Tier 3 has no vocabulary in this repository at all**, and tier 3 is where deletion residue actually hides. An index entry is not a memory unit, so nothing obliges it to declare what it was built from; a cache is not a memory unit, so no lifecycle state applies to it; an embedding is not a memory unit, so no authority governs its refresh. The governed tiers are the ones already under observation. The residue risk is concentrated in the tier the schema cannot see.
+
+This is the spike's headline finding: **P4 is mostly a tier-3 problem, and tier 3 currently has no declaration surface.**
+
+## The canonical test
+
+Storage location does not determine canonicity, and neither does the word "cache" appearing in a variable name. The operational test is disagreement:
+
+> If this state and its putative source disagree, which one is wrong?
+>
+> Canonical state can only be wrong on its own terms. Derived state can additionally be wrong by being out of date with respect to something else.
+
+A corollary is more useful in practice than the definition: derived state has a *second* failure mode that canonical state does not have, and every invariant in this document exists to make that second failure mode visible.
+
+## What a projection must declare
+
+For staleness and residue to be computable at all, tier-3 state needs a declaration — not a schema for its contents, which are the substrate's business, but a declaration of its relationship to canonical state.
+
+```text
+basis           the canonical units read, each with the state version read
+transform       deterministic | estimator_mediated
+content_class   reference_only | derived_content | recoverable_content
+rebuild         reproducible | approximable | irreproducible
+scope           the tenancy and sensitivity envelope the projection inherits
+```
+
+`content_class` and `rebuild` are the two that carry consequence, and they are independent:
+
+| | reproducible | approximable | irreproducible |
+|---|---|---|---|
+| **reference_only** | index of IDs | — | orphaned ID list |
+| **derived_content** | embedding, pinned model | embedding, drifted model | embedding, model retired |
+| **recoverable_content** | deterministic extract | LLM summary | LLM summary, model retired |
+
+The dangerous cell is the bottom-right region: state that both *holds recoverable content* and *cannot be rebuilt*. It survives deletion of its source while carrying the source's content, and it cannot be repaired after a correction without producing something materially new. Every hard case in P4 lives there. Doc 28 already refuses to let this be waved away: *the system should not claim full deletion where it cannot demonstrate it.*
+
+Note that `scope` is inherited, not declared freely. A projection over tenant-scoped canonical units is tenant-scoped whether or not its substrate knows what a tenant is — and per the substrate mapping, isolation is frequently a query-filter convention rather than an enforced boundary. A projection is a cross-tenant leak waiting for a missing filter.
+
+## Staleness is a relation, not a flag
+
+A boolean `stale` field on a projection is unmaintainable and dishonest under concurrency: it is only correct if something reliably sets it, and the substrates in scope reliably do not. Push-invalidation is precisely what the mapping found absent.
+
+Define staleness instead as a computable relation between the projection's recorded basis and current canonical state:
+
+```text
+current(P)   ⟺  ∀ m ∈ basis(P) : version(m) = basis(P)[m]  ∧  ¬tombstoned(m)
+stale(P)     ⟺  ∃ m ∈ basis(P) : version(m) ≠ basis(P)[m]  ∧  ¬tombstoned(m)
+residual(P)  ⟺  ∃ m ∈ basis(P) : tombstoned(m) ∨ purged(m)
+```
+
+Three consequences follow, and they are the reason to prefer the relation.
+
+**It is a pull-model invariant.** No notification is required. The check runs at read time, which is where [ADR-020 Rule 7](../../adr/ADR-020-probabilistic-discovery-deterministic-governance.md) already places governance. A substrate that never self-invalidates is therefore governable without modification — the wrapper computes freshness at admission rather than trusting the substrate to have maintained it.
+
+**Staleness is not an error.** Admitting a stale projection is often legitimate. Admitting one *without recording that it was stale* is not. Staleness belongs in the admission decision and the receipt, not in a background job whose job is to make the flag briefly true.
+
+**Stale and residual are different states with different authorities.** A stale projection has a correctness problem, and recomputation may resolve it. A residual projection has a governance problem, and only the deletion authority may resolve it. Collapsing the two into one "invalid" state loses exactly the distinction ADR-020 exists to protect. This trichotomy is the design's load-bearing element.
+
+## Correction propagation
+
+Correction is not deletion — doc 28 is explicit, and the reason is that correction preserves the fact that an earlier claim was wrong.
+
+When canonical unit `m` is corrected from v12 to v13, every projection with `m` in its basis becomes stale. What must *not* happen is silent recomputation of a content-bearing projection that has already been used in a consequential decision, because that erases the evidence that the decision rested on the earlier value. The supersede-don't-erase rule that governs canonical memory governs its projections for the same reason.
+
+```text
+correction  ->  projections become stale
+            ->  content-bearing projections are superseded, not overwritten
+            ->  the superseded version remains reconstructable for decisions that used it
+            ->  unless privacy or deletion policy requires otherwise
+```
+
+## Deletion propagation, and where it collides with correction
+
+Deletion inverts the preservation rule. A superseded projection version retained for reconstructability is, after its source is purged, exactly the recoverable residue the deletion was supposed to eliminate.
+
+The two rules therefore genuinely conflict, and the conflict must be resolved by stated precedence rather than discovered at runtime:
+
+> **Deletion dominates correction.** Where a projection has been superseded for reconstructability and its basis is later purged, the retained superseded versions are in scope for the purge. Reconstructability degrades to content-free evidence — receipts, hashes, tombstones — as doc 28 already contemplates for the evidence-retention tension.
+
+Purge scope is the transitive closure over the basis relation, not one hop. Projections are routinely built from other projections, and the existing `undeclared_residue()` probe in the reference adapter checks a single hop against a single substrate. That is a start, not the requirement.
+
+## Rebuild is a governed mutation
+
+The most consequential finding in this spike, and the least obvious.
+
+For an `estimator_mediated` transform, rebuild is not idempotent. Rebuilding a summary after its source changed does not restore a projection; it *commits new content* derived from an estimator. If staleness detection is allowed to trigger rebuild automatically, then an estimator has acquired the ability to write content into memory whenever it can cause a version bump — which is authority laundering with a maintenance job in front of it, structurally identical to [`authority-laundering`](../../../fixtures/authority-laundering.json).
+
+```text
+prohibited   staleness detected -> estimator recomputes -> content committed
+             (invalidation as a write channel)
+
+required     staleness detected -> rebuild proposed -> governance evaluates
+             -> permitted action selected -> content committed -> receipt
+```
+
+Deterministic, reproducible rebuilds are the exception that proves the rule: they can be authorized categorically in advance, precisely because the committed content is a function of canonical state rather than of an estimator's mood. That is a policy decision about a class of transforms, not an exemption from governance.
+
+## Measuring residue
+
+The metric is not a volume. It is a partition, and one cell of it must be empty:
+
+```text
+purged                     demonstrated removed
+declared residual          known to survive, reported in the deletion receipt,
+  controlled                 within the deleting system's reach
+declared residual          known to survive, reported, outside its reach
+  uncontrollable             (exports, third-party copies, model weights)
+undeclared residual        survives and was not reported
+```
+
+`undeclared residual = 0` is a hard invariant gate in the sense of [doc 32](../../32-memory-quality-metrics.md): disqualifying and un-averageable. A deletion that leaves recoverable content it did not report is a failed deletion regardless of how much it did remove.
+
+Two honesty constraints keep the metric from measuring itself:
+
+1. **Unknown is not a fourth bucket to hide in.** State whose derivation cannot be enumerated is `declared residual uncontrollable` — declared, and reported — not omitted because it was hard to find. Doc 28 already forbids `deleted from vector store` as evidence about model weights.
+2. **Traversal completeness is itself the measurement.** Undeclared residue is discovered by an independent sweep over the derivation closure, not by asking the purge whether it finished. A purge that reports zero residue because it traversed one hop has measured its own optimism.
+
+## What would discharge ADR-020 item 12
+
+Stated now so the evidence bar is fixed before the implementation that must clear it:
+
+1. A projection declaration exists for tier-3 state, with basis recorded at build time.
+2. `stale` and `residual` are computed from the relation above against a real substrate, not asserted by a flag.
+3. Correction of a canonical unit marks dependent projections stale and supersedes content-bearing ones without erasing the superseded version.
+4. Purge of a canonical unit reaches the transitive closure of its basis, including superseded projection versions.
+5. An independent sweep finds zero undeclared residue, and the deletion receipt's declared-residual buckets match what the sweep found.
+6. Automatic rebuild of an estimator-mediated projection is refused without an authority decision, and the refusal is on a negative path in the test corpus.
+7. The whole run is pinned, reproducible, and reconstructable from receipts, per the program's evidence rules.
+
+Items 4, 5, and 6 are the ones a persuasive demonstration would skip.
+
+## Open questions
+
+- What basis granularity is affordable? Per-unit versions are exact and expensive; per-partition watermarks are cheap and coarse enough to mark everything stale constantly.
+- Derivation graphs may contain cycles once projections feed consolidation that feeds projections. Is the closure well-founded, or does it need an explicit acyclicity constraint?
+- Does a projection over a tombstoned unit's *metadata only* count as residual? The trichotomy says yes; that may be too strong for reference-only projections, and the exception needs stating rather than assuming.
+- Can a projection legitimately outlive its basis by policy — a lawful-retention aggregate over purged sources — and what makes that different from residue?
+- Where does the declaration live for substrates that cannot store it? A sidecar owned by the adapter is the obvious answer and reintroduces the consistency problem one level up.
+
+## Doctrine candidate
+
+Derived state inherits every obligation of the memory it derives from, and acquires one more: it can be wrong by being late.
+
+A system that cannot say when its projections were last true is not caching. It is remembering things it has already been told to forget.

--- a/wiki-src/Canonical-and-Derived-State.md
+++ b/wiki-src/Canonical-and-Derived-State.md
@@ -1,0 +1,126 @@
+# Canonical and Derived State
+
+> **Status: design spike.** This page describes vocabulary and proposed invariants, not implemented behavior. Nothing here has been executed, and no Architecture Decision Record has adopted it. It is published because the definitions are what make the requirements testable — the alternative is a requirement everyone agrees with and no one can fail.
+
+Deleting a memory is easy. Proving it is gone is the hard part, and almost every hard case involves state that was *derived* from the memory rather than the memory itself.
+
+## The problem in one paragraph
+
+A user asks for a record to be deleted. The record disappears. But a summary written from it still contains the content, an embedding built from it still encodes it, a search index still points at it, and a cached view still serves it. Each of those is a legitimate piece of engineering. Together they mean the deletion was a gesture. **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)** already says deletion must propagate through derived state. This page is about what that sentence has to mean before anyone can test it.
+
+## Three tiers, not two
+
+"Canonical memory versus derived projections" sounds like one boundary. There are two, and the difference decides where the risk lives.
+
+| Tier | What it is | Governed today? |
+|---|---|---|
+| **Canonical memory units** | Authoritative state. Can only be wrong on its own terms. | Yes — identity, lifecycle, authority, provenance |
+| **Derived memory units** | Summaries, semantic and procedural memory. First-class memory that happens to have sources. | Partly — they carry derivation links and lifecycle state |
+| **Projections** | Indices, embeddings, caches, materialized views, community summaries. | **No** — not memory units, so no schema, identity, lifecycle, or authority applies |
+
+The third tier is the uncomfortable one. An index entry is not a memory unit, so nothing obliges it to record what it was built from. A cache has no lifecycle state. An embedding has no authority governing its refresh. The two tiers already under observation are the two that were easiest to observe, and the residue risk is concentrated in the tier the schema cannot see.
+
+## How to tell canonical from derived
+
+Not by where it is stored, and not by whether the word "cache" appears in the variable name. The test is disagreement:
+
+> If this state and its source disagree, which one is wrong?
+
+Canonical state can only be wrong on its own terms. Derived state has a **second failure mode**: it can be wrong by being out of date. Every invariant below exists to make that second failure mode visible rather than silent.
+
+## What a projection has to declare
+
+For any of this to be checkable, projections need to declare their relationship to canonical state — not their contents, which are the storage engine's business.
+
+| Field | Meaning |
+|---|---|
+| **Basis** | Which canonical units it was built from, and at which version of each |
+| **Transform** | Deterministic, or mediated by an estimator such as a language model |
+| **Content class** | Holds references only, derived content, or recoverable content |
+| **Rebuild** | Reproducible, approximable, or irreproducible |
+| **Scope** | The tenancy and sensitivity envelope it inherits from its sources |
+
+The last two matter most, and they are independent. The dangerous combination is state that **holds recoverable content and cannot be rebuilt** — a language-model summary whose model has since been retired, for instance. It survives the deletion of its source while still carrying that source's content, and it cannot be repaired after a correction without producing something materially new. Every genuinely hard case lives there.
+
+Scope is inherited, not chosen. A projection over tenant-scoped memory is tenant-scoped whether or not the storage engine has ever heard of tenants.
+
+## Stale is a relationship, not a flag
+
+The obvious design is a `stale` boolean on each projection. It does not work, for a boring reason: a flag is only correct if something reliably sets it, and real substrates reliably do not. The **[substrate capability mapping](Runtime-Evidence)** found exactly this — embeddings, indices, and community summaries all exist, and none of them self-invalidate when their sources change.
+
+So define staleness as something you *compute* instead, by comparing what the projection recorded about its sources against those sources now:
+
+| State | Condition | What it means |
+|---|---|---|
+| **Current** | every source is at the version the projection recorded | safe to use |
+| **Stale** | some source has changed since | content may be **wrong** |
+| **Residual** | some source has been tombstoned or purged | content may be **prohibited** |
+
+Three things follow, and they are why the relationship beats the flag.
+
+**Nothing has to notify anything.** The check runs when the projection is read, which is where Agent Memory already puts recall governance. A substrate that never invalidates anything becomes governable without modifying the substrate.
+
+**Stale is not an error.** Using a stale projection is often perfectly reasonable. Using one *without recording that it was stale* is not. Staleness belongs in the admission decision and the receipt, not in a background job whose purpose is to briefly make the flag true.
+
+**Stale and residual are different problems.** Staleness is a correctness problem, and recomputation may fix it. Residue is a governance problem, and only the deletion authority may fix it. Treating both as "invalid" throws away the distinction the whole architecture exists to protect.
+
+## When correction and deletion give opposite orders
+
+Agent Memory prefers preserved history to silent overwrite, so when a memory is corrected, the old version of a derived summary is normally kept — otherwise you destroy the evidence of what earlier decisions were actually based on.
+
+Deletion wants the opposite. That retained old version is, once its source is purged, precisely the recoverable content the deletion was supposed to eliminate.
+
+```text
+correction says:  keep the superseded projection, it is evidence
+deletion says:    destroy the superseded projection, it is residue
+```
+
+This is a real conflict, not a modelling mistake, and it has to be resolved by stated precedence rather than discovered in production. The spike sets **deletion dominant**: reconstructability degrades to content-free evidence — receipts, hashes, tombstones — which is the tradeoff **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)** already contemplates for the tension between audit and erasure.
+
+Purge scope is the *transitive* closure. Projections are routinely built from other projections, and stopping after one hop is how residue survives.
+
+## Rebuilding is a governed mutation
+
+The least obvious finding, and the one most likely to be built wrong.
+
+When a projection's transform involves a language model, rebuilding it does not restore anything. It **commits new content**. So if detecting staleness is allowed to trigger a rebuild automatically, an estimator has acquired the ability to write into memory whenever it can cause a version bump — which is the confidence-becomes-authority failure with a maintenance job in front of it, structurally identical to the authority-laundering case in **[Security and Privacy](Security-and-Privacy)**.
+
+```text
+prohibited   staleness detected → model recomputes → content committed
+required     staleness detected → rebuild proposed → governance decides
+                                → permitted action → committed → receipt
+```
+
+Deterministic rebuilds are the exception that proves the rule. They can be authorized in advance as a class, precisely because their output is a function of canonical state rather than of a model's disposition on the day.
+
+## Measuring residue honestly
+
+The measurement is not a volume. It is a partition, and one cell has to be empty:
+
+| Bucket | Meaning |
+|---|---|
+| **Purged** | demonstrated removed |
+| **Declared residual, controlled** | known to survive, reported, still reachable |
+| **Declared residual, uncontrollable** | known to survive, reported, out of reach — exports, third-party copies, model weights |
+| **Undeclared residual** | survives, and nobody said so |
+
+**Undeclared residue must be zero.** It is a disqualifying gate, not a score to average away: a deletion that leaves recoverable content it never reported is a failed deletion regardless of how much it correctly removed.
+
+Two rules keep the measurement honest. State that cannot be enumerated goes in the *uncontrollable* bucket — declared and reported — rather than being quietly omitted because it was hard to find. And undeclared residue is found by an independent sweep over the derivation graph, never by asking the deletion process whether it finished. A purge that reports no residue because it only looked one hop deep has measured its own optimism.
+
+## Where this sits
+
+This slice is why ADR-020 remains Proposed. Its proof bar requires that derived-memory deletion residue be *tested*, and that single line sits on top of everything above. The spike fixes the bar before building the thing that has to clear it — including the parts a persuasive demonstration would quietly skip: reaching the full transitive closure, matching an independent sweep against the receipt, and refusing an automatic rebuild.
+
+## Canonical sources
+
+- Design spike: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/programs/runtime-evidence/canonical-and-derived-state.md
+- Retention, deletion, tombstones: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/28-retention-deletion-and-tombstones.md
+- Recovery and replay: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/31-recovery-rollback-and-replay.md
+- Substrate capability mapping: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/programs/runtime-evidence/graphiti-conformance.md
+
+## Next
+
+- **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)** for the forgetting operations this refines
+- **[Security and Privacy](Security-and-Privacy)** for deletion residue as an attack surface
+- **[Runtime Evidence](Runtime-Evidence)** for what has actually been executed, which is not this

--- a/wiki-src/Conformance-and-Evidence.md
+++ b/wiki-src/Conformance-and-Evidence.md
@@ -110,6 +110,8 @@ estimate / proposal
 
 with repeated stochastic trials, cross-scope admission tests, real concurrency behavior, deletion propagation, and reconstructable decision receipts.
 
+Deletion propagation carries the most hidden weight in that list, because a requirement stated in one clause can rest on vocabulary the architecture has not defined yet. **[Canonical and Derived State](Canonical-and-Derived-State)** sets out what has to be demonstrated — reaching the full transitive closure of derived state, matching an independent residue sweep against what the deletion receipt claimed, and refusing an automatic model-driven rebuild — and says plainly which of those a convincing demonstration would omit.
+
 ## Canonical sources
 
 - Conformance test plan: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/06-conformance-test-plan.md

--- a/wiki-src/Core-Concepts.md
+++ b/wiki-src/Core-Concepts.md
@@ -63,6 +63,9 @@ relevance != permission
 saturation != truth
 utility != deletion authority
 proposal != commit
+canonical != derived
+raw delete != full delete
+rebuild != maintenance
 historical truth != current truth
 chronology != causality
 uncertain sensitivity != non-sensitive
@@ -79,10 +82,13 @@ A memory can remain historically valid while no longer describing the present.
 ```text
 historically true != currently true
 stale != false
+stale != residual
 superseded != corrected
 ```
 
 Agent Memory keeps those distinctions because silently overwriting history destroys evidence.
+
+The last two lines carry more weight than they look. *Stale* means a source has changed, so derived content may be wrong and recomputing it may help. *Residual* means a source was deleted, so derived content may be prohibited and recomputing it helps nobody — only the deletion authority can resolve that. Collapsing both into "invalid" is the most natural mistake in this area and the most expensive. See **[Canonical and Derived State](Canonical-and-Derived-State)**.
 
 ## Canonical sources
 

--- a/wiki-src/Glossary.md
+++ b/wiki-src/Glossary.md
@@ -6,11 +6,13 @@ A compact reader-facing glossary. The canonical terminology lives in `docs/00-gl
 |---|---|
 | **Agentic memory** | Retained state that can alter future agent interpretation, reasoning, planning, tool use, action, or adaptation across a persistence boundary. |
 | **Authority** | Permission to create a consequence. Not the same as confidence, trust, or relevance. |
+| **Basis** | The canonical units a projection was built from, each recorded at the version that was read. What makes staleness computable instead of asserted. |
 | **Candidate** | State being considered for stronger persistence or another governed transition. |
+| **Canonical state** | State that can only be wrong on its own terms. Derived state can additionally be wrong by being out of date, which is the difference that defines the boundary. |
 | **Certification** | Required confirmation that a transition or artifact met a defined evidence/authority bar. |
 | **Consolidation** | Transforming retained experience into summarized, generalized, semantic, procedural, or model-like state. |
 | **Decision receipt** | Reconstructable evidence describing a governed decision, permitted actions, selected action, policy/version context, and before/after state. |
-| **Derived state** | Non-canonical projection created from memory, such as an index, embedding, summary, cache, or graph projection. |
+| **Derived state** | Any non-canonical state created from memory. Splits into derived *memory units*, which are governed and carry derivation links, and *projections*, which are not. |
 | **Epistemics** | The system's uncertain interpretation of evidence: relevance, trust, contradiction, sensitivity, utility, etc. |
 | **Forgetting** | A family of governed operations including decay, suppression, pruning, archival, redaction, tombstoning, deletion, and specialized unlearning. |
 | **Governance envelope** | The bounded set of consequences allowed under current policy, scope, authority, and state. |
@@ -19,11 +21,15 @@ A compact reader-facing glossary. The canonical terminology lives in `docs/00-gl
 | **Lifecycle strength** | Degree of persistence/reinforcement associated with retained state. |
 | **PAMA** | Proportional Adaptive Mutation Authority, native Agent Memory doctrine for scaling authority to mutation consequence. |
 | **Permitted action set** | Finite set of actions a selector may choose from after governance constraints are applied. |
+| **Projection** | Derived state that is not a memory unit: an index, embedding, cache, materialized view, or clustered summary. Has no identity, lifecycle, or authority of its own, which is why deletion residue collects there. |
 | **Provenance** | Evidence of origin, derivation, witnesses, scope, and transformation history. |
 | **Recall admission** | Decision that a candidate memory may actually enter active context. |
+| **Rebuild** | Recomputing a projection from its sources. Reproducible for deterministic transforms; for model-mediated transforms it commits new content and is therefore a governed mutation, not maintenance. |
+| **Residue** | Content that survives a deletion. Acceptable when declared in the deletion receipt, disqualifying when undeclared. |
 | **Saturation** | Persistence/lifecycle pressure derived from repeated or reinforcing state. It is not truth. |
 | **Scope** | Boundary in which memory is valid, visible, or usable. |
 | **Source trust** | Scoped evidence about expected source reliability. It is not authority. |
+| **Stale** | A projection whose basis has changed since it was built. A relationship between projection and current state, not a flag on the projection — flags require something to reliably set them, and substrates reliably do not. |
 | **Tombstone** | Durable record that a memory has been removed or invalidated while preserving enough history to prevent silent resurrection. |
 
 ## Canonical glossary
@@ -35,3 +41,4 @@ https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/00-glossary.m
 - **[Core Concepts](Core-Concepts)**
 - **[PAMA](PAMA)**
 - **[Governed Uncertainty](Governed-Uncertainty)**
+- **[Canonical and Derived State](Canonical-and-Derived-State)**

--- a/wiki-src/Home.md
+++ b/wiki-src/Home.md
@@ -22,6 +22,7 @@ Agent Memory asks a larger question than _“how do we retrieve old context?”_
 | Learn the core vocabulary and invariants | **[Core Concepts](Core-Concepts)** |
 | Understand adaptive authority | **[PAMA](PAMA)** |
 | Design retention, consolidation, and forgetting | **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)** |
+| Understand why deleting a memory does not delete what was derived from it | **[Canonical and Derived State](Canonical-and-Derived-State)** |
 | Separate probabilistic inference from consequential authority | **[Governed Uncertainty](Governed-Uncertainty)** |
 | Review threat, privacy, and deletion risks | **[Security and Privacy](Security-and-Privacy)** |
 | Evaluate evidence or runtime claims | **[Conformance and Evidence](Conformance-and-Evidence)** |

--- a/wiki-src/Lifecycle-and-Forgetting.md
+++ b/wiki-src/Lifecycle-and-Forgetting.md
@@ -87,6 +87,17 @@ Deleting one canonical record may leave behind:
 
 A deletion guarantee is only as strong as the propagation boundary it actually controls.
 
+Two of those items are governed memory in their own right — a consolidated semantic memory carries identity, lifecycle, and derivation links. The rest are **projections**: infrastructure with no identity, no lifecycle state, and nothing obliging them to record what they were built from. That asymmetry is the point. The residue risk concentrates in exactly the state the architecture currently cannot see, and a projection's most dangerous property is not that it is stale but that it is *unaccounted for*.
+
+Derived state also fails in a way canonical state cannot — by being out of date. Distinguishing the two failure modes is what makes deletion propagation testable rather than merely required:
+
+```text
+stale     a source changed         content may be wrong
+residual  a source was purged      content may be prohibited
+```
+
+Staleness may be repairable by recomputation. Residue is not: it is a governance problem, and only the deletion authority may resolve it. **[Canonical and Derived State](Canonical-and-Derived-State)** develops both, along with the case where correction and deletion give opposite instructions about the same superseded summary.
+
 ## Correction is not erasure
 
 Agent Memory prefers preserved history over silent overwrite.
@@ -108,5 +119,6 @@ When evidence changes, the architecture should preserve what was known, what cha
 
 ## Next
 
+- **[Canonical and Derived State](Canonical-and-Derived-State)** for how deletion and correction propagate into derived state
 - **[Security and Privacy](Security-and-Privacy)** for deletion residue and lifecycle attack surfaces
 - **[Conformance and Evidence](Conformance-and-Evidence)** for proving lifecycle behavior

--- a/wiki-src/README.md
+++ b/wiki-src/README.md
@@ -22,9 +22,11 @@ GitHub stores Wiki content in a separate Git repository:
 https://github.com/MythologIQ-Labs-LLC/agent-memory.wiki.git
 ```
 
-The current ChatGPT GitHub connector does not expose Wiki write operations, so publication requires a git-capable environment.
+Publication is automated. [`.github/workflows/publish-wiki.yml`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/.github/workflows/publish-wiki.yml) validates this tree and republishes it whenever `wiki-src/**` changes on `main`, and can also be run on demand through workflow dispatch. It treats `wiki-src` as canonical: the published pages are replaced from the validated source rather than merged into, so an edit made directly in the GitHub Wiki UI will be overwritten on the next publish. Edit the source here instead.
 
-After the repository Wiki has been initialized once from the GitHub UI if necessary:
+`README.md` is deliberately excluded from publication — it documents the source tree and is not a reader-facing page. Every other `*.md` file in this directory becomes a Wiki page, so adding a page means adding a file here, a sidebar entry, and an inventory line below.
+
+Manual publication remains possible from any git-capable environment, which matters because some connectors expose no Wiki write operations at all:
 
 ```bash
 git clone https://github.com/MythologIQ-Labs-LLC/agent-memory.wiki.git
@@ -54,6 +56,7 @@ The validator understands GitHub Wiki extensionless page links such as `[PAMA](P
 - `Core-Concepts.md`
 - `PAMA.md`
 - `Lifecycle-and-Forgetting.md`
+- `Canonical-and-Derived-State.md`
 - `Governed-Uncertainty.md`
 - `Security-and-Privacy.md`
 - `Conformance-and-Evidence.md`

--- a/wiki-src/Runtime-Evidence.md
+++ b/wiki-src/Runtime-Evidence.md
@@ -58,10 +58,13 @@ Running the binding revised three conclusions that source reading alone had reac
 
 Closer, and not close enough. The proof bar in **[Architecture Decisions](Architecture-Decisions)** additionally expects concurrency behavior, deletion propagation measurement, and evidence gathered across a wider surface than one reference adapter. ADR-020 stays Proposed.
 
+Deletion propagation is the slice now in progress, and it began by discovering that the requirement was not yet expressible. "This projection is stale with respect to canonical state" had no defined meaning here, which made it untestable rather than merely unproven. **[Canonical and Derived State](Canonical-and-Derived-State)** supplies the missing definitions and fixes the evidence bar in advance — deliberately including the parts a persuasive demonstration would skip. It is a design spike: no code, no fixtures, and no claim on this page's ledger until something executes.
+
 ## Canonical sources
 
 - Runtime evidence program: https://github.com/MythologIQ-Labs-LLC/agent-memory/tree/main/docs/programs/runtime-evidence
 - Substrate capability mapping: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/programs/runtime-evidence/graphiti-conformance.md
+- Canonical and derived state design spike: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/programs/runtime-evidence/canonical-and-derived-state.md
 - Reference adapter: https://github.com/MythologIQ-Labs-LLC/agent-memory/tree/main/reference
 - Conformance test plan: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/06-conformance-test-plan.md
 

--- a/wiki-src/Security-and-Privacy.md
+++ b/wiki-src/Security-and-Privacy.md
@@ -86,7 +86,18 @@ Deletion is not complete merely because the canonical record disappeared. Contro
 - exported state
 - consolidated memories
 
-The system must state what it can actually purge and what remains outside its control.
+The system must state what it can actually purge and what remains outside its control. Stating it means sorting every affected artifact into one of four buckets:
+
+| Bucket | Meaning |
+|---|---|
+| Purged | demonstrated removed |
+| Declared residual, controlled | survives, reported, still reachable |
+| Declared residual, uncontrollable | survives, reported, out of reach |
+| **Undeclared residual** | survives, and nobody said so |
+
+The fourth bucket must be empty. A deletion that leaves recoverable content it never reported is a failed deletion regardless of how much it correctly removed, which makes this a disqualifying gate rather than a metric to average.
+
+Residue is also an authority problem and not only a completeness problem. Automatically rebuilding a stale summary looks like maintenance and is actually a write: if a language model recomputes content whenever a source version changes, an estimator has acquired a durable write channel without ever passing through the authority gate. That is authority laundering with a scheduler in front of it. **[Canonical and Derived State](Canonical-and-Derived-State)** works through both problems.
 
 ## Security reporting
 

--- a/wiki-src/_Sidebar.md
+++ b/wiki-src/_Sidebar.md
@@ -9,6 +9,7 @@
 **Architecture**
 - [PAMA](PAMA)
 - [Lifecycle and Forgetting](Lifecycle-and-Forgetting)
+- [Canonical and Derived State](Canonical-and-Derived-State)
 - [Governed Uncertainty](Governed-Uncertainty)
 - [Security and Privacy](Security-and-Privacy)
 - [Architecture Decisions](Architecture-Decisions)


### PR DESCRIPTION
## Summary

This PR introduces a design spike that establishes vocabulary and formal semantics for distinguishing canonical state from derived state (projections), making deletion propagation testable rather than merely required. It addresses the missing framework needed to discharge ADR-020 item 12 (derived-memory deletion residue testing).

## Key Changes

- **New design document** (`docs/programs/runtime-evidence/canonical-and-derived-state.md`): Comprehensive 175-line spike defining:
  - Three-tier model: canonical memory units, derived memory units, and projections (tier 3 currently ungoverned)
  - Formal definitions of staleness and residue as computable relations rather than flags
  - Projection declaration requirements: basis, transform type, content class, rebuild capability, and scope
  - Distinction between stale (source changed, potentially repairable) and residual (source purged, governance problem)
  - Rules for correction vs. deletion propagation, with deletion dominance principle
  - Governance requirement that estimator-mediated rebuilds require authority decisions, not automatic triggers
  - Honest residue measurement with four buckets, where undeclared residue must be zero

- **Wiki documentation** (`wiki-src/Canonical-and-Derived-State.md`): Accessible summary of the spike for non-specialist readers

- **Cross-document updates**: Integrated the new framework into existing doctrine:
  - `README.md`: Added explanation of stale vs. residual distinction
  - `Security-and-Privacy.md`: Added residue bucket model and authority-laundering risk from automatic rebuilds
  - `Lifecycle-and-Forgetting.md`: Clarified projection vs. memory distinction and failure modes
  - `Core-Concepts.md`: Added key distinctions (canonical ≠ derived, stale ≠ residual, rebuild ≠ maintenance)
  - `Glossary.md`: Added basis, canonical state, and related terms
  - `Runtime-Evidence.md`: Cross-referenced the spike
  - `_Sidebar.md`: Added navigation link

- **Validation**: Updated `.github/workflows/validate-doctrine-evidence.yml` to include the new document in validation

## Notable Design Findings

1. **Tier 3 is ungoverned**: Projections (indices, embeddings, caches) have no schema-enforced identity, lifecycle, or authority, concentrating residue risk in the tier the architecture cannot currently see.

2. **Staleness is a relation, not a flag**: Defined as a computable comparison between recorded basis versions and current canonical state, enabling pull-model governance without requiring push-invalidation from substrates.

3. **Deletion dominates correction**: Where a projection is superseded for reconstructability and later purged, the retained versions are in scope for deletion, resolving the genuine conflict between preservation-for-evidence and deletion-completeness.

4. **Rebuild is a governed mutation**: Automatic recomputation of estimator-mediated projections is authority laundering; only deterministic rebuilds can be pre-authorized as a class.

5. **Undeclared residue is a disqualifying gate**: Not a metric to average. A deletion leaving recoverable content it never reported is a failed deletion regardless of volume removed.

## Discharge Criteria

The spike explicitly defines what would discharge ADR-020 item 12, including the hard cases (transitive closure traversal, independent sweep validation, refusal of automatic estimator rebuilds) that a persuasive demonstration might skip.