### PR TITLE
P4.5a: implement portable memory governance evidence core

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install schema validator
-        run: python -m pip install --disable-pip-version-check jsonschema
+      - name: Install validation dependencies
+        run: python -m pip install --disable-pip-version-check jsonschema cryptography
 
       - name: Validate fixture invariants
         run: python scripts/validate_fixtures.py fixtures
@@ -62,6 +62,7 @@ jobs:
           docs/programs/runtime-evidence/README.md
           docs/programs/runtime-evidence/graphiti-conformance.md
           docs/programs/runtime-evidence/canonical-and-derived-state.md
+          docs/programs/runtime-evidence/portable-governance-evidence.md
           reference/README.md
 
       - name: Validate GitHub Wiki source links
@@ -81,10 +82,12 @@ jobs:
             echo "Commands run by this workflow (reproducible locally):"
             echo ""
             echo '```'
+            echo "python -m pip install jsonschema cryptography"
             echo "python scripts/validate_fixtures.py fixtures"
-            echo "python scripts/validate_schemas.py  # requires: pip install jsonschema"
+            echo "python scripts/validate_schemas.py"
             echo "python scripts/validate_doctrine_boundaries.py"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md reference/README.md"
+            echo "python -m unittest discover -s reference/tests -t reference"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md reference/README.md"
             echo "python scripts/validate_wiki_links.py wiki-src"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'

--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install validation dependencies
-        run: python -m pip install --disable-pip-version-check jsonschema cryptography
+        run: python -m pip install --disable-pip-version-check jsonschema==4.26.0 cryptography==50.0.0
 
       - name: Validate fixture invariants
         run: python scripts/validate_fixtures.py fixtures
@@ -82,7 +82,7 @@ jobs:
             echo "Commands run by this workflow (reproducible locally):"
             echo ""
             echo '```'
-            echo "python -m pip install jsonschema cryptography"
+            echo "python -m pip install jsonschema==4.26.0 cryptography==50.0.0"
             echo "python scripts/validate_fixtures.py fixtures"
             echo "python scripts/validate_schemas.py"
             echo "python scripts/validate_doctrine_boundaries.py"

--- a/docs/programs/runtime-evidence/README.md
+++ b/docs/programs/runtime-evidence/README.md
@@ -27,6 +27,8 @@ reconstructable a receipt reconstructs estimate, authority, selection,
 
 Evidence that omits the negative paths is a demo. Evidence that cannot be re-run is an anecdote. Both are welcome in a discussion and neither moves an ADR.
 
+P4.5a is intentionally a **substrate-independent interoperability precondition** rather than a claim that another runtime substrate has been exercised. Its job is to make the portable evidence boundary executable and adversarially testable before correlation to Agent Manifest, TRACE, or another external runtime surface.
+
 ## Comparator discipline
 
 External systems enter this program to answer one architectural question each, and are barred from becoming something else:
@@ -41,7 +43,7 @@ External systems enter this program to answer one architectural question each, a
 | Telemetry conventions | observability interoperability | licence to emit memory content |
 | Systems characterization | cost, latency, and scaling pressure | an authority signal |
 
-Two standing rules follow from this table. A missing guarantee in an external system is a **classified gap**, not a bug, unless that system claims the guarantee. And a behavior observed in one product does not become Agent Memory doctrine without independent justification — otherwise the architecture is just the union of whatever shipped recently.
+Two standing rules follow from this table. A missing guarantee in an external system is a **classified gap**, not a bug, unless that system claims the guarantee. And a behavior observed in one product does not become Agent Memory doctrine without independent justification, otherwise the architecture is just the union of whatever shipped recently.
 
 ## Evidence rules for imported material
 
@@ -74,6 +76,7 @@ Documents are added when their slice is ready to execute, not in advance. A dire
 | [`graphiti-conformance.md`](graphiti-conformance.md) | first substrate capability mapping | documentation-verified, with key findings confirmed by execution |
 | [`../../../reference/README.md`](../../../reference/README.md) | minimal governed adapter | bound and executed against a real substrate |
 | [`canonical-and-derived-state.md`](canonical-and-derived-state.md) | canonical memory versus derived projections | design spike executed: all seven evidence-bar items run in CI |
+| [`portable-governance-evidence.md`](portable-governance-evidence.md) | P4.5a portable governance evidence core | executable substrate-independent Ed25519 issuer/verifier and adversarial vectors |
 
 ## Preconditions
 
@@ -83,7 +86,7 @@ Before runtime evidence from a first-party implementation is treated as disposit
 2. doctrine-to-implementation identity is established for any implementation used as evidence, earned through a concrete responsibility or conformance surface rather than asserted;
 3. the exact implementation, policy, estimator, fixture, and evidence bundle versions are reproducible.
 
-External comparators do not require precondition 2 — a comparator is measured, not adopted.
+External comparators do not require precondition 2. A comparator is measured, not adopted.
 
 ## Non-goals
 

--- a/docs/programs/runtime-evidence/portable-governance-evidence.md
+++ b/docs/programs/runtime-evidence/portable-governance-evidence.md
@@ -106,6 +106,8 @@ The first executable profile is **Ed25519**, implemented with the Python `crypto
 
 The additional dependency is intentional. A symmetric HMAC profile would let a verifier forge evidence because verification requires possession of the signing secret; that fails the independent-verification premise of #63. Ed25519 lets the issuer retain the private key while independent verifiers receive only the public trust key.
 
+The CI validation profile pins `cryptography==50.0.0` and `jsonschema==4.26.0`, the exact direct validation-package versions exercised by the first successful P4.5a CI run. Pinning those direct dependencies keeps this evidence slice reproducible without pretending P4.5a owns the separate real-substrate dependency graph.
+
 The profile demonstrates:
 
 - deterministic canonicalization
@@ -205,7 +207,7 @@ If execution is observed but execution-time authority continuity is unknown, run
 Run:
 
 ```bash
-python -m pip install jsonschema cryptography
+python -m pip install jsonschema==4.26.0 cryptography==50.0.0
 python -m unittest discover -s reference/tests -t reference
 python scripts/validate_schemas.py
 ```

--- a/docs/programs/runtime-evidence/portable-governance-evidence.md
+++ b/docs/programs/runtime-evidence/portable-governance-evidence.md
@@ -1,0 +1,220 @@
+# P4.5a portable memory governance evidence
+
+Status: **Executable reference profile**. This work provides evidence toward proposed ADR-021; it does not accept ADR-020, ADR-021, or ADR-022 and does not raise the repository conformance level.
+
+Parent implementation issue: #63.
+
+## Purpose
+
+P4.5a exports a small, content-free projection of an Agent Memory governance decision so another process can verify integrity and correlate runtime behavior without receiving the raw memory or taking ownership of Agent Memory semantics.
+
+The ownership boundary remains:
+
+```text
+canonical Agent Memory receipt
+        |
+        | content-free projection
+        v
+portable governance evidence
+        |
+        | independent observations
+        v
+verifier result
+```
+
+The canonical receipt remains authoritative. The portable object is evidence about it, not a replacement for it.
+
+## Non-escalation invariant
+
+The verifier deliberately emits four separate outcome dimensions:
+
+```text
+evidence integrity/binding
+governance disposition
+runtime execution
+lifecycle satisfaction
+```
+
+Therefore all of these are representable without contradiction:
+
+```text
+valid evidence + denied + unauthorized execution
+valid evidence + committed + executed as authorized + residual
+valid evidence + committed + executed as authorized + satisfied
+```
+
+A valid authentication result never manufactures PAMA permission. A valid runtime action never proves lifecycle satisfaction.
+
+## Portable evidence v1
+
+Schema: `schemas/portable-governance-evidence.schema.json`.
+
+The v1 projection contains:
+
+- evidence type and version
+- canonicalization profile
+- issuer ID, key ID, and authentication algorithm
+- issuance time
+- runtime `action_ref`
+- memory action class/name
+- SHA-256 reference to the canonical decision receipt
+- governance disposition
+- policy reference
+- decision-time authority-state reference
+- decision time
+- privacy-safe scope reference
+- optional source/destination isolation-domain references
+- optional domain-authorization-state reference
+- before/after state references
+- lifecycle result
+- authentication tag
+
+It intentionally does **not** contain:
+
+- raw memory content
+- hidden reasoning
+- the full canonical decision receipt
+- tenant/project/domain display names when an opaque reference is sufficient
+- a generic `valid: true` field
+
+Low-entropy tenant, user, project, repository, and isolation-domain names should not be converted to plain unsalted hashes and treated as private. Callers should supply opaque IDs or keyed/privacy-preserving references where disclosure would matter.
+
+## Canonicalization
+
+`agent-memory-canonical-json-v1` is:
+
+- UTF-8 JSON
+- object keys sorted lexicographically
+- no insignificant whitespace
+- non-ASCII text preserved
+- floating-point values prohibited
+
+The float prohibition is intentional. Cross-runtime numeric canonicalization is not necessary for this first contract and should not be smuggled in as an accidental interoperability claim.
+
+The canonical receipt reference is:
+
+```text
+sha256:<hex sha256 of canonical receipt JSON>
+```
+
+The portable object's authentication covers every evidence field except the `authentication` object itself.
+
+## Reference trust profile
+
+The first executable profile is `HMAC-SHA256` using Python's standard library.
+
+This is a deliberately small **symmetric trust-domain profile**. It demonstrates deterministic canonicalization, issuer/key binding, trust configuration, key validity windows, rotation, distrust/revocation timing, tamper detection, and detached verification without adding a crypto dependency to the reference implementation.
+
+It does **not** provide:
+
+- public verifiability
+- asymmetric issuer identity
+- non-repudiation
+- a universal PKI
+- cross-organization trust discovery
+
+Those are future profile concerns. The wire contract names the algorithm explicitly so a later Ed25519 or other asymmetric profile can be introduced without redefining memory semantics.
+
+Historical evidence remains verifiable after key rotation when the verifier retains the historical trust key and the key was valid at evidence issuance time. A key revoked before issuance cannot produce acceptable new evidence.
+
+## Receipt resolution and forgetting
+
+A verifier can operate in three relevant states:
+
+`resolved`
+: The canonical receipt is available and its canonical hash matches the signed reference.
+
+`detached`
+: The canonical content is not supplied, but the portable evidence remains cryptographically verifiable. This is the reference path for content-bearing canonical state that was legitimately pruned while content-free verification evidence remains.
+
+`mismatch`
+: A supplied canonical receipt does not match the signed receipt reference.
+
+Detached verification is not proof that deleted memory content still exists. Conversely, inability to resolve pruned content is not automatically invalid evidence.
+
+## Binding checks
+
+The reference verifier can compare signed evidence to independently observed runtime facts:
+
+- action reference
+- policy reference
+- authority-state reference
+- source isolation domain
+- destination isolation domain
+- execution-time authority continuity
+
+Wrong action catches replay against another execution. Wrong policy/authority references expose stale or mismatched decision state. Wrong domain catches an isolation-boundary mismatch without requiring raw domain contents.
+
+If an execution time is supplied but execution-time authority continuity is unknown, runtime authorization is reported as `unverifiable`, not optimistically permitted.
+
+## Machine-readable result taxonomy
+
+`verify_evidence()` returns:
+
+```json
+{
+  "evidence_integrity": "valid | invalid | unverifiable",
+  "binding_failures": [],
+  "receipt_resolution": "resolved | detached | mismatch | unresolved",
+  "governance_disposition": "permitted | denied | deferred | review_required | committed | unverifiable",
+  "runtime_execution": "executed_as_authorized | not_executed | execution_mismatch | unauthorized_execution | unverifiable",
+  "lifecycle_satisfaction": "satisfied | residual | incomplete | unverifiable | not_applicable"
+}
+```
+
+`binding_failures` is intentionally explicit because a verifier needs to distinguish tampering, unknown trust, replay, stale policy, stale authority, and wrong isolation domain rather than flattening them into the same red light.
+
+## Executed vectors
+
+`reference/tests/test_portable_evidence.py` covers:
+
+- deterministic canonicalization
+- float rejection
+- successful receipt/action/policy/authority/domain binding
+- no raw canonical receipt or memory content in the portable projection
+- tamper detection
+- unknown/untrusted issuer
+- replay against a different `action_ref`
+- stale/wrong policy reference
+- stale/wrong authority-state reference
+- wrong source isolation domain
+- valid denial plus unauthorized runtime execution
+- authorized deletion with residual lifecycle state
+- detached verification after canonical content is unavailable
+- wrong canonical receipt
+- historical verification across key rotation
+- rejection of evidence newly issued after key revocation
+
+Run:
+
+```bash
+python -m unittest discover -s reference/tests -t reference
+python scripts/validate_schemas.py
+```
+
+## What this slice proves
+
+P4.5a now has an executable substrate-independent boundary for content-free portable governance evidence. It demonstrates that Agent Memory can authenticate and independently check the binding among a canonical receipt reference, decision-time governance state, isolation-domain references, and a runtime action while preserving lifecycle outcome as a separate semantic dimension.
+
+The implementation also demonstrates the core deletion distinction:
+
+```text
+valid evidence of authorized deletion != proof of forgetting
+```
+
+A signed, correctly executed delete may still carry `lifecycle_satisfaction = residual`.
+
+## What remains unproven
+
+This slice does not yet prove:
+
+- Agent Manifest checkpoint/delta correlation (P4.5b)
+- TRACE/AgenTrust external action-evidence interoperability (P4.5c)
+- asymmetric or publicly verifiable trust
+- production key storage or remote key discovery
+- external revocation infrastructure
+- multi-implementation interoperability
+- runtime-enforcement composition with AGT or another policy peer
+- ADR acceptance or a higher conformance level
+
+Those remain later evidence gates rather than assumptions smuggled into a successful unit test.

--- a/docs/programs/runtime-evidence/portable-governance-evidence.md
+++ b/docs/programs/runtime-evidence/portable-governance-evidence.md
@@ -6,7 +6,7 @@ Parent implementation issue: #63.
 
 ## Purpose
 
-P4.5a exports a small, content-free projection of an Agent Memory governance decision so another process can verify integrity and correlate runtime behavior without receiving the raw memory or taking ownership of Agent Memory semantics.
+P4.5a exports a small, content-free projection of an Agent Memory governance decision so another process can verify integrity and correlate runtime behavior without receiving the raw memory, hidden reasoning, or a signing secret.
 
 The ownership boundary remains:
 
@@ -43,17 +43,17 @@ valid evidence + committed + executed as authorized + residual
 valid evidence + committed + executed as authorized + satisfied
 ```
 
-A valid authentication result never manufactures PAMA permission. A valid runtime action never proves lifecycle satisfaction.
+A valid signature never manufactures PAMA permission. A valid runtime action never proves lifecycle satisfaction.
 
 ## Portable evidence v1
 
-Schema: `schemas/portable-governance-evidence.schema.json`.
+Schema: `../../../schemas/portable-governance-evidence.schema.json`.
 
 The v1 projection contains:
 
 - evidence type and version
 - canonicalization profile
-- issuer ID, key ID, and authentication algorithm
+- issuer ID, key ID, and signature algorithm
 - issuance time
 - runtime `action_ref`
 - memory action class/name
@@ -67,7 +67,7 @@ The v1 projection contains:
 - optional domain-authorization-state reference
 - before/after state references
 - lifecycle result
-- authentication tag
+- signature
 
 It intentionally does **not** contain:
 
@@ -76,6 +76,7 @@ It intentionally does **not** contain:
 - the full canonical decision receipt
 - tenant/project/domain display names when an opaque reference is sufficient
 - a generic `valid: true` field
+- a private signing key or shared verification secret
 
 Low-entropy tenant, user, project, repository, and isolation-domain names should not be converted to plain unsalted hashes and treated as private. Callers should supply opaque IDs or keyed/privacy-preserving references where disclosure would matter.
 
@@ -97,25 +98,37 @@ The canonical receipt reference is:
 sha256:<hex sha256 of canonical receipt JSON>
 ```
 
-The portable object's authentication covers every evidence field except the `authentication` object itself.
+The Ed25519 signature covers every evidence field except the `authentication` object itself.
 
 ## Reference trust profile
 
-The first executable profile is `HMAC-SHA256` using Python's standard library.
+The first executable profile is **Ed25519**, implemented with the Python `cryptography` package.
 
-This is a deliberately small **symmetric trust-domain profile**. It demonstrates deterministic canonicalization, issuer/key binding, trust configuration, key validity windows, rotation, distrust/revocation timing, tamper detection, and detached verification without adding a crypto dependency to the reference implementation.
+The additional dependency is intentional. A symmetric HMAC profile would let a verifier forge evidence because verification requires possession of the signing secret; that fails the independent-verification premise of #63. Ed25519 lets the issuer retain the private key while independent verifiers receive only the public trust key.
 
-It does **not** provide:
+The profile demonstrates:
 
-- public verifiability
-- asymmetric issuer identity
-- non-repudiation
+- deterministic canonicalization
+- issuer/key binding
+- public-key verification
+- key-validity windows
+- key rotation with historical verification
+- revocation/distrust timing
+- tamper detection
+- detached verification after canonical content is no longer supplied
+
+It still does **not** invent:
+
 - a universal PKI
 - cross-organization trust discovery
+- production key storage
+- remote key distribution
+- certificate semantics
+- automatic online revocation infrastructure
 
-Those are future profile concerns. The wire contract names the algorithm explicitly so a later Ed25519 or other asymmetric profile can be introduced without redefining memory semantics.
+Those are later trust-profile concerns, not memory semantics.
 
-Historical evidence remains verifiable after key rotation when the verifier retains the historical trust key and the key was valid at evidence issuance time. A key revoked before issuance cannot produce acceptable new evidence.
+Historical evidence remains verifiable after key rotation when the verifier retains the historical public key and that key was valid at evidence issuance time. A key revoked before issuance cannot produce acceptable new evidence.
 
 ## Receipt resolution and forgetting
 
@@ -141,11 +154,12 @@ The reference verifier can compare signed evidence to independently observed run
 - authority-state reference
 - source isolation domain
 - destination isolation domain
+- execution time
 - execution-time authority continuity
 
-Wrong action catches replay against another execution. Wrong policy/authority references expose stale or mismatched decision state. Wrong domain catches an isolation-boundary mismatch without requiring raw domain contents.
+Wrong action catches replay against another execution. Wrong policy/authority references expose stale or mismatched decision state. Wrong domain catches an isolation-boundary mismatch without requiring raw domain contents. Execution before the signed decision is rejected.
 
-If an execution time is supplied but execution-time authority continuity is unknown, runtime authorization is reported as `unverifiable`, not optimistically permitted.
+If execution is observed but execution-time authority continuity is unknown, runtime authorization is reported as `unverifiable`, not optimistically permitted.
 
 ## Machine-readable result taxonomy
 
@@ -162,39 +176,43 @@ If an execution time is supplied but execution-time authority continuity is unkn
 }
 ```
 
-`binding_failures` is intentionally explicit because a verifier needs to distinguish tampering, unknown trust, replay, stale policy, stale authority, and wrong isolation domain rather than flattening them into the same red light.
+`binding_failures` is intentionally explicit because a verifier needs to distinguish tampering, unknown trust, replay, stale policy, stale authority, temporal mismatch, and wrong isolation domain rather than flattening them into the same red light.
 
 ## Executed vectors
 
-`reference/tests/test_portable_evidence.py` covers:
+`../../../reference/tests/test_portable_evidence.py` covers:
 
 - deterministic canonicalization
 - float rejection
+- schema validation of emitted evidence
 - successful receipt/action/policy/authority/domain binding
 - no raw canonical receipt or memory content in the portable projection
-- tamper detection
+- signature tamper detection
 - unknown/untrusted issuer
 - replay against a different `action_ref`
 - stale/wrong policy reference
 - stale/wrong authority-state reference
 - wrong source isolation domain
+- execution preceding the signed decision
+- fail-closed execution when authority continuity is unknown
 - valid denial plus unauthorized runtime execution
 - authorized deletion with residual lifecycle state
 - detached verification after canonical content is unavailable
 - wrong canonical receipt
-- historical verification across key rotation
+- historical public-key verification across key rotation
 - rejection of evidence newly issued after key revocation
 
 Run:
 
 ```bash
+python -m pip install jsonschema cryptography
 python -m unittest discover -s reference/tests -t reference
 python scripts/validate_schemas.py
 ```
 
 ## What this slice proves
 
-P4.5a now has an executable substrate-independent boundary for content-free portable governance evidence. It demonstrates that Agent Memory can authenticate and independently check the binding among a canonical receipt reference, decision-time governance state, isolation-domain references, and a runtime action while preserving lifecycle outcome as a separate semantic dimension.
+P4.5a now has an executable substrate-independent boundary for content-free, independently verifiable governance evidence. It demonstrates that Agent Memory can sign and independently check the binding among a canonical receipt reference, decision-time governance state, isolation-domain references, and a runtime action while preserving lifecycle outcome as a separate semantic dimension.
 
 The implementation also demonstrates the core deletion distinction:
 
@@ -202,7 +220,7 @@ The implementation also demonstrates the core deletion distinction:
 valid evidence of authorized deletion != proof of forgetting
 ```
 
-A signed, correctly executed delete may still carry `lifecycle_satisfaction = residual`.
+A correctly signed, authorized, correctly executed delete may still carry `lifecycle_satisfaction = residual`.
 
 ## What remains unproven
 
@@ -210,8 +228,7 @@ This slice does not yet prove:
 
 - Agent Manifest checkpoint/delta correlation (P4.5b)
 - TRACE/AgenTrust external action-evidence interoperability (P4.5c)
-- asymmetric or publicly verifiable trust
-- production key storage or remote key discovery
+- production key storage or remote trust-anchor discovery
 - external revocation infrastructure
 - multi-implementation interoperability
 - runtime-enforcement composition with AGT or another policy peer

--- a/reference/README.md
+++ b/reference/README.md
@@ -2,53 +2,57 @@
 
 A minimal, executable demonstration that the governed path in
 [`../docs/programs/runtime-evidence/README.md`](../docs/programs/runtime-evidence/README.md)
-can be implemented over a temporal-graph substrate that provides no governance of its own.
+can be implemented over a temporal-graph substrate that provides no governance of its own, plus the substrate-independent P4.5a portable governance-evidence boundary.
 
 ## What this is not
 
 Read this section before citing anything in this directory.
 
 - **Not a conformance claim.** The emitted report states conformance level 0 and says why. The doctrine fixture corpus *is* now driven through the adapter's authority enforcement, but doc 06 levels are cumulative and this adapter implements neither decay nor calibrated saturation, so levels 2 and 3 are unmet however well enforcement does. Nothing here substantiates a level, a profile, or ADR-020.
-- **Not a reference implementation of Agent Memory.** It implements the narrow slice needed to exercise governance paths, and nothing else.
-- **Not an endorsement of any substrate.** The model reproduces one mapped substrate's verified semantics so the tests have something realistic to push against.
+- **Not a reference implementation of Agent Memory.** It implements the narrow slices needed to exercise governance paths and portable evidence, and nothing else.
+- **Not an endorsement of any substrate or trust infrastructure.** The model reproduces one mapped substrate's verified semantics so the tests have something realistic to push against. The Ed25519 profile proves an evidence boundary, not a universal PKI.
 
 ## What it does demonstrate
 
-Two things, at different evidential weight.
+Several things, at different evidential weight.
 
 **Against a real substrate (runtime evidence).** Seven governance paths execute against `graphiti-core` 0.29.3 backed by an embedded graph database, with no LLM, no embedder, no API key and no server. Facts are written through the substrate's no-LLM direct-write path, superseded, pruned, physically deleted, and refused across partitions, all under the authority gate.
 
-**Against a substrate model (precondition).** Twelve further paths run against an in-memory model, covering cases the live binding does not reach — stale authorization, self-approval, undeclared derived residue, and version-drift separation.
+**Against a substrate model (precondition).** Twelve further paths run against an in-memory model, covering cases the live binding does not reach: stale authorization, self-approval, undeclared derived residue, and version-drift separation.
 
 **Against the doctrine fixture corpus.** All 26 repository fixtures are driven through the adapter's own enforcement rule, 18 of which declare an authority envelope. This matters because the corpus was authored to describe doctrine, not to satisfy this implementation, so agreement between them is evidence rather than a suite agreeing with itself. The checker is mutation-tested in `tests/test_fixture_corpus.py`: four deliberately corrupted envelopes must be detected, because a conformance check that cannot fail is decoration.
 
-The common point is that the governance layer is load-bearing. The substrate model is deliberately permissive in exactly the ways the mapping verified: identity is opaque rather than content-derived, the partition filter defaults to unfiltered, deletion is physical with no tombstone, and **no operation checks authority**. Several tests assert both halves — that the substrate *would* misbehave, and that the adapter refuses anyway. A test that only checked the adapter would not prove the governance was doing any work.
+**Against the P4.5a portable-evidence contract.** A content-free projection of a canonical decision receipt is signed with Ed25519 and verified using only the configured public trust key. The verifier independently checks receipt, runtime-action, policy, authority-state, temporal, and isolation-domain bindings while preserving governance disposition, runtime execution, and lifecycle satisfaction as separate outcomes. Adversarial vectors exercise tampering, replay, stale authority, wrong domains, key rotation, revocation timing, detached receipt verification, and valid deletion with residual lifecycle state.
+
+The common point is that the governance layer is load-bearing. The substrate model is deliberately permissive in exactly the ways the mapping verified: identity is opaque rather than content-derived, the partition filter defaults to unfiltered, deletion is physical with no tombstone, and **no operation checks authority**. Several tests assert both halves: that the substrate *would* misbehave, and that the adapter refuses anyway. A test that only checked the adapter would not prove the governance was doing any work.
 
 ## Layout
 
 ```text
 reference/
   agentmem_ref/
-    substrate.py    port + permissive in-memory temporal graph
-    policy.py       PAMA evaluation: base table, class floors, modifiers
-    receipts.py     schema-conformant decisions, receipts, audit events
-    adapter.py      the governed path
-    fixture_conformance.py  drives the doctrine corpus through enforcement
-    projections.py          tier-3 declarations and the freshness relation
-    residue.py              deletion residue partition and independent sweep
+    substrate.py             port + permissive in-memory temporal graph
+    policy.py                PAMA evaluation: base table, class floors, modifiers
+    receipts.py              schema-conformant decisions, receipts, audit events
+    adapter.py               the governed path
+    fixture_conformance.py   drives the doctrine corpus through enforcement
+    projections.py           tier-3 declarations and the freshness relation
+    residue.py               deletion residue partition and independent sweep
     projection_governance.py governed correction, purge, and rebuild
+    portable_evidence.py     P4.5a Ed25519 portable issuer/verifier
     (selectors live in adapter.py: deterministic and seeded stochastic)
   agentmem_ref/graphiti_driver.py   binding to a real temporal knowledge graph
-  tests/            model paths and real-substrate paths
+  tests/                            model, real-substrate, and portable-evidence paths
   run_conformance.py
 ```
 
-Everything is standard-library except schema validation, which uses `jsonschema` under the dependency policy in `../CONTRIBUTING.md`.
+Schema validation uses `jsonschema`. P4.5a Ed25519 signing and public-key verification use `cryptography`, added under the explicit dependency-justification rule in `../CONTRIBUTING.md`. The low-cost fixture, doctrine-boundary, and link validators remain standard-library only.
 
 ## Running it
 
 ```bash
-# model paths only; standard library plus jsonschema
+# reference model and portable-evidence paths
+python -m pip install jsonschema cryptography
 python -m unittest discover -s reference/tests -t reference
 
 # stochastic containment sweep with an explicit trial count
@@ -60,7 +64,7 @@ python -m unittest discover -s reference/tests -t reference
 python reference/run_conformance.py
 ```
 
-Runs are deterministic: identifiers are counter-based and the clock is injected, so repeated runs produce identical receipts and identical reports. Stochastic selection is seeded per trial, so it varies across trials and reproduces exactly for a given seed.
+Runs are deterministic where the contract requires determinism: identifiers are counter-based and the clock is injected, so repeated governed-adapter runs produce identical receipts and identical reports. Stochastic selection is seeded per trial, so it varies across trials and reproduces exactly for a given seed. Ed25519 signatures are deterministic for a fixed private key and canonical payload.
 
 ## The governed path
 
@@ -70,7 +74,7 @@ evidence -> proposal -> authority envelope -> permitted action set
          -> retrieval candidate -> governed admission -> active context
 ```
 
-The adapter supplies what the substrate cannot: an authority gate before every write, always-explicit scope filtering, external lifecycle state, tombstones, and receipts. Artifacts are emitted against schemas already canonical in this repository rather than shapes invented here — `pama-decision`, `decision-receipt`, `memory-audit-event`, and `conformance-report`.
+The adapter supplies what the substrate cannot: an authority gate before every write, always-explicit scope filtering, external lifecycle state, tombstones, and receipts. Artifacts are emitted against schemas already canonical in this repository rather than shapes invented beside the implementation: `pama-decision`, `decision-receipt`, `memory-audit-event`, `conformance-report`, and the P4.5a `portable-governance-evidence` projection.
 
 ## Paths exercised
 
@@ -88,7 +92,7 @@ The adapter supplies what the substrate cannot: an authority gate before every w
 | pruning | tombstones and removes from recall while content stays recoverable |
 | undeclared derived residue | a projection nobody declared is detected after removal |
 | version drift | policy version and estimator versions stay separable in the receipt |
-| fixture corpus | all 25 doctrine fixtures pass envelope enforcement; the checker is mutation-tested |
+| fixture corpus | all 26 doctrine fixtures pass envelope enforcement; the checker is mutation-tested |
 | stochastic containment | hundreds of sampled trials never escape the permitted set, and the selector demonstrably varies |
 | hostile selector | a selector returning a prohibited action is contained by the adapter and the violation recorded |
 | derived-state freshness | stale and residual are computed from a recorded basis, never set by a flag |
@@ -96,6 +100,9 @@ The adapter supplies what the substrate cannot: an authority gate before every w
 | transitive purge | the whole derivation closure is reached, and a deliberate one-hop purge is caught by the sweep |
 | undeclared residue | the four-way partition holds, with the undeclared cell empty as a hard gate |
 | rebuild authority | estimator-mediated rebuild is refused without an authority decision; deterministic reproducible rebuild is categorical |
+| portable receipt binding | Ed25519 evidence binds the canonical receipt reference, action, policy, authority state, time, and optional isolation domains |
+| portable negative outcomes | authentic denial, unauthorized execution, and residual lifecycle state remain distinct machine-readable outcomes |
+| portable replay and trust failures | wrong action/domain/state, signature tampering, unknown issuer, rotation, and revocation timing are exercised |
 
 ## Known limitations
 
@@ -108,3 +115,5 @@ Stated rather than left to be discovered:
 5. Node topology is simplified to one edge per fact. This exercises governance invariants, not knowledge modelling.
 6. Derived-state governance operates on an adapter-owned sidecar. The design spike names this as the obvious home for substrates that cannot store a projection declaration, and notes that it reintroduces the consistency problem one level up. That trade is accepted here rather than solved.
 7. Residue is measured over declared projections. State that was never declared is outside the sweep's reach by construction, which is why the declaration surface is the load-bearing part rather than the traversal.
+8. The P4.5a trust profile assumes configured Ed25519 public trust keys. Production key custody, trust discovery, certificates, and external revocation infrastructure remain outside this slice.
+9. P4.5a is substrate-independent interoperability evidence. Agent Manifest and TRACE correlation remain P4.5b/P4.5c and must be demonstrated separately.

--- a/reference/README.md
+++ b/reference/README.md
@@ -46,13 +46,13 @@ reference/
   run_conformance.py
 ```
 
-Schema validation uses `jsonschema`. P4.5a Ed25519 signing and public-key verification use `cryptography`, added under the explicit dependency-justification rule in `../CONTRIBUTING.md`. The low-cost fixture, doctrine-boundary, and link validators remain standard-library only.
+Schema validation uses `jsonschema`. P4.5a Ed25519 signing and public-key verification use `cryptography`, added under the explicit dependency-justification rule in `../CONTRIBUTING.md`. CI pins the direct validation profile to `jsonschema==4.26.0` and `cryptography==50.0.0`. The low-cost fixture, doctrine-boundary, and link validators remain standard-library only.
 
 ## Running it
 
 ```bash
 # reference model and portable-evidence paths
-python -m pip install jsonschema cryptography
+python -m pip install jsonschema==4.26.0 cryptography==50.0.0
 python -m unittest discover -s reference/tests -t reference
 
 # stochastic containment sweep with an explicit trial count

--- a/reference/agentmem_ref/portable_evidence.py
+++ b/reference/agentmem_ref/portable_evidence.py
@@ -1,0 +1,305 @@
+"""Portable Agent Memory governance evidence, P4.5a reference profile.
+
+This module projects a canonical Agent Memory decision receipt into a content-free,
+portable evidence object.  The canonical receipt remains authoritative; the
+portable object only binds that receipt to governance, authority, domain, runtime,
+and lifecycle references so another process can verify what happened without
+receiving raw memory content.
+
+The first executable trust profile deliberately uses HMAC-SHA256 from the Python
+standard library.  It is a symmetric trust-domain profile, not a public-key or
+non-repudiation scheme.  The evidence format names the algorithm explicitly so a
+later asymmetric profile can replace it without changing the semantic boundary.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping
+
+EVIDENCE_TYPE = "agent-memory-governance-evidence"
+EVIDENCE_VERSION = "1.0.0"
+ALGORITHM = "HMAC-SHA256"
+
+INTEGRITY_VALID = "valid"
+INTEGRITY_INVALID = "invalid"
+INTEGRITY_UNVERIFIABLE = "unverifiable"
+
+GOVERNANCE_VALUES = {
+    "permitted",
+    "denied",
+    "deferred",
+    "review_required",
+    "committed",
+}
+LIFECYCLE_VALUES = {
+    "satisfied",
+    "residual",
+    "incomplete",
+    "unverifiable",
+    "not_applicable",
+}
+
+
+def canonical_json(value: object) -> bytes:
+    """Return the v1 canonical JSON byte representation.
+
+    v1 is UTF-8 JSON with sorted object keys, no insignificant whitespace, and
+    non-ASCII characters preserved.  Floats are intentionally unsupported in
+    the evidence contract because cross-runtime float canonicalization is a
+    larger problem than this reference profile needs to invent.
+    """
+    _reject_floats(value)
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _reject_floats(value: object) -> None:
+    if isinstance(value, float):
+        raise TypeError("portable evidence v1 does not permit floating-point values")
+    if isinstance(value, dict):
+        for item in value.values():
+            _reject_floats(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _reject_floats(item)
+
+
+def sha256_ref(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamps must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class TrustKey:
+    """One configured symmetric trust anchor for the reference profile."""
+
+    issuer_id: str
+    key_id: str
+    secret: bytes
+    valid_from: str
+    valid_until: str | None = None
+    revoked_at: str | None = None
+
+    def usable_at(self, timestamp: str) -> bool:
+        point = _parse_time(timestamp)
+        if point < _parse_time(self.valid_from):
+            return False
+        if self.valid_until and point > _parse_time(self.valid_until):
+            return False
+        if self.revoked_at and point >= _parse_time(self.revoked_at):
+            return False
+        return True
+
+
+@dataclass(frozen=True)
+class RuntimeObservation:
+    """Optional execution-time facts supplied independently by a verifier."""
+
+    action_ref: str | None = None
+    execution_time: str | None = None
+    policy_ref: str | None = None
+    authority_state_ref: str | None = None
+    source_domain_ref: str | None = None
+    destination_domain_ref: str | None = None
+    authority_valid_at_execution: bool | None = None
+
+
+def issue_evidence(
+    canonical_receipt: Mapping[str, object],
+    *,
+    issuer_id: str,
+    key: TrustKey,
+    issued_at: str,
+    action_ref: str,
+    memory_action: str,
+    governance_disposition: str,
+    policy_ref: str,
+    authority_state_ref: str,
+    decision_time: str,
+    scope_ref: str,
+    before_state_ref: str,
+    after_state_ref: str,
+    lifecycle_result: str = "not_applicable",
+    source_domain_ref: str | None = None,
+    destination_domain_ref: str | None = None,
+    domain_authorization_state_ref: str | None = None,
+) -> dict:
+    """Create and authenticate a portable projection of a canonical receipt."""
+    if issuer_id != key.issuer_id:
+        raise ValueError("issuer_id must match the configured trust key")
+    if governance_disposition not in GOVERNANCE_VALUES:
+        raise ValueError(f"unsupported governance disposition: {governance_disposition}")
+    if lifecycle_result not in LIFECYCLE_VALUES:
+        raise ValueError(f"unsupported lifecycle result: {lifecycle_result}")
+    if not key.usable_at(issued_at):
+        raise ValueError("trust key is not valid at evidence issuance time")
+
+    scope = {"scope_ref": scope_ref}
+    for name, value in (
+        ("source_domain_ref", source_domain_ref),
+        ("destination_domain_ref", destination_domain_ref),
+        ("domain_authorization_state_ref", domain_authorization_state_ref),
+    ):
+        if value is not None:
+            scope[name] = value
+
+    evidence = {
+        "evidence_type": EVIDENCE_TYPE,
+        "version": EVIDENCE_VERSION,
+        "canonicalization": "agent-memory-canonical-json-v1",
+        "issuer": {
+            "id": issuer_id,
+            "key_id": key.key_id,
+            "algorithm": ALGORITHM,
+        },
+        "issued_at": issued_at,
+        "action_ref": action_ref,
+        "memory_action": memory_action,
+        "canonical_receipt_ref": sha256_ref(dict(canonical_receipt)),
+        "governance": {
+            "disposition": governance_disposition,
+            "policy_ref": policy_ref,
+            "authority_state_ref": authority_state_ref,
+            "decision_time": decision_time,
+        },
+        "scope": scope,
+        "state": {
+            "before_ref": before_state_ref,
+            "after_ref": after_state_ref,
+        },
+        "lifecycle_result": lifecycle_result,
+    }
+    evidence["authentication"] = {
+        "algorithm": ALGORITHM,
+        "key_id": key.key_id,
+        "value": _mac(evidence, key.secret),
+    }
+    return evidence
+
+
+def _signable(evidence: Mapping[str, object]) -> dict:
+    payload = copy.deepcopy(dict(evidence))
+    payload.pop("authentication", None)
+    return payload
+
+
+def _mac(evidence: Mapping[str, object], secret: bytes) -> str:
+    return hmac.new(secret, canonical_json(_signable(evidence)), hashlib.sha256).hexdigest()
+
+
+def verify_evidence(
+    evidence: Mapping[str, object],
+    trust_keys: Mapping[tuple[str, str], TrustKey],
+    *,
+    canonical_receipt: Mapping[str, object] | None = None,
+    runtime: RuntimeObservation | None = None,
+) -> dict:
+    """Verify evidence while keeping semantic outcome dimensions separate.
+
+    A cryptographically authentic denial is still a denial.  Likewise, a valid
+    authorized delete with residual derived state remains a lifecycle failure.
+    """
+    runtime = runtime or RuntimeObservation()
+    failures: list[str] = []
+
+    if evidence.get("evidence_type") != EVIDENCE_TYPE or evidence.get("version") != EVIDENCE_VERSION:
+        return _result(INTEGRITY_INVALID, ["unsupported_evidence_profile"], evidence, "unresolved", runtime)
+
+    issuer = evidence.get("issuer")
+    auth = evidence.get("authentication")
+    if not isinstance(issuer, dict) or not isinstance(auth, dict):
+        return _result(INTEGRITY_INVALID, ["missing_authentication_metadata"], evidence, "unresolved", runtime)
+
+    issuer_id = issuer.get("id")
+    key_id = issuer.get("key_id")
+    if issuer.get("algorithm") != ALGORITHM or auth.get("algorithm") != ALGORITHM or auth.get("key_id") != key_id:
+        return _result(INTEGRITY_INVALID, ["algorithm_or_key_binding_mismatch"], evidence, "unresolved", runtime)
+
+    key = trust_keys.get((str(issuer_id), str(key_id)))
+    if key is None:
+        return _result(INTEGRITY_UNVERIFIABLE, ["unknown_or_untrusted_issuer_key"], evidence, "unresolved", runtime)
+
+    issued_at = evidence.get("issued_at")
+    if not isinstance(issued_at, str) or not key.usable_at(issued_at):
+        return _result(INTEGRITY_UNVERIFIABLE, ["issuer_key_not_valid_at_issuance"], evidence, "unresolved", runtime)
+
+    expected_mac = _mac(evidence, key.secret)
+    if not hmac.compare_digest(str(auth.get("value", "")), expected_mac):
+        return _result(INTEGRITY_INVALID, ["authentication_failed"], evidence, "unresolved", runtime)
+
+    receipt_resolution = "detached"
+    if canonical_receipt is not None:
+        if sha256_ref(dict(canonical_receipt)) != evidence.get("canonical_receipt_ref"):
+            failures.append("canonical_receipt_hash_mismatch")
+            receipt_resolution = "mismatch"
+        else:
+            receipt_resolution = "resolved"
+
+    governance = evidence.get("governance") if isinstance(evidence.get("governance"), dict) else {}
+    scope = evidence.get("scope") if isinstance(evidence.get("scope"), dict) else {}
+
+    for observed, signed, failure in (
+        (runtime.action_ref, evidence.get("action_ref"), "wrong_action_ref"),
+        (runtime.policy_ref, governance.get("policy_ref"), "stale_or_wrong_policy_ref"),
+        (runtime.authority_state_ref, governance.get("authority_state_ref"), "stale_or_wrong_authority_state_ref"),
+        (runtime.source_domain_ref, scope.get("source_domain_ref"), "wrong_source_domain"),
+        (runtime.destination_domain_ref, scope.get("destination_domain_ref"), "wrong_destination_domain"),
+    ):
+        if observed is not None and observed != signed:
+            failures.append(failure)
+
+    integrity = INTEGRITY_VALID if not failures else INTEGRITY_INVALID
+    return _result(integrity, failures, evidence, receipt_resolution, runtime)
+
+
+def _result(
+    integrity: str,
+    failures: list[str],
+    evidence: Mapping[str, object],
+    receipt_resolution: str,
+    runtime: RuntimeObservation,
+) -> dict:
+    governance = evidence.get("governance") if isinstance(evidence.get("governance"), dict) else {}
+    disposition = governance.get("disposition", "unverifiable")
+    lifecycle = evidence.get("lifecycle_result", "unverifiable")
+
+    if runtime.action_ref is None:
+        execution = "not_executed"
+    elif "wrong_action_ref" in failures:
+        execution = "execution_mismatch"
+    elif disposition in {"denied", "deferred", "review_required"}:
+        execution = "unauthorized_execution"
+    elif runtime.authority_valid_at_execution is False:
+        execution = "unauthorized_execution"
+    elif runtime.authority_valid_at_execution is None and runtime.execution_time is not None:
+        execution = "unverifiable"
+    elif integrity == INTEGRITY_VALID:
+        execution = "executed_as_authorized"
+    else:
+        execution = "unverifiable"
+
+    return {
+        "evidence_integrity": integrity,
+        "binding_failures": failures,
+        "receipt_resolution": receipt_resolution,
+        "governance_disposition": disposition,
+        "runtime_execution": execution,
+        "lifecycle_satisfaction": lifecycle,
+    }

--- a/reference/agentmem_ref/portable_evidence.py
+++ b/reference/agentmem_ref/portable_evidence.py
@@ -1,30 +1,29 @@
 """Portable Agent Memory governance evidence, P4.5a reference profile.
 
 This module projects a canonical Agent Memory decision receipt into a content-free,
-portable evidence object.  The canonical receipt remains authoritative; the
-portable object only binds that receipt to governance, authority, domain, runtime,
-and lifecycle references so another process can verify what happened without
-receiving raw memory content.
-
-The first executable trust profile deliberately uses HMAC-SHA256 from the Python
-standard library.  It is a symmetric trust-domain profile, not a public-key or
-non-repudiation scheme.  The evidence format names the algorithm explicitly so a
-later asymmetric profile can replace it without changing the semantic boundary.
+portable evidence object. The canonical receipt remains authoritative; the
+portable object binds that receipt to governance, authority, domain, runtime, and
+lifecycle references so an independent verifier can check what happened without
+receiving raw memory content or a signing secret.
 """
 
 from __future__ import annotations
 
+import base64
+import binascii
 import copy
 import hashlib
-import hmac
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Mapping
 
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+
 EVIDENCE_TYPE = "agent-memory-governance-evidence"
 EVIDENCE_VERSION = "1.0.0"
-ALGORITHM = "HMAC-SHA256"
+ALGORITHM = "Ed25519"
 
 INTEGRITY_VALID = "valid"
 INTEGRITY_INVALID = "invalid"
@@ -47,13 +46,7 @@ LIFECYCLE_VALUES = {
 
 
 def canonical_json(value: object) -> bytes:
-    """Return the v1 canonical JSON byte representation.
-
-    v1 is UTF-8 JSON with sorted object keys, no insignificant whitespace, and
-    non-ASCII characters preserved.  Floats are intentionally unsupported in
-    the evidence contract because cross-runtime float canonicalization is a
-    larger problem than this reference profile needs to invent.
-    """
+    """Return the deterministic v1 canonical JSON byte representation."""
     _reject_floats(value)
     return json.dumps(
         value,
@@ -87,25 +80,54 @@ def _parse_time(value: str) -> datetime:
 
 
 @dataclass(frozen=True)
-class TrustKey:
-    """One configured symmetric trust anchor for the reference profile."""
+class IssuerKey:
+    """Private signing key and its issuance-validity metadata."""
 
     issuer_id: str
     key_id: str
-    secret: bytes
+    private_key: Ed25519PrivateKey
     valid_from: str
     valid_until: str | None = None
     revoked_at: str | None = None
 
     def usable_at(self, timestamp: str) -> bool:
-        point = _parse_time(timestamp)
-        if point < _parse_time(self.valid_from):
-            return False
-        if self.valid_until and point > _parse_time(self.valid_until):
-            return False
-        if self.revoked_at and point >= _parse_time(self.revoked_at):
-            return False
-        return True
+        return _usable_at(timestamp, self.valid_from, self.valid_until, self.revoked_at)
+
+    def trust_key(self) -> "TrustKey":
+        return TrustKey(
+            issuer_id=self.issuer_id,
+            key_id=self.key_id,
+            public_key=self.private_key.public_key(),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+            revoked_at=self.revoked_at,
+        )
+
+
+@dataclass(frozen=True)
+class TrustKey:
+    """Public verification key configured as a verifier trust anchor."""
+
+    issuer_id: str
+    key_id: str
+    public_key: Ed25519PublicKey
+    valid_from: str
+    valid_until: str | None = None
+    revoked_at: str | None = None
+
+    def usable_at(self, timestamp: str) -> bool:
+        return _usable_at(timestamp, self.valid_from, self.valid_until, self.revoked_at)
+
+
+def _usable_at(timestamp: str, valid_from: str, valid_until: str | None, revoked_at: str | None) -> bool:
+    point = _parse_time(timestamp)
+    if point < _parse_time(valid_from):
+        return False
+    if valid_until and point > _parse_time(valid_until):
+        return False
+    if revoked_at and point >= _parse_time(revoked_at):
+        return False
+    return True
 
 
 @dataclass(frozen=True)
@@ -125,7 +147,7 @@ def issue_evidence(
     canonical_receipt: Mapping[str, object],
     *,
     issuer_id: str,
-    key: TrustKey,
+    key: IssuerKey,
     issued_at: str,
     action_ref: str,
     memory_action: str,
@@ -141,15 +163,17 @@ def issue_evidence(
     destination_domain_ref: str | None = None,
     domain_authorization_state_ref: str | None = None,
 ) -> dict:
-    """Create and authenticate a portable projection of a canonical receipt."""
+    """Create and sign a portable projection of a canonical decision receipt."""
     if issuer_id != key.issuer_id:
-        raise ValueError("issuer_id must match the configured trust key")
+        raise ValueError("issuer_id must match the configured issuer key")
     if governance_disposition not in GOVERNANCE_VALUES:
         raise ValueError(f"unsupported governance disposition: {governance_disposition}")
     if lifecycle_result not in LIFECYCLE_VALUES:
         raise ValueError(f"unsupported lifecycle result: {lifecycle_result}")
     if not key.usable_at(issued_at):
-        raise ValueError("trust key is not valid at evidence issuance time")
+        raise ValueError("issuer key is not valid at evidence issuance time")
+    if _parse_time(decision_time) > _parse_time(issued_at):
+        raise ValueError("decision_time cannot be after evidence issuance")
 
     scope = {"scope_ref": scope_ref}
     for name, value in (
@@ -186,10 +210,11 @@ def issue_evidence(
         },
         "lifecycle_result": lifecycle_result,
     }
+    signature = key.private_key.sign(canonical_json(_signable(evidence)))
     evidence["authentication"] = {
         "algorithm": ALGORITHM,
         "key_id": key.key_id,
-        "value": _mac(evidence, key.secret),
+        "value": base64.b64encode(signature).decode("ascii"),
     }
     return evidence
 
@@ -200,10 +225,6 @@ def _signable(evidence: Mapping[str, object]) -> dict:
     return payload
 
 
-def _mac(evidence: Mapping[str, object], secret: bytes) -> str:
-    return hmac.new(secret, canonical_json(_signable(evidence)), hashlib.sha256).hexdigest()
-
-
 def verify_evidence(
     evidence: Mapping[str, object],
     trust_keys: Mapping[tuple[str, str], TrustKey],
@@ -211,62 +232,138 @@ def verify_evidence(
     canonical_receipt: Mapping[str, object] | None = None,
     runtime: RuntimeObservation | None = None,
 ) -> dict:
-    """Verify evidence while keeping semantic outcome dimensions separate.
-
-    A cryptographically authentic denial is still a denial.  Likewise, a valid
-    authorized delete with residual derived state remains a lifecycle failure.
-    """
+    """Verify evidence while keeping all semantic outcome dimensions separate."""
     runtime = runtime or RuntimeObservation()
-    failures: list[str] = []
+    failures = _structural_failures(evidence)
+    if failures:
+        return _result(INTEGRITY_INVALID, failures, evidence, "unresolved", runtime)
 
-    if evidence.get("evidence_type") != EVIDENCE_TYPE or evidence.get("version") != EVIDENCE_VERSION:
-        return _result(INTEGRITY_INVALID, ["unsupported_evidence_profile"], evidence, "unresolved", runtime)
+    issuer = evidence["issuer"]
+    auth = evidence["authentication"]
+    issuer_id = issuer["id"]
+    key_id = issuer["key_id"]
 
-    issuer = evidence.get("issuer")
-    auth = evidence.get("authentication")
-    if not isinstance(issuer, dict) or not isinstance(auth, dict):
-        return _result(INTEGRITY_INVALID, ["missing_authentication_metadata"], evidence, "unresolved", runtime)
-
-    issuer_id = issuer.get("id")
-    key_id = issuer.get("key_id")
-    if issuer.get("algorithm") != ALGORITHM or auth.get("algorithm") != ALGORITHM or auth.get("key_id") != key_id:
-        return _result(INTEGRITY_INVALID, ["algorithm_or_key_binding_mismatch"], evidence, "unresolved", runtime)
-
-    key = trust_keys.get((str(issuer_id), str(key_id)))
+    key = trust_keys.get((issuer_id, key_id))
     if key is None:
-        return _result(INTEGRITY_UNVERIFIABLE, ["unknown_or_untrusted_issuer_key"], evidence, "unresolved", runtime)
+        return _result(
+            INTEGRITY_UNVERIFIABLE,
+            ["unknown_or_untrusted_issuer_key"],
+            evidence,
+            "unresolved",
+            runtime,
+        )
 
-    issued_at = evidence.get("issued_at")
-    if not isinstance(issued_at, str) or not key.usable_at(issued_at):
-        return _result(INTEGRITY_UNVERIFIABLE, ["issuer_key_not_valid_at_issuance"], evidence, "unresolved", runtime)
+    issued_at = evidence["issued_at"]
+    if not key.usable_at(issued_at):
+        return _result(
+            INTEGRITY_UNVERIFIABLE,
+            ["issuer_key_not_valid_at_issuance"],
+            evidence,
+            "unresolved",
+            runtime,
+        )
 
-    expected_mac = _mac(evidence, key.secret)
-    if not hmac.compare_digest(str(auth.get("value", "")), expected_mac):
-        return _result(INTEGRITY_INVALID, ["authentication_failed"], evidence, "unresolved", runtime)
+    try:
+        signature = base64.b64decode(auth["value"], validate=True)
+        key.public_key.verify(signature, canonical_json(_signable(evidence)))
+    except (InvalidSignature, ValueError, TypeError, binascii.Error):
+        return _result(
+            INTEGRITY_INVALID,
+            ["signature_verification_failed"],
+            evidence,
+            "unresolved",
+            runtime,
+        )
 
+    failures = []
     receipt_resolution = "detached"
     if canonical_receipt is not None:
-        if sha256_ref(dict(canonical_receipt)) != evidence.get("canonical_receipt_ref"):
+        if sha256_ref(dict(canonical_receipt)) != evidence["canonical_receipt_ref"]:
             failures.append("canonical_receipt_hash_mismatch")
             receipt_resolution = "mismatch"
         else:
             receipt_resolution = "resolved"
 
-    governance = evidence.get("governance") if isinstance(evidence.get("governance"), dict) else {}
-    scope = evidence.get("scope") if isinstance(evidence.get("scope"), dict) else {}
-
+    governance = evidence["governance"]
+    scope = evidence["scope"]
     for observed, signed, failure in (
-        (runtime.action_ref, evidence.get("action_ref"), "wrong_action_ref"),
-        (runtime.policy_ref, governance.get("policy_ref"), "stale_or_wrong_policy_ref"),
-        (runtime.authority_state_ref, governance.get("authority_state_ref"), "stale_or_wrong_authority_state_ref"),
+        (runtime.action_ref, evidence["action_ref"], "wrong_action_ref"),
+        (runtime.policy_ref, governance["policy_ref"], "stale_or_wrong_policy_ref"),
+        (runtime.authority_state_ref, governance["authority_state_ref"], "stale_or_wrong_authority_state_ref"),
         (runtime.source_domain_ref, scope.get("source_domain_ref"), "wrong_source_domain"),
         (runtime.destination_domain_ref, scope.get("destination_domain_ref"), "wrong_destination_domain"),
     ):
         if observed is not None and observed != signed:
             failures.append(failure)
 
+    if runtime.execution_time is not None:
+        try:
+            if _parse_time(runtime.execution_time) < _parse_time(governance["decision_time"]):
+                failures.append("execution_precedes_decision")
+        except ValueError:
+            failures.append("invalid_execution_time")
+
     integrity = INTEGRITY_VALID if not failures else INTEGRITY_INVALID
     return _result(integrity, failures, evidence, receipt_resolution, runtime)
+
+
+def _structural_failures(evidence: Mapping[str, object]) -> list[str]:
+    failures: list[str] = []
+    if evidence.get("evidence_type") != EVIDENCE_TYPE or evidence.get("version") != EVIDENCE_VERSION:
+        failures.append("unsupported_evidence_profile")
+    if evidence.get("canonicalization") != "agent-memory-canonical-json-v1":
+        failures.append("unsupported_canonicalization")
+
+    issuer = evidence.get("issuer")
+    auth = evidence.get("authentication")
+    governance = evidence.get("governance")
+    scope = evidence.get("scope")
+    state = evidence.get("state")
+    if not all(isinstance(item, dict) for item in (issuer, auth, governance, scope, state)):
+        failures.append("missing_required_object")
+        return failures
+
+    if issuer.get("algorithm") != ALGORITHM or auth.get("algorithm") != ALGORITHM:
+        failures.append("unsupported_signature_algorithm")
+    if issuer.get("key_id") != auth.get("key_id"):
+        failures.append("key_binding_mismatch")
+    if governance.get("disposition") not in GOVERNANCE_VALUES:
+        failures.append("invalid_governance_disposition")
+    if evidence.get("lifecycle_result") not in LIFECYCLE_VALUES:
+        failures.append("invalid_lifecycle_result")
+
+    required_strings = (
+        issuer.get("id"),
+        issuer.get("key_id"),
+        auth.get("value"),
+        evidence.get("issued_at"),
+        evidence.get("action_ref"),
+        evidence.get("memory_action"),
+        evidence.get("canonical_receipt_ref"),
+        governance.get("policy_ref"),
+        governance.get("authority_state_ref"),
+        governance.get("decision_time"),
+        scope.get("scope_ref"),
+        state.get("before_ref"),
+        state.get("after_ref"),
+    )
+    if any(not isinstance(value, str) or not value for value in required_strings):
+        failures.append("missing_required_string")
+
+    try:
+        if isinstance(evidence.get("issued_at"), str) and isinstance(governance.get("decision_time"), str):
+            if _parse_time(governance["decision_time"]) > _parse_time(evidence["issued_at"]):
+                failures.append("decision_after_issuance")
+    except ValueError:
+        failures.append("invalid_evidence_timestamp")
+
+    receipt_ref = evidence.get("canonical_receipt_ref")
+    if isinstance(receipt_ref, str):
+        digest = receipt_ref.removeprefix("sha256:")
+        if not receipt_ref.startswith("sha256:") or len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+            failures.append("invalid_canonical_receipt_ref")
+
+    return failures
 
 
 def _result(
@@ -288,7 +385,7 @@ def _result(
         execution = "unauthorized_execution"
     elif runtime.authority_valid_at_execution is False:
         execution = "unauthorized_execution"
-    elif runtime.authority_valid_at_execution is None and runtime.execution_time is not None:
+    elif runtime.authority_valid_at_execution is None:
         execution = "unverifiable"
     elif integrity == INTEGRITY_VALID:
         execution = "executed_as_authorized"

--- a/reference/tests/test_portable_evidence.py
+++ b/reference/tests/test_portable_evidence.py
@@ -1,0 +1,232 @@
+"""P4.5a portable governance evidence core.
+
+These tests intentionally exercise valid negative outcomes as well as signature
+and binding failures.  A denial with a valid authentication tag is evidence, not
+a verifier malfunction; an authorized delete with residual state remains a
+lifecycle failure.
+
+Run: python -m unittest discover -s reference/tests -t reference
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.portable_evidence import (  # noqa: E402
+    RuntimeObservation,
+    TrustKey,
+    canonical_json,
+    issue_evidence,
+    verify_evidence,
+)
+
+ISSUER = "issuer:agent-memory-reference"
+KEY = TrustKey(
+    issuer_id=ISSUER,
+    key_id="key-2026-08",
+    secret=b"test-only-portable-evidence-key",
+    valid_from="2026-08-01T00:00:00Z",
+    valid_until="2026-08-31T23:59:59Z",
+)
+RECEIPT = {
+    "schema_version": "1.0.0",
+    "receipt_id": "receipt:42",
+    "memory_id": "mem:alpha",
+    "selected_action": "delete",
+    "policy_version": "pama-2026-08",
+    "timestamp": "2026-08-11T18:00:00Z",
+}
+
+
+def make_evidence(**overrides):
+    args = dict(
+        canonical_receipt=RECEIPT,
+        issuer_id=ISSUER,
+        key=KEY,
+        issued_at="2026-08-11T18:00:01Z",
+        action_ref="action:delete:42",
+        memory_action="permanent_deletion",
+        governance_disposition="committed",
+        policy_ref="policy:pama-2026-08",
+        authority_state_ref="authority:rev-12",
+        decision_time="2026-08-11T18:00:00Z",
+        scope_ref="scope:hmac:4fc2",
+        before_state_ref="state:before:42",
+        after_state_ref="state:after:42",
+        lifecycle_result="satisfied",
+        source_domain_ref="domain:hmac:project-a",
+        destination_domain_ref="domain:hmac:archive",
+        domain_authorization_state_ref="domain-auth:9",
+    )
+    args.update(overrides)
+    return issue_evidence(**args)
+
+
+class CanonicalizationTests(unittest.TestCase):
+    def test_object_order_does_not_change_bytes(self):
+        self.assertEqual(canonical_json({"b": 2, "a": 1}), canonical_json({"a": 1, "b": 2}))
+
+    def test_floats_are_rejected_in_v1(self):
+        with self.assertRaises(TypeError):
+            canonical_json({"score": 0.9})
+
+
+class PortableEvidenceTests(unittest.TestCase):
+    def setUp(self):
+        self.trust = {(KEY.issuer_id, KEY.key_id): KEY}
+
+    def test_happy_path_binds_receipt_action_policy_authority_and_domains(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            canonical_receipt=RECEIPT,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                execution_time="2026-08-11T18:00:02Z",
+                policy_ref="policy:pama-2026-08",
+                authority_state_ref="authority:rev-12",
+                source_domain_ref="domain:hmac:project-a",
+                destination_domain_ref="domain:hmac:archive",
+                authority_valid_at_execution=True,
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "valid")
+        self.assertEqual(result["receipt_resolution"], "resolved")
+        self.assertEqual(result["governance_disposition"], "committed")
+        self.assertEqual(result["runtime_execution"], "executed_as_authorized")
+        self.assertEqual(result["lifecycle_satisfaction"], "satisfied")
+
+    def test_projection_contains_no_canonical_receipt_or_memory_content(self):
+        evidence = make_evidence()
+        rendered = str(evidence)
+        self.assertNotIn("receipt_id", rendered)
+        self.assertNotIn("memory_id", rendered)
+        self.assertNotIn("selected_action", rendered)
+        self.assertNotIn("mem:alpha", rendered)
+
+    def test_tamper_is_invalid(self):
+        evidence = make_evidence()
+        evidence["governance"]["disposition"] = "denied"
+        result = verify_evidence(evidence, self.trust)
+        self.assertEqual(result["evidence_integrity"], "invalid")
+        self.assertIn("authentication_failed", result["binding_failures"])
+
+    def test_unknown_issuer_is_unverifiable_not_governance_denial(self):
+        evidence = make_evidence()
+        result = verify_evidence(evidence, {})
+        self.assertEqual(result["evidence_integrity"], "unverifiable")
+        self.assertEqual(result["governance_disposition"], "committed")
+
+    def test_wrong_action_detects_replay_against_another_execution(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(action_ref="action:delete:99", authority_valid_at_execution=True),
+        )
+        self.assertEqual(result["evidence_integrity"], "invalid")
+        self.assertIn("wrong_action_ref", result["binding_failures"])
+        self.assertEqual(result["runtime_execution"], "execution_mismatch")
+
+    def test_stale_policy_and_authority_state_fail_binding(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                policy_ref="policy:pama-2026-09",
+                authority_state_ref="authority:rev-13",
+                authority_valid_at_execution=True,
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "invalid")
+        self.assertIn("stale_or_wrong_policy_ref", result["binding_failures"])
+        self.assertIn("stale_or_wrong_authority_state_ref", result["binding_failures"])
+
+    def test_wrong_isolation_domain_fails_binding(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                source_domain_ref="domain:hmac:project-b",
+                destination_domain_ref="domain:hmac:archive",
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "invalid")
+        self.assertIn("wrong_source_domain", result["binding_failures"])
+
+    def test_valid_denial_plus_runtime_action_is_unauthorized_execution(self):
+        evidence = make_evidence(governance_disposition="denied", lifecycle_result="not_applicable")
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(action_ref="action:delete:42", authority_valid_at_execution=True),
+        )
+        self.assertEqual(result["evidence_integrity"], "valid")
+        self.assertEqual(result["governance_disposition"], "denied")
+        self.assertEqual(result["runtime_execution"], "unauthorized_execution")
+
+    def test_authorized_delete_can_still_have_residual_lifecycle_failure(self):
+        evidence = make_evidence(lifecycle_result="residual")
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(action_ref="action:delete:42", authority_valid_at_execution=True),
+        )
+        self.assertEqual(result["evidence_integrity"], "valid")
+        self.assertEqual(result["runtime_execution"], "executed_as_authorized")
+        self.assertEqual(result["lifecycle_satisfaction"], "residual")
+
+    def test_detached_verification_survives_pruned_canonical_content(self):
+        evidence = make_evidence()
+        result = verify_evidence(evidence, self.trust)
+        self.assertEqual(result["evidence_integrity"], "valid")
+        self.assertEqual(result["receipt_resolution"], "detached")
+
+    def test_wrong_canonical_receipt_fails_binding(self):
+        evidence = make_evidence()
+        wrong = dict(RECEIPT, receipt_id="receipt:other")
+        result = verify_evidence(evidence, self.trust, canonical_receipt=wrong)
+        self.assertEqual(result["evidence_integrity"], "invalid")
+        self.assertEqual(result["receipt_resolution"], "mismatch")
+
+    def test_historical_key_remains_verifiable_after_rotation(self):
+        old_key = TrustKey(
+            issuer_id=ISSUER,
+            key_id="key-old",
+            secret=b"old-test-key",
+            valid_from="2026-07-01T00:00:00Z",
+            valid_until="2026-08-15T00:00:00Z",
+        )
+        new_key = TrustKey(
+            issuer_id=ISSUER,
+            key_id="key-new",
+            secret=b"new-test-key",
+            valid_from="2026-08-15T00:00:01Z",
+        )
+        evidence = make_evidence(key=old_key, issued_at="2026-08-11T18:00:01Z")
+        trust = {(old_key.issuer_id, old_key.key_id): old_key, (new_key.issuer_id, new_key.key_id): new_key}
+        result = verify_evidence(evidence, trust)
+        self.assertEqual(result["evidence_integrity"], "valid")
+
+    def test_revoked_key_cannot_issue_new_evidence(self):
+        revoked = TrustKey(
+            issuer_id=ISSUER,
+            key_id="key-revoked",
+            secret=b"revoked-test-key",
+            valid_from="2026-08-01T00:00:00Z",
+            revoked_at="2026-08-10T00:00:00Z",
+        )
+        with self.assertRaises(ValueError):
+            make_evidence(key=revoked, issued_at="2026-08-11T18:00:01Z")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_portable_evidence.py
+++ b/reference/tests/test_portable_evidence.py
@@ -1,34 +1,37 @@
 """P4.5a portable governance evidence core.
 
-These tests intentionally exercise valid negative outcomes as well as signature
-and binding failures.  A denial with a valid authentication tag is evidence, not
-a verifier malfunction; an authorized delete with residual state remains a
-lifecycle failure.
+These tests exercise valid negative outcomes as well as signature and binding
+failures. A denial with a valid signature is evidence, not a verifier malfunction;
+an authorized delete with residual state remains a lifecycle failure.
 
 Run: python -m unittest discover -s reference/tests -t reference
 """
 
 from __future__ import annotations
 
+import json
 import sys
 import unittest
 from pathlib import Path
 
+import jsonschema
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from agentmem_ref.portable_evidence import (  # noqa: E402
+    IssuerKey,
     RuntimeObservation,
-    TrustKey,
     canonical_json,
     issue_evidence,
     verify_evidence,
 )
 
 ISSUER = "issuer:agent-memory-reference"
-KEY = TrustKey(
+KEY = IssuerKey(
     issuer_id=ISSUER,
     key_id="key-2026-08",
-    secret=b"test-only-portable-evidence-key",
+    private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(1, 33))),
     valid_from="2026-08-01T00:00:00Z",
     valid_until="2026-08-31T23:59:59Z",
 )
@@ -54,12 +57,12 @@ def make_evidence(**overrides):
         policy_ref="policy:pama-2026-08",
         authority_state_ref="authority:rev-12",
         decision_time="2026-08-11T18:00:00Z",
-        scope_ref="scope:hmac:4fc2",
+        scope_ref="scope:opaque:4fc2",
         before_state_ref="state:before:42",
         after_state_ref="state:after:42",
         lifecycle_result="satisfied",
-        source_domain_ref="domain:hmac:project-a",
-        destination_domain_ref="domain:hmac:archive",
+        source_domain_ref="domain:opaque:project-a",
+        destination_domain_ref="domain:opaque:archive",
         domain_authorization_state_ref="domain-auth:9",
     )
     args.update(overrides)
@@ -77,7 +80,8 @@ class CanonicalizationTests(unittest.TestCase):
 
 class PortableEvidenceTests(unittest.TestCase):
     def setUp(self):
-        self.trust = {(KEY.issuer_id, KEY.key_id): KEY}
+        trust_key = KEY.trust_key()
+        self.trust = {(trust_key.issuer_id, trust_key.key_id): trust_key}
 
     def test_happy_path_binds_receipt_action_policy_authority_and_domains(self):
         evidence = make_evidence()
@@ -90,8 +94,8 @@ class PortableEvidenceTests(unittest.TestCase):
                 execution_time="2026-08-11T18:00:02Z",
                 policy_ref="policy:pama-2026-08",
                 authority_state_ref="authority:rev-12",
-                source_domain_ref="domain:hmac:project-a",
-                destination_domain_ref="domain:hmac:archive",
+                source_domain_ref="domain:opaque:project-a",
+                destination_domain_ref="domain:opaque:archive",
                 authority_valid_at_execution=True,
             ),
         )
@@ -100,6 +104,12 @@ class PortableEvidenceTests(unittest.TestCase):
         self.assertEqual(result["governance_disposition"], "committed")
         self.assertEqual(result["runtime_execution"], "executed_as_authorized")
         self.assertEqual(result["lifecycle_satisfaction"], "satisfied")
+
+    def test_projection_satisfies_the_versioned_json_schema(self):
+        evidence = make_evidence()
+        root = Path(__file__).resolve().parents[2]
+        schema = json.loads((root / "schemas" / "portable-governance-evidence.schema.json").read_text())
+        jsonschema.Draft202012Validator(schema).validate(evidence)
 
     def test_projection_contains_no_canonical_receipt_or_memory_content(self):
         evidence = make_evidence()
@@ -114,7 +124,7 @@ class PortableEvidenceTests(unittest.TestCase):
         evidence["governance"]["disposition"] = "denied"
         result = verify_evidence(evidence, self.trust)
         self.assertEqual(result["evidence_integrity"], "invalid")
-        self.assertIn("authentication_failed", result["binding_failures"])
+        self.assertIn("signature_verification_failed", result["binding_failures"])
 
     def test_unknown_issuer_is_unverifiable_not_governance_denial(self):
         evidence = make_evidence()
@@ -155,12 +165,39 @@ class PortableEvidenceTests(unittest.TestCase):
             evidence,
             self.trust,
             runtime=RuntimeObservation(
-                source_domain_ref="domain:hmac:project-b",
-                destination_domain_ref="domain:hmac:archive",
+                source_domain_ref="domain:opaque:project-b",
+                destination_domain_ref="domain:opaque:archive",
             ),
         )
         self.assertEqual(result["evidence_integrity"], "invalid")
         self.assertIn("wrong_source_domain", result["binding_failures"])
+
+    def test_execution_before_decision_fails_binding(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                execution_time="2026-08-11T17:59:59Z",
+                authority_valid_at_execution=True,
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "invalid")
+        self.assertIn("execution_precedes_decision", result["binding_failures"])
+
+    def test_unknown_execution_time_authority_fails_closed(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                execution_time="2026-08-11T18:00:02Z",
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "valid")
+        self.assertEqual(result["runtime_execution"], "unverifiable")
 
     def test_valid_denial_plus_runtime_action_is_unauthorized_execution(self):
         evidence = make_evidence(governance_disposition="denied", lifecycle_result="not_applicable")
@@ -197,30 +234,35 @@ class PortableEvidenceTests(unittest.TestCase):
         self.assertEqual(result["evidence_integrity"], "invalid")
         self.assertEqual(result["receipt_resolution"], "mismatch")
 
-    def test_historical_key_remains_verifiable_after_rotation(self):
-        old_key = TrustKey(
+    def test_historical_public_key_remains_verifiable_after_rotation(self):
+        old_key = IssuerKey(
             issuer_id=ISSUER,
             key_id="key-old",
-            secret=b"old-test-key",
+            private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(33, 65))),
             valid_from="2026-07-01T00:00:00Z",
             valid_until="2026-08-15T00:00:00Z",
         )
-        new_key = TrustKey(
+        new_key = IssuerKey(
             issuer_id=ISSUER,
             key_id="key-new",
-            secret=b"new-test-key",
+            private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(65, 97))),
             valid_from="2026-08-15T00:00:01Z",
         )
         evidence = make_evidence(key=old_key, issued_at="2026-08-11T18:00:01Z")
-        trust = {(old_key.issuer_id, old_key.key_id): old_key, (new_key.issuer_id, new_key.key_id): new_key}
+        old_trust = old_key.trust_key()
+        new_trust = new_key.trust_key()
+        trust = {
+            (old_trust.issuer_id, old_trust.key_id): old_trust,
+            (new_trust.issuer_id, new_trust.key_id): new_trust,
+        }
         result = verify_evidence(evidence, trust)
         self.assertEqual(result["evidence_integrity"], "valid")
 
     def test_revoked_key_cannot_issue_new_evidence(self):
-        revoked = TrustKey(
+        revoked = IssuerKey(
             issuer_id=ISSUER,
             key_id="key-revoked",
-            secret=b"revoked-test-key",
+            private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(97, 129))),
             valid_from="2026-08-01T00:00:00Z",
             revoked_at="2026-08-10T00:00:00Z",
         )

--- a/schemas/portable-governance-evidence.schema.json
+++ b/schemas/portable-governance-evidence.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mythologiq-labs-llc.github.io/agent-memory/schemas/portable-governance-evidence.schema.json",
+  "title": "Agent Memory Portable Governance Evidence",
+  "description": "Content-free portable projection of a canonical Agent Memory governance receipt. Integrity, governance disposition, runtime execution, and lifecycle satisfaction remain separate verifier dimensions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "evidence_type",
+    "version",
+    "canonicalization",
+    "issuer",
+    "issued_at",
+    "action_ref",
+    "memory_action",
+    "canonical_receipt_ref",
+    "governance",
+    "scope",
+    "state",
+    "lifecycle_result",
+    "authentication"
+  ],
+  "properties": {
+    "evidence_type": {"const": "agent-memory-governance-evidence"},
+    "version": {"const": "1.0.0"},
+    "canonicalization": {"const": "agent-memory-canonical-json-v1"},
+    "issuer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "key_id", "algorithm"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "key_id": {"type": "string", "minLength": 1},
+        "algorithm": {"const": "HMAC-SHA256"}
+      }
+    },
+    "issued_at": {"type": "string", "format": "date-time"},
+    "action_ref": {"type": "string", "minLength": 1},
+    "memory_action": {"type": "string", "minLength": 1},
+    "canonical_receipt_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["disposition", "policy_ref", "authority_state_ref", "decision_time"],
+      "properties": {
+        "disposition": {
+          "enum": ["permitted", "denied", "deferred", "review_required", "committed"]
+        },
+        "policy_ref": {"type": "string", "minLength": 1},
+        "authority_state_ref": {"type": "string", "minLength": 1},
+        "decision_time": {"type": "string", "format": "date-time"}
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope_ref"],
+      "properties": {
+        "scope_ref": {"type": "string", "minLength": 1},
+        "source_domain_ref": {"type": "string", "minLength": 1},
+        "destination_domain_ref": {"type": "string", "minLength": 1},
+        "domain_authorization_state_ref": {"type": "string", "minLength": 1}
+      }
+    },
+    "state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["before_ref", "after_ref"],
+      "properties": {
+        "before_ref": {"type": "string", "minLength": 1},
+        "after_ref": {"type": "string", "minLength": 1}
+      }
+    },
+    "lifecycle_result": {
+      "enum": ["satisfied", "residual", "incomplete", "unverifiable", "not_applicable"]
+    },
+    "authentication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "key_id", "value"],
+      "properties": {
+        "algorithm": {"const": "HMAC-SHA256"},
+        "key_id": {"type": "string", "minLength": 1},
+        "value": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    }
+  }
+}

--- a/schemas/portable-governance-evidence.schema.json
+++ b/schemas/portable-governance-evidence.schema.json
@@ -31,7 +31,7 @@
       "properties": {
         "id": {"type": "string", "minLength": 1},
         "key_id": {"type": "string", "minLength": 1},
-        "algorithm": {"const": "HMAC-SHA256"}
+        "algorithm": {"const": "Ed25519"}
       }
     },
     "issued_at": {"type": "string", "format": "date-time"},
@@ -79,9 +79,14 @@
       "additionalProperties": false,
       "required": ["algorithm", "key_id", "value"],
       "properties": {
-        "algorithm": {"const": "HMAC-SHA256"},
+        "algorithm": {"const": "Ed25519"},
         "key_id": {"type": "string", "minLength": 1},
-        "value": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        "value": {
+          "type": "string",
+          "minLength": 88,
+          "maxLength": 88,
+          "pattern": "^[A-Za-z0-9+/]{86}==$"
+        }
       }
     }
   }


### PR DESCRIPTION
## Objective

Implement the first executable P4.5a portable memory-governance evidence boundary from #63 without making TRACE, Agent Manifest, AGT, or an upstream repository a dependency.

## What changed

- adds `schemas/portable-governance-evidence.schema.json`
- adds `reference/agentmem_ref/portable_evidence.py`
- adds adversarial and positive vectors in `reference/tests/test_portable_evidence.py`
- adds `docs/programs/runtime-evidence/portable-governance-evidence.md`
- indexes the slice in the runtime-evidence and reference documentation
- installs and pins `jsonschema==4.26.0` and `cryptography==50.0.0` for the validation profile

## Boundary preserved

The canonical Agent Memory receipt remains authoritative. Portable evidence contains only content-free references/digests plus governance, authority-state, isolation-domain, runtime-action, lifecycle, issuer, and signature metadata.

The verifier keeps four dimensions separate:

```text
evidence integrity/binding
governance disposition
runtime execution
lifecycle satisfaction
```

So these remain representable as distinct outcomes:

```text
valid signature + denied + unauthorized execution
valid signature + committed + executed + residual
valid signature + committed + executed + satisfied
```

No signature or runtime execution can manufacture PAMA authority or lifecycle satisfaction.

## Trust-profile decision

This PR intentionally adds `cryptography` for Ed25519.

I initially evaluated a stdlib-only HMAC-SHA256 profile, but rejected it because an independent verifier would need the shared signing secret and could therefore forge evidence. That violates the independent-verification premise of #63. Ed25519 gives verifiers only the public trust key while the issuer retains the private key.

This is the explicit dependency justification required by `CONTRIBUTING.md`. The direct validation dependencies are pinned to the exact versions exercised by the first successful P4.5a CI run: `jsonschema==4.26.0` and `cryptography==50.0.0`. The PR does not introduce a universal PKI, remote trust discovery, production key storage, or online revocation infrastructure.

## Adversarial vectors

The executable suite covers:

- deterministic canonicalization and float rejection
- emitted-object schema validation
- successful receipt/action/policy/authority/domain binding
- absence of raw canonical receipt or memory content
- signature tampering
- unknown/untrusted issuer
- replay against a different action
- stale/wrong policy reference
- stale/wrong authority-state reference
- wrong source isolation domain
- execution preceding the signed decision
- fail-closed unknown execution-time authority continuity
- valid denial plus unauthorized runtime execution
- authorized deletion with residual lifecycle state
- detached verification after canonical content is unavailable
- wrong canonical receipt
- historical public-key verification across rotation
- refusal to issue new evidence after key revocation

## What this proves

This creates an executable, substrate-independent P4.5a evidence core that can bind a canonical Agent Memory receipt reference to decision-time governance state, isolation-domain references, and a runtime action while remaining independently verifiable and content-free.

Most importantly:

```text
valid evidence of authorized deletion != proof of forgetting
```

A correctly signed and authorized deletion can still produce `lifecycle_satisfaction = residual`.

## What remains unproven

- Agent Manifest checkpoint/delta correlation (P4.5b)
- TRACE/AgenTrust action-evidence interoperability (P4.5c)
- production trust-anchor distribution and key custody
- external revocation infrastructure
- multi-implementation interoperability
- AGT/runtime-policy composition
- any higher conformance level
- acceptance of ADR-020, ADR-021, or ADR-022

Closes no parent program automatically; this is one evidence slice toward #63 and #46.