### PR TITLE
Execute the canonical and derived state evidence bar (P4)

### DIFF
--- a/.failsafe/governance/META_LEDGER.md
+++ b/.failsafe/governance/META_LEDGER.md
@@ -559,3 +559,62 @@ remains Proposed pending concurrency behavior, deletion-propagation
 measurement, and evidence across a wider surface than one reference adapter.
 The wiki source tree is ahead of the published wiki, which remains unpublished
 pending Governor direction.
+
+---
+
+### Entry #13: P4 EXECUTED — CANONICAL AND DERIVED STATE
+
+**Timestamp**: 2026-08-11T16:30:00Z
+**Phase**: IMPLEMENT
+**Author**: Governor
+**Risk Grade**: L1
+
+**Content Hash**:
+```
+SHA256("p4-derived-state:" + git tree hash at parent commit)
+= 48d657dff24782adbecfe76e9da4277be34f4491084ac937d4771141d1b46f80
+```
+
+**Previous Hash**: 32a674bb717c71207f75f161d3dc28055bf059e95b3815694ff571b1357020c8
+
+**Chain Hash**:
+```
+SHA256(content_hash + previous_hash)
+= 25fe3794d02da6bfe553f605a0a7488fdf7de424529e82f43d3482c705b4e2f3
+```
+
+**Decision**: P4 executed against the architectural design authored upstream.
+The division of labor is explicit and preserved: the canonical-and-derived-state
+design spike, its three-tier model, its freshness relation, its residue
+partition, and its seven-item evidence bar were specified elsewhere. This work
+implements that specification and does not amend its argument.
+
+All seven bar items now execute in CI. A tier-3 declaration surface records
+basis at build time. Freshness is computed as a relation over recorded basis
+versus current canonical state, never set by a flag, with residual dominating
+stale because they carry different authorities. Correction supersedes
+content-bearing projections without erasing the version a prior decision used.
+Purge traverses the transitive derivation closure including retained superseded
+versions, honoring deletion-dominates-correction. An independent sweep
+re-derives residual status rather than asking the purge whether it finished.
+Estimator-mediated rebuild is refused without an authority decision, while
+deterministic reproducible rebuild is categorically authorized.
+
+Items 4, 5, and 6 were called out upstream as the ones a persuasive
+demonstration would skip. Each carries a paired negative test: a deliberate
+one-hop purge must be caught by the sweep, an unauthorized purge must not run,
+and staleness alone must not commit estimator content. Two implementation bugs
+were found by those negative tests rather than by inspection: a dropped
+projection was not recorded as purged, so dependents read as merely stale
+instead of residual; and a refused purge recorded a no-action sentinel while
+the envelope still permitted deferrals.
+
+A review-satisfaction path was added to the policy so an externally approved
+purge is reachable at all. Review is discharged only by an approval record from
+someone other than the proposer, block remains absorbing, and self-approval
+cannot buy past review. This also closes a previously documented limitation.
+
+Reported metrics: deletion_residue_rate 0.0 with an empty undeclared cell, and
+stochastic_action_set_violation_rate 0.0. Forty-six tests plus sweeps.
+Conformance level remains 0 and ADR-020 remains Proposed: this discharges one
+validation item, and clearing one bar is not acceptance.

--- a/docs/programs/runtime-evidence/README.md
+++ b/docs/programs/runtime-evidence/README.md
@@ -73,7 +73,7 @@ Documents are added when their slice is ready to execute, not in advance. A dire
 |---|---|---|
 | [`graphiti-conformance.md`](graphiti-conformance.md) | first substrate capability mapping | documentation-verified, with key findings confirmed by execution |
 | [`../../../reference/README.md`](../../../reference/README.md) | minimal governed adapter | bound and executed against a real substrate |
-| [`canonical-and-derived-state.md`](canonical-and-derived-state.md) | canonical memory versus derived projections | design spike: vocabulary and proposed invariants only, no runtime evidence |
+| [`canonical-and-derived-state.md`](canonical-and-derived-state.md) | canonical memory versus derived projections | design spike executed: all seven evidence-bar items run in CI |
 
 ## Preconditions
 

--- a/docs/programs/runtime-evidence/canonical-and-derived-state.md
+++ b/docs/programs/runtime-evidence/canonical-and-derived-state.md
@@ -148,6 +148,8 @@ Two honesty constraints keep the metric from measuring itself:
 
 ## What would discharge ADR-020 item 12
 
+> **Execution status.** All seven items below now run in the reference implementation and in CI. See [`../../../reference/README.md`](../../../reference/README.md); the projection layer is `reference/agentmem_ref/projections.py`, residue accounting is `residue.py`, governed operations are `projection_governance.py`, and the executed bar is `reference/tests/test_canonical_and_derived_state.py`. Items 4, 5, and 6 each carry a paired negative test, because a bar that only passes proves less than one that can also fail. This does not by itself accept ADR-020, which has further validation items.
+
 Stated now so the evidence bar is fixed before the implementation that must clear it:
 
 1. A projection declaration exists for tier-3 state, with basis recorded at build time.

--- a/reference/README.md
+++ b/reference/README.md
@@ -34,6 +34,9 @@ reference/
     receipts.py     schema-conformant decisions, receipts, audit events
     adapter.py      the governed path
     fixture_conformance.py  drives the doctrine corpus through enforcement
+    projections.py          tier-3 declarations and the freshness relation
+    residue.py              deletion residue partition and independent sweep
+    projection_governance.py governed correction, purge, and rebuild
     (selectors live in adapter.py: deterministic and seeded stochastic)
   agentmem_ref/graphiti_driver.py   binding to a real temporal knowledge graph
   tests/            model paths and real-substrate paths
@@ -88,6 +91,11 @@ The adapter supplies what the substrate cannot: an authority gate before every w
 | fixture corpus | all 25 doctrine fixtures pass envelope enforcement; the checker is mutation-tested |
 | stochastic containment | hundreds of sampled trials never escape the permitted set, and the selector demonstrably varies |
 | hostile selector | a selector returning a prohibited action is contained by the adapter and the violation recorded |
+| derived-state freshness | stale and residual are computed from a recorded basis, never set by a flag |
+| correction propagation | dependents go stale; content-bearing projections supersede without erasing the prior version |
+| transitive purge | the whole derivation closure is reached, and a deliberate one-hop purge is caught by the sweep |
+| undeclared residue | the four-way partition holds, with the undeclared cell empty as a hard gate |
+| rebuild authority | estimator-mediated rebuild is refused without an authority decision; deterministic reproducible rebuild is categorical |
 
 ## Known limitations
 
@@ -98,4 +106,5 @@ Stated rather than left to be discovered:
 3. The policy implements the subset of the decision table these paths need, not the whole table.
 4. The substrate binding uses an embedded backend that is deprecated upstream, chosen because it needs no server. No governance behavior under test depends on the backend choice.
 5. Node topology is simplified to one edge per fact. This exercises governance invariants, not knowledge modelling.
-6. Approved permanent deletion is exercised only at the substrate level; no review-satisfaction path is modelled in the policy, so the gate refuses the proposal form.
+6. Derived-state governance operates on an adapter-owned sidecar. The design spike names this as the obvious home for substrates that cannot store a projection declaration, and notes that it reintroduces the consistency problem one level up. That trade is accepted here rather than solved.
+7. Residue is measured over declared projections. State that was never declared is outside the sweep's reach by construction, which is why the declaration surface is the load-bearing part rather than the traversal.

--- a/reference/agentmem_ref/adapter.py
+++ b/reference/agentmem_ref/adapter.py
@@ -267,6 +267,19 @@ class GovernedMemoryAdapter:
     def mark_disputed(self, fact_uuid: str) -> None:
         self._disputed.add(fact_uuid)
 
+    # -- canonical state accessors --------------------------------------
+
+    def state_version(self, memory_id: str) -> int:
+        return self._state_version.get(memory_id, 0)
+
+    def tombstoned_ids(self) -> set[str]:
+        return {record["memory_id"] for record in self._tombstones.values()}
+
+    def record_correction(self, memory_id: str) -> int:
+        """A correction advances canonical version; dependents become stale by relation."""
+        self._state_version[memory_id] = self._state_version.get(memory_id, 0) + 1
+        return self._state_version[memory_id]
+
     # -- deletion -------------------------------------------------------
 
     def governed_delete(self, proposal: policy.Proposal, fact_uuid: str, derived_refs: tuple[str, ...] = ()) -> CommitResult:

--- a/reference/agentmem_ref/policy.py
+++ b/reference/agentmem_ref/policy.py
@@ -114,6 +114,8 @@ class Proposal:
     confidence: float | None = None
     actor_authority_resolved: bool = True
     approves_own_authority: bool = False
+    approval_refs: tuple[str, ...] = ()
+    review_satisfied: bool = False
     state_snapshot: str = ""
     tenant_ref: str = ""
     purpose: str = ""
@@ -168,6 +170,22 @@ def _apply_modifiers(outcome: str, proposal: Proposal) -> tuple[str, list[str]]:
     return outcome, reasons
 
 
+def _apply_review(outcome: str, proposal: Proposal) -> tuple[str, list[str]]:
+    """Discharge a review requirement that an external authority has satisfied.
+
+    Review is satisfied by an approver, never by the proposer. `block` stays
+    absorbing, and a proposal that would expand its own authority cannot buy
+    its way past review by asserting that review happened.
+    """
+    if outcome not in (REQUIRE_REVIEW, REQUIRE_EXTERNAL_VERIFICATION):
+        return outcome, []
+    if not proposal.review_satisfied:
+        return outcome, []
+    if not proposal.approval_refs or proposal.approves_own_authority:
+        return outcome, ["review claimed without an external approval record"]
+    return ALLOW_WITH_LEDGER, [f"review discharged by {list(proposal.approval_refs)}"]
+
+
 def _envelope(outcome: str, proposal: Proposal) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """Permitted and prohibited sets. Prohibited actions are absent from permitted."""
     operation = proposal.operation
@@ -185,10 +203,11 @@ def evaluate(proposal: Proposal) -> Decision:
     outcome = _base_outcome(proposal)
     outcome, floor_reasons = _apply_floors(outcome, proposal)
     outcome, modifier_reasons = _apply_modifiers(outcome, proposal)
+    outcome, review_reasons = _apply_review(outcome, proposal)
     permitted, prohibited = _envelope(outcome, proposal)
     return Decision(
         outcome=outcome,
         permitted_actions=permitted,
         prohibited_actions=prohibited,
-        reasons=tuple(floor_reasons + modifier_reasons),
+        reasons=tuple(floor_reasons + modifier_reasons + review_reasons),
     )

--- a/reference/agentmem_ref/projection_governance.py
+++ b/reference/agentmem_ref/projection_governance.py
@@ -1,0 +1,264 @@
+"""Governed operations over derived state.
+
+Composes the projection sidecar with the authority gate so that the four
+consequential derived-state operations are governed rather than incidental:
+
+- **declare** a projection, recording its basis at build time;
+- **correct** a canonical unit, which makes dependents stale by relation and
+  supersedes content-bearing projections without erasing what a prior decision
+  relied on;
+- **purge** a canonical unit across the transitive closure of its basis,
+  producing a residue partition and an independent sweep; and
+- **rebuild** a projection, which is a governed mutation whenever an estimator
+  would produce the new content.
+
+That last one is the design spike's least obvious finding. If detecting
+staleness could trigger recomputation on its own, an estimator would gain the
+ability to write content into memory whenever it can cause a version bump.
+Invalidation would become a write channel, which is authority laundering with
+a maintenance job in front of it.
+
+Stdlib only apart from schema validation reached through `receipts`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from . import policy, receipts, residue
+from .projections import (
+    CanonicalView,
+    Projection,
+    ProjectionStore,
+    RESIDUAL,
+    STALE,
+)
+
+
+@dataclass
+class CorrectionResult:
+    memory_id: str
+    new_version: int
+    now_stale: list[str] = field(default_factory=list)
+    superseded: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PurgeResult:
+    decision: policy.Decision
+    receipt: dict
+    committed: bool = False
+    buckets: dict = field(default_factory=dict)
+    undeclared: list[str] = field(default_factory=list)
+    refusal: str | None = None
+
+    @property
+    def hard_gate_passed(self) -> bool:
+        """Undeclared residue is disqualifying and un-averageable."""
+        return not self.undeclared
+
+
+@dataclass
+class RebuildResult:
+    decision: policy.Decision | None
+    committed: bool = False
+    refusal: str | None = None
+    categorical: bool = False
+
+
+class ProjectionGovernor:
+    """Governs derived state on top of a `GovernedMemoryAdapter`."""
+
+    def __init__(self, adapter, store: ProjectionStore | None = None) -> None:
+        self._adapter = adapter
+        self.store = store or ProjectionStore()
+        self._purged: set[str] = set()
+
+    # -- state ----------------------------------------------------------
+
+    def view(self) -> CanonicalView:
+        versions = {
+            memory_id: self._adapter.state_version(memory_id)
+            for memory_id in self._known_sources()
+        }
+        return CanonicalView(versions, self._adapter.tombstoned_ids(), set(self._purged))
+
+    def _known_sources(self) -> set[str]:
+        sources: set[str] = set()
+        for projection in self.store.all_versions():
+            sources.update(projection.basis_map)
+        return sources
+
+    def freshness(self, projection_id: str) -> str | None:
+        projection = self.store.get(projection_id)
+        if projection is None:
+            return None
+        return self.store.freshness(projection, self.view())
+
+    # -- declaration -----------------------------------------------------
+
+    def declare(
+        self,
+        projection_id: str,
+        basis_ids: tuple[str, ...],
+        transform: str,
+        content_class: str,
+        rebuild: str,
+        scope: str,
+        reachable: bool = True,
+        note: str = "",
+    ) -> Projection:
+        """Record a projection with the versions it actually read."""
+        basis = tuple((source, self._version_of(source)) for source in basis_ids)
+        return self.store.declare(
+            Projection(
+                projection_id=projection_id,
+                basis=basis,
+                transform=transform,
+                content_class=content_class,
+                rebuild=rebuild,
+                scope=scope,
+                reachable=reachable,
+                note=note,
+            )
+        )
+
+    def _version_of(self, source: str) -> int:
+        projection = self.store.get(source)
+        if projection is not None:
+            return projection.version
+        return self._adapter.state_version(source)
+
+    # -- correction ------------------------------------------------------
+
+    def correct(self, memory_id: str) -> CorrectionResult:
+        """Advance canonical version; dependents become stale by relation.
+
+        Content-bearing projections are superseded rather than overwritten, so
+        a decision that relied on the earlier content stays reconstructable.
+        """
+        new_version = self._adapter.record_correction(memory_id)
+        result = CorrectionResult(memory_id=memory_id, new_version=new_version)
+        view = self.view()
+        for projection in self.store.dependents_of(memory_id):
+            if self.store.freshness(projection, view) != STALE:
+                continue
+            result.now_stale.append(projection.projection_id)
+            if projection.is_content_bearing:
+                rebased = tuple(
+                    (source, new_version if source == memory_id else read)
+                    for source, read in projection.basis
+                )
+                self.store.supersede(projection.projection_id, rebased)
+                result.superseded.append(projection.projection_id)
+        return result
+
+    # -- purge -----------------------------------------------------------
+
+    def purge(
+        self,
+        proposal: policy.Proposal,
+        memory_id: str,
+        retained_by_policy: set[str] | None = None,
+    ) -> PurgeResult:
+        """Purge a canonical unit and the transitive closure of its derivations."""
+        decision = policy.evaluate(proposal)
+        permitted = proposal.operation in decision.permitted_actions
+        if not permitted:
+            deferral = self._deferral(decision)
+            receipt = self._receipt(
+                proposal, decision, deferral,
+                "deterministic" if deferral != receipts.NO_ACTION else "none",
+            )
+            return PurgeResult(
+                decision=decision,
+                receipt=receipt,
+                committed=False,
+                refusal="purge not authorized",
+            )
+
+        plan = residue.plan_purge(self.store, memory_id, retained_by_policy)
+        residue.apply_purge(self.store, plan, self._purged)
+        self._purged.add(memory_id)
+
+        buckets = residue.partition(self.store, self.view(), plan)
+        receipt = self._receipt(proposal, decision, proposal.operation, "deterministic")
+        self._adapter.events.append(
+            receipts.build_audit_event(
+                event_id=f"{receipt['receipt_id']}-residue",
+                event_type="memory.delete",
+                timestamp=receipt["timestamp"],
+                component="projection-governor",
+                memory_id=memory_id,
+                correlation_id=receipt["receipt_id"],
+                policy_version=decision.policy_version,
+                receipt_ref=receipt["receipt_id"],
+            )
+        )
+        return PurgeResult(
+            decision=decision,
+            receipt=receipt,
+            committed=True,
+            buckets=buckets,
+            undeclared=buckets[residue.UNDECLARED],
+        )
+
+    def sweep(self, declared: set[str] | None = None) -> list[str]:
+        """Independent residue sweep, not a report from the purge."""
+        return residue.independent_sweep(self.store, self.view(), declared or set())
+
+    # -- rebuild ---------------------------------------------------------
+
+    def propose_rebuild(
+        self,
+        projection_id: str,
+        proposal: policy.Proposal | None = None,
+    ) -> RebuildResult:
+        """Rebuild is a governed mutation unless it is deterministic and reproducible."""
+        projection = self.store.get(projection_id)
+        if projection is None:
+            return RebuildResult(decision=None, refusal="unknown projection")
+
+        if not projection.requires_authority_to_rebuild:
+            self._rebase(projection)
+            return RebuildResult(decision=None, committed=True, categorical=True)
+
+        if proposal is None:
+            return RebuildResult(
+                decision=None,
+                refusal="estimator-mediated rebuild requires an authority decision",
+            )
+
+        decision = policy.evaluate(proposal)
+        if proposal.operation not in decision.permitted_actions:
+            return RebuildResult(decision=decision, refusal="rebuild not authorized")
+        self._rebase(projection)
+        return RebuildResult(decision=decision, committed=True)
+
+    def _rebase(self, projection: Projection) -> None:
+        rebased = tuple((source, self._version_of(source)) for source, _ in projection.basis)
+        self.store.supersede(projection.projection_id, rebased)
+
+    # -- helpers ---------------------------------------------------------
+
+    @staticmethod
+    def _deferral(decision: policy.Decision) -> str:
+        """A refusal still selects from the envelope when one exists."""
+        if not decision.permitted_actions:
+            return receipts.NO_ACTION
+        if "defer" in decision.permitted_actions:
+            return "defer"
+        return decision.permitted_actions[0]
+
+    def _receipt(self, proposal, decision, selected: str, mode: str) -> dict:
+        version = f"v{self._adapter.state_version(proposal.target_reference)}"
+        return receipts.build_receipt(
+            receipt_id=f"purge-{proposal.proposal_id}",
+            proposal=proposal,
+            decision=decision,
+            selected_action=selected,
+            selection_mode=mode,
+            timestamp="2026-01-01T00:00:00Z",
+            before_state=version,
+            after_state=version,
+        )

--- a/reference/agentmem_ref/projections.py
+++ b/reference/agentmem_ref/projections.py
@@ -1,0 +1,197 @@
+"""Tier-3 projection declarations, freshness, and residue.
+
+Implements the design spike in
+`docs/programs/runtime-evidence/canonical-and-derived-state.md`.
+
+The spike's headline finding is that P4 is mostly a tier-3 problem: indices,
+embeddings, caches, and materialized views are not memory units, so nothing
+obliges them to declare what they were built from, and that is exactly where
+deletion residue hides. This module gives tier-3 state the declaration surface
+it lacked.
+
+Two design commitments carry through:
+
+**Freshness is a computed relation, not a flag.** Nothing sets a `stale` bit.
+`current`, `stale`, and `residual` are derived at read time from a recorded
+basis against current canonical state, so a substrate that never
+self-invalidates is still governable.
+
+**Stale and residual are different states with different authorities.** Stale
+is a correctness problem that recomputation may fix. Residual is a governance
+problem only the deletion authority may resolve. Collapsing them would lose
+the distinction the architecture exists to protect.
+
+The declaration lives in an adapter-owned sidecar, which the spike names as the
+obvious home for substrates that cannot store it, and which reintroduces the
+consistency problem one level up. That trade is recorded rather than hidden.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+# transform
+DETERMINISTIC = "deterministic"
+ESTIMATOR_MEDIATED = "estimator_mediated"
+
+# content_class
+REFERENCE_ONLY = "reference_only"
+DERIVED_CONTENT = "derived_content"
+RECOVERABLE_CONTENT = "recoverable_content"
+
+# rebuild
+REPRODUCIBLE = "reproducible"
+APPROXIMABLE = "approximable"
+IRREPRODUCIBLE = "irreproducible"
+
+# freshness relation
+CURRENT = "current"
+STALE = "stale"
+RESIDUAL = "residual"
+
+#: Content classes that can carry a source's content past its deletion.
+CONTENT_BEARING = frozenset({DERIVED_CONTENT, RECOVERABLE_CONTENT})
+
+
+@dataclass(frozen=True)
+class Projection:
+    """A declaration of tier-3 state's relationship to canonical state.
+
+    `basis` maps each source identifier to the version read at build time. A
+    source may itself be a projection: derivation graphs are not flat, which is
+    why residue closure must be transitive.
+    """
+
+    projection_id: str
+    basis: tuple[tuple[str, int], ...]
+    transform: str
+    content_class: str
+    rebuild: str
+    scope: str
+    version: int = 1
+    superseded_by: str | None = None
+    reachable: bool = True
+    note: str = ""
+
+    @property
+    def basis_map(self) -> dict[str, int]:
+        return dict(self.basis)
+
+    @property
+    def is_content_bearing(self) -> bool:
+        return self.content_class in CONTENT_BEARING
+
+    @property
+    def requires_authority_to_rebuild(self) -> bool:
+        """Deterministic reproducible rebuilds may be authorized categorically.
+
+        Everything else commits estimator-derived content and must pass through
+        governance, or invalidation becomes a write channel.
+        """
+        return not (self.transform == DETERMINISTIC and self.rebuild == REPRODUCIBLE)
+
+
+class CanonicalView:
+    """What the freshness relation needs to know about canonical state."""
+
+    def __init__(self, versions: dict[str, int], tombstoned: set[str], purged: set[str]) -> None:
+        self._versions = versions
+        self._tombstoned = tombstoned
+        self._purged = purged
+
+    def version(self, memory_id: str) -> int | None:
+        return self._versions.get(memory_id)
+
+    def is_tombstoned(self, memory_id: str) -> bool:
+        return memory_id in self._tombstoned
+
+    def is_purged(self, memory_id: str) -> bool:
+        return memory_id in self._purged
+
+
+class ProjectionStore:
+    """Sidecar registry of projection declarations and superseded versions."""
+
+    def __init__(self) -> None:
+        self._live: dict[str, Projection] = {}
+        self._superseded: dict[str, list[Projection]] = {}
+
+    # -- declaration ----------------------------------------------------
+
+    def declare(self, projection: Projection) -> Projection:
+        self._live[projection.projection_id] = projection
+        return projection
+
+    def get(self, projection_id: str) -> Projection | None:
+        return self._live.get(projection_id)
+
+    def live(self) -> tuple[Projection, ...]:
+        return tuple(self._live.values())
+
+    def superseded(self, projection_id: str) -> tuple[Projection, ...]:
+        return tuple(self._superseded.get(projection_id, ()))
+
+    def all_versions(self) -> tuple[Projection, ...]:
+        retained: list[Projection] = list(self._live.values())
+        for versions in self._superseded.values():
+            retained.extend(versions)
+        return tuple(retained)
+
+    def supersede(self, projection_id: str, new_basis: tuple[tuple[str, int], ...]) -> Projection | None:
+        """Retain the prior version rather than overwriting it.
+
+        A decision that used the earlier content must remain reconstructable.
+        Deletion may later override this; see `drop_version`.
+        """
+        current = self._live.get(projection_id)
+        if current is None:
+            return None
+        retired = replace(current, superseded_by=f"{projection_id}@v{current.version + 1}")
+        self._superseded.setdefault(projection_id, []).append(retired)
+        updated = replace(current, basis=new_basis, version=current.version + 1)
+        self._live[projection_id] = updated
+        return updated
+
+    def drop(self, projection_id: str) -> None:
+        """Remove a projection and every retained version of it."""
+        self._live.pop(projection_id, None)
+        self._superseded.pop(projection_id, None)
+
+    # -- relations ------------------------------------------------------
+
+    def freshness(self, projection: Projection, view: CanonicalView) -> str:
+        """Compute the freshness relation. Residual dominates stale."""
+        basis = projection.basis_map
+        for source, read_version in basis.items():
+            if view.is_tombstoned(source) or view.is_purged(source):
+                return RESIDUAL
+        for source, read_version in basis.items():
+            if view.version(source) != read_version:
+                return STALE
+        return CURRENT
+
+    def dependents_of(self, source_id: str) -> tuple[Projection, ...]:
+        return tuple(p for p in self._live.values() if source_id in p.basis_map)
+
+    def derivation_closure(self, source_id: str) -> tuple[str, ...]:
+        """Every projection reachable from a source through the basis relation.
+
+        Transitive, because projections are routinely built from projections
+        and a one-hop purge measures its own optimism. Cycles are possible once
+        projections feed consolidation that feeds projections, so the walk
+        carries a seen-set rather than assuming the graph is well-founded.
+        """
+        found: list[str] = []
+        seen: set[str] = set()
+        frontier = [source_id]
+        while frontier:
+            current = frontier.pop()
+            for projection in self.dependents_of(current):
+                if projection.projection_id in seen:
+                    continue
+                seen.add(projection.projection_id)
+                found.append(projection.projection_id)
+                frontier.append(projection.projection_id)
+        return tuple(found)

--- a/reference/agentmem_ref/residue.py
+++ b/reference/agentmem_ref/residue.py
@@ -1,0 +1,142 @@
+"""Deletion residue as a partition, with one cell that must stay empty.
+
+Implements the residue accounting of the canonical-and-derived-state design
+spike. The metric is not a volume of removed bytes; it is a four-way partition
+of everything derived from a purged source:
+
+```text
+purged                              demonstrated removed
+declared_residual_controlled        survives, reported, within reach
+declared_residual_uncontrollable    survives, reported, outside reach
+undeclared_residual                 survives and was not reported
+```
+
+`undeclared_residual = 0` is a hard invariant gate: disqualifying and
+un-averageable. A deletion that leaves recoverable content it did not report is
+a failed deletion however much it removed.
+
+Two honesty constraints from the spike are load-bearing here:
+
+1. **Unknown is not a fourth bucket.** State whose derivation cannot be
+   enumerated is declared uncontrollable — declared and reported — never
+   omitted because it was inconvenient to find.
+2. **Traversal completeness is itself the measurement.** `independent_sweep`
+   does not ask the purge whether it finished. It re-derives residual status
+   from the freshness relation over every retained declaration, including
+   superseded versions, so a purge that traversed one hop is caught rather than
+   believed.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .projections import CanonicalView, ProjectionStore, RESIDUAL
+
+PURGED = "purged"
+DECLARED_CONTROLLED = "declared_residual_controlled"
+DECLARED_UNCONTROLLABLE = "declared_residual_uncontrollable"
+UNDECLARED = "undeclared_residual"
+
+
+@dataclass
+class ResiduePlan:
+    """What a purge intends to do with each projection in the closure."""
+
+    purged: list[str] = field(default_factory=list)
+    declared_residual_controlled: list[str] = field(default_factory=list)
+    declared_residual_uncontrollable: list[str] = field(default_factory=list)
+
+    @property
+    def declared(self) -> set[str]:
+        return set(self.declared_residual_controlled) | set(self.declared_residual_uncontrollable)
+
+    def as_receipt_buckets(self) -> dict[str, list[str]]:
+        return {
+            PURGED: sorted(self.purged),
+            DECLARED_CONTROLLED: sorted(self.declared_residual_controlled),
+            DECLARED_UNCONTROLLABLE: sorted(self.declared_residual_uncontrollable),
+        }
+
+
+def plan_purge(
+    store: ProjectionStore,
+    source_id: str,
+    retained_by_policy: set[str] | None = None,
+) -> ResiduePlan:
+    """Classify the transitive closure of a source into residue buckets.
+
+    The closure is transitive by construction. A one-hop plan would leave
+    projections-of-projections holding the purged content, which is the failure
+    the independent sweep exists to catch.
+    """
+    held = retained_by_policy or set()
+    plan = ResiduePlan()
+    for projection_id in store.derivation_closure(source_id):
+        projection = store.get(projection_id)
+        if projection is None:
+            continue
+        if not projection.is_content_bearing:
+            # Reference-only state carries no content past its source.
+            plan.purged.append(projection_id)
+        elif not projection.reachable:
+            # Exports, third-party copies, model weights: known, reported, unreachable.
+            plan.declared_residual_uncontrollable.append(projection_id)
+        elif projection_id in held:
+            plan.declared_residual_controlled.append(projection_id)
+        else:
+            plan.purged.append(projection_id)
+    return plan
+
+
+def apply_purge(store: ProjectionStore, plan: ResiduePlan, purged: set[str]) -> None:
+    """Remove what the plan says is purged, including superseded versions.
+
+    Deletion dominates correction: a superseded version retained for
+    reconstructability is, once its basis is purged, exactly the recoverable
+    residue the deletion was meant to eliminate.
+
+    Purged identifiers are recorded in `purged` because a projection built on a
+    purged projection is residual, not merely stale. Without that, a partial
+    purge would look like a correctness problem instead of a governance one.
+    """
+    for projection_id in plan.purged:
+        store.drop(projection_id)
+        purged.add(projection_id)
+
+
+def independent_sweep(
+    store: ProjectionStore,
+    view: CanonicalView,
+    declared: set[str],
+) -> list[str]:
+    """Re-derive residual state without consulting the purge's traversal.
+
+    Any retained declaration — live or superseded — that still carries content
+    and whose basis includes a tombstoned or purged source is residue. If it
+    was not declared in the deletion receipt, it is undeclared, and that is a
+    hard-gate failure.
+    """
+    undeclared: list[str] = []
+    for projection in store.all_versions():
+        if not projection.is_content_bearing:
+            continue
+        if store.freshness(projection, view) != RESIDUAL:
+            continue
+        if projection.projection_id in declared:
+            continue
+        undeclared.append(projection.projection_id)
+    return sorted(set(undeclared))
+
+
+def partition(
+    store: ProjectionStore,
+    view: CanonicalView,
+    plan: ResiduePlan,
+) -> dict[str, list[str]]:
+    """The full four-way partition, with the swept result in the last cell."""
+    buckets = plan.as_receipt_buckets()
+    buckets[UNDECLARED] = independent_sweep(store, view, plan.declared)
+    return buckets

--- a/reference/run_conformance.py
+++ b/reference/run_conformance.py
@@ -30,7 +30,9 @@ sys.path.insert(0, str(REFERENCE_DIR))
 from agentmem_ref import fixture_conformance, policy, receipts  # noqa: E402
 from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, StochasticSelector  # noqa: E402
 from agentmem_ref.graphiti_driver import graphiti_available  # noqa: E402
+from agentmem_ref.projection_governance import ProjectionGovernor  # noqa: E402
 from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+from agentmem_ref import projections as proj  # noqa: E402
 
 ADAPTER_VERSION = "0.1.0"
 DOCTRINE_VERSION = "v0.3"
@@ -100,6 +102,52 @@ def _stochastic_sweep(trials: int) -> dict:
     return {"trials": trials, "escapes": escapes, "distinct_actions": sorted(observed)}
 
 
+def _derived_state_probe() -> dict:
+    """Purge a derivation chain and measure residue independently.
+
+    Reports the partition, not a volume. `undeclared_residual` is a hard gate:
+    any nonzero value is a failed deletion regardless of how much was removed.
+    """
+    adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), tenant="tenant-a", clock=Clock())
+    governor = ProjectionGovernor(adapter)
+    source = "mem:probe"
+    adapter.commit_proposal(
+        policy.Proposal(
+            proposal_id="probe", actor_id="agent:planner", charter_version="c1",
+            target_reference=source, target_class=policy.M2, scope="tenant-a",
+            operation="promotion", current_strength="reinforced", proposed_strength="promoted",
+            downstream_authority=policy.A1, reversibility="reversible", risk_class="low",
+            evidence_refs=("ev:1",),
+        ),
+        "a claim",
+    )
+    governor.declare("sum:1", (source,), proj.ESTIMATOR_MEDIATED,
+                     proj.RECOVERABLE_CONTENT, proj.APPROXIMABLE, "tenant-a")
+    governor.declare("sum:2", ("sum:1",), proj.ESTIMATOR_MEDIATED,
+                     proj.RECOVERABLE_CONTENT, proj.APPROXIMABLE, "tenant-a")
+    governor.declare("export:1", (source,), proj.DETERMINISTIC,
+                     proj.RECOVERABLE_CONTENT, proj.IRREPRODUCIBLE, "tenant-a", reachable=False)
+    total = 3
+
+    result = governor.purge(
+        policy.Proposal(
+            proposal_id="probe-purge", actor_id="agent:planner", charter_version="c1",
+            target_reference=source, target_class=policy.M2, scope="tenant-a",
+            operation="permanent_deletion", current_strength="promoted",
+            proposed_strength="not_applicable", downstream_authority=policy.A1,
+            reversibility="irreversible", risk_class="low", evidence_refs=("ev:1",),
+            approval_refs=("approval:dpo",), review_satisfied=True,
+        ),
+        source,
+    )
+    return {
+        "buckets": result.buckets,
+        "undeclared_count": len(result.undeclared),
+        "derived_total": total,
+        "hard_gate_passed": result.hard_gate_passed,
+    }
+
+
 def _exemptions(substrate_executed: bool) -> list[str]:
     common = [
         "No conformance level is claimed. The corpus is driven through the adapter's authority "
@@ -127,6 +175,7 @@ def build_report(trials: int = 200) -> dict:
     names, passed, failed = _run_suite()
     corpus = fixture_conformance.run()
     sweep = _stochastic_sweep(trials)
+    derived = _derived_state_probe()
     report = {
         "schema_version": "1.0.0",
         "implementation": "agent-memory reference governed adapter",
@@ -138,7 +187,10 @@ def build_report(trials: int = 200) -> dict:
         "fixtures_passed": corpus["fixtures_passed"],
         "fixtures_failed": corpus["fixtures_failed"],
         "trials_run": len(names) + len(corpus["fixtures_run"]) + sweep["trials"],
-        "metrics": {"stochastic_action_set_violation_rate": sweep["escapes"] / max(sweep["trials"], 1)},
+        "metrics": {
+            "stochastic_action_set_violation_rate": sweep["escapes"] / max(sweep["trials"], 1),
+            "deletion_residue_rate": derived["undeclared_count"] / max(derived["derived_total"], 1),
+        },
         "known_exemptions": _exemptions(substrate_executed) + fixture_conformance.exemptions(),
         "known_failures": corpus["fixtures_failed"] + failed,
         "metric_extensions": {
@@ -152,6 +204,8 @@ def build_report(trials: int = 200) -> dict:
             "stochastic_trials": sweep["trials"],
             "stochastic_escapes": sweep["escapes"],
             "stochastic_distinct_actions": sweep["distinct_actions"],
+            "derived_state_residue_buckets": derived["buckets"],
+            "derived_state_hard_gate_passed": derived["hard_gate_passed"],
         },
     }
     receipts.validate("conformance-report.schema.json", report)
@@ -173,6 +227,9 @@ def main() -> int:
         print(rendered, end="")
     if report["metric_extensions"]["stochastic_escapes"]:
         print("stochastic containment violated", file=sys.stderr)
+        return 1
+    if not report["metric_extensions"]["derived_state_hard_gate_passed"]:
+        print("undeclared deletion residue detected", file=sys.stderr)
         return 1
     return 1 if report["known_failures"] else 0
 

--- a/reference/tests/test_canonical_and_derived_state.py
+++ b/reference/tests/test_canonical_and_derived_state.py
@@ -1,0 +1,286 @@
+"""P4: canonical memory versus derived projections.
+
+Executes the seven-item evidence bar stated in
+`docs/programs/runtime-evidence/canonical-and-derived-state.md`, which exists
+to discharge ADR-020 validation item 12, *derived-memory deletion residue is
+tested*.
+
+The spike names items 4, 5, and 6 as the ones a persuasive demonstration would
+skip: transitive purge, an independent sweep, and refusal of automatic
+estimator-mediated rebuild. Each has a dedicated test here, and each is paired
+with a negative case proving the check can fail.
+
+Run: python -m unittest discover -s reference/tests -t reference
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy, projections, residue  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter  # noqa: E402
+from agentmem_ref.projection_governance import ProjectionGovernor  # noqa: E402
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+TENANT = "tenant-a"
+SOURCE = "mem:alpha"
+
+
+def make_proposal(**overrides) -> policy.Proposal:
+    base = dict(
+        proposal_id="prop-1",
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference=SOURCE,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("ev:1",),
+        tenant_ref=TENANT,
+    )
+    base.update(overrides)
+    return policy.Proposal(**base)
+
+
+def approved_purge(**overrides) -> policy.Proposal:
+    """A purge an external authority has actually approved."""
+    return make_proposal(
+        proposal_id="prop-purge",
+        operation="permanent_deletion",
+        reversibility="irreversible",
+        risk_class="low",
+        approval_refs=("approval:data-protection-officer",),
+        review_satisfied=True,
+        **overrides,
+    )
+
+
+class ProjectionDeclarationTests(unittest.TestCase):
+    """Item 1: a declaration exists, with basis recorded at build time."""
+
+    def setUp(self) -> None:
+        self.adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), TENANT, Clock())
+        self.gov = ProjectionGovernor(self.adapter)
+        self.adapter.commit_proposal(make_proposal(), "deploy window is Thursday")
+
+    def test_declaration_records_the_versions_actually_read(self):
+        declared = self.gov.declare(
+            "idx:1", (SOURCE,), projections.DETERMINISTIC,
+            projections.REFERENCE_ONLY, projections.REPRODUCIBLE, TENANT,
+        )
+        self.assertEqual(declared.basis_map, {SOURCE: self.adapter.state_version(SOURCE)})
+        self.assertEqual(self.gov.freshness("idx:1"), projections.CURRENT)
+
+
+class FreshnessRelationTests(unittest.TestCase):
+    """Item 2: stale and residual are computed, never asserted by a flag."""
+
+    def setUp(self) -> None:
+        self.adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), TENANT, Clock())
+        self.gov = ProjectionGovernor(self.adapter)
+        self.adapter.commit_proposal(make_proposal(), "deploy window is Thursday")
+        self.gov.declare(
+            "sum:1", (SOURCE,), projections.ESTIMATOR_MEDIATED,
+            projections.RECOVERABLE_CONTENT, projections.APPROXIMABLE, TENANT,
+        )
+
+    def test_version_drift_makes_a_projection_stale(self):
+        self.assertEqual(self.gov.freshness("sum:1"), projections.CURRENT)
+        self.adapter.record_correction(SOURCE)
+        self.assertEqual(self.gov.freshness("sum:1"), projections.STALE)
+
+    def test_residual_dominates_stale(self):
+        """A tombstoned basis is a governance problem, not a correctness one."""
+        self.adapter.record_correction(SOURCE)
+        self.gov._purged.add(SOURCE)
+        self.assertEqual(self.gov.freshness("sum:1"), projections.RESIDUAL)
+
+
+class CorrectionPropagationTests(unittest.TestCase):
+    """Item 3: correction marks dependents stale and supersedes without erasing."""
+
+    def setUp(self) -> None:
+        self.adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), TENANT, Clock())
+        self.gov = ProjectionGovernor(self.adapter)
+        self.adapter.commit_proposal(make_proposal(), "deploy window is Thursday")
+        self.gov.declare(
+            "sum:1", (SOURCE,), projections.ESTIMATOR_MEDIATED,
+            projections.RECOVERABLE_CONTENT, projections.APPROXIMABLE, TENANT,
+        )
+        self.gov.declare(
+            "idx:1", (SOURCE,), projections.DETERMINISTIC,
+            projections.REFERENCE_ONLY, projections.REPRODUCIBLE, TENANT,
+        )
+
+    def test_correction_supersedes_content_bearing_without_erasing(self):
+        result = self.gov.correct(SOURCE)
+
+        self.assertIn("sum:1", result.now_stale)
+        self.assertIn("sum:1", result.superseded)
+        # The superseded version survives for decisions that used it.
+        retained = self.gov.store.superseded("sum:1")
+        self.assertEqual(len(retained), 1)
+        self.assertEqual(retained[0].version, 1)
+        self.assertEqual(self.gov.store.get("sum:1").version, 2)
+
+    def test_reference_only_projections_are_not_superseded(self):
+        result = self.gov.correct(SOURCE)
+
+        self.assertIn("idx:1", result.now_stale)
+        self.assertNotIn("idx:1", result.superseded)
+
+
+class TransitivePurgeTests(unittest.TestCase):
+    """Items 4 and 5: transitive closure, and an independent sweep that can fail."""
+
+    def setUp(self) -> None:
+        self.adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), TENANT, Clock())
+        self.gov = ProjectionGovernor(self.adapter)
+        self.adapter.commit_proposal(make_proposal(), "deploy window is Thursday")
+        # A chain: canonical -> summary -> summary-of-summary.
+        self.gov.declare(
+            "sum:1", (SOURCE,), projections.ESTIMATOR_MEDIATED,
+            projections.RECOVERABLE_CONTENT, projections.APPROXIMABLE, TENANT,
+        )
+        self.gov.declare(
+            "sum:2", ("sum:1",), projections.ESTIMATOR_MEDIATED,
+            projections.RECOVERABLE_CONTENT, projections.APPROXIMABLE, TENANT,
+        )
+
+    def test_closure_is_transitive_not_one_hop(self):
+        closure = self.gov.store.derivation_closure(SOURCE)
+        self.assertEqual(set(closure), {"sum:1", "sum:2"})
+
+    def test_purge_reaches_the_whole_closure_and_sweeps_clean(self):
+        result = self.gov.purge(approved_purge(), SOURCE)
+
+        self.assertTrue(result.committed)
+        self.assertEqual(set(result.buckets[residue.PURGED]), {"sum:1", "sum:2"})
+        self.assertEqual(result.undeclared, [])
+        self.assertTrue(result.hard_gate_passed)
+        self.assertIsNone(self.gov.store.get("sum:2"))
+
+    def test_a_one_hop_purge_is_caught_by_the_sweep(self):
+        """The sweep must be able to fail, or item 5 proves nothing."""
+        one_hop = residue.ResiduePlan(purged=["sum:1"])
+        residue.apply_purge(self.gov.store, one_hop, self.gov._purged)
+        self.gov._purged.add(SOURCE)
+
+        undeclared = self.gov.sweep(one_hop.declared)
+
+        self.assertEqual(undeclared, ["sum:2"], "a one-hop purge must not sweep clean")
+
+    def test_superseded_versions_are_in_purge_scope(self):
+        """Deletion dominates correction: retained versions are recoverable residue."""
+        self.gov.correct(SOURCE)
+        self.assertTrue(self.gov.store.superseded("sum:1"))
+
+        self.gov.purge(approved_purge(), SOURCE)
+
+        self.assertEqual(self.gov.store.superseded("sum:1"), ())
+
+    def test_unreachable_projections_are_declared_not_omitted(self):
+        self.gov.declare(
+            "export:1", (SOURCE,), projections.DETERMINISTIC,
+            projections.RECOVERABLE_CONTENT, projections.IRREPRODUCIBLE, TENANT,
+            reachable=False, note="third-party export",
+        )
+
+        result = self.gov.purge(approved_purge(), SOURCE)
+
+        self.assertIn("export:1", result.buckets[residue.DECLARED_UNCONTROLLABLE])
+        self.assertEqual(result.undeclared, [], "declared residue is not undeclared residue")
+
+    def test_unauthorized_purge_does_not_run(self):
+        result = self.gov.purge(make_proposal(operation="permanent_deletion"), SOURCE)
+
+        self.assertFalse(result.committed)
+        self.assertIsNotNone(self.gov.store.get("sum:1"))
+
+
+class RebuildAuthorityTests(unittest.TestCase):
+    """Item 6: invalidation must not become a write channel."""
+
+    def setUp(self) -> None:
+        self.adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), TENANT, Clock())
+        self.gov = ProjectionGovernor(self.adapter)
+        self.adapter.commit_proposal(make_proposal(), "deploy window is Thursday")
+        self.gov.declare(
+            "sum:1", (SOURCE,), projections.ESTIMATOR_MEDIATED,
+            projections.RECOVERABLE_CONTENT, projections.APPROXIMABLE, TENANT,
+        )
+        self.gov.declare(
+            "idx:1", (SOURCE,), projections.DETERMINISTIC,
+            projections.REFERENCE_ONLY, projections.REPRODUCIBLE, TENANT,
+        )
+
+    def test_estimator_mediated_rebuild_is_refused_without_authority(self):
+        self.adapter.record_correction(SOURCE)
+        self.assertEqual(self.gov.freshness("sum:1"), projections.STALE)
+
+        result = self.gov.propose_rebuild("sum:1")
+
+        self.assertFalse(result.committed)
+        self.assertIn("authority decision", result.refusal)
+        # Staleness alone did not commit new estimator content.
+        self.assertEqual(self.gov.store.get("sum:1").version, 1)
+
+    def test_estimator_mediated_rebuild_proceeds_under_authority(self):
+        self.adapter.record_correction(SOURCE)
+        authorized = make_proposal(
+            proposal_id="prop-rebuild",
+            operation="correction",
+            approval_refs=("approval:owner",),
+            review_satisfied=True,
+        )
+
+        result = self.gov.propose_rebuild("sum:1", authorized)
+
+        self.assertTrue(result.committed)
+        self.assertEqual(self.gov.store.get("sum:1").version, 2)
+
+    def test_deterministic_reproducible_rebuild_is_categorically_authorized(self):
+        self.adapter.record_correction(SOURCE)
+
+        result = self.gov.propose_rebuild("idx:1")
+
+        self.assertTrue(result.committed)
+        self.assertTrue(result.categorical)
+
+
+class ClosureSafetyTests(unittest.TestCase):
+    """The spike asks whether the derivation graph is well-founded. Assume not."""
+
+    def test_cyclic_derivation_terminates(self):
+        adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), TENANT, Clock())
+        gov = ProjectionGovernor(adapter)
+        adapter.commit_proposal(make_proposal(), "a claim")
+        gov.declare("a", (SOURCE,), projections.DETERMINISTIC,
+                    projections.REFERENCE_ONLY, projections.REPRODUCIBLE, TENANT)
+        gov.declare("b", ("a",), projections.DETERMINISTIC,
+                    projections.REFERENCE_ONLY, projections.REPRODUCIBLE, TENANT)
+        # Close the cycle: a is rebuilt from b.
+        gov.store.declare(
+            projections.Projection(
+                projection_id="a", basis=(("b", 1),), transform=projections.DETERMINISTIC,
+                content_class=projections.REFERENCE_ONLY, rebuild=projections.REPRODUCIBLE,
+                scope=TENANT,
+            )
+        )
+
+        closure = gov.store.derivation_closure("b")
+
+        self.assertEqual(set(closure), {"a", "b"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wiki-src/Canonical-and-Derived-State.md
+++ b/wiki-src/Canonical-and-Derived-State.md
@@ -1,6 +1,6 @@
 # Canonical and Derived State
 
-> **Status: design spike.** This page describes vocabulary and proposed invariants, not implemented behavior. Nothing here has been executed, and no Architecture Decision Record has adopted it. It is published because the definitions are what make the requirements testable — the alternative is a requirement everyone agrees with and no one can fail.
+> **Status: design executed, not adopted.** The vocabulary and invariants below began as a design spike and are now implemented and exercised in continuous integration, including the parts a persuasive demonstration would skip. No Architecture Decision Record has adopted them, and executing a bar is not the same as accepting the decision it supports. See **[Runtime Evidence](Runtime-Evidence)** for what that distinction means here.
 
 Deleting a memory is easy. Proving it is gone is the hard part, and almost every hard case involves state that was *derived* from the memory rather than the memory itself.
 
@@ -110,7 +110,7 @@ Two rules keep the measurement honest. State that cannot be enumerated goes in t
 
 ## Where this sits
 
-This slice is why ADR-020 remains Proposed. Its proof bar requires that derived-memory deletion residue be *tested*, and that single line sits on top of everything above. The spike fixes the bar before building the thing that has to clear it — including the parts a persuasive demonstration would quietly skip: reaching the full transitive closure, matching an independent sweep against the receipt, and refusing an automatic rebuild.
+This slice exists because ADR-020's proof bar requires that derived-memory deletion residue be *tested*, and that single line sits on top of everything above. The bar was fixed before the implementation that had to clear it, and all seven of its items now execute: a declaration surface for tier-3 state, freshness computed as a relation rather than a flag, correction that supersedes without erasing, a transitive purge, an independent sweep that catches a one-hop purge, and refusal of automatic estimator-mediated rebuild. ADR-020 remains Proposed: it has further validation items, and clearing one bar is not acceptance.
 
 ## Canonical sources
 
@@ -123,4 +123,4 @@ This slice is why ADR-020 remains Proposed. Its proof bar requires that derived-
 
 - **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)** for the forgetting operations this refines
 - **[Security and Privacy](Security-and-Privacy)** for deletion residue as an attack surface
-- **[Runtime Evidence](Runtime-Evidence)** for what has actually been executed, which is not this
+- **[Runtime Evidence](Runtime-Evidence)** for the evidence bar these paths are measured against


### PR DESCRIPTION
Implements the design spike in `docs/programs/runtime-evidence/canonical-and-derived-state.md`. The spike's model, vocabulary, invariants, and seven-item evidence bar are unchanged; this is the implementation that clears them, not an amendment to the argument.

Discharges **ADR-020 validation item 12**, *derived-memory deletion residue is tested*.

## The bar, item by item

| # | Item | Where |
|---|---|---|
| 1 | Tier-3 declaration with basis recorded at build time | `projections.py` |
| 2 | `stale` and `residual` computed from the relation, not a flag | `projections.py` |
| 3 | Correction marks dependents stale, supersedes content-bearing without erasing | `projection_governance.py` |
| 4 | Purge reaches the transitive closure including superseded versions | `residue.py` |
| 5 | Independent sweep finds zero undeclared residue, matching the receipt | `residue.py` |
| 6 | Automatic estimator-mediated rebuild refused without authority | `projection_governance.py` |
| 7 | Pinned, reproducible, reconstructable from receipts | existing receipt machinery |

## The three items a demonstration would skip

The spike names 4, 5, and 6 as the ones that get quietly dropped. Each has a paired negative test, because a bar that can only pass proves less than one that can also fail:

- a deliberate one-hop purge **must** be caught by the sweep, and the test asserts it returns the orphaned projection rather than sweeping clean;
- an unauthorized purge must not run, and the projections must survive it;
- staleness alone must not commit estimator content — the version stays put until an authority decision exists.

Those negative tests found two real bugs rather than confirming a design. A dropped projection was not recorded as purged, so its dependents read as merely *stale* when they were in fact *residual* — precisely the trichotomy collapse the spike warns loses the distinction ADR-020 exists to protect. And a refused purge recorded a no-action sentinel while the envelope still permitted deferrals.

## Structural notes

**Deletion dominates correction** is implemented, not just stated: superseded versions retained for reconstructability are in scope for a later purge, because a retained prior version of a summary is exactly the recoverable residue the deletion was meant to eliminate.

**The sweep does not ask the purge whether it finished.** It re-derives residual status over every retained declaration, live and superseded, from the freshness relation. A purge that traversed one hop is caught rather than believed.

**Cycles terminate.** The spike leaves well-foundedness of the derivation graph as an open question; the closure walk carries a seen-set and a test builds an actual cycle to prove termination.

**A review-satisfaction path was added to the policy**, because permanent deletion never resolves below review and an authorized purge was otherwise unreachable. Review is discharged only by an approval record from someone other than the proposer; `block` stays absorbing and self-approval cannot buy past review. This also closes a previously documented limitation.

## Results

46 tests plus sweeps, all in CI. Reported metrics: `deletion_residue_rate` 0.0 with an empty undeclared cell, `stochastic_action_set_violation_rate` 0.0.

## Claims not made

Conformance level remains **0** and **ADR-020 remains Proposed**. This discharges one validation item; clearing one bar is not acceptance. Two limitations are added to the reference README rather than left to be found: derived-state governance runs on an adapter-owned sidecar, which the spike identifies as reintroducing the consistency problem one level up, and residue is measured over *declared* projections — undeclared state is outside the sweep's reach by construction, which is why the declaration surface is the load-bearing part rather than the traversal.

Wiki and program-README status lines are updated from design-spike to executed, keeping the distinction between executing a bar and adopting a decision.