### PR TITLE
P4.5b: correlate Agent Manifest memory checkpoints without duplicating protocol

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -20,7 +20,11 @@ jobs:
           python-version: '3.12'
 
       - name: Install validation dependencies
-        run: python -m pip install --disable-pip-version-check jsonschema==4.26.0 cryptography==50.0.0
+        run: >-
+          python -m pip install --disable-pip-version-check
+          jsonschema==4.26.0
+          cryptography==50.0.0
+          agent-manifest==0.11.0
 
       - name: Validate fixture invariants
         run: python scripts/validate_fixtures.py fixtures
@@ -63,6 +67,7 @@ jobs:
           docs/programs/runtime-evidence/graphiti-conformance.md
           docs/programs/runtime-evidence/canonical-and-derived-state.md
           docs/programs/runtime-evidence/portable-governance-evidence.md
+          docs/programs/runtime-evidence/agent-manifest-correlation.md
           reference/README.md
 
       - name: Validate GitHub Wiki source links
@@ -82,12 +87,12 @@ jobs:
             echo "Commands run by this workflow (reproducible locally):"
             echo ""
             echo '```'
-            echo "python -m pip install jsonschema==4.26.0 cryptography==50.0.0"
+            echo "python -m pip install jsonschema==4.26.0 cryptography==50.0.0 agent-manifest==0.11.0"
             echo "python scripts/validate_fixtures.py fixtures"
             echo "python scripts/validate_schemas.py"
             echo "python scripts/validate_doctrine_boundaries.py"
             echo "python -m unittest discover -s reference/tests -t reference"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md reference/README.md"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md reference/README.md"
             echo "python scripts/validate_wiki_links.py wiki-src"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'

--- a/docs/programs/runtime-evidence/README.md
+++ b/docs/programs/runtime-evidence/README.md
@@ -29,6 +29,8 @@ Evidence that omits the negative paths is a demo. Evidence that cannot be re-run
 
 P4.5a is intentionally a **substrate-independent interoperability precondition** rather than a claim that another runtime substrate has been exercised. Its job is to make the portable evidence boundary executable and adversarially testable before correlation to Agent Manifest, TRACE, or another external runtime surface.
 
+P4.5b is **external comparator evidence**: the tests execute the pinned Agent Manifest package's own checkpoint/delta verifier and correlate its verdict to Agent Memory receipts and portable evidence. Agent Memory does not copy the external checkpoint protocol or inherit its semantics.
+
 ## Comparator discipline
 
 External systems enter this program to answer one architectural question each, and are barred from becoming something else:
@@ -77,6 +79,7 @@ Documents are added when their slice is ready to execute, not in advance. A dire
 | [`../../../reference/README.md`](../../../reference/README.md) | minimal governed adapter | bound and executed against a real substrate |
 | [`canonical-and-derived-state.md`](canonical-and-derived-state.md) | canonical memory versus derived projections | design spike executed: all seven evidence-bar items run in CI |
 | [`portable-governance-evidence.md`](portable-governance-evidence.md) | P4.5a portable governance evidence core | executable substrate-independent Ed25519 issuer/verifier and adversarial vectors |
+| [`agent-manifest-correlation.md`](agent-manifest-correlation.md) | P4.5b Agent Manifest memory checkpoint correlation | pinned external comparator executed; accepted `DEL` remains distinct from lifecycle satisfaction |
 
 ## Preconditions
 

--- a/docs/programs/runtime-evidence/README.md
+++ b/docs/programs/runtime-evidence/README.md
@@ -79,7 +79,7 @@ Documents are added when their slice is ready to execute, not in advance. A dire
 | [`../../../reference/README.md`](../../../reference/README.md) | minimal governed adapter | bound and executed against a real substrate |
 | [`canonical-and-derived-state.md`](canonical-and-derived-state.md) | canonical memory versus derived projections | design spike executed: all seven evidence-bar items run in CI |
 | [`portable-governance-evidence.md`](portable-governance-evidence.md) | P4.5a portable governance evidence core | executable substrate-independent Ed25519 issuer/verifier and adversarial vectors |
-| [`agent-manifest-correlation.md`](agent-manifest-correlation.md) | P4.5b Agent Manifest memory checkpoint correlation | pinned external comparator executed; accepted `DEL` remains distinct from lifecycle satisfaction |
+| [`agent-manifest-correlation.md`](agent-manifest-correlation.md) | P4.5b Agent Manifest memory checkpoint correlation | pinned external comparator executed; a checkpoint built from a test log containing `DEL` remains distinct from Agent Memory lifecycle satisfaction |
 
 ## Preconditions
 

--- a/docs/programs/runtime-evidence/agent-manifest-correlation.md
+++ b/docs/programs/runtime-evidence/agent-manifest-correlation.md
@@ -1,0 +1,222 @@
+# P4.5b Agent Manifest memory checkpoint correlation
+
+Status: **Executable interoperability evidence**. This slice correlates Agent Memory portable governance evidence with the existing Agent Manifest v0.2 memory checkpoint/delta protocol. It does not adopt Agent Manifest as Agent Memory doctrine, does not duplicate its checkpoint protocol, and does not change repository conformance level.
+
+Parent implementation issue: #63.
+
+## Pinned external comparator
+
+The executable comparator is pinned to:
+
+```text
+repository: https://github.com/agentrust-io/agent-manifest
+spec:       Agent Manifest v0.2
+package:    agent-manifest==0.11.0
+tag commit: 98cead8e8809e3302dc388ca869882d15b812b7f
+```
+
+Pinned upstream source surfaces:
+
+- [v0.2 memory checkpoint/delta implementation](https://github.com/agentrust-io/agent-manifest/blob/98cead8e8809e3302dc388ca869882d15b812b7f/python/src/agent_manifest/_memory_delta.py)
+- [v0.2 RFC 9162 Merkle implementation](https://github.com/agentrust-io/agent-manifest/blob/98cead8e8809e3302dc388ca869882d15b812b7f/python/src/agent_manifest/_merkle.py)
+- [v0.2 specification](https://github.com/agentrust-io/agent-manifest/blob/98cead8e8809e3302dc388ca869882d15b812b7f/spec/agent-manifest-spec-v0.2.md)
+
+The upstream package is a **test comparator**, not an Agent Memory runtime dependency. P4.5b deliberately calls the upstream checkpoint verifier instead of copying its Merkle, sequence, TTL, drift, or delta-budget logic into this repository.
+
+## Ownership boundary
+
+Agent Manifest v0.2 models evolving memory as an append-only operation log. A checkpoint binds:
+
+```text
+memory_root
+tree_size
+seq
+approved_at
+ttl_seconds
+```
+
+Its verifier owns whether a checkpoint advance is a valid append-only delta under its consistency-proof, monotonic-sequence, TTL, and delta-budget rules.
+
+Agent Memory owns:
+
+```text
+what the memory action means
+whether PAMA permitted it
+what canonical receipt records it
+whether execution was authorized
+whether correction/deletion lifecycle obligations are satisfied
+whether declared or undeclared derived residue remains
+```
+
+The composition is therefore:
+
+```text
+Agent Manifest delta verdict
+        |
+        | integrity of memory-log evolution
+        v
+content-addressed checkpoint reference
+        |
+        | canonical receipt evidence_refs
+        v
+Agent Memory canonical receipt
+        |
+        | P4.5a receipt hash + before/after state refs
+        v
+portable Agent Memory governance evidence
+        |
+        v
+P4.5b correlation artifact
+```
+
+No arrow reverses semantic ownership.
+
+## Correlation contract
+
+Schema: `../../../schemas/agent-manifest-memory-correlation.schema.json`.
+
+The canonical Agent Memory decision receipt already has a generic `evidence_refs` array. P4.5b therefore does not modify the receipt schema. The new checkpoint tuple is projected without operation content and content-addressed with Agent Memory canonical JSON:
+
+```text
+checkpoint_ref = sha256(canonical({
+  memory_root,
+  tree_size,
+  seq,
+  approved_at,
+  ttl_seconds
+}))
+```
+
+That `checkpoint_ref` is placed in the canonical receipt's `evidence_refs`.
+
+P4.5a portable evidence then binds:
+
+```text
+canonical_receipt_ref
+state.before_ref = previous checkpoint_ref
+state.after_ref  = new checkpoint_ref
+```
+
+P4.5b validates all three relationships:
+
+1. the portable evidence signature resolves to the supplied canonical receipt;
+2. the receipt contains the new checkpoint reference in `evidence_refs`;
+3. the portable before/after state references match the previous/new checkpoint references.
+
+The correlation artifact also records the pinned upstream spec/package/commit identity and the **upstream verifier's** `accepted/rejected` verdict and reason.
+
+## What is not duplicated
+
+Agent Memory does not reproduce:
+
+- RFC 9162 consistency proof generation or verification
+- Agent Manifest Merkle leaf construction
+- Agent Manifest sequence monotonicity rules
+- checkpoint TTL evaluation
+- delta-budget evaluation
+- Agent Manifest drift classification
+
+Those are executed by `agent-manifest==0.11.0` in CI. The local correlation layer only binds the resulting checkpoint identity and verdict to Agent Memory evidence.
+
+## DEL is not forgetting
+
+Agent Manifest encodes a key-value deletion as an appended `DEL` operation. That proves a particular memory-log evolution when the checkpoint delta verifies. It does not prove that Agent Memory's semantic forgetting obligations are satisfied.
+
+P4.5b executes the same accepted upstream `DEL` checkpoint in two Agent Memory outcomes:
+
+```text
+Agent Manifest: accepted DEL
+Agent Memory:    committed deletion
+Lifecycle:       residual
+```
+
+and:
+
+```text
+Agent Manifest: accepted DEL
+Agent Memory:    committed deletion
+Lifecycle:       satisfied
+```
+
+Both correlation artifacts are valid. The difference is Agent Memory lifecycle evidence, not Agent Manifest checkpoint integrity.
+
+This is the executable version of:
+
+```text
+valid DEL != forgetting
+```
+
+## Negative outcomes remain evidence
+
+A failed Agent Manifest consistency proof produces the upstream `drift` verdict. P4.5b records that as:
+
+```text
+correlation_integrity = valid
+agent_manifest.delta_verification = rejected
+agent_manifest.delta_reason = drift
+```
+
+The correlation itself is valid because it correctly binds a negative external result. It does not mutate the negative result into an Agent Memory governance denial.
+
+By contrast, these are correlation-integrity failures:
+
+- the portable evidence does not verify against the canonical receipt;
+- the receipt does not reference the new checkpoint;
+- portable `before_ref` does not identify the previous checkpoint;
+- portable `after_ref` does not identify the new checkpoint.
+
+## Privacy boundary
+
+The correlation artifact contains checkpoint roots and metadata, not operation payloads. The executed deletion vector intentionally uses a memory key and value that are absent from the emitted correlation object.
+
+The upstream verifier receives the operation log because it owns checkpoint verification. P4.5b does not copy those operations into Agent Memory portable evidence or the correlation artifact.
+
+## Executed vectors
+
+`../../../reference/tests/test_agent_manifest_correlation.py` executes:
+
+- the exact `agent-manifest==0.11.0` package identity
+- the pinned upstream commit identity
+- the Agent Manifest v0.2 normative KV root vector
+- a valid RFC 9162 checkpoint advance containing `DEL`
+- canonical receipt to checkpoint-reference binding
+- portable before/after state to checkpoint-reference binding
+- accepted `DEL` plus Agent Memory lifecycle `residual`
+- accepted `DEL` plus Agent Memory lifecycle `satisfied`
+- rejected consistency proof surfaced as Agent Manifest `drift`
+- missing receipt checkpoint reference
+- tampered portable after-state binding
+- schema validation of the content-free correlation artifact
+- absence of the raw deleted key/value from the correlation artifact
+
+Run:
+
+```bash
+python -m pip install \
+  jsonschema==4.26.0 \
+  cryptography==50.0.0 \
+  agent-manifest==0.11.0
+python -m unittest discover -s reference/tests -t reference
+python scripts/validate_schemas.py
+```
+
+## What this slice proves
+
+P4.5b demonstrates that Agent Memory can correlate its canonical receipt and P4.5a portable evidence to Agent Manifest's existing memory checkpoint/delta protocol without duplicating that protocol or delegating memory semantics to it.
+
+It also executes the key non-escalation claim: an Agent Manifest-valid `DEL` checkpoint can coexist with either residual or satisfied Agent Memory lifecycle evidence.
+
+## What remains unproven
+
+This slice does not yet prove:
+
+- TRACE/AgenTrust external action-evidence interoperability (P4.5c)
+- production Agent Manifest trust/attestation deployment
+- hardware attestation of Agent Memory runtime state
+- multi-party checkpoint approval
+- a generic cross-standard checkpoint URI or registry
+- production key/trust-anchor distribution
+- any Agent Memory conformance level increase
+- acceptance of ADR-020, ADR-021, or ADR-022
+
+Those remain separate evidence gates.

--- a/docs/programs/runtime-evidence/agent-manifest-correlation.md
+++ b/docs/programs/runtime-evidence/agent-manifest-correlation.md
@@ -93,17 +93,21 @@ P4.5a portable evidence then binds:
 
 ```text
 canonical_receipt_ref
+memory_action
 state.before_ref = previous checkpoint_ref
 state.after_ref  = new checkpoint_ref
 ```
 
-P4.5b validates all three relationships:
+P4.5b validates all four relationships:
 
 1. the portable evidence signature resolves to the supplied canonical receipt;
-2. the receipt contains the new checkpoint reference in `evidence_refs`;
-3. the portable before/after state references match the previous/new checkpoint references.
+2. canonical receipt `selected_action` equals signed portable `memory_action`;
+3. the receipt contains the new checkpoint reference in `evidence_refs`;
+4. the portable before/after state references match the previous/new checkpoint references.
 
 The correlation artifact also records the pinned upstream spec/package/commit identity and the **upstream verifier's** `accepted/rejected` verdict and reason.
+
+Checkpoint projection is deliberately strict at the boundary: hash values must use a supported algorithm plus a 64-character lowercase hexadecimal digest, counters must be non-negative integers rather than booleans masquerading as integers, TTL must be positive, and approval time must be timezone-aware.
 
 ## What is not duplicated
 
@@ -167,6 +171,7 @@ The correlation itself is valid because it correctly binds a negative external r
 By contrast, these are correlation-integrity failures:
 
 - the portable evidence does not verify against the canonical receipt;
+- canonical receipt `selected_action` disagrees with signed portable `memory_action`;
 - the receipt does not reference the new checkpoint;
 - portable `before_ref` does not identify the previous checkpoint;
 - portable `after_ref` does not identify the new checkpoint.
@@ -187,11 +192,14 @@ The upstream verifier receives the operation log because it owns checkpoint veri
 - a valid RFC 9162 checkpoint advance whose upstream operation log contains `DEL`
 - canonical receipt to checkpoint-reference binding
 - portable before/after state to checkpoint-reference binding
+- canonical receipt action to signed portable memory-action binding
 - accepted checkpoint + signed Agent Memory `permanent_deletion` + lifecycle `residual`
 - accepted checkpoint + signed Agent Memory `permanent_deletion` + lifecycle `satisfied`
 - rejected consistency proof surfaced as Agent Manifest `drift`
 - missing receipt checkpoint reference
+- mismatched receipt/portable action
 - tampered portable after-state binding
+- malformed checkpoint root and timezone-less timestamp rejection
 - schema validation of the content-free correlation artifact
 - absence of the raw deleted key/value from the correlation artifact
 - absence of an unproven `operation_kind` claim from the correlation artifact

--- a/docs/programs/runtime-evidence/agent-manifest-correlation.md
+++ b/docs/programs/runtime-evidence/agent-manifest-correlation.md
@@ -120,22 +120,28 @@ Those are executed by `agent-manifest==0.11.0` in CI. The local correlation laye
 
 ## DEL is not forgetting
 
-Agent Manifest encodes a key-value deletion as an appended `DEL` operation. That proves a particular memory-log evolution when the checkpoint delta verifies. It does not prove that Agent Memory's semantic forgetting obligations are satisfied.
+Agent Manifest encodes a key-value deletion as an appended `DEL` operation. The P4.5b test constructs the upstream operation log with an actual `DEL` and then executes the upstream checkpoint verifier against that log.
 
-P4.5b executes the same accepted upstream `DEL` checkpoint in two Agent Memory outcomes:
+A crucial boundary follows: **the checkpoint root and consistency proof do not, by themselves, let a third party infer the semantic class of the appended operation without additional operation or inclusion evidence.** The correlation artifact therefore does not claim `operation_kind = DEL`. The deletion semantic is carried by signed Agent Memory `memory_action = permanent_deletion`; the fact that the executed comparator vector used a real upstream `DEL` remains an executable test fact.
+
+This avoids turning a known test input into a portable proof claim the checkpoint protocol does not make.
+
+P4.5b executes the same upstream-accepted checkpoint advance, whose test input contains `DEL`, in two Agent Memory outcomes:
 
 ```text
-Agent Manifest: accepted DEL
-Agent Memory:    committed deletion
-Lifecycle:       residual
+Agent Manifest: accepted checkpoint advance
+Test input:     appended DEL
+Agent Memory:   committed permanent_deletion
+Lifecycle:      residual
 ```
 
 and:
 
 ```text
-Agent Manifest: accepted DEL
-Agent Memory:    committed deletion
-Lifecycle:       satisfied
+Agent Manifest: accepted checkpoint advance
+Test input:     appended DEL
+Agent Memory:   committed permanent_deletion
+Lifecycle:      satisfied
 ```
 
 Both correlation artifacts are valid. The difference is Agent Memory lifecycle evidence, not Agent Manifest checkpoint integrity.
@@ -143,7 +149,7 @@ Both correlation artifacts are valid. The difference is Agent Memory lifecycle e
 This is the executable version of:
 
 ```text
-valid DEL != forgetting
+accepted checkpoint containing DEL != forgetting
 ```
 
 ## Negative outcomes remain evidence
@@ -169,7 +175,7 @@ By contrast, these are correlation-integrity failures:
 
 The correlation artifact contains checkpoint roots and metadata, not operation payloads. The executed deletion vector intentionally uses a memory key and value that are absent from the emitted correlation object.
 
-The upstream verifier receives the operation log because it owns checkpoint verification. P4.5b does not copy those operations into Agent Memory portable evidence or the correlation artifact.
+The upstream verifier receives the operation log because it owns checkpoint verification. P4.5b does not copy those operations into Agent Memory portable evidence or the correlation artifact. Avoiding an `operation_kind` claim also prevents the compact artifact from pretending to reveal semantics its root alone cannot establish.
 
 ## Executed vectors
 
@@ -178,16 +184,17 @@ The upstream verifier receives the operation log because it owns checkpoint veri
 - the exact `agent-manifest==0.11.0` package identity
 - the pinned upstream commit identity
 - the Agent Manifest v0.2 normative KV root vector
-- a valid RFC 9162 checkpoint advance containing `DEL`
+- a valid RFC 9162 checkpoint advance whose upstream operation log contains `DEL`
 - canonical receipt to checkpoint-reference binding
 - portable before/after state to checkpoint-reference binding
-- accepted `DEL` plus Agent Memory lifecycle `residual`
-- accepted `DEL` plus Agent Memory lifecycle `satisfied`
+- accepted checkpoint + signed Agent Memory `permanent_deletion` + lifecycle `residual`
+- accepted checkpoint + signed Agent Memory `permanent_deletion` + lifecycle `satisfied`
 - rejected consistency proof surfaced as Agent Manifest `drift`
 - missing receipt checkpoint reference
 - tampered portable after-state binding
 - schema validation of the content-free correlation artifact
 - absence of the raw deleted key/value from the correlation artifact
+- absence of an unproven `operation_kind` claim from the correlation artifact
 
 Run:
 
@@ -204,12 +211,13 @@ python scripts/validate_schemas.py
 
 P4.5b demonstrates that Agent Memory can correlate its canonical receipt and P4.5a portable evidence to Agent Manifest's existing memory checkpoint/delta protocol without duplicating that protocol or delegating memory semantics to it.
 
-It also executes the key non-escalation claim: an Agent Manifest-valid `DEL` checkpoint can coexist with either residual or satisfied Agent Memory lifecycle evidence.
+It also executes the key non-escalation claim: a checkpoint advance built from an upstream log containing `DEL` and accepted by the Agent Manifest verifier can coexist with either residual or satisfied Agent Memory lifecycle evidence.
 
 ## What remains unproven
 
 This slice does not yet prove:
 
+- a content-free third-party proof that a checkpoint's newly appended operation was specifically `DEL`; that would require an additional operation/inclusion-evidence convention rather than inference from the checkpoint root
 - TRACE/AgenTrust external action-evidence interoperability (P4.5c)
 - production Agent Manifest trust/attestation deployment
 - hardware attestation of Agent Memory runtime state

--- a/reference/README.md
+++ b/reference/README.md
@@ -2,7 +2,7 @@
 
 A minimal, executable demonstration that the governed path in
 [`../docs/programs/runtime-evidence/README.md`](../docs/programs/runtime-evidence/README.md)
-can be implemented over a temporal-graph substrate that provides no governance of its own, plus the substrate-independent P4.5a portable governance-evidence boundary.
+can be implemented over a temporal-graph substrate that provides no governance of its own, plus the P4.5 portable evidence and external-checkpoint correlation boundaries.
 
 ## What this is not
 
@@ -10,7 +10,7 @@ Read this section before citing anything in this directory.
 
 - **Not a conformance claim.** The emitted report states conformance level 0 and says why. The doctrine fixture corpus *is* now driven through the adapter's authority enforcement, but doc 06 levels are cumulative and this adapter implements neither decay nor calibrated saturation, so levels 2 and 3 are unmet however well enforcement does. Nothing here substantiates a level, a profile, or ADR-020.
 - **Not a reference implementation of Agent Memory.** It implements the narrow slices needed to exercise governance paths and portable evidence, and nothing else.
-- **Not an endorsement of any substrate or trust infrastructure.** The model reproduces one mapped substrate's verified semantics so the tests have something realistic to push against. The Ed25519 profile proves an evidence boundary, not a universal PKI.
+- **Not an endorsement of any substrate or trust infrastructure.** The model reproduces one mapped substrate's verified semantics so the tests have something realistic to push against. The Ed25519 profile proves an evidence boundary, not a universal PKI. The Agent Manifest package is a pinned external comparator, not a doctrine dependency.
 
 ## What it does demonstrate
 
@@ -24,6 +24,8 @@ Several things, at different evidential weight.
 
 **Against the P4.5a portable-evidence contract.** A content-free projection of a canonical decision receipt is signed with Ed25519 and verified using only the configured public trust key. The verifier independently checks receipt, runtime-action, policy, authority-state, temporal, and isolation-domain bindings while preserving governance disposition, runtime execution, and lifecycle satisfaction as separate outcomes. Adversarial vectors exercise tampering, replay, stale authority, wrong domains, key rotation, revocation timing, detached receipt verification, and valid deletion with residual lifecycle state.
 
+**Against the P4.5b Agent Manifest comparator.** CI installs `agent-manifest==0.11.0`, pinned to release commit `98cead8e8809e3302dc388ca869882d15b812b7f`, and executes its own v0.2 memory checkpoint/delta implementation. Agent Memory content-addresses the checkpoint tuple and binds it through the canonical receipt and P4.5a state references. The same upstream-accepted `DEL` checkpoint is exercised once with lifecycle `residual` and once with lifecycle `satisfied`, proving checkpoint integrity does not manufacture forgetting.
+
 The common point is that the governance layer is load-bearing. The substrate model is deliberately permissive in exactly the ways the mapping verified: identity is opaque rather than content-derived, the partition filter defaults to unfiltered, deletion is physical with no tombstone, and **no operation checks authority**. Several tests assert both halves: that the substrate *would* misbehave, and that the adapter refuses anyway. A test that only checked the adapter would not prove the governance was doing any work.
 
 ## Layout
@@ -31,28 +33,32 @@ The common point is that the governance layer is load-bearing. The substrate mod
 ```text
 reference/
   agentmem_ref/
-    substrate.py             port + permissive in-memory temporal graph
-    policy.py                PAMA evaluation: base table, class floors, modifiers
-    receipts.py              schema-conformant decisions, receipts, audit events
-    adapter.py               the governed path
-    fixture_conformance.py   drives the doctrine corpus through enforcement
-    projections.py           tier-3 declarations and the freshness relation
-    residue.py               deletion residue partition and independent sweep
-    projection_governance.py governed correction, purge, and rebuild
-    portable_evidence.py     P4.5a Ed25519 portable issuer/verifier
+    substrate.py                     port + permissive in-memory temporal graph
+    policy.py                        PAMA evaluation: base table, class floors, modifiers
+    receipts.py                      schema-conformant decisions, receipts, audit events
+    adapter.py                       the governed path
+    fixture_conformance.py           drives the doctrine corpus through enforcement
+    projections.py                   tier-3 declarations and the freshness relation
+    residue.py                       deletion residue partition and independent sweep
+    projection_governance.py         governed correction, purge, and rebuild
+    portable_evidence.py             P4.5a Ed25519 portable issuer/verifier
+    agent_manifest_correlation.py    P4.5b checkpoint correlation boundary
     (selectors live in adapter.py: deterministic and seeded stochastic)
-  agentmem_ref/graphiti_driver.py   binding to a real temporal knowledge graph
-  tests/                            model, real-substrate, and portable-evidence paths
+  agentmem_ref/graphiti_driver.py     binding to a real temporal knowledge graph
+  tests/                              model, real-substrate, and interoperability paths
   run_conformance.py
 ```
 
-Schema validation uses `jsonschema`. P4.5a Ed25519 signing and public-key verification use `cryptography`, added under the explicit dependency-justification rule in `../CONTRIBUTING.md`. CI pins the direct validation profile to `jsonschema==4.26.0` and `cryptography==50.0.0`. The low-cost fixture, doctrine-boundary, and link validators remain standard-library only.
+Schema validation uses `jsonschema`. P4.5a Ed25519 signing and public-key verification use `cryptography`, added under the explicit dependency-justification rule in `../CONTRIBUTING.md`. P4.5b uses `agent-manifest==0.11.0` as a test-only comparator and does not import it from production reference modules. CI pins the direct validation profile to `jsonschema==4.26.0`, `cryptography==50.0.0`, and `agent-manifest==0.11.0`. The low-cost fixture, doctrine-boundary, and link validators remain standard-library only.
 
 ## Running it
 
 ```bash
-# reference model and portable-evidence paths
-python -m pip install jsonschema==4.26.0 cryptography==50.0.0
+# reference model and interoperability paths
+python -m pip install \
+  jsonschema==4.26.0 \
+  cryptography==50.0.0 \
+  agent-manifest==0.11.0
 python -m unittest discover -s reference/tests -t reference
 
 # stochastic containment sweep with an explicit trial count
@@ -64,7 +70,7 @@ python -m unittest discover -s reference/tests -t reference
 python reference/run_conformance.py
 ```
 
-Runs are deterministic where the contract requires determinism: identifiers are counter-based and the clock is injected, so repeated governed-adapter runs produce identical receipts and identical reports. Stochastic selection is seeded per trial, so it varies across trials and reproduces exactly for a given seed. Ed25519 signatures are deterministic for a fixed private key and canonical payload.
+Runs are deterministic where the contract requires determinism: identifiers are counter-based and the clock is injected, so repeated governed-adapter runs produce identical receipts and identical reports. Stochastic selection is seeded per trial, so it varies across trials and reproduces exactly for a given seed. Ed25519 signatures are deterministic for a fixed private key and canonical payload. P4.5b pins the external package version and upstream release commit so comparator drift is explicit rather than accidental.
 
 ## The governed path
 
@@ -74,7 +80,7 @@ evidence -> proposal -> authority envelope -> permitted action set
          -> retrieval candidate -> governed admission -> active context
 ```
 
-The adapter supplies what the substrate cannot: an authority gate before every write, always-explicit scope filtering, external lifecycle state, tombstones, and receipts. Artifacts are emitted against schemas already canonical in this repository rather than shapes invented beside the implementation: `pama-decision`, `decision-receipt`, `memory-audit-event`, `conformance-report`, and the P4.5a `portable-governance-evidence` projection.
+The adapter supplies what the substrate cannot: an authority gate before every write, always-explicit scope filtering, external lifecycle state, tombstones, and receipts. Artifacts are emitted against schemas already canonical in this repository rather than shapes invented beside the implementation: `pama-decision`, `decision-receipt`, `memory-audit-event`, `conformance-report`, P4.5a `portable-governance-evidence`, and P4.5b `agent-manifest-memory-correlation`.
 
 ## Paths exercised
 
@@ -103,6 +109,10 @@ The adapter supplies what the substrate cannot: an authority gate before every w
 | portable receipt binding | Ed25519 evidence binds the canonical receipt reference, action, policy, authority state, time, and optional isolation domains |
 | portable negative outcomes | authentic denial, unauthorized execution, and residual lifecycle state remain distinct machine-readable outcomes |
 | portable replay and trust failures | wrong action/domain/state, signature tampering, unknown issuer, rotation, and revocation timing are exercised |
+| Agent Manifest normative root | the pinned upstream implementation reproduces the v0.2 KV memory-root vector |
+| Agent Manifest DEL correlation | upstream verifier accepts an RFC 9162 delta containing `DEL`; canonical receipt and portable state refs bind the checkpoint |
+| DEL versus forgetting | the same accepted checkpoint remains compatible with either residual or satisfied Agent Memory lifecycle evidence |
+| external negative outcome | invalid consistency proof yields upstream `drift` while the correlation remains a valid record of a rejected delta |
 
 ## Known limitations
 
@@ -116,4 +126,5 @@ Stated rather than left to be discovered:
 6. Derived-state governance operates on an adapter-owned sidecar. The design spike names this as the obvious home for substrates that cannot store a projection declaration, and notes that it reintroduces the consistency problem one level up. That trade is accepted here rather than solved.
 7. Residue is measured over declared projections. State that was never declared is outside the sweep's reach by construction, which is why the declaration surface is the load-bearing part rather than the traversal.
 8. The P4.5a trust profile assumes configured Ed25519 public trust keys. Production key custody, trust discovery, certificates, and external revocation infrastructure remain outside this slice.
-9. P4.5a is substrate-independent interoperability evidence. Agent Manifest and TRACE correlation remain P4.5b/P4.5c and must be demonstrated separately.
+9. P4.5b intentionally imports Agent Manifest private checkpoint modules only in its pinned comparator tests because the upstream implementation issue and specification surface those exact functions. This is not a stable production API commitment and is isolated from Agent Memory runtime code.
+10. P4.5b proves checkpoint/delta correlation, not hardware attestation of an Agent Memory process and not TRACE action-evidence interoperability. TRACE remains P4.5c.

--- a/reference/README.md
+++ b/reference/README.md
@@ -24,7 +24,7 @@ Several things, at different evidential weight.
 
 **Against the P4.5a portable-evidence contract.** A content-free projection of a canonical decision receipt is signed with Ed25519 and verified using only the configured public trust key. The verifier independently checks receipt, runtime-action, policy, authority-state, temporal, and isolation-domain bindings while preserving governance disposition, runtime execution, and lifecycle satisfaction as separate outcomes. Adversarial vectors exercise tampering, replay, stale authority, wrong domains, key rotation, revocation timing, detached receipt verification, and valid deletion with residual lifecycle state.
 
-**Against the P4.5b Agent Manifest comparator.** CI installs `agent-manifest==0.11.0`, pinned to release commit `98cead8e8809e3302dc388ca869882d15b812b7f`, and executes its own v0.2 memory checkpoint/delta implementation. Agent Memory content-addresses the checkpoint tuple and binds it through the canonical receipt and P4.5a state references. The same upstream-accepted `DEL` checkpoint is exercised once with lifecycle `residual` and once with lifecycle `satisfied`, proving checkpoint integrity does not manufacture forgetting.
+**Against the P4.5b Agent Manifest comparator.** CI installs `agent-manifest==0.11.0`, pinned to release commit `98cead8e8809e3302dc388ca869882d15b812b7f`, and executes its own v0.2 memory checkpoint/delta implementation. Agent Memory content-addresses the checkpoint tuple and binds it through the canonical receipt and P4.5a state references. The executed upstream log appends a real `DEL`; the resulting accepted checkpoint is exercised once with lifecycle `residual` and once with lifecycle `satisfied`, proving checkpoint integrity does not manufacture forgetting. Because a checkpoint root alone does not disclose the appended operation class, the portable correlation artifact deliberately carries signed Agent Memory `memory_action` rather than an unproven Agent Manifest `operation_kind` claim.
 
 The common point is that the governance layer is load-bearing. The substrate model is deliberately permissive in exactly the ways the mapping verified: identity is opaque rather than content-derived, the partition filter defaults to unfiltered, deletion is physical with no tombstone, and **no operation checks authority**. Several tests assert both halves: that the substrate *would* misbehave, and that the adapter refuses anyway. A test that only checked the adapter would not prove the governance was doing any work.
 
@@ -110,8 +110,8 @@ The adapter supplies what the substrate cannot: an authority gate before every w
 | portable negative outcomes | authentic denial, unauthorized execution, and residual lifecycle state remain distinct machine-readable outcomes |
 | portable replay and trust failures | wrong action/domain/state, signature tampering, unknown issuer, rotation, and revocation timing are exercised |
 | Agent Manifest normative root | the pinned upstream implementation reproduces the v0.2 KV memory-root vector |
-| Agent Manifest DEL correlation | upstream verifier accepts an RFC 9162 delta containing `DEL`; canonical receipt and portable state refs bind the checkpoint |
-| DEL versus forgetting | the same accepted checkpoint remains compatible with either residual or satisfied Agent Memory lifecycle evidence |
+| Agent Manifest deletion-vector correlation | the upstream verifier accepts an RFC 9162 checkpoint built from a log whose appended test operation is `DEL`; canonical receipt and portable state refs bind the checkpoint |
+| DEL versus forgetting | that accepted checkpoint remains compatible with either residual or satisfied Agent Memory lifecycle evidence |
 | external negative outcome | invalid consistency proof yields upstream `drift` while the correlation remains a valid record of a rejected delta |
 
 ## Known limitations
@@ -127,4 +127,5 @@ Stated rather than left to be discovered:
 7. Residue is measured over declared projections. State that was never declared is outside the sweep's reach by construction, which is why the declaration surface is the load-bearing part rather than the traversal.
 8. The P4.5a trust profile assumes configured Ed25519 public trust keys. Production key custody, trust discovery, certificates, and external revocation infrastructure remain outside this slice.
 9. P4.5b intentionally imports Agent Manifest private checkpoint modules only in its pinned comparator tests because the upstream implementation issue and specification surface those exact functions. This is not a stable production API commitment and is isolated from Agent Memory runtime code.
-10. P4.5b proves checkpoint/delta correlation, not hardware attestation of an Agent Memory process and not TRACE action-evidence interoperability. TRACE remains P4.5c.
+10. An Agent Manifest checkpoint root proves the bound log state but does not independently reveal the semantic class of a new operation. P4.5b demonstrates a real upstream `DEL` through executed test input; a compact content-free third-party proof of operation class would require additional upstream operation/inclusion evidence and is not invented here.
+11. P4.5b proves checkpoint/delta correlation, not hardware attestation of an Agent Memory process and not TRACE action-evidence interoperability. TRACE remains P4.5c.

--- a/reference/agentmem_ref/agent_manifest_correlation.py
+++ b/reference/agentmem_ref/agent_manifest_correlation.py
@@ -1,8 +1,8 @@
 """P4.5b correlation with the Agent Manifest memory checkpoint protocol.
 
 Agent Manifest owns checkpoint construction, RFC 9162 consistency proofs, TTL,
-sequence, and delta-budget verification.  This module does not reimplement that
-protocol.  It content-addresses the checkpoint tuple, proves that the canonical
+sequence, and delta-budget verification. This module does not reimplement that
+protocol. It content-addresses the checkpoint tuple, proves that the canonical
 Agent Memory receipt references that checkpoint, and preserves the external
 checkpoint verdict beside Agent Memory governance and lifecycle outcomes.
 """
@@ -51,7 +51,7 @@ def checkpoint_payload(checkpoint: object) -> dict:
     """Project only fields Agent Manifest v0.2 binds into a checkpoint.
 
     The upstream protocol defines the bound tuple as
-    ``{memory_root, tree_size, seq, approved_at, ttl_seconds}``.  We preserve
+    ``{memory_root, tree_size, seq, approved_at, ttl_seconds}``. We preserve
     exactly that tuple here and intentionally omit operation content and the
     upstream verifier's internal proof representation.
     """
@@ -99,12 +99,12 @@ def correlate_agent_manifest_delta(
     """Bind an externally verified Agent Manifest delta to Agent Memory evidence.
 
     ``delta_accepted`` and ``delta_reason`` MUST come from the pinned Agent
-    Manifest verifier (or another conforming implementation).  This function
+    Manifest verifier (or another conforming implementation). This function
     never recomputes a consistency proof, TTL verdict, sequence verdict, or
     delta budget; those semantics remain owned by Agent Manifest.
 
     A rejected delta still yields a valid correlation artifact when the records
-    are correctly bound.  Likewise, an accepted ``DEL`` never upgrades Agent
+    are correctly bound. Likewise, an accepted ``DEL`` never upgrades Agent
     Memory lifecycle satisfaction from ``residual`` to ``satisfied``.
     """
     if delta_reason not in DELTA_REASONS:
@@ -118,6 +118,7 @@ def correlate_agent_manifest_delta(
 
     previous = checkpoint_payload(previous_checkpoint)
     new = checkpoint_payload(new_checkpoint)
+    previous_ref = checkpoint_reference(previous_checkpoint)
     checkpoint_ref = checkpoint_reference(new_checkpoint)
 
     failures: list[str] = []
@@ -134,6 +135,15 @@ def correlate_agent_manifest_delta(
     evidence_refs = canonical_receipt.get("evidence_refs", [])
     if not isinstance(evidence_refs, list) or checkpoint_ref not in evidence_refs:
         failures.append("receipt_missing_checkpoint_ref")
+
+    state = portable_evidence.get("state")
+    if not isinstance(state, Mapping):
+        failures.append("portable_state_binding_missing")
+    else:
+        if state.get("before_ref") != previous_ref:
+            failures.append("before_checkpoint_ref_mismatch")
+        if state.get("after_ref") != checkpoint_ref:
+            failures.append("after_checkpoint_ref_mismatch")
 
     governance = portable_evidence.get("governance")
     if not isinstance(governance, Mapping):

--- a/reference/agentmem_ref/agent_manifest_correlation.py
+++ b/reference/agentmem_ref/agent_manifest_correlation.py
@@ -26,6 +26,7 @@ AGENT_MANIFEST_UPSTREAM_COMMIT = "98cead8e8809e3302dc388ca869882d15b812b7f"
 
 DELTA_REASONS = {"accepted", "drift", "rollback", "expired", "budget"}
 REPRESENTATIONS = {"kv", "vector", "graph"}
+_HASH_ALGORITHMS = {"sha256", "shake256"}
 
 
 def _value(checkpoint: object, name: str) -> object:
@@ -39,15 +40,41 @@ def _value(checkpoint: object, name: str) -> object:
         raise ValueError(f"checkpoint missing {name}") from exc
 
 
+def _parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("checkpoint approved_at must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
 def _timestamp(value: object) -> str:
     if isinstance(value, datetime):
         if value.tzinfo is None:
-            value = value.replace(tzinfo=timezone.utc)
-        text = value.astimezone(timezone.utc).isoformat()
-        return text.replace("+00:00", "Z")
-    if isinstance(value, str) and value:
-        return value
-    raise ValueError("checkpoint approved_at must be a datetime or non-empty string")
+            raise ValueError("checkpoint approved_at must include a timezone")
+        parsed = value.astimezone(timezone.utc)
+    elif isinstance(value, str) and value:
+        try:
+            parsed = _parse_timestamp(value)
+        except ValueError as exc:
+            raise ValueError("checkpoint approved_at must be a valid timezone-aware datetime") from exc
+    else:
+        raise ValueError("checkpoint approved_at must be a datetime or non-empty string")
+    return parsed.isoformat().replace("+00:00", "Z")
+
+
+def _validate_hashvalue(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("checkpoint memory_root must be a HashValue")
+    algorithm, sep, digest = value.partition(":")
+    if (
+        not sep
+        or algorithm not in _HASH_ALGORITHMS
+        or len(digest) != 64
+        or digest != digest.lower()
+        or any(char not in "0123456789abcdef" for char in digest)
+    ):
+        raise ValueError("checkpoint memory_root must be sha256/shake256 plus 64 lowercase hex characters")
+    return value
 
 
 def checkpoint_payload(checkpoint: object) -> dict:
@@ -58,19 +85,17 @@ def checkpoint_payload(checkpoint: object) -> dict:
     exactly that tuple here and intentionally omit operation content and the
     upstream verifier's internal proof representation.
     """
-    memory_root = _value(checkpoint, "memory_root")
+    memory_root = _validate_hashvalue(_value(checkpoint, "memory_root"))
     tree_size = _value(checkpoint, "tree_size")
     seq = _value(checkpoint, "seq")
     ttl_seconds = _value(checkpoint, "ttl_seconds")
     approved_at = _timestamp(_value(checkpoint, "approved_at"))
 
-    if not isinstance(memory_root, str) or not memory_root.startswith(("sha256:", "shake256:")):
-        raise ValueError("checkpoint memory_root must be a HashValue")
-    if not isinstance(tree_size, int) or tree_size < 0:
+    if not isinstance(tree_size, int) or isinstance(tree_size, bool) or tree_size < 0:
         raise ValueError("checkpoint tree_size must be a non-negative integer")
-    if not isinstance(seq, int) or seq < 0:
+    if not isinstance(seq, int) or isinstance(seq, bool) or seq < 0:
         raise ValueError("checkpoint seq must be a non-negative integer")
-    if not isinstance(ttl_seconds, int) or ttl_seconds <= 0:
+    if not isinstance(ttl_seconds, int) or isinstance(ttl_seconds, bool) or ttl_seconds <= 0:
         raise ValueError("checkpoint ttl_seconds must be a positive integer")
 
     return {
@@ -132,6 +157,10 @@ def correlate_agent_manifest_delta(
     if portable_result["receipt_resolution"] != "resolved":
         failures.append("canonical_receipt_not_resolved")
 
+    memory_action = portable_evidence.get("memory_action")
+    if canonical_receipt.get("selected_action") != memory_action:
+        failures.append("receipt_memory_action_mismatch")
+
     evidence_refs = canonical_receipt.get("evidence_refs", [])
     if not isinstance(evidence_refs, list) or checkpoint_ref not in evidence_refs:
         failures.append("receipt_missing_checkpoint_ref")
@@ -158,7 +187,7 @@ def correlate_agent_manifest_delta(
             "portable_evidence_ref": sha256_ref(dict(portable_evidence)),
             "canonical_receipt_ref": portable_evidence.get("canonical_receipt_ref", ""),
             "action_ref": portable_evidence.get("action_ref", ""),
-            "memory_action": portable_evidence.get("memory_action", ""),
+            "memory_action": memory_action or "",
             "governance_disposition": governance.get("disposition", "unverifiable"),
             "lifecycle_satisfaction": portable_evidence.get("lifecycle_result", "unverifiable"),
         },

--- a/reference/agentmem_ref/agent_manifest_correlation.py
+++ b/reference/agentmem_ref/agent_manifest_correlation.py
@@ -1,0 +1,166 @@
+"""P4.5b correlation with the Agent Manifest memory checkpoint protocol.
+
+Agent Manifest owns checkpoint construction, RFC 9162 consistency proofs, TTL,
+sequence, and delta-budget verification.  This module does not reimplement that
+protocol.  It content-addresses the checkpoint tuple, proves that the canonical
+Agent Memory receipt references that checkpoint, and preserves the external
+checkpoint verdict beside Agent Memory governance and lifecycle outcomes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Mapping
+
+from .portable_evidence import TrustKey, sha256_ref, verify_evidence
+
+CORRELATION_TYPE = "agent-memory-agent-manifest-correlation"
+CORRELATION_VERSION = "1.0.0"
+AGENT_MANIFEST_SPEC_VERSION = "0.2"
+AGENT_MANIFEST_SDK_VERSION = "0.11.0"
+AGENT_MANIFEST_UPSTREAM_COMMIT = "98cead8e8809e3302dc388ca869882d15b812b7f"
+
+DELTA_REASONS = {"accepted", "drift", "rollback", "expired", "budget"}
+REPRESENTATIONS = {"kv", "vector", "graph"}
+OPERATION_KINDS = {"PUT", "DEL", "ADD"}
+
+
+def _value(checkpoint: object, name: str) -> object:
+    if isinstance(checkpoint, Mapping):
+        if name not in checkpoint:
+            raise ValueError(f"checkpoint missing {name}")
+        return checkpoint[name]
+    try:
+        return getattr(checkpoint, name)
+    except AttributeError as exc:
+        raise ValueError(f"checkpoint missing {name}") from exc
+
+
+def _timestamp(value: object) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        text = value.astimezone(timezone.utc).isoformat()
+        return text.replace("+00:00", "Z")
+    if isinstance(value, str) and value:
+        return value
+    raise ValueError("checkpoint approved_at must be a datetime or non-empty string")
+
+
+def checkpoint_payload(checkpoint: object) -> dict:
+    """Project only fields Agent Manifest v0.2 binds into a checkpoint.
+
+    The upstream protocol defines the bound tuple as
+    ``{memory_root, tree_size, seq, approved_at, ttl_seconds}``.  We preserve
+    exactly that tuple here and intentionally omit operation content and the
+    upstream verifier's internal proof representation.
+    """
+    memory_root = _value(checkpoint, "memory_root")
+    tree_size = _value(checkpoint, "tree_size")
+    seq = _value(checkpoint, "seq")
+    ttl_seconds = _value(checkpoint, "ttl_seconds")
+    approved_at = _timestamp(_value(checkpoint, "approved_at"))
+
+    if not isinstance(memory_root, str) or not memory_root.startswith(("sha256:", "shake256:")):
+        raise ValueError("checkpoint memory_root must be a HashValue")
+    if not isinstance(tree_size, int) or tree_size < 0:
+        raise ValueError("checkpoint tree_size must be a non-negative integer")
+    if not isinstance(seq, int) or seq < 0:
+        raise ValueError("checkpoint seq must be a non-negative integer")
+    if not isinstance(ttl_seconds, int) or ttl_seconds <= 0:
+        raise ValueError("checkpoint ttl_seconds must be a positive integer")
+
+    return {
+        "memory_root": memory_root,
+        "tree_size": tree_size,
+        "seq": seq,
+        "approved_at": approved_at,
+        "ttl_seconds": ttl_seconds,
+    }
+
+
+def checkpoint_reference(checkpoint: object) -> str:
+    """Return a content-addressed reference suitable for receipt.evidence_refs."""
+    return sha256_ref(checkpoint_payload(checkpoint))
+
+
+def correlate_agent_manifest_delta(
+    portable_evidence: Mapping[str, object],
+    canonical_receipt: Mapping[str, object],
+    trust_keys: Mapping[tuple[str, str], TrustKey],
+    *,
+    previous_checkpoint: object,
+    new_checkpoint: object,
+    delta_accepted: bool,
+    delta_reason: str,
+    representation: str,
+    operation_kind: str,
+) -> dict:
+    """Bind an externally verified Agent Manifest delta to Agent Memory evidence.
+
+    ``delta_accepted`` and ``delta_reason`` MUST come from the pinned Agent
+    Manifest verifier (or another conforming implementation).  This function
+    never recomputes a consistency proof, TTL verdict, sequence verdict, or
+    delta budget; those semantics remain owned by Agent Manifest.
+
+    A rejected delta still yields a valid correlation artifact when the records
+    are correctly bound.  Likewise, an accepted ``DEL`` never upgrades Agent
+    Memory lifecycle satisfaction from ``residual`` to ``satisfied``.
+    """
+    if delta_reason not in DELTA_REASONS:
+        raise ValueError(f"unsupported Agent Manifest delta reason: {delta_reason}")
+    if delta_accepted != (delta_reason == "accepted"):
+        raise ValueError("delta_accepted and delta_reason disagree")
+    if representation not in REPRESENTATIONS:
+        raise ValueError(f"unsupported memory representation: {representation}")
+    if operation_kind not in OPERATION_KINDS:
+        raise ValueError(f"unsupported operation kind: {operation_kind}")
+
+    previous = checkpoint_payload(previous_checkpoint)
+    new = checkpoint_payload(new_checkpoint)
+    checkpoint_ref = checkpoint_reference(new_checkpoint)
+
+    failures: list[str] = []
+    portable_result = verify_evidence(
+        portable_evidence,
+        trust_keys,
+        canonical_receipt=canonical_receipt,
+    )
+    if portable_result["evidence_integrity"] != "valid":
+        failures.append("portable_evidence_invalid")
+    if portable_result["receipt_resolution"] != "resolved":
+        failures.append("canonical_receipt_not_resolved")
+
+    evidence_refs = canonical_receipt.get("evidence_refs", [])
+    if not isinstance(evidence_refs, list) or checkpoint_ref not in evidence_refs:
+        failures.append("receipt_missing_checkpoint_ref")
+
+    governance = portable_evidence.get("governance")
+    if not isinstance(governance, Mapping):
+        governance = {}
+
+    return {
+        "correlation_type": CORRELATION_TYPE,
+        "version": CORRELATION_VERSION,
+        "correlation_integrity": "valid" if not failures else "invalid",
+        "binding_failures": failures,
+        "agent_memory": {
+            "portable_evidence_ref": sha256_ref(dict(portable_evidence)),
+            "canonical_receipt_ref": portable_evidence.get("canonical_receipt_ref", ""),
+            "action_ref": portable_evidence.get("action_ref", ""),
+            "governance_disposition": governance.get("disposition", "unverifiable"),
+            "lifecycle_satisfaction": portable_evidence.get("lifecycle_result", "unverifiable"),
+        },
+        "agent_manifest": {
+            "spec_version": AGENT_MANIFEST_SPEC_VERSION,
+            "sdk_version": AGENT_MANIFEST_SDK_VERSION,
+            "upstream_commit": AGENT_MANIFEST_UPSTREAM_COMMIT,
+            "representation": representation,
+            "operation_kind": operation_kind,
+            "checkpoint_ref": checkpoint_ref,
+            "previous_checkpoint": previous,
+            "new_checkpoint": new,
+            "delta_verification": "accepted" if delta_accepted else "rejected",
+            "delta_reason": delta_reason,
+        },
+    }

--- a/reference/agentmem_ref/agent_manifest_correlation.py
+++ b/reference/agentmem_ref/agent_manifest_correlation.py
@@ -5,6 +5,10 @@ sequence, and delta-budget verification. This module does not reimplement that
 protocol. It content-addresses the checkpoint tuple, proves that the canonical
 Agent Memory receipt references that checkpoint, and preserves the external
 checkpoint verdict beside Agent Memory governance and lifecycle outcomes.
+
+A checkpoint root proves the bound log state; it does not, by itself, disclose
+or independently prove the semantic class of a newly appended operation. Agent
+Memory action semantics therefore remain in the signed Agent Memory evidence.
 """
 
 from __future__ import annotations
@@ -22,7 +26,6 @@ AGENT_MANIFEST_UPSTREAM_COMMIT = "98cead8e8809e3302dc388ca869882d15b812b7f"
 
 DELTA_REASONS = {"accepted", "drift", "rollback", "expired", "budget"}
 REPRESENTATIONS = {"kv", "vector", "graph"}
-OPERATION_KINDS = {"PUT", "DEL", "ADD"}
 
 
 def _value(checkpoint: object, name: str) -> object:
@@ -94,18 +97,17 @@ def correlate_agent_manifest_delta(
     delta_accepted: bool,
     delta_reason: str,
     representation: str,
-    operation_kind: str,
 ) -> dict:
     """Bind an externally verified Agent Manifest delta to Agent Memory evidence.
 
     ``delta_accepted`` and ``delta_reason`` MUST come from the pinned Agent
     Manifest verifier (or another conforming implementation). This function
-    never recomputes a consistency proof, TTL verdict, sequence verdict, or
-    delta budget; those semantics remain owned by Agent Manifest.
+    never recomputes a consistency proof, TTL verdict, sequence verdict, delta
+    budget, or operation semantics; those remain owned by their source systems.
 
     A rejected delta still yields a valid correlation artifact when the records
-    are correctly bound. Likewise, an accepted ``DEL`` never upgrades Agent
-    Memory lifecycle satisfaction from ``residual`` to ``satisfied``.
+    are correctly bound. Likewise, an accepted checkpoint advance never upgrades
+    Agent Memory lifecycle satisfaction from ``residual`` to ``satisfied``.
     """
     if delta_reason not in DELTA_REASONS:
         raise ValueError(f"unsupported Agent Manifest delta reason: {delta_reason}")
@@ -113,8 +115,6 @@ def correlate_agent_manifest_delta(
         raise ValueError("delta_accepted and delta_reason disagree")
     if representation not in REPRESENTATIONS:
         raise ValueError(f"unsupported memory representation: {representation}")
-    if operation_kind not in OPERATION_KINDS:
-        raise ValueError(f"unsupported operation kind: {operation_kind}")
 
     previous = checkpoint_payload(previous_checkpoint)
     new = checkpoint_payload(new_checkpoint)
@@ -158,6 +158,7 @@ def correlate_agent_manifest_delta(
             "portable_evidence_ref": sha256_ref(dict(portable_evidence)),
             "canonical_receipt_ref": portable_evidence.get("canonical_receipt_ref", ""),
             "action_ref": portable_evidence.get("action_ref", ""),
+            "memory_action": portable_evidence.get("memory_action", ""),
             "governance_disposition": governance.get("disposition", "unverifiable"),
             "lifecycle_satisfaction": portable_evidence.get("lifecycle_result", "unverifiable"),
         },
@@ -166,7 +167,6 @@ def correlate_agent_manifest_delta(
             "sdk_version": AGENT_MANIFEST_SDK_VERSION,
             "upstream_commit": AGENT_MANIFEST_UPSTREAM_COMMIT,
             "representation": representation,
-            "operation_kind": operation_kind,
             "checkpoint_ref": checkpoint_ref,
             "previous_checkpoint": previous,
             "new_checkpoint": new,

--- a/reference/tests/test_agent_manifest_correlation.py
+++ b/reference/tests/test_agent_manifest_correlation.py
@@ -36,6 +36,7 @@ except ImportError:  # local low-dependency runs may omit the comparator
 from agentmem_ref.agent_manifest_correlation import (  # noqa: E402
     AGENT_MANIFEST_SDK_VERSION,
     AGENT_MANIFEST_UPSTREAM_COMMIT,
+    checkpoint_payload,
     checkpoint_reference,
     correlate_agent_manifest_delta,
 )
@@ -90,17 +91,24 @@ class AgentManifestCorrelationTests(unittest.TestCase):
             now=APPROVED_AT + timedelta(seconds=5),
         )
 
-    def _receipt_and_evidence(self, lifecycle_result: str = "residual", *, include_checkpoint: bool = True):
+    def _receipt_and_evidence(
+        self,
+        lifecycle_result: str = "residual",
+        *,
+        include_checkpoint: bool = True,
+        receipt_action: str = "permanent_deletion",
+        portable_action: str = "permanent_deletion",
+    ):
         previous_ref = checkpoint_reference(self.previous)
         new_ref = checkpoint_reference(self.new)
         receipt = {
             "schema_version": "1.0.0",
             "receipt_id": "receipt:manifest-del:8",
             "memory_id": "mem:alpha",
-            "requested_action": "permanent_deletion",
+            "requested_action": receipt_action,
             "policy_version": "pama-2026-08",
-            "permitted_actions": ["permanent_deletion"],
-            "selected_action": "permanent_deletion",
+            "permitted_actions": [receipt_action],
+            "selected_action": receipt_action,
             "selection_mode": "deterministic",
             "evidence_refs": [new_ref] if include_checkpoint else [],
             "timestamp": "2026-08-11T20:00:01Z",
@@ -111,7 +119,7 @@ class AgentManifestCorrelationTests(unittest.TestCase):
             key=KEY,
             issued_at="2026-08-11T20:00:02Z",
             action_ref="action:delete:manifest:8",
-            memory_action="permanent_deletion",
+            memory_action=portable_action,
             governance_disposition="committed",
             policy_ref="policy:pama-2026-08",
             authority_state_ref="authority:rev-21",
@@ -200,6 +208,26 @@ class AgentManifestCorrelationTests(unittest.TestCase):
         self.assertEqual(correlation["correlation_integrity"], "invalid")
         self.assertIn("receipt_missing_checkpoint_ref", correlation["binding_failures"])
 
+    def test_receipt_action_must_match_signed_portable_memory_action(self):
+        receipt, evidence = self._receipt_and_evidence(
+            "residual",
+            receipt_action="retain",
+            portable_action="permanent_deletion",
+        )
+        correlation = correlate_agent_manifest_delta(
+            evidence,
+            receipt,
+            self.trust,
+            previous_checkpoint=self.previous,
+            new_checkpoint=self.new,
+            delta_accepted=self.verdict.accepted,
+            delta_reason=self.verdict.reason,
+            representation="kv",
+        )
+        self.assertEqual(correlation["correlation_integrity"], "invalid")
+        self.assertNotIn("portable_evidence_invalid", correlation["binding_failures"])
+        self.assertIn("receipt_memory_action_mismatch", correlation["binding_failures"])
+
     def test_portable_before_and_after_state_must_match_checkpoint_refs(self):
         receipt, evidence = self._receipt_and_evidence("residual")
         evidence["state"]["after_ref"] = checkpoint_reference(self.previous)
@@ -216,6 +244,23 @@ class AgentManifestCorrelationTests(unittest.TestCase):
         self.assertEqual(correlation["correlation_integrity"], "invalid")
         self.assertIn("portable_evidence_invalid", correlation["binding_failures"])
         self.assertIn("after_checkpoint_ref_mismatch", correlation["binding_failures"])
+
+    def test_checkpoint_projection_rejects_malformed_hash_and_naive_time(self):
+        bad_hash = {
+            "memory_root": "sha256:not-a-digest",
+            "tree_size": 1,
+            "seq": 1,
+            "approved_at": "2026-08-11T20:00:00Z",
+            "ttl_seconds": 3600,
+        }
+        with self.assertRaises(ValueError):
+            checkpoint_payload(bad_hash)
+
+        naive_time = dict(bad_hash)
+        naive_time["memory_root"] = "sha256:" + ("0" * 64)
+        naive_time["approved_at"] = "2026-08-11T20:00:00"
+        with self.assertRaises(ValueError):
+            checkpoint_payload(naive_time)
 
     def test_correlation_artifact_is_content_free_and_schema_valid(self):
         correlation = self._correlate("residual")

--- a/reference/tests/test_agent_manifest_correlation.py
+++ b/reference/tests/test_agent_manifest_correlation.py
@@ -1,0 +1,231 @@
+"""P4.5b Agent Manifest memory checkpoint correlation.
+
+The upstream Agent Manifest implementation owns checkpoint/delta verification.
+These tests import the pinned release directly, execute its RFC 9162 path, and
+then prove that Agent Memory can correlate to the accepted or rejected checkpoint
+without treating checkpoint integrity as memory-governance or forgetting proof.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import jsonschema
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+try:
+    from agent_manifest._memory_delta import (  # type: ignore[import-not-found]
+        MemoryCheckpoint,
+        build_memory_tree,
+        memory_merkletree,
+        verify_delta,
+    )
+except ImportError:  # local low-dependency runs may omit the comparator
+    MemoryCheckpoint = None  # type: ignore[assignment,misc]
+    build_memory_tree = None  # type: ignore[assignment]
+    memory_merkletree = None  # type: ignore[assignment]
+    verify_delta = None  # type: ignore[assignment]
+
+from agentmem_ref.agent_manifest_correlation import (  # noqa: E402
+    AGENT_MANIFEST_SDK_VERSION,
+    AGENT_MANIFEST_UPSTREAM_COMMIT,
+    checkpoint_reference,
+    correlate_agent_manifest_delta,
+)
+from agentmem_ref.portable_evidence import IssuerKey, issue_evidence  # noqa: E402
+
+ISSUER = "issuer:agent-memory-reference"
+KEY = IssuerKey(
+    issuer_id=ISSUER,
+    key_id="key-2026-08",
+    private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(1, 33))),
+    valid_from="2026-08-01T00:00:00Z",
+    valid_until="2026-08-31T23:59:59Z",
+)
+APPROVED_AT = datetime(2026, 8, 11, 20, 0, 0, tzinfo=timezone.utc)
+
+
+@unittest.skipIf(MemoryCheckpoint is None, "agent-manifest comparator is not installed")
+class AgentManifestCorrelationTests(unittest.TestCase):
+    def setUp(self):
+        trust = KEY.trust_key()
+        self.trust = {(trust.issuer_id, trust.key_id): trust}
+        self.before_ops = [
+            {"op": "PUT", "key": "memory:key:alpha", "value": "secret-memory-value"},
+        ]
+        self.after_ops = [
+            *self.before_ops,
+            {"op": "DEL", "key": "memory:key:alpha"},
+        ]
+        self.previous = MemoryCheckpoint.from_ops(
+            self.before_ops,
+            "kv",
+            seq=7,
+            approved_at=APPROVED_AT,
+            ttl_seconds=3600,
+            max_delta_fraction=1.0,
+        )
+        self.new = MemoryCheckpoint.from_ops(
+            self.after_ops,
+            "kv",
+            seq=8,
+            approved_at=APPROVED_AT,
+            ttl_seconds=3600,
+            max_delta_fraction=1.0,
+        )
+        tree = memory_merkletree(self.after_ops, "kv")
+        self.proof = tree.consistency_proof(self.previous.tree_size)
+        self.verdict = verify_delta(
+            self.previous,
+            self.new,
+            self.after_ops,
+            self.proof,
+            now=APPROVED_AT + timedelta(seconds=5),
+        )
+
+    def _receipt_and_evidence(self, lifecycle_result: str = "residual", *, include_checkpoint: bool = True):
+        previous_ref = checkpoint_reference(self.previous)
+        new_ref = checkpoint_reference(self.new)
+        receipt = {
+            "schema_version": "1.0.0",
+            "receipt_id": "receipt:manifest-del:8",
+            "memory_id": "mem:alpha",
+            "requested_action": "permanent_deletion",
+            "policy_version": "pama-2026-08",
+            "permitted_actions": ["permanent_deletion"],
+            "selected_action": "permanent_deletion",
+            "selection_mode": "deterministic",
+            "evidence_refs": [new_ref] if include_checkpoint else [],
+            "timestamp": "2026-08-11T20:00:01Z",
+        }
+        evidence = issue_evidence(
+            receipt,
+            issuer_id=ISSUER,
+            key=KEY,
+            issued_at="2026-08-11T20:00:02Z",
+            action_ref="action:delete:manifest:8",
+            memory_action="permanent_deletion",
+            governance_disposition="committed",
+            policy_ref="policy:pama-2026-08",
+            authority_state_ref="authority:rev-21",
+            decision_time="2026-08-11T20:00:01Z",
+            scope_ref="scope:opaque:manifest-test",
+            before_state_ref=previous_ref,
+            after_state_ref=new_ref,
+            lifecycle_result=lifecycle_result,
+            source_domain_ref="domain:opaque:project-a",
+            destination_domain_ref="domain:opaque:deleted",
+        )
+        return receipt, evidence
+
+    def _correlate(self, lifecycle_result: str = "residual", *, include_checkpoint: bool = True, verdict=None):
+        receipt, evidence = self._receipt_and_evidence(lifecycle_result, include_checkpoint=include_checkpoint)
+        verdict = verdict or self.verdict
+        return correlate_agent_manifest_delta(
+            evidence,
+            receipt,
+            self.trust,
+            previous_checkpoint=self.previous,
+            new_checkpoint=self.new,
+            delta_accepted=verdict.accepted,
+            delta_reason=verdict.reason,
+            representation="kv",
+            operation_kind="DEL",
+        )
+
+    def test_pinned_release_and_repository_identity_are_explicit(self):
+        self.assertEqual(importlib.metadata.version("agent-manifest"), AGENT_MANIFEST_SDK_VERSION)
+        self.assertEqual(AGENT_MANIFEST_SDK_VERSION, "0.11.0")
+        self.assertEqual(AGENT_MANIFEST_UPSTREAM_COMMIT, "98cead8e8809e3302dc388ca869882d15b812b7f")
+
+    def test_upstream_v02_normative_kv_root_vector_matches(self):
+        root = build_memory_tree(
+            [
+                {"op": "PUT", "key": "a", "value": 1},
+                {"op": "PUT", "key": "b", "value": 2},
+            ],
+            "kv",
+        )
+        self.assertEqual(
+            root,
+            "sha256:9a41dee8ec223727525f8b26685e413664190d2b82cd62d4f7c15180a9e1f5af",
+        )
+
+    def test_upstream_del_checkpoint_is_accepted(self):
+        self.assertTrue(self.verdict.accepted)
+        self.assertEqual(self.verdict.reason, "accepted")
+        self.assertEqual(self.new.tree_size, self.previous.tree_size + 1)
+        self.assertGreater(self.new.seq, self.previous.seq)
+
+    def test_valid_del_checkpoint_does_not_imply_forgetting(self):
+        correlation = self._correlate("residual")
+        self.assertEqual(correlation["correlation_integrity"], "valid")
+        self.assertEqual(correlation["agent_manifest"]["delta_verification"], "accepted")
+        self.assertEqual(correlation["agent_manifest"]["operation_kind"], "DEL")
+        self.assertEqual(correlation["agent_memory"]["governance_disposition"], "committed")
+        self.assertEqual(correlation["agent_memory"]["lifecycle_satisfaction"], "residual")
+
+    def test_same_valid_del_checkpoint_can_accompany_satisfied_lifecycle(self):
+        correlation = self._correlate("satisfied")
+        self.assertEqual(correlation["correlation_integrity"], "valid")
+        self.assertEqual(correlation["agent_manifest"]["delta_verification"], "accepted")
+        self.assertEqual(correlation["agent_memory"]["lifecycle_satisfaction"], "satisfied")
+
+    def test_rejected_manifest_delta_is_a_valid_correlated_negative_outcome(self):
+        bad_verdict = verify_delta(
+            self.previous,
+            self.new,
+            self.after_ops,
+            [],
+            now=APPROVED_AT + timedelta(seconds=5),
+        )
+        self.assertFalse(bad_verdict.accepted)
+        self.assertEqual(bad_verdict.reason, "drift")
+        correlation = self._correlate("residual", verdict=bad_verdict)
+        self.assertEqual(correlation["correlation_integrity"], "valid")
+        self.assertEqual(correlation["agent_manifest"]["delta_verification"], "rejected")
+        self.assertEqual(correlation["agent_manifest"]["delta_reason"], "drift")
+
+    def test_receipt_must_reference_the_new_checkpoint(self):
+        correlation = self._correlate("residual", include_checkpoint=False)
+        self.assertEqual(correlation["correlation_integrity"], "invalid")
+        self.assertIn("receipt_missing_checkpoint_ref", correlation["binding_failures"])
+
+    def test_portable_before_and_after_state_must_match_checkpoint_refs(self):
+        receipt, evidence = self._receipt_and_evidence("residual")
+        evidence["state"]["after_ref"] = checkpoint_reference(self.previous)
+        correlation = correlate_agent_manifest_delta(
+            evidence,
+            receipt,
+            self.trust,
+            previous_checkpoint=self.previous,
+            new_checkpoint=self.new,
+            delta_accepted=self.verdict.accepted,
+            delta_reason=self.verdict.reason,
+            representation="kv",
+            operation_kind="DEL",
+        )
+        self.assertEqual(correlation["correlation_integrity"], "invalid")
+        self.assertIn("portable_evidence_invalid", correlation["binding_failures"])
+        self.assertIn("after_checkpoint_ref_mismatch", correlation["binding_failures"])
+
+    def test_correlation_artifact_is_content_free_and_schema_valid(self):
+        correlation = self._correlate("residual")
+        rendered = json.dumps(correlation, sort_keys=True)
+        self.assertNotIn("secret-memory-value", rendered)
+        self.assertNotIn("memory:key:alpha", rendered)
+
+        root = Path(__file__).resolve().parents[2]
+        schema = json.loads((root / "schemas" / "agent-manifest-memory-correlation.schema.json").read_text())
+        jsonschema.Draft202012Validator(schema).validate(correlation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_agent_manifest_correlation.py
+++ b/reference/tests/test_agent_manifest_correlation.py
@@ -137,7 +137,6 @@ class AgentManifestCorrelationTests(unittest.TestCase):
             delta_accepted=verdict.accepted,
             delta_reason=verdict.reason,
             representation="kv",
-            operation_kind="DEL",
         )
 
     def test_pinned_release_and_repository_identity_are_explicit(self):
@@ -158,7 +157,8 @@ class AgentManifestCorrelationTests(unittest.TestCase):
             "sha256:9a41dee8ec223727525f8b26685e413664190d2b82cd62d4f7c15180a9e1f5af",
         )
 
-    def test_upstream_del_checkpoint_is_accepted(self):
+    def test_upstream_checkpoint_advance_executed_with_del_is_accepted(self):
+        self.assertEqual(self.after_ops[-1]["op"], "DEL")
         self.assertTrue(self.verdict.accepted)
         self.assertEqual(self.verdict.reason, "accepted")
         self.assertEqual(self.new.tree_size, self.previous.tree_size + 1)
@@ -168,14 +168,16 @@ class AgentManifestCorrelationTests(unittest.TestCase):
         correlation = self._correlate("residual")
         self.assertEqual(correlation["correlation_integrity"], "valid")
         self.assertEqual(correlation["agent_manifest"]["delta_verification"], "accepted")
-        self.assertEqual(correlation["agent_manifest"]["operation_kind"], "DEL")
+        self.assertEqual(correlation["agent_memory"]["memory_action"], "permanent_deletion")
         self.assertEqual(correlation["agent_memory"]["governance_disposition"], "committed")
         self.assertEqual(correlation["agent_memory"]["lifecycle_satisfaction"], "residual")
+        self.assertNotIn("operation_kind", correlation["agent_manifest"])
 
     def test_same_valid_del_checkpoint_can_accompany_satisfied_lifecycle(self):
         correlation = self._correlate("satisfied")
         self.assertEqual(correlation["correlation_integrity"], "valid")
         self.assertEqual(correlation["agent_manifest"]["delta_verification"], "accepted")
+        self.assertEqual(correlation["agent_memory"]["memory_action"], "permanent_deletion")
         self.assertEqual(correlation["agent_memory"]["lifecycle_satisfaction"], "satisfied")
 
     def test_rejected_manifest_delta_is_a_valid_correlated_negative_outcome(self):
@@ -210,7 +212,6 @@ class AgentManifestCorrelationTests(unittest.TestCase):
             delta_accepted=self.verdict.accepted,
             delta_reason=self.verdict.reason,
             representation="kv",
-            operation_kind="DEL",
         )
         self.assertEqual(correlation["correlation_integrity"], "invalid")
         self.assertIn("portable_evidence_invalid", correlation["binding_failures"])

--- a/schemas/agent-manifest-memory-correlation.schema.json
+++ b/schemas/agent-manifest-memory-correlation.schema.json
@@ -29,6 +29,7 @@
         "portable_evidence_ref",
         "canonical_receipt_ref",
         "action_ref",
+        "memory_action",
         "governance_disposition",
         "lifecycle_satisfaction"
       ],
@@ -36,6 +37,7 @@
         "portable_evidence_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
         "canonical_receipt_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
         "action_ref": {"type": "string", "minLength": 1},
+        "memory_action": {"type": "string", "minLength": 1},
         "governance_disposition": {
           "enum": ["permitted", "denied", "deferred", "review_required", "committed", "unverifiable"]
         },
@@ -52,7 +54,6 @@
         "sdk_version",
         "upstream_commit",
         "representation",
-        "operation_kind",
         "checkpoint_ref",
         "previous_checkpoint",
         "new_checkpoint",
@@ -64,7 +65,6 @@
         "sdk_version": {"const": "0.11.0"},
         "upstream_commit": {"const": "98cead8e8809e3302dc388ca869882d15b812b7f"},
         "representation": {"enum": ["kv", "vector", "graph"]},
-        "operation_kind": {"enum": ["PUT", "DEL", "ADD"]},
         "checkpoint_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
         "previous_checkpoint": {"$ref": "#/$defs/checkpoint"},
         "new_checkpoint": {"$ref": "#/$defs/checkpoint"},

--- a/schemas/agent-manifest-memory-correlation.schema.json
+++ b/schemas/agent-manifest-memory-correlation.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mythologiq-labs-llc.github.io/agent-memory/schemas/agent-manifest-memory-correlation.schema.json",
+  "title": "Agent Memory / Agent Manifest Memory Correlation",
+  "description": "Content-free correlation between portable Agent Memory governance evidence and an externally verified Agent Manifest v0.2 memory checkpoint delta.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "correlation_type",
+    "version",
+    "correlation_integrity",
+    "binding_failures",
+    "agent_memory",
+    "agent_manifest"
+  ],
+  "properties": {
+    "correlation_type": {"const": "agent-memory-agent-manifest-correlation"},
+    "version": {"const": "1.0.0"},
+    "correlation_integrity": {"enum": ["valid", "invalid"]},
+    "binding_failures": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "agent_memory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "portable_evidence_ref",
+        "canonical_receipt_ref",
+        "action_ref",
+        "governance_disposition",
+        "lifecycle_satisfaction"
+      ],
+      "properties": {
+        "portable_evidence_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "canonical_receipt_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "action_ref": {"type": "string", "minLength": 1},
+        "governance_disposition": {
+          "enum": ["permitted", "denied", "deferred", "review_required", "committed", "unverifiable"]
+        },
+        "lifecycle_satisfaction": {
+          "enum": ["satisfied", "residual", "incomplete", "unverifiable", "not_applicable"]
+        }
+      }
+    },
+    "agent_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec_version",
+        "sdk_version",
+        "upstream_commit",
+        "representation",
+        "operation_kind",
+        "checkpoint_ref",
+        "previous_checkpoint",
+        "new_checkpoint",
+        "delta_verification",
+        "delta_reason"
+      ],
+      "properties": {
+        "spec_version": {"const": "0.2"},
+        "sdk_version": {"const": "0.11.0"},
+        "upstream_commit": {"const": "98cead8e8809e3302dc388ca869882d15b812b7f"},
+        "representation": {"enum": ["kv", "vector", "graph"]},
+        "operation_kind": {"enum": ["PUT", "DEL", "ADD"]},
+        "checkpoint_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "previous_checkpoint": {"$ref": "#/$defs/checkpoint"},
+        "new_checkpoint": {"$ref": "#/$defs/checkpoint"},
+        "delta_verification": {"enum": ["accepted", "rejected"]},
+        "delta_reason": {"enum": ["accepted", "drift", "rollback", "expired", "budget"]}
+      }
+    }
+  },
+  "$defs": {
+    "checkpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["memory_root", "tree_size", "seq", "approved_at", "ttl_seconds"],
+      "properties": {
+        "memory_root": {"type": "string", "pattern": "^(sha256|shake256):[0-9a-f]{64}$"},
+        "tree_size": {"type": "integer", "minimum": 0},
+        "seq": {"type": "integer", "minimum": 0},
+        "approved_at": {"type": "string", "format": "date-time"},
+        "ttl_seconds": {"type": "integer", "minimum": 1}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Objective

Implement P4.5b from #63 by executing the existing Agent Manifest v0.2 memory checkpoint/delta protocol as a pinned external comparator and correlating its result to Agent Memory's canonical receipt and P4.5a portable evidence.

This PR deliberately does **not** reimplement the Agent Manifest checkpoint protocol.

## Pinned comparator

```text
Agent Manifest spec: 0.2
Python package:       agent-manifest==0.11.0
release commit:       98cead8e8809e3302dc388ca869882d15b812b7f
```

CI installs the released package and executes its own `_memory_delta` / RFC 9162 implementation. The upstream dependency is test-only; Agent Memory runtime modules do not import it.

## Correlation boundary

The existing Agent Memory `decision-receipt` already has `evidence_refs`, so no canonical receipt schema change is required.

P4.5b content-addresses the Agent Manifest checkpoint tuple:

```text
memory_root
tree_size
seq
approved_at
ttl_seconds
```

and requires:

1. P4.5a portable evidence to verify against the supplied canonical receipt;
2. canonical receipt `selected_action` to equal signed portable `memory_action`;
3. the canonical receipt to include the new checkpoint reference in `evidence_refs`;
4. P4.5a portable `state.before_ref` to bind the prior checkpoint;
5. P4.5a portable `state.after_ref` to bind the new checkpoint.

The local layer records the **upstream verifier's** accepted/rejected delta verdict. It does not recompute Merkle consistency, sequence monotonicity, TTL, budget, drift classification, or operation semantics.

## Important operation-semantics boundary

The executed upstream test log really appends a KV `DEL`, and the pinned Agent Manifest verifier accepts the resulting checkpoint advance. But the checkpoint root and consistency proof alone do not let a third-party verifier infer that the newly appended operation was specifically `DEL` without additional operation/inclusion evidence.

Accordingly, the portable correlation artifact does **not** claim `operation_kind = DEL`. The deletion semantic is carried by signed Agent Memory `memory_action = permanent_deletion`; the fact that the comparator vector uses a real upstream `DEL` remains an executable test fact.

This avoids promoting a known test input into a proof claim the checkpoint root cannot independently establish.

## New artifacts

- `reference/agentmem_ref/agent_manifest_correlation.py`
- `reference/tests/test_agent_manifest_correlation.py`
- `schemas/agent-manifest-memory-correlation.schema.json`
- `docs/programs/runtime-evidence/agent-manifest-correlation.md`
- runtime/reference documentation index updates
- CI pin for `agent-manifest==0.11.0`

## Executed evidence

The tests exercise:

- exact Agent Manifest package version and release-commit identity
- upstream v0.2 normative KV memory-root vector
- real upstream RFC 9162 checkpoint/delta verification
- accepted checkpoint advance whose executed upstream log appends `DEL`
- canonical receipt -> checkpoint reference binding
- portable before/after state -> checkpoint reference binding
- canonical receipt action -> signed portable memory-action binding
- accepted checkpoint + signed Agent Memory `permanent_deletion` + lifecycle `residual`
- accepted checkpoint + signed Agent Memory `permanent_deletion` + lifecycle `satisfied`
- invalid consistency proof -> upstream `drift`
- negative external verdict retained as valid evidence rather than converted into Agent Memory denial
- missing canonical receipt checkpoint reference
- mismatched receipt/portable action
- tampered portable after-state binding
- malformed checkpoint root/time rejection
- content-free correlation artifact and schema validation
- absence of an unproven `operation_kind` claim

## Semantic result

This executes the narrower, supportable claim:

```text
Agent Manifest accepts a checkpoint built from a log with DEL
!=
Agent Memory proves forgetting
```

The same accepted checkpoint can be correlated to either:

```text
Agent Memory memory_action = permanent_deletion
Agent Memory lifecycle = residual
```

or:

```text
Agent Memory memory_action = permanent_deletion
Agent Memory lifecycle = satisfied
```

Agent Manifest proves append-only memory-log evolution under its checkpoint rules. Agent Memory remains authoritative for PAMA, deletion meaning, derived-state residue, and lifecycle satisfaction.

## Dependency justification

`agent-manifest==0.11.0` is a test-only interoperability comparator. Importing the released implementation is materially stronger and less duplicative than copying its RFC 9162/checkpoint logic into Agent Memory. Its exact release commit is recorded so package/repository drift is explicit.

## What remains unproven

- content-free third-party proof of the newly appended operation class; that needs additional operation/inclusion evidence rather than inference from the checkpoint root
- TRACE/AgenTrust external action-evidence interoperability (P4.5c)
- production Agent Manifest trust/attestation deployment
- hardware attestation of Agent Memory runtime state
- multi-party checkpoint approval
- production cross-standard checkpoint discovery/registry
- any Agent Memory conformance-level increase
- acceptance of ADR-020, ADR-021, or ADR-022

This advances #63 but intentionally does not close the parent P4.5 program.