### PR TITLE
P4.5c: bind portable memory evidence to TRACE/cMCP action receipts

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -25,6 +25,8 @@ jobs:
           jsonschema==4.26.0
           cryptography==50.0.0
           agent-manifest==0.11.0
+          agentrust-trace==0.8.0
+          rfc8785==0.1.4
 
       - name: Validate fixture invariants
         run: python scripts/validate_fixtures.py fixtures
@@ -37,6 +39,17 @@ jobs:
 
       - name: Execute reference governed-adapter paths
         run: python -m unittest discover -s reference/tests -t reference
+
+      - name: Execute released TRACE/cMCP comparator
+        run: |
+          python -m venv /tmp/agent-memory-p45c-cmcp
+          /tmp/agent-memory-p45c-cmcp/bin/python -m pip install --disable-pip-version-check \
+            cmcp-runtime==0.4.0 \
+            agentrust-trace==0.8.0 \
+            agent-manifest==0.11.0 \
+            rfc8785==0.1.4
+          PYTHONPATH=reference \
+            /tmp/agent-memory-p45c-cmcp/bin/python reference/run_trace_cmcp_comparator.py
 
       - name: Install real substrate for runtime evidence
         continue-on-error: true
@@ -68,6 +81,7 @@ jobs:
           docs/programs/runtime-evidence/canonical-and-derived-state.md
           docs/programs/runtime-evidence/portable-governance-evidence.md
           docs/programs/runtime-evidence/agent-manifest-correlation.md
+          docs/programs/runtime-evidence/trace-action-evidence.md
           reference/README.md
 
       - name: Validate GitHub Wiki source links
@@ -87,12 +101,13 @@ jobs:
             echo "Commands run by this workflow (reproducible locally):"
             echo ""
             echo '```'
-            echo "python -m pip install jsonschema==4.26.0 cryptography==50.0.0 agent-manifest==0.11.0"
+            echo "python -m pip install jsonschema==4.26.0 cryptography==50.0.0 agent-manifest==0.11.0 agentrust-trace==0.8.0 rfc8785==0.1.4"
             echo "python scripts/validate_fixtures.py fixtures"
             echo "python scripts/validate_schemas.py"
             echo "python scripts/validate_doctrine_boundaries.py"
             echo "python -m unittest discover -s reference/tests -t reference"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md reference/README.md"
+            echo "python -m venv /tmp/agent-memory-p45c-cmcp && /tmp/agent-memory-p45c-cmcp/bin/python -m pip install cmcp-runtime==0.4.0 agentrust-trace==0.8.0 agent-manifest==0.11.0 rfc8785==0.1.4 && PYTHONPATH=reference /tmp/agent-memory-p45c-cmcp/bin/python reference/run_trace_cmcp_comparator.py"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md reference/README.md"
             echo "python scripts/validate_wiki_links.py wiki-src"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'

--- a/docs/programs/runtime-evidence/README.md
+++ b/docs/programs/runtime-evidence/README.md
@@ -31,6 +31,8 @@ P4.5a is intentionally a **substrate-independent interoperability precondition**
 
 P4.5b is **external comparator evidence**: the tests execute the pinned Agent Manifest package's own checkpoint/delta verifier and correlate its verdict to Agent Memory receipts and portable evidence. Agent Memory does not copy the external checkpoint protocol or inherit its semantics.
 
+P4.5c is **external action-evidence interoperability**: Agent Memory projects only content-free references into the existing TRACE/cMCP external execution-evidence path, keeps call identity distinct from Agent Memory action identity, and executes the resulting envelope through the released cMCP verifier. TRACE receipt validity remains separate from PAMA, runtime authorization, and lifecycle satisfaction.
+
 ## Comparator discipline
 
 External systems enter this program to answer one architectural question each, and are barred from becoming something else:
@@ -80,6 +82,7 @@ Documents are added when their slice is ready to execute, not in advance. A dire
 | [`canonical-and-derived-state.md`](canonical-and-derived-state.md) | canonical memory versus derived projections | design spike executed: all seven evidence-bar items run in CI |
 | [`portable-governance-evidence.md`](portable-governance-evidence.md) | P4.5a portable governance evidence core | executable substrate-independent Ed25519 issuer/verifier and adversarial vectors |
 | [`agent-manifest-correlation.md`](agent-manifest-correlation.md) | P4.5b Agent Manifest memory checkpoint correlation | pinned external comparator executed; a checkpoint built from a test log containing `DEL` remains distinct from Agent Memory lifecycle satisfaction |
+| [`trace-action-evidence.md`](trace-action-evidence.md) | P4.5c TRACE/cMCP action-evidence binding | content-free action receipt adapter plus released cMCP verifier comparator; TRACE receipt state remains separate from Agent Memory governance and lifecycle |
 
 ## Preconditions
 

--- a/docs/programs/runtime-evidence/trace-action-evidence.md
+++ b/docs/programs/runtime-evidence/trace-action-evidence.md
@@ -1,0 +1,287 @@
+# P4.5c TRACE-compatible external action evidence
+
+Status: **Executable interoperability evidence**. This slice maps P4.5a portable Agent Memory governance evidence into the existing AgenTrust external action-evidence surface without making TRACE or cMCP responsible for PAMA or memory lifecycle semantics.
+
+Parent implementation issue: #63.
+
+## Pinned external surfaces
+
+The executable/reference surfaces are pinned to:
+
+```text
+TRACE SDK:        agentrust-trace==0.8.0
+TRACE release:    671f2a8b22f1c995798a0c6d711b4b0b77dad4c7
+cMCP runtime:     cmcp-runtime==0.4.0
+cMCP release:     a2e95151356c9ae6c545330c900f3d4af0e447c1
+RFC 8785 library: rfc8785==0.1.4
+```
+
+Relevant upstream contracts:
+
+- [TRACE action-receipt verification guidance](https://github.com/agentrust-io/trace-spec/blob/671f2a8b22f1c995798a0c6d711b4b0b77dad4c7/docs/verification.md)
+- [TRACE action-receipt planning](https://github.com/agentrust-io/trace-spec/issues/66)
+- [TRACE external execution evidence guidance](https://github.com/agentrust-io/trace-spec/issues/34)
+- [cMCP external execution evidence schema](https://github.com/agentrust-io/cmcp/blob/a2e95151356c9ae6c545330c900f3d4af0e447c1/schemas/audit-entry.schema.json)
+- [cMCP released verifier implementation](https://github.com/agentrust-io/cmcp/blob/a2e95151356c9ae6c545330c900f3d4af0e447c1/src/cmcp_verify/verify.py)
+- [cMCP embodied action evidence profile](https://github.com/agentrust-io/cmcp/blob/a2e95151356c9ae6c545330c900f3d4af0e447c1/docs/spec/embodied-action-evidence.md)
+- [AgenTrust integration front door](https://github.com/agentrust-io/integrations/tree/main/integrations)
+
+The released packages are comparators and interoperability dependencies for this reference slice. They do not become Agent Memory doctrine.
+
+## Ownership boundary
+
+The evidence chain is:
+
+```text
+Agent Memory canonical receipt
+        |
+        | P4.5a content-free signed projection
+        v
+portable Agent Memory governance evidence
+        |
+        | content-addressed reference + action_ref
+        v
+P4.5c detached action payload
+        |
+        | evidence_hash
+        v
+cMCP external_execution_evidence envelope
+        |
+        | linked_call_id + issuer signature
+        v
+TRACE/cMCP action-receipt verification
+```
+
+The meanings remain separate:
+
+```text
+TRACE/cMCP receipt integrity != PAMA permission
+external accepted outcome    != lifecycle satisfaction
+external rejected outcome    != malformed evidence
+valid action evidence         != physical completion
+```
+
+Agent Memory remains authoritative for memory-action meaning, PAMA, canonical receipt semantics, isolation-domain meaning, correction/deletion obligations, residue, and lifecycle satisfaction.
+
+## Existing envelope, no new TRACE wire format
+
+P4.5c uses the existing six-field cMCP `external_execution_evidence` envelope exactly:
+
+```json
+{
+  "issuer": "spiffe://runtime.example/agent-memory-controller",
+  "issuer_key_id": "<sha256 raw Ed25519 public key hex>",
+  "signature": "<base64url Ed25519 signature>",
+  "evidence_hash": "sha256:<detached payload hash>",
+  "evidence_type": "opaque-receipt",
+  "linked_call_id": "<audit call_id>"
+}
+```
+
+`opaque-receipt` is deliberate. Agent Memory evidence is not itself a controller-native receipt, a TEE attestation, or a JWT. Reusing an existing generic envelope value is more accurate than proposing a new normative TRACE evidence type before implementation exposes a generic need.
+
+`linked_call_id` remains the audit-chain identifier. It is not overloaded with Agent Memory `action_ref`.
+
+## Detached payload
+
+Schema: `../../../schemas/trace-action-evidence-bundle.schema.json`.
+
+The detached payload is content-free:
+
+```json
+{
+  "profile": "agent-memory.trace-action-evidence.v1",
+  "call_id": "<audit call_id>",
+  "action_ref": "<signed Agent Memory runtime action reference>",
+  "portable_evidence_ref": "sha256:<P4.5a evidence reference>",
+  "canonical_receipt_ref": "sha256:<Agent Memory receipt reference>",
+  "execution_outcome": "accepted | rejected",
+  "execution_time": "2026-08-11T21:00:03Z",
+  "source_domain_ref": "<optional opaque reference>",
+  "destination_domain_ref": "<optional opaque reference>"
+}
+```
+
+It intentionally excludes:
+
+- raw memory content;
+- hidden reasoning;
+- full canonical receipts;
+- PAMA policy contents;
+- tenant/project/domain display names when opaque references suffice;
+- a claim that TRACE understands Agent Memory lifecycle semantics.
+
+## Two canonicalization domains
+
+The upstream contracts currently use two serialization rules, and P4.5c preserves both.
+
+The detached payload uses **RFC 8785/JCS**, matching TRACE/cMCP action-evidence guidance:
+
+```text
+evidence_hash = sha256(JCS(detached_payload))
+```
+
+The cMCP released verifier signs the six-field envelope using compact, key-sorted JSON with `ensure_ascii=True`, excluding only `signature` from the signing input.
+
+P4.5c reproduces that verifier behavior exactly for the envelope. It does not silently substitute JCS and claim wire compatibility where the released verifier has a different pre-image.
+
+## Replay and binding model
+
+P4.5c deliberately checks both identifiers:
+
+```text
+linked_call_id -> audit-chain call identity
+action_ref     -> Agent Memory runtime action identity
+```
+
+A receipt replayed onto another call fails `linked_call_id` binding. A receipt correlated to the wrong Agent Memory action fails `action_ref` binding even if the call identifier is unchanged.
+
+The verifier also binds:
+
+- detached payload hash to the signed external envelope;
+- detached `portable_evidence_ref` to the supplied P4.5a evidence;
+- detached `canonical_receipt_ref` to the signed P4.5a receipt reference;
+- optional source/destination opaque domain references to the P4.5a scope;
+- external execution time to the P4.5a decision-time ordering check.
+
+No external receipt is allowed to manufacture execution-time PAMA authority. When authority continuity is supplied, it remains an Agent Memory verifier input rather than a TRACE semantic.
+
+## TRACE result taxonomy
+
+The local adapter follows the action-receipt states documented by TRACE:
+
+```text
+receipt_valid_accepted
+receipt_valid_rejected
+receipt_missing_required
+receipt_invalid
+receipt_unverified
+```
+
+A valid rejection is first-class negative evidence. It does not make the receipt malformed.
+
+Unknown issuer trust is reported locally as `receipt_unverified` when every non-cryptographic binding is otherwise sound. This matches TRACE guidance for an unpinned optional issuer.
+
+The released cMCP `verify_audit_bundle()` comparator is stricter once `external_evidence_keys` verification is enabled: an envelope whose `issuer_key_id` is absent from the supplied trusted-key map fails the bundle verification. P4.5c executes and records both behaviors instead of pretending the policy choices are identical.
+
+## Lifecycle non-escalation
+
+P4.5c executes an externally accepted action receipt with both:
+
+```text
+Agent Memory lifecycle = residual
+```
+
+and:
+
+```text
+Agent Memory lifecycle = satisfied
+```
+
+Both TRACE bindings remain valid. The lifecycle difference comes from Agent Memory evidence.
+
+It also executes a valid external `rejected` outcome while retaining the Agent Memory governance and lifecycle dimensions separately. This demonstrates that a downstream negative outcome is evidence, not a signature failure.
+
+## Real upstream comparator
+
+`../../../reference/run_trace_cmcp_comparator.py` runs in a dedicated virtual environment and calls the released:
+
+```python
+cmcp_verify.verify_audit_bundle()
+```
+
+against the P4.5c envelope.
+
+The comparator proves that the real upstream verifier:
+
+- accepts the correctly signed P4.5c envelope;
+- rejects replay to a different `linked_call_id`;
+- rejects signature tampering;
+- fails closed when its configured external issuer trust map does not contain the receipt key.
+
+The isolated environment is intentional because the current cMCP/AGT dependency line resolves a cryptography version below the repository's P4.5a `cryptography==50.0.0` validation pin. Comparator isolation avoids weakening the primary evidence environment merely to make dependency resolvers happier.
+
+## Executed local vectors
+
+`../../../reference/tests/test_trace_action_evidence.py` covers:
+
+- exact TRACE and cMCP release identities;
+- accepted external receipt plus lifecycle `residual`;
+- accepted external receipt plus lifecycle `satisfied`;
+- valid external rejection as negative evidence;
+- wrong `linked_call_id` replay;
+- wrong Agent Memory `action_ref` replay;
+- detached payload tampering;
+- external envelope signature tampering;
+- unknown/untrusted external issuer;
+- missing required receipt;
+- isolation-domain mismatch;
+- schema validation;
+- absence of raw memory content;
+- exact reuse of the existing six-field cMCP envelope.
+
+Run the local profile:
+
+```bash
+python -m pip install \
+  jsonschema==4.26.0 \
+  cryptography==50.0.0 \
+  agent-manifest==0.11.0 \
+  agentrust-trace==0.8.0 \
+  rfc8785==0.1.4
+python -m unittest discover -s reference/tests -t reference
+python scripts/validate_schemas.py
+```
+
+Run the isolated upstream comparator:
+
+```bash
+python -m venv /tmp/agent-memory-p45c-cmcp
+/tmp/agent-memory-p45c-cmcp/bin/python -m pip install \
+  cmcp-runtime==0.4.0 \
+  agentrust-trace==0.8.0 \
+  agent-manifest==0.11.0 \
+  rfc8785==0.1.4
+PYTHONPATH=reference \
+  /tmp/agent-memory-p45c-cmcp/bin/python reference/run_trace_cmcp_comparator.py
+```
+
+## Upstream contribution surface
+
+The implementation evidence supports an upstream integration contribution under the existing AgenTrust integration front door, preferably:
+
+```text
+agentrust-io/integrations/
+  integrations/agent-memory/
+```
+
+The initial target should be a Community integration containing the technical README, reproducible vectors, explicit claim boundaries, and a pointer to the verifier/adapter implementation.
+
+P4.5c does **not** justify a normative TRACE schema proposal. The current external execution evidence envelope is sufficient for this implementation. A core-spec change should be proposed only if later integration work exposes a generic requirement that cannot be represented without one.
+
+## What this slice proves
+
+P4.5c demonstrates that P4.5a Agent Memory governance evidence can be bound to an existing TRACE/cMCP action-evidence path, checked for both call and action replay, verified by the released cMCP implementation, and interpreted without TRACE implementing PAMA or receiving raw memory.
+
+The evidence remains multi-dimensional:
+
+```text
+valid TRACE receipt + committed Agent Memory decision + lifecycle residual
+valid TRACE receipt + committed Agent Memory decision + lifecycle satisfied
+valid TRACE rejection + independently valid Agent Memory governance evidence
+```
+
+## What remains unproven
+
+This slice does not prove:
+
+- TRACE Trust Record hardware attestation of an Agent Memory process;
+- physical completion or functional-safety certification;
+- production issuer-key discovery or revocation infrastructure;
+- upstream Community/Verified integration acceptance;
+- generic cross-organization trust-anchor discovery;
+- AGT/runtime-policy composition (optional P4.5d);
+- any Agent Memory conformance-level increase;
+- acceptance of ADR-020, ADR-021, or ADR-022.
+
+Those remain separate evidence and governance decisions.

--- a/reference/README.md
+++ b/reference/README.md
@@ -2,7 +2,7 @@
 
 A minimal, executable demonstration that the governed path in
 [`../docs/programs/runtime-evidence/README.md`](../docs/programs/runtime-evidence/README.md)
-can be implemented over a temporal-graph substrate that provides no governance of its own, plus the P4.5 portable evidence and external-checkpoint correlation boundaries.
+can be implemented over a temporal-graph substrate that provides no governance of its own, plus the P4.5 portable evidence, external-checkpoint correlation, and TRACE/cMCP action-evidence boundaries.
 
 ## What this is not
 
@@ -10,7 +10,7 @@ Read this section before citing anything in this directory.
 
 - **Not a conformance claim.** The emitted report states conformance level 0 and says why. The doctrine fixture corpus *is* now driven through the adapter's authority enforcement, but doc 06 levels are cumulative and this adapter implements neither decay nor calibrated saturation, so levels 2 and 3 are unmet however well enforcement does. Nothing here substantiates a level, a profile, or ADR-020.
 - **Not a reference implementation of Agent Memory.** It implements the narrow slices needed to exercise governance paths and portable evidence, and nothing else.
-- **Not an endorsement of any substrate or trust infrastructure.** The model reproduces one mapped substrate's verified semantics so the tests have something realistic to push against. The Ed25519 profile proves an evidence boundary, not a universal PKI. The Agent Manifest package is a pinned external comparator, not a doctrine dependency.
+- **Not an endorsement of any substrate or trust infrastructure.** The model reproduces one mapped substrate's verified semantics so the tests have something realistic to push against. The Ed25519 profile proves an evidence boundary, not a universal PKI. Agent Manifest, TRACE, and cMCP are pinned external comparators/interoperability surfaces, not doctrine dependencies.
 
 ## What it does demonstrate
 
@@ -25,6 +25,8 @@ Several things, at different evidential weight.
 **Against the P4.5a portable-evidence contract.** A content-free projection of a canonical decision receipt is signed with Ed25519 and verified using only the configured public trust key. The verifier independently checks receipt, runtime-action, policy, authority-state, temporal, and isolation-domain bindings while preserving governance disposition, runtime execution, and lifecycle satisfaction as separate outcomes. Adversarial vectors exercise tampering, replay, stale authority, wrong domains, key rotation, revocation timing, detached receipt verification, and valid deletion with residual lifecycle state.
 
 **Against the P4.5b Agent Manifest comparator.** CI installs `agent-manifest==0.11.0`, pinned to release commit `98cead8e8809e3302dc388ca869882d15b812b7f`, and executes its own v0.2 memory checkpoint/delta implementation. Agent Memory content-addresses the checkpoint tuple and binds it through the canonical receipt and P4.5a state references. The executed upstream log appends a real `DEL`; the resulting accepted checkpoint is exercised once with lifecycle `residual` and once with lifecycle `satisfied`, proving checkpoint integrity does not manufacture forgetting. Because a checkpoint root alone does not disclose the appended operation class, the portable correlation artifact deliberately carries signed Agent Memory `memory_action` rather than an unproven Agent Manifest `operation_kind` claim.
+
+**Against the P4.5c TRACE/cMCP action-evidence surface.** The reference adapter wraps P4.5a evidence in the existing six-field cMCP `external_execution_evidence` envelope, hashes the detached payload with RFC 8785/JCS, and preserves `linked_call_id` as a separate audit identity from Agent Memory `action_ref`. Local vectors exercise TRACE-style receipt outcomes, wrong-call and wrong-action replay, payload/signature tampering, missing trust, domain mismatch, and lifecycle separation. A second CI path creates an isolated environment with `cmcp-runtime==0.4.0` and calls the released `cmcp_verify.verify_audit_bundle()` verifier against the emitted envelope.
 
 The common point is that the governance layer is load-bearing. The substrate model is deliberately permissive in exactly the ways the mapping verified: identity is opaque rather than content-derived, the partition filter defaults to unfiltered, deletion is physical with no tombstone, and **no operation checks authority**. Several tests assert both halves: that the substrate *would* misbehave, and that the adapter refuses anyway. A test that only checked the adapter would not prove the governance was doing any work.
 
@@ -43,13 +45,15 @@ reference/
     projection_governance.py         governed correction, purge, and rebuild
     portable_evidence.py             P4.5a Ed25519 portable issuer/verifier
     agent_manifest_correlation.py    P4.5b checkpoint correlation boundary
+    trace_action_evidence.py         P4.5c TRACE/cMCP external action evidence
     (selectors live in adapter.py: deterministic and seeded stochastic)
   agentmem_ref/graphiti_driver.py     binding to a real temporal knowledge graph
   tests/                              model, real-substrate, and interoperability paths
+  run_trace_cmcp_comparator.py        isolated released cMCP verifier execution
   run_conformance.py
 ```
 
-Schema validation uses `jsonschema`. P4.5a Ed25519 signing and public-key verification use `cryptography`, added under the explicit dependency-justification rule in `../CONTRIBUTING.md`. P4.5b uses `agent-manifest==0.11.0` as a test-only comparator and does not import it from production reference modules. CI pins the direct validation profile to `jsonschema==4.26.0`, `cryptography==50.0.0`, and `agent-manifest==0.11.0`. The low-cost fixture, doctrine-boundary, and link validators remain standard-library only.
+Schema validation uses `jsonschema`. P4.5a Ed25519 signing and public-key verification use `cryptography`, added under the explicit dependency-justification rule in `../CONTRIBUTING.md`. P4.5b uses `agent-manifest==0.11.0` as a test-only comparator and does not import it from production reference modules. P4.5c uses `agentrust-trace==0.8.0` plus `rfc8785==0.1.4` for the TRACE/JCS contract and runs `cmcp-runtime==0.4.0` in an isolated comparator environment. CI pins the main validation profile to `jsonschema==4.26.0`, `cryptography==50.0.0`, `agent-manifest==0.11.0`, `agentrust-trace==0.8.0`, and `rfc8785==0.1.4`. The low-cost fixture, doctrine-boundary, and link validators remain standard-library only.
 
 ## Running it
 
@@ -58,8 +62,20 @@ Schema validation uses `jsonschema`. P4.5a Ed25519 signing and public-key verifi
 python -m pip install \
   jsonschema==4.26.0 \
   cryptography==50.0.0 \
-  agent-manifest==0.11.0
+  agent-manifest==0.11.0 \
+  agentrust-trace==0.8.0 \
+  rfc8785==0.1.4
 python -m unittest discover -s reference/tests -t reference
+
+# TRACE/cMCP comparator in a dependency-isolated environment
+python -m venv /tmp/agent-memory-p45c-cmcp
+/tmp/agent-memory-p45c-cmcp/bin/python -m pip install \
+  cmcp-runtime==0.4.0 \
+  agentrust-trace==0.8.0 \
+  agent-manifest==0.11.0 \
+  rfc8785==0.1.4
+PYTHONPATH=reference \
+  /tmp/agent-memory-p45c-cmcp/bin/python reference/run_trace_cmcp_comparator.py
 
 # stochastic containment sweep with an explicit trial count
 python reference/run_conformance.py --trials 500
@@ -70,7 +86,7 @@ python -m unittest discover -s reference/tests -t reference
 python reference/run_conformance.py
 ```
 
-Runs are deterministic where the contract requires determinism: identifiers are counter-based and the clock is injected, so repeated governed-adapter runs produce identical receipts and identical reports. Stochastic selection is seeded per trial, so it varies across trials and reproduces exactly for a given seed. Ed25519 signatures are deterministic for a fixed private key and canonical payload. P4.5b pins the external package version and upstream release commit so comparator drift is explicit rather than accidental.
+Runs are deterministic where the contract requires determinism: identifiers are counter-based and the clock is injected, so repeated governed-adapter runs produce identical receipts and identical reports. Stochastic selection is seeded per trial, so it varies across trials and reproduces exactly for a given seed. Ed25519 signatures are deterministic for a fixed private key and canonical payload. P4.5b and P4.5c pin external package versions and upstream release commits so comparator drift is explicit rather than accidental.
 
 ## The governed path
 
@@ -80,7 +96,7 @@ evidence -> proposal -> authority envelope -> permitted action set
          -> retrieval candidate -> governed admission -> active context
 ```
 
-The adapter supplies what the substrate cannot: an authority gate before every write, always-explicit scope filtering, external lifecycle state, tombstones, and receipts. Artifacts are emitted against schemas already canonical in this repository rather than shapes invented beside the implementation: `pama-decision`, `decision-receipt`, `memory-audit-event`, `conformance-report`, P4.5a `portable-governance-evidence`, and P4.5b `agent-manifest-memory-correlation`.
+The adapter supplies what the substrate cannot: an authority gate before every write, always-explicit scope filtering, external lifecycle state, tombstones, and receipts. Artifacts are emitted against schemas already canonical in this repository rather than shapes invented beside the implementation: `pama-decision`, `decision-receipt`, `memory-audit-event`, `conformance-report`, P4.5a `portable-governance-evidence`, P4.5b `agent-manifest-memory-correlation`, and P4.5c `trace-action-evidence-bundle`.
 
 ## Paths exercised
 
@@ -112,7 +128,13 @@ The adapter supplies what the substrate cannot: an authority gate before every w
 | Agent Manifest normative root | the pinned upstream implementation reproduces the v0.2 KV memory-root vector |
 | Agent Manifest deletion-vector correlation | the upstream verifier accepts an RFC 9162 checkpoint built from a log whose appended test operation is `DEL`; canonical receipt and portable state refs bind the checkpoint |
 | DEL versus forgetting | that accepted checkpoint remains compatible with either residual or satisfied Agent Memory lifecycle evidence |
-| external negative outcome | invalid consistency proof yields upstream `drift` while the correlation remains a valid record of a rejected delta |
+| external negative checkpoint outcome | invalid consistency proof yields upstream `drift` while the correlation remains a valid record of a rejected delta |
+| TRACE/cMCP envelope compatibility | emitted evidence uses the existing six-field external-execution envelope and the released cMCP verifier accepts it |
+| TRACE call replay | released cMCP verifier rejects a receipt whose `linked_call_id` does not match the audit call |
+| Agent Memory action replay | local verifier separately rejects a detached action reference that does not match the P4.5a signed `action_ref` |
+| TRACE negative action outcome | a correctly bound external `rejected` receipt remains valid negative evidence rather than malformed evidence |
+| TRACE versus lifecycle | accepted action evidence remains compatible with both residual and satisfied Agent Memory lifecycle evidence |
+| TRACE trust failure | local TRACE-style classification reports unknown issuer as unverified; configured cMCP external-key verification fails closed on the same missing trust anchor |
 
 ## Known limitations
 
@@ -128,4 +150,6 @@ Stated rather than left to be discovered:
 8. The P4.5a trust profile assumes configured Ed25519 public trust keys. Production key custody, trust discovery, certificates, and external revocation infrastructure remain outside this slice.
 9. P4.5b intentionally imports Agent Manifest private checkpoint modules only in its pinned comparator tests because the upstream implementation issue and specification surface those exact functions. This is not a stable production API commitment and is isolated from Agent Memory runtime code.
 10. An Agent Manifest checkpoint root proves the bound log state but does not independently reveal the semantic class of a new operation. P4.5b demonstrates a real upstream `DEL` through executed test input; a compact content-free third-party proof of operation class would require additional upstream operation/inclusion evidence and is not invented here.
-11. P4.5b proves checkpoint/delta correlation, not hardware attestation of an Agent Memory process and not TRACE action-evidence interoperability. TRACE remains P4.5c.
+11. P4.5c binds Agent Memory action evidence into TRACE/cMCP receipt infrastructure; it does not prove a physical or business outcome occurred and does not make TRACE a PAMA interpreter.
+12. The released cMCP 0.4.0 dependency graph is intentionally isolated from the main evidence environment because its AGT dependency line resolves a lower cryptography range. This is comparator containment, not a production dependency recommendation.
+13. P4.5c does not demonstrate hardware attestation of the Agent Memory process, production trust-anchor discovery, or upstream Community/Verified integration acceptance.

--- a/reference/agentmem_ref/trace_action_evidence.py
+++ b/reference/agentmem_ref/trace_action_evidence.py
@@ -1,0 +1,394 @@
+"""P4.5c TRACE/cMCP-compatible external action evidence.
+
+This module adapts P4.5a portable Agent Memory governance evidence into the
+existing AgenTrust external-execution-evidence shape. TRACE/cMCP owns receipt
+integrity and call binding. Agent Memory remains authoritative for PAMA,
+memory-action semantics, lifecycle satisfaction, and isolation-domain meaning.
+
+Two canonicalization domains are intentionally preserved:
+
+* detached payload: RFC 8785/JCS, matching TRACE action-evidence guidance;
+* cMCP envelope: deterministic JSON used by cmcp_verify.verify_audit_bundle().
+
+Do not collapse these into one serializer unless the upstream contracts converge.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping
+
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+
+from .portable_evidence import RuntimeObservation, TrustKey, sha256_ref, verify_evidence
+
+PROFILE = "agent-memory.trace-action-evidence.v1"
+EVIDENCE_TYPE = "opaque-receipt"
+TRACE_SDK_VERSION = "0.8.0"
+TRACE_RELEASE_COMMIT = "671f2a8b22f1c995798a0c6d711b4b0b77dad4c7"
+CMCP_RUNTIME_VERSION = "0.4.0"
+CMCP_RELEASE_COMMIT = "a2e95151356c9ae6c545330c900f3d4af0e447c1"
+
+TRACE_RECEIPT_VALID_ACCEPTED = "receipt_valid_accepted"
+TRACE_RECEIPT_VALID_REJECTED = "receipt_valid_rejected"
+TRACE_RECEIPT_MISSING_REQUIRED = "receipt_missing_required"
+TRACE_RECEIPT_INVALID = "receipt_invalid"
+TRACE_RECEIPT_UNVERIFIED = "receipt_unverified"
+
+_OUTCOMES = {"accepted", "rejected"}
+_ENVELOPE_FIELDS = {
+    "issuer",
+    "issuer_key_id",
+    "signature",
+    "evidence_hash",
+    "evidence_type",
+    "linked_call_id",
+}
+
+
+def _raw_public_key(public_key: Ed25519PublicKey) -> bytes:
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+
+def _key_id(public_key: Ed25519PublicKey) -> str:
+    return hashlib.sha256(_raw_public_key(public_key)).hexdigest()
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _parse_time(value: str) -> datetime:
+    if not value.endswith("Z"):
+        raise ValueError("TRACE action-evidence timestamps must use RFC3339 UTC with Z")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("TRACE action-evidence timestamps must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def jcs_bytes(value: object) -> bytes:
+    """RFC 8785/JCS bytes for the detached evidence payload."""
+    return rfc8785.dumps(value)
+
+
+def detached_payload_hash(payload: Mapping[str, object]) -> str:
+    return "sha256:" + hashlib.sha256(jcs_bytes(dict(payload))).hexdigest()
+
+
+def cmcp_envelope_signing_input(envelope: Mapping[str, object]) -> bytes:
+    """Reproduce cMCP #301 envelope serialization exactly.
+
+    cMCP's released verifier signs/verifies the envelope with sorted compact JSON
+    and ``ensure_ascii=True``. The detached payload uses JCS separately.
+    """
+    body = {k: v for k, v in envelope.items() if k != "signature"}
+    return json.dumps(
+        body,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class TraceReceiptIssuer:
+    """Independent runtime/action-evidence issuer."""
+
+    issuer_id: str
+    private_key: Ed25519PrivateKey
+
+    @property
+    def key_id(self) -> str:
+        return _key_id(self.private_key.public_key())
+
+    def trust_key(self) -> "TraceReceiptTrustKey":
+        return TraceReceiptTrustKey(
+            issuer_id=self.issuer_id,
+            public_key=self.private_key.public_key(),
+        )
+
+
+@dataclass(frozen=True)
+class TraceReceiptTrustKey:
+    """Pinned public key for an external action-evidence issuer."""
+
+    issuer_id: str
+    public_key: Ed25519PublicKey
+
+    @property
+    def key_id(self) -> str:
+        return _key_id(self.public_key)
+
+    @property
+    def raw_public_key(self) -> bytes:
+        return _raw_public_key(self.public_key)
+
+
+def issue_trace_action_evidence(
+    portable_evidence: Mapping[str, object],
+    *,
+    issuer: TraceReceiptIssuer,
+    call_id: str,
+    execution_outcome: str,
+    execution_time: str,
+) -> dict:
+    """Issue a cMCP-compatible external execution-evidence envelope.
+
+    The detached payload carries only content-free Agent Memory references plus
+    opaque domain references already present in the signed P4.5a evidence. It
+    never copies raw memory or asks TRACE/cMCP to interpret PAMA.
+    """
+    if execution_outcome not in _OUTCOMES:
+        raise ValueError(f"unsupported external execution outcome: {execution_outcome}")
+    if not isinstance(call_id, str) or not call_id:
+        raise ValueError("call_id must be a non-empty string")
+    _parse_time(execution_time)
+
+    action_ref = portable_evidence.get("action_ref")
+    canonical_receipt_ref = portable_evidence.get("canonical_receipt_ref")
+    scope = portable_evidence.get("scope")
+    if not isinstance(action_ref, str) or not action_ref:
+        raise ValueError("portable evidence is missing action_ref")
+    if not isinstance(canonical_receipt_ref, str) or not canonical_receipt_ref:
+        raise ValueError("portable evidence is missing canonical_receipt_ref")
+    if not isinstance(scope, Mapping):
+        raise ValueError("portable evidence is missing scope")
+
+    payload: dict[str, object] = {
+        "profile": PROFILE,
+        "call_id": call_id,
+        "action_ref": action_ref,
+        "portable_evidence_ref": sha256_ref(dict(portable_evidence)),
+        "canonical_receipt_ref": canonical_receipt_ref,
+        "execution_outcome": execution_outcome,
+        "execution_time": execution_time,
+    }
+    for name in ("source_domain_ref", "destination_domain_ref"):
+        value = scope.get(name)
+        if value is not None:
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"portable {name} must be a non-empty opaque reference")
+            payload[name] = value
+
+    envelope: dict[str, object] = {
+        "issuer": issuer.issuer_id,
+        "issuer_key_id": issuer.key_id,
+        "evidence_hash": detached_payload_hash(payload),
+        "evidence_type": EVIDENCE_TYPE,
+        "linked_call_id": call_id,
+    }
+    signature = issuer.private_key.sign(cmcp_envelope_signing_input(envelope))
+    envelope["signature"] = _b64url(signature)
+
+    return {
+        "external_execution_evidence": envelope,
+        "detached_payload": payload,
+    }
+
+
+def _portable_scope_failures(payload: Mapping[str, object], portable_evidence: Mapping[str, object]) -> list[str]:
+    scope = portable_evidence.get("scope")
+    if not isinstance(scope, Mapping):
+        return ["portable_scope_missing"]
+    failures: list[str] = []
+    for name in ("source_domain_ref", "destination_domain_ref"):
+        signed = scope.get(name)
+        detached = payload.get(name)
+        if signed != detached:
+            failures.append(f"{name}_mismatch")
+    return failures
+
+
+def verify_trace_action_evidence(
+    bundle: Mapping[str, object] | None,
+    portable_evidence: Mapping[str, object],
+    agent_memory_trust_keys: Mapping[tuple[str, str], TrustKey],
+    trace_trust_keys: Mapping[str, TraceReceiptTrustKey],
+    *,
+    canonical_receipt: Mapping[str, object] | None = None,
+    observed_call_id: str | None = None,
+    observed_action_ref: str | None = None,
+    authority_valid_at_execution: bool | None = None,
+) -> dict:
+    """Verify TRACE/cMCP action evidence without importing Agent Memory semantics.
+
+    TRACE receipt validity, Agent Memory governance, runtime authorization, and
+    lifecycle satisfaction remain separate result dimensions. Unknown external
+    issuer trust is ``receipt_unverified`` rather than ``receipt_invalid`` when
+    every independently checkable binding still holds.
+    """
+    if bundle is None:
+        portable_result = verify_evidence(
+            portable_evidence,
+            agent_memory_trust_keys,
+            canonical_receipt=canonical_receipt,
+        )
+        return _result(
+            TRACE_RECEIPT_MISSING_REQUIRED,
+            "unverifiable",
+            ["required_action_receipt_missing"],
+            None,
+            portable_result,
+        )
+
+    envelope = bundle.get("external_execution_evidence")
+    payload = bundle.get("detached_payload")
+    if not isinstance(envelope, Mapping) or not isinstance(payload, Mapping):
+        portable_result = verify_evidence(
+            portable_evidence,
+            agent_memory_trust_keys,
+            canonical_receipt=canonical_receipt,
+        )
+        return _result(
+            TRACE_RECEIPT_INVALID,
+            "invalid",
+            ["missing_envelope_or_detached_payload"],
+            None,
+            portable_result,
+        )
+
+    failures: list[str] = []
+    unknown_trust = False
+
+    if set(envelope.keys()) != _ENVELOPE_FIELDS:
+        failures.append("invalid_external_evidence_envelope_shape")
+    if envelope.get("evidence_type") != EVIDENCE_TYPE:
+        failures.append("unsupported_evidence_type")
+    if payload.get("profile") != PROFILE:
+        failures.append("unsupported_detached_payload_profile")
+
+    call_id = payload.get("call_id")
+    action_ref = payload.get("action_ref")
+    execution_outcome = payload.get("execution_outcome")
+    execution_time = payload.get("execution_time")
+    if not all(isinstance(v, str) and v for v in (call_id, action_ref, execution_outcome, execution_time)):
+        failures.append("missing_required_detached_payload_field")
+    if execution_outcome not in _OUTCOMES:
+        failures.append("invalid_execution_outcome")
+    if isinstance(execution_time, str):
+        try:
+            _parse_time(execution_time)
+        except ValueError:
+            failures.append("invalid_execution_time")
+
+    if envelope.get("linked_call_id") != call_id:
+        failures.append("linked_call_id_mismatch")
+    if observed_call_id is not None and observed_call_id != call_id:
+        failures.append("wrong_call_id")
+
+    if action_ref != portable_evidence.get("action_ref"):
+        failures.append("portable_action_ref_mismatch")
+    if observed_action_ref is not None and observed_action_ref != action_ref:
+        failures.append("wrong_action_ref")
+
+    if payload.get("portable_evidence_ref") != sha256_ref(dict(portable_evidence)):
+        failures.append("portable_evidence_ref_mismatch")
+    if payload.get("canonical_receipt_ref") != portable_evidence.get("canonical_receipt_ref"):
+        failures.append("canonical_receipt_ref_mismatch")
+    failures.extend(_portable_scope_failures(payload, portable_evidence))
+
+    try:
+        expected_hash = detached_payload_hash(payload)
+    except Exception:  # rfc8785 exposes several canonicalization errors
+        expected_hash = ""
+        failures.append("detached_payload_canonicalization_failed")
+    if envelope.get("evidence_hash") != expected_hash:
+        failures.append("detached_payload_hash_mismatch")
+
+    issuer = envelope.get("issuer")
+    key_id = envelope.get("issuer_key_id")
+    signature = envelope.get("signature")
+    if not all(isinstance(v, str) and v for v in (issuer, key_id, signature)):
+        failures.append("missing_external_issuer_field")
+    elif not isinstance(key_id, str) or len(key_id) != 64 or any(c not in "0123456789abcdef" for c in key_id):
+        failures.append("invalid_issuer_key_id")
+    else:
+        trust_key = trace_trust_keys.get(key_id)
+        if trust_key is None:
+            unknown_trust = True
+        else:
+            if trust_key.issuer_id != issuer:
+                failures.append("external_issuer_identity_mismatch")
+            if trust_key.key_id != key_id:
+                failures.append("external_issuer_key_binding_mismatch")
+            try:
+                trust_key.public_key.verify(
+                    _b64url_decode(str(signature)),
+                    cmcp_envelope_signing_input(envelope),
+                )
+            except (InvalidSignature, ValueError, TypeError):
+                failures.append("external_evidence_signature_invalid")
+
+    runtime = RuntimeObservation(
+        action_ref=str(action_ref) if isinstance(action_ref, str) else None,
+        execution_time=str(execution_time) if isinstance(execution_time, str) else None,
+        source_domain_ref=(
+            str(payload.get("source_domain_ref")) if payload.get("source_domain_ref") is not None else None
+        ),
+        destination_domain_ref=(
+            str(payload.get("destination_domain_ref")) if payload.get("destination_domain_ref") is not None else None
+        ),
+        authority_valid_at_execution=authority_valid_at_execution,
+    )
+    portable_result = verify_evidence(
+        portable_evidence,
+        agent_memory_trust_keys,
+        canonical_receipt=canonical_receipt,
+        runtime=runtime,
+    )
+    if portable_result["evidence_integrity"] != "valid":
+        failures.append("agent_memory_portable_evidence_invalid")
+
+    if failures:
+        status = TRACE_RECEIPT_INVALID
+        trace_binding = "invalid"
+    elif unknown_trust:
+        status = TRACE_RECEIPT_UNVERIFIED
+        trace_binding = "unverifiable"
+    elif execution_outcome == "accepted":
+        status = TRACE_RECEIPT_VALID_ACCEPTED
+        trace_binding = "valid"
+    else:
+        status = TRACE_RECEIPT_VALID_REJECTED
+        trace_binding = "valid"
+
+    return _result(
+        status,
+        trace_binding,
+        failures,
+        str(execution_outcome) if execution_outcome in _OUTCOMES else None,
+        portable_result,
+    )
+
+
+def _result(
+    receipt_status: str,
+    trace_binding: str,
+    failures: list[str],
+    external_execution_outcome: str | None,
+    portable_result: Mapping[str, object],
+) -> dict:
+    return {
+        "trace_receipt_status": receipt_status,
+        "trace_binding": trace_binding,
+        "binding_failures": list(dict.fromkeys(failures)),
+        "external_execution_outcome": external_execution_outcome,
+        "agent_memory": copy.deepcopy(dict(portable_result)),
+    }

--- a/reference/agentmem_ref/trace_action_evidence.py
+++ b/reference/agentmem_ref/trace_action_evidence.py
@@ -16,6 +16,7 @@ Do not collapse these into one serializer unless the upstream contracts converge
 from __future__ import annotations
 
 import base64
+import binascii
 import copy
 import hashlib
 import json
@@ -333,11 +334,12 @@ def verify_trace_action_evidence(
                     _b64url_decode(str(signature)),
                     cmcp_envelope_signing_input(envelope),
                 )
-            except (InvalidSignature, ValueError, TypeError):
+            except (InvalidSignature, ValueError, TypeError, binascii.Error):
                 failures.append("external_evidence_signature_invalid")
 
+    runtime_action_ref = observed_action_ref if observed_action_ref is not None else action_ref
     runtime = RuntimeObservation(
-        action_ref=str(action_ref) if isinstance(action_ref, str) else None,
+        action_ref=str(runtime_action_ref) if isinstance(runtime_action_ref, str) else None,
         execution_time=str(execution_time) if isinstance(execution_time, str) else None,
         source_domain_ref=(
             str(payload.get("source_domain_ref")) if payload.get("source_domain_ref") is not None else None

--- a/reference/run_trace_cmcp_comparator.py
+++ b/reference/run_trace_cmcp_comparator.py
@@ -1,0 +1,159 @@
+"""Execute P4.5c evidence through the released cMCP audit-bundle verifier.
+
+Run this in an isolated environment containing the pinned external packages:
+
+    cmcp-runtime==0.4.0
+    agentrust-trace==0.8.0
+    agent-manifest==0.11.0
+    rfc8785==0.1.4
+
+The isolation is intentional: cmcp-runtime 0.4.0's AGT dependency line resolves a
+cryptography version below the P4.5a validation profile's cryptography==50.0.0.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.metadata
+import json
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.portable_evidence import IssuerKey, issue_evidence  # noqa: E402
+from agentmem_ref.trace_action_evidence import (  # noqa: E402
+    TraceReceiptIssuer,
+    issue_trace_action_evidence,
+)
+from cmcp_verify import verify_audit_bundle  # type: ignore[import-not-found]  # noqa: E402
+
+
+def _audit_entry(call_id: str, external_execution_evidence: dict) -> dict:
+    entry = {
+        "call_id": call_id,
+        "external_execution_evidence": external_execution_evidence,
+        "prev_entry_hash": "genesis",
+    }
+    entry["entry_hash"] = hashlib.sha256(
+        json.dumps(entry, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    ).hexdigest()
+    return entry
+
+
+def main() -> None:
+    expected_versions = {
+        "cmcp-runtime": "0.4.0",
+        "agentrust-trace": "0.8.0",
+        "agent-manifest": "0.11.0",
+        "rfc8785": "0.1.4",
+    }
+    actual_versions = {name: importlib.metadata.version(name) for name in expected_versions}
+    if actual_versions != expected_versions:
+        raise AssertionError(f"comparator version drift: {actual_versions!r}")
+
+    am_key = IssuerKey(
+        issuer_id="issuer:agent-memory-reference",
+        key_id="am-key-p45c",
+        private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(1, 33))),
+        valid_from="2026-08-01T00:00:00Z",
+        valid_until="2026-08-31T23:59:59Z",
+    )
+    runtime_issuer = TraceReceiptIssuer(
+        issuer_id="spiffe://runtime.example/agent-memory-controller",
+        private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(33, 65))),
+    )
+    receipt = {
+        "schema_version": "1.0.0",
+        "receipt_id": "receipt:p45c:cmcp",
+        "requested_action": "permanent_deletion",
+        "policy_version": "pama-2026-08",
+        "permitted_actions": ["permanent_deletion"],
+        "selected_action": "permanent_deletion",
+        "selection_mode": "deterministic",
+        "timestamp": "2026-08-11T21:10:01Z",
+    }
+    portable = issue_evidence(
+        receipt,
+        issuer_id=am_key.issuer_id,
+        key=am_key,
+        issued_at="2026-08-11T21:10:02Z",
+        action_ref="action:p45c:cmcp",
+        memory_action="permanent_deletion",
+        governance_disposition="committed",
+        policy_ref="policy:pama-2026-08",
+        authority_state_ref="authority:rev-32",
+        decision_time="2026-08-11T21:10:01Z",
+        scope_ref="scope:opaque:p45c",
+        before_state_ref="sha256:" + "3" * 64,
+        after_state_ref="sha256:" + "4" * 64,
+        lifecycle_result="residual",
+        source_domain_ref="domain:opaque:source",
+        destination_domain_ref="domain:opaque:deleted",
+    )
+    call_id = "call:p45c:cmcp"
+    trace_bundle = issue_trace_action_evidence(
+        portable,
+        issuer=runtime_issuer,
+        call_id=call_id,
+        execution_outcome="accepted",
+        execution_time="2026-08-11T21:10:03Z",
+    )
+    envelope = trace_bundle["external_execution_evidence"]
+    key = runtime_issuer.trust_key()
+    trusted = {key.key_id: key.raw_public_key}
+
+    good = verify_audit_bundle(
+        {"entries": [_audit_entry(call_id, envelope)]},
+        external_evidence_keys=trusted,
+    )
+    if not good.verified:
+        raise AssertionError(f"released cMCP verifier rejected P4.5c envelope: {good.failures}")
+
+    replayed = copy.deepcopy(envelope)
+    replayed["linked_call_id"] = "call:p45c:other"
+    wrong_call = verify_audit_bundle(
+        {"entries": [_audit_entry(call_id, replayed)]},
+        external_evidence_keys=trusted,
+    )
+    if wrong_call.verified or not any("linked_call_id" in item for item in wrong_call.failures):
+        raise AssertionError(f"released cMCP verifier did not reject wrong-call replay: {wrong_call.failures}")
+
+    bad_signature = copy.deepcopy(envelope)
+    bad_signature["signature"] = "A" * 86
+    signature_result = verify_audit_bundle(
+        {"entries": [_audit_entry(call_id, bad_signature)]},
+        external_evidence_keys=trusted,
+    )
+    if signature_result.verified or not any("signature" in item for item in signature_result.failures):
+        raise AssertionError(
+            f"released cMCP verifier did not reject signature tamper: {signature_result.failures}"
+        )
+
+    unknown_key = verify_audit_bundle(
+        {"entries": [_audit_entry(call_id, envelope)]},
+        external_evidence_keys={},
+    )
+    if unknown_key.verified or not any("no trusted key" in item for item in unknown_key.failures):
+        raise AssertionError(f"released cMCP verifier did not fail closed on missing trust: {unknown_key.failures}")
+
+    print(
+        json.dumps(
+            {
+                "comparator": "cmcp_verify.verify_audit_bundle",
+                "versions": actual_versions,
+                "valid_envelope": good.verified,
+                "wrong_call_rejected": not wrong_call.verified,
+                "signature_tamper_rejected": not signature_result.verified,
+                "unknown_key_rejected": not unknown_key.verified,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/reference/tests/test_trace_action_evidence.py
+++ b/reference/tests/test_trace_action_evidence.py
@@ -152,6 +152,8 @@ class TraceActionEvidenceTests(unittest.TestCase):
         result = self._verify(receipt, portable, bundle, observed_action_ref="action:other")
         self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_INVALID)
         self.assertIn("wrong_action_ref", result["binding_failures"])
+        self.assertEqual(result["agent_memory"]["runtime_execution"], "execution_mismatch")
+        self.assertIn("wrong_action_ref", result["agent_memory"]["binding_failures"])
 
     def test_detached_payload_tamper_is_detected(self):
         receipt, portable, bundle = self._bundle()

--- a/reference/tests/test_trace_action_evidence.py
+++ b/reference/tests/test_trace_action_evidence.py
@@ -1,0 +1,241 @@
+"""P4.5c TRACE/cMCP-compatible external action evidence vectors."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import sys
+import unittest
+from pathlib import Path
+
+import jsonschema
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.portable_evidence import IssuerKey, issue_evidence  # noqa: E402
+from agentmem_ref.trace_action_evidence import (  # noqa: E402
+    CMCP_RELEASE_COMMIT,
+    CMCP_RUNTIME_VERSION,
+    TRACE_RECEIPT_INVALID,
+    TRACE_RECEIPT_MISSING_REQUIRED,
+    TRACE_RECEIPT_UNVERIFIED,
+    TRACE_RECEIPT_VALID_ACCEPTED,
+    TRACE_RECEIPT_VALID_REJECTED,
+    TRACE_RELEASE_COMMIT,
+    TRACE_SDK_VERSION,
+    TraceReceiptIssuer,
+    detached_payload_hash,
+    issue_trace_action_evidence,
+    verify_trace_action_evidence,
+)
+
+AM_ISSUER = "issuer:agent-memory-reference"
+AM_KEY = IssuerKey(
+    issuer_id=AM_ISSUER,
+    key_id="am-key-2026-08",
+    private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(1, 33))),
+    valid_from="2026-08-01T00:00:00Z",
+    valid_until="2026-08-31T23:59:59Z",
+)
+TRACE_ISSUER = TraceReceiptIssuer(
+    issuer_id="spiffe://runtime.example/agent-memory-controller",
+    private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(33, 65))),
+)
+
+
+class TraceActionEvidenceTests(unittest.TestCase):
+    def setUp(self):
+        am_trust = AM_KEY.trust_key()
+        self.am_trust = {(am_trust.issuer_id, am_trust.key_id): am_trust}
+        trace_trust = TRACE_ISSUER.trust_key()
+        self.trace_trust = {trace_trust.key_id: trace_trust}
+        self.call_id = "call:trace:delete:42"
+        self.action_ref = "action:delete:42"
+
+    def _receipt_and_portable(self, lifecycle: str = "residual"):
+        receipt = {
+            "schema_version": "1.0.0",
+            "receipt_id": "receipt:trace:delete:42",
+            "memory_id": "mem:trace:alpha",
+            "requested_action": "permanent_deletion",
+            "policy_version": "pama-2026-08",
+            "permitted_actions": ["permanent_deletion"],
+            "selected_action": "permanent_deletion",
+            "selection_mode": "deterministic",
+            "timestamp": "2026-08-11T21:00:01Z",
+        }
+        portable = issue_evidence(
+            receipt,
+            issuer_id=AM_ISSUER,
+            key=AM_KEY,
+            issued_at="2026-08-11T21:00:02Z",
+            action_ref=self.action_ref,
+            memory_action="permanent_deletion",
+            governance_disposition="committed",
+            policy_ref="policy:pama-2026-08",
+            authority_state_ref="authority:rev-31",
+            decision_time="2026-08-11T21:00:01Z",
+            scope_ref="scope:opaque:trace-test",
+            before_state_ref="sha256:" + "1" * 64,
+            after_state_ref="sha256:" + "2" * 64,
+            lifecycle_result=lifecycle,
+            source_domain_ref="domain:opaque:project-a",
+            destination_domain_ref="domain:opaque:deleted",
+        )
+        return receipt, portable
+
+    def _bundle(self, lifecycle: str = "residual", outcome: str = "accepted"):
+        receipt, portable = self._receipt_and_portable(lifecycle)
+        bundle = issue_trace_action_evidence(
+            portable,
+            issuer=TRACE_ISSUER,
+            call_id=self.call_id,
+            execution_outcome=outcome,
+            execution_time="2026-08-11T21:00:03Z",
+        )
+        return receipt, portable, bundle
+
+    def _verify(self, receipt, portable, bundle, **kwargs):
+        return verify_trace_action_evidence(
+            bundle,
+            portable,
+            self.am_trust,
+            self.trace_trust,
+            canonical_receipt=receipt,
+            observed_call_id=kwargs.pop("observed_call_id", self.call_id),
+            observed_action_ref=kwargs.pop("observed_action_ref", self.action_ref),
+            authority_valid_at_execution=kwargs.pop("authority_valid_at_execution", True),
+            **kwargs,
+        )
+
+    def test_pinned_trace_release_identity_is_explicit(self):
+        self.assertEqual(importlib.metadata.version("agentrust-trace"), TRACE_SDK_VERSION)
+        self.assertEqual(TRACE_SDK_VERSION, "0.8.0")
+        self.assertEqual(TRACE_RELEASE_COMMIT, "671f2a8b22f1c995798a0c6d711b4b0b77dad4c7")
+        self.assertEqual(CMCP_RUNTIME_VERSION, "0.4.0")
+        self.assertEqual(CMCP_RELEASE_COMMIT, "a2e95151356c9ae6c545330c900f3d4af0e447c1")
+
+    def test_accepted_receipt_preserves_residual_lifecycle(self):
+        receipt, portable, bundle = self._bundle("residual", "accepted")
+        result = self._verify(receipt, portable, bundle)
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_VALID_ACCEPTED)
+        self.assertEqual(result["trace_binding"], "valid")
+        self.assertEqual(result["external_execution_outcome"], "accepted")
+        self.assertEqual(result["agent_memory"]["governance_disposition"], "committed")
+        self.assertEqual(result["agent_memory"]["runtime_execution"], "executed_as_authorized")
+        self.assertEqual(result["agent_memory"]["lifecycle_satisfaction"], "residual")
+
+    def test_same_action_receipt_can_preserve_satisfied_lifecycle(self):
+        receipt, portable, bundle = self._bundle("satisfied", "accepted")
+        result = self._verify(receipt, portable, bundle)
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_VALID_ACCEPTED)
+        self.assertEqual(result["agent_memory"]["lifecycle_satisfaction"], "satisfied")
+
+    def test_valid_rejection_is_negative_evidence_not_malformed_evidence(self):
+        receipt, portable, bundle = self._bundle("residual", "rejected")
+        result = self._verify(receipt, portable, bundle)
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_VALID_REJECTED)
+        self.assertEqual(result["trace_binding"], "valid")
+        self.assertEqual(result["external_execution_outcome"], "rejected")
+        self.assertEqual(result["agent_memory"]["governance_disposition"], "committed")
+        self.assertEqual(result["agent_memory"]["lifecycle_satisfaction"], "residual")
+
+    def test_wrong_call_id_blocks_replay(self):
+        receipt, portable, bundle = self._bundle()
+        result = self._verify(receipt, portable, bundle, observed_call_id="call:trace:other")
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_INVALID)
+        self.assertIn("wrong_call_id", result["binding_failures"])
+
+    def test_wrong_action_ref_blocks_replay(self):
+        receipt, portable, bundle = self._bundle()
+        result = self._verify(receipt, portable, bundle, observed_action_ref="action:other")
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_INVALID)
+        self.assertIn("wrong_action_ref", result["binding_failures"])
+
+    def test_detached_payload_tamper_is_detected(self):
+        receipt, portable, bundle = self._bundle()
+        bundle["detached_payload"]["execution_outcome"] = "rejected"
+        result = self._verify(receipt, portable, bundle)
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_INVALID)
+        self.assertIn("detached_payload_hash_mismatch", result["binding_failures"])
+
+    def test_envelope_signature_tamper_is_detected(self):
+        receipt, portable, bundle = self._bundle()
+        bundle["external_execution_evidence"]["issuer"] = "spiffe://attacker.example/controller"
+        result = self._verify(receipt, portable, bundle)
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_INVALID)
+        self.assertTrue(
+            "external_issuer_identity_mismatch" in result["binding_failures"]
+            or "external_evidence_signature_invalid" in result["binding_failures"]
+        )
+
+    def test_unknown_external_issuer_is_unverified_not_invalid(self):
+        receipt, portable, bundle = self._bundle()
+        result = verify_trace_action_evidence(
+            bundle,
+            portable,
+            self.am_trust,
+            {},
+            canonical_receipt=receipt,
+            observed_call_id=self.call_id,
+            observed_action_ref=self.action_ref,
+            authority_valid_at_execution=True,
+        )
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_UNVERIFIED)
+        self.assertEqual(result["trace_binding"], "unverifiable")
+        self.assertEqual(result["binding_failures"], [])
+        self.assertEqual(result["agent_memory"]["evidence_integrity"], "valid")
+
+    def test_required_receipt_missing_is_distinct(self):
+        receipt, portable = self._receipt_and_portable()
+        result = verify_trace_action_evidence(
+            None,
+            portable,
+            self.am_trust,
+            self.trace_trust,
+            canonical_receipt=receipt,
+        )
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_MISSING_REQUIRED)
+        self.assertIn("required_action_receipt_missing", result["binding_failures"])
+
+    def test_isolation_domain_mismatch_is_detected(self):
+        receipt, portable, bundle = self._bundle()
+        bundle["detached_payload"]["destination_domain_ref"] = "domain:opaque:wrong"
+        bundle["external_execution_evidence"]["evidence_hash"] = detached_payload_hash(
+            bundle["detached_payload"]
+        )
+        # The issuer signature still commits the old hash, so this is both an envelope
+        # signature failure and a semantic domain-binding failure.
+        result = self._verify(receipt, portable, bundle)
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_INVALID)
+        self.assertIn("destination_domain_ref_mismatch", result["binding_failures"])
+
+    def test_bundle_is_content_free_and_schema_valid(self):
+        _, _, bundle = self._bundle()
+        rendered = json.dumps(bundle, sort_keys=True)
+        self.assertNotIn("secret-memory", rendered)
+        self.assertNotIn("memory content", rendered.lower())
+
+        root = Path(__file__).resolve().parents[2]
+        schema = json.loads((root / "schemas" / "trace-action-evidence-bundle.schema.json").read_text())
+        jsonschema.Draft202012Validator(schema).validate(bundle)
+
+    def test_envelope_uses_existing_cmcp_six_field_shape(self):
+        _, _, bundle = self._bundle()
+        self.assertEqual(
+            set(bundle["external_execution_evidence"]),
+            {
+                "issuer",
+                "issuer_key_id",
+                "signature",
+                "evidence_hash",
+                "evidence_type",
+                "linked_call_id",
+            },
+        )
+        self.assertEqual(bundle["external_execution_evidence"]["evidence_type"], "opaque-receipt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/trace-action-evidence-bundle.schema.json
+++ b/schemas/trace-action-evidence-bundle.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mythologiq-labs-llc.github.io/agent-memory/schemas/trace-action-evidence-bundle.schema.json",
+  "title": "Agent Memory TRACE-Compatible Action Evidence Bundle",
+  "description": "Content-free detached Agent Memory action evidence carried through the existing cMCP external_execution_evidence envelope.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["external_execution_evidence", "detached_payload"],
+  "properties": {
+    "external_execution_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "issuer",
+        "issuer_key_id",
+        "signature",
+        "evidence_hash",
+        "evidence_type",
+        "linked_call_id"
+      ],
+      "properties": {
+        "issuer": {"type": "string", "minLength": 1},
+        "issuer_key_id": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "signature": {"type": "string", "minLength": 1},
+        "evidence_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "evidence_type": {"const": "opaque-receipt"},
+        "linked_call_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "detached_payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile",
+        "call_id",
+        "action_ref",
+        "portable_evidence_ref",
+        "canonical_receipt_ref",
+        "execution_outcome",
+        "execution_time"
+      ],
+      "properties": {
+        "profile": {"const": "agent-memory.trace-action-evidence.v1"},
+        "call_id": {"type": "string", "minLength": 1},
+        "action_ref": {"type": "string", "minLength": 1},
+        "portable_evidence_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "canonical_receipt_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "execution_outcome": {"enum": ["accepted", "rejected"]},
+        "execution_time": {"type": "string", "format": "date-time"},
+        "source_domain_ref": {"type": "string", "minLength": 1},
+        "destination_domain_ref": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Objective

Implement P4.5c from #63 by binding P4.5a Agent Memory governance evidence to the existing TRACE/cMCP external action-evidence surface without moving PAMA, memory semantics, or lifecycle authority into TRACE.

## Existing upstream contract reused

This PR deliberately reuses the released six-field cMCP `external_execution_evidence` envelope:

```text
issuer
issuer_key_id
signature
evidence_hash
evidence_type
linked_call_id
```

The Agent Memory adapter uses `evidence_type = opaque-receipt`; no new TRACE/cMCP wire field or normative evidence type is proposed.

The detached payload binds:

```text
call_id
action_ref
portable_evidence_ref
canonical_receipt_ref
execution_outcome
execution_time
optional opaque source/destination domain refs
```

Raw memory and hidden reasoning are excluded.

## Pinned interoperability surfaces

```text
agentrust-trace==0.8.0
TRACE release commit 671f2a8b22f1c995798a0c6d711b4b0b77dad4c7
cmcp-runtime==0.4.0
cMCP release commit a2e95151356c9ae6c545330c900f3d4af0e447c1
rfc8785==0.1.4
```

The released cMCP verifier is executed in a dedicated venv because its current AGT dependency line resolves a cryptography version below the primary P4.5a `cryptography==50.0.0` validation profile. The comparator does not weaken the main environment to make dependency resolution convenient.

## Canonicalization boundary

Two upstream serialization domains are preserved intentionally:

1. detached action payload: RFC 8785/JCS;
2. cMCP external-evidence envelope: the exact compact sorted JSON pre-image used by released `cmcp_verify.verify_audit_bundle()`.

P4.5c does not substitute one for the other and overclaim wire compatibility.

## Result separation

The verifier keeps TRACE receipt state separate from Agent Memory outcomes:

```text
receipt_valid_accepted
receipt_valid_rejected
receipt_missing_required
receipt_invalid
receipt_unverified
```

alongside the existing Agent Memory dimensions:

```text
evidence integrity
governance disposition
runtime execution
lifecycle satisfaction
```

A valid TRACE rejection is negative evidence, not malformed evidence. An accepted external receipt does not manufacture lifecycle satisfaction.

## Replay and binding vectors

The implementation independently binds both:

```text
linked_call_id -> audit-chain call identity
action_ref     -> Agent Memory runtime action identity
```

Tests cover:

- accepted receipt + lifecycle residual
- accepted receipt + lifecycle satisfied
- valid rejected external outcome
- wrong-call replay
- wrong-action replay
- detached payload tampering
- envelope signature tampering
- unknown/untrusted external issuer
- missing required receipt
- isolation-domain mismatch
- content-free schema validation
- exact reuse of the existing cMCP six-field envelope

## Real upstream verifier

`reference/run_trace_cmcp_comparator.py` calls released:

```python
cmcp_verify.verify_audit_bundle()
```

and requires it to:

- accept the P4.5c envelope;
- reject a different `linked_call_id`;
- reject signature tampering;
- fail closed when configured external issuer trust is absent.

## What this does not claim

- TRACE understands or enforces PAMA
- valid action evidence proves physical completion
- valid action evidence proves deletion/forgetting completeness
- TRACE Trust Record hardware attestation of Agent Memory is demonstrated
- production trust discovery or revocation is solved
- a new TRACE schema field is needed
- ADR-020, ADR-021, or ADR-022 is accepted
- Agent Memory conformance level increases

## Upstream contribution direction

The implementation is structured for a Community integration under `agentrust-io/integrations/integrations/agent-memory/` once the local exact-head evidence is green. A normative TRACE schema proposal is explicitly not justified by this slice because the existing external execution evidence surface is sufficient.

Advances #63 and #46 without closing either automatically.