### PR TITLE
P4.5 lifecycle gate: compose actual residue sweeps into portable evidence

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -40,6 +40,21 @@ jobs:
       - name: Execute reference governed-adapter paths
         run: python -m unittest discover -s reference/tests -t reference
 
+      - name: Emit deletion-completeness evidence
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_deletion_completeness.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output deletion-completeness.json
+
+      - name: Upload deletion-completeness evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: deletion-completeness-evidence
+          path: deletion-completeness.json
+          if-no-files-found: error
+
       - name: Execute released TRACE/cMCP comparator
         run: |
           python -m venv /tmp/agent-memory-p45c-cmcp
@@ -82,6 +97,7 @@ jobs:
           docs/programs/runtime-evidence/portable-governance-evidence.md
           docs/programs/runtime-evidence/agent-manifest-correlation.md
           docs/programs/runtime-evidence/trace-action-evidence.md
+          docs/programs/runtime-evidence/deletion-completeness-evidence.md
           reference/README.md
 
       - name: Validate GitHub Wiki source links
@@ -106,8 +122,9 @@ jobs:
             echo "python scripts/validate_schemas.py"
             echo "python scripts/validate_doctrine_boundaries.py"
             echo "python -m unittest discover -s reference/tests -t reference"
+            echo "python reference/run_deletion_completeness.py --agent-memory-commit <exact-40-hex-commit> --output deletion-completeness.json"
             echo "python -m venv /tmp/agent-memory-p45c-cmcp && /tmp/agent-memory-p45c-cmcp/bin/python -m pip install cmcp-runtime==0.4.0 agentrust-trace==0.8.0 agent-manifest==0.11.0 rfc8785==0.1.4 && PYTHONPATH=reference /tmp/agent-memory-p45c-cmcp/bin/python reference/run_trace_cmcp_comparator.py"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md reference/README.md"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md docs/programs/runtime-evidence/deletion-completeness-evidence.md reference/README.md"
             echo "python scripts/validate_wiki_links.py wiki-src"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'

--- a/docs/programs/runtime-evidence/README.md
+++ b/docs/programs/runtime-evidence/README.md
@@ -33,6 +33,8 @@ P4.5b is **external comparator evidence**: the tests execute the pinned Agent Ma
 
 P4.5c is **external action-evidence interoperability**: Agent Memory projects only content-free references into the existing TRACE/cMCP external execution-evidence path, keeps call identity distinct from Agent Memory action identity, and executes the resulting envelope through the released cMCP verifier. TRACE receipt validity remains separate from PAMA, runtime authorization, and lifecycle satisfaction.
 
+The P4.5 lifecycle composition is **derived lifecycle evidence**: the actual P4 residue partition and independent sweep deterministically produce the public residual/zero-residue measurement, and that measurement drives the signed P4.5a `lifecycle_result`. The portable result is therefore downstream of the deletion-completeness evidence instead of being an adjacent assertion.
+
 ## Comparator discipline
 
 External systems enter this program to answer one architectural question each, and are barred from becoming something else:
@@ -83,6 +85,7 @@ Documents are added when their slice is ready to execute, not in advance. A dire
 | [`portable-governance-evidence.md`](portable-governance-evidence.md) | P4.5a portable governance evidence core | executable substrate-independent Ed25519 issuer/verifier and adversarial vectors |
 | [`agent-manifest-correlation.md`](agent-manifest-correlation.md) | P4.5b Agent Manifest memory checkpoint correlation | pinned external comparator executed; a checkpoint built from a test log containing `DEL` remains distinct from Agent Memory lifecycle satisfaction |
 | [`trace-action-evidence.md`](trace-action-evidence.md) | P4.5c TRACE/cMCP action-evidence binding | content-free action receipt adapter plus released cMCP verifier comparator; TRACE receipt state remains separate from Agent Memory governance and lifecycle |
+| [`deletion-completeness-evidence.md`](deletion-completeness-evidence.md) | P4 -> P4.5 deletion lifecycle composition | declared residual, undeclared hard-gate failure, and zero-residue success drive signed portable lifecycle evidence and an exact-commit JSON report |
 
 ## Preconditions
 

--- a/docs/programs/runtime-evidence/deletion-completeness-evidence.md
+++ b/docs/programs/runtime-evidence/deletion-completeness-evidence.md
@@ -1,0 +1,181 @@
+# P4.5 deletion-completeness evidence composition
+
+Status: **Executable lifecycle composition**. This slice closes the evidence seam between the P4 canonical/derived-state residue model and P4.5 portable governance evidence. It does not change deletion semantics, accept an ADR, or raise a conformance level.
+
+Parent implementation issue: #63.
+
+## Why this composition exists
+
+P4 already executes transitive purge and an independent residue sweep. P4.5a already carries `lifecycle_satisfaction` as a signed portable dimension. Those facts are necessary but, by themselves, do not prove that the portable lifecycle result was derived from the residue measurement rather than typed independently.
+
+This composition makes that relationship executable:
+
+```text
+governed permanent deletion
+        |
+        v
+P4 residue partition + independent sweep
+        |
+        | deterministic content-free measurement
+        v
+lifecycle = residual | satisfied
+        |
+        | signed by P4.5a
+        v
+portable deletion-completeness chain
+```
+
+The portable outcome is now a consequence of the P4 measurement.
+
+## Public measurement
+
+Schema: `../../../schemas/deletion-completeness-chain.schema.json`.
+
+The public measurement contains counts, not projection identifiers:
+
+```text
+purged_count
+declared_residual_controlled_count
+declared_residual_uncontrollable_count
+undeclared_residual_count
+independently_observed_residual_count
+total_residual_count
+hard_gate_passed
+lifecycle_satisfaction
+```
+
+The lifecycle rule is deliberately simple:
+
+```text
+total residual = 0  -> satisfied
+total residual > 0  -> residual
+```
+
+The undeclared-residue gate remains separate:
+
+```text
+undeclared residual = 0  -> hard gate passed
+undeclared residual > 0  -> hard gate failed
+```
+
+Therefore a deletion may be truthfully represented as `lifecycle = residual` while the undeclared-residue hard gate still passes, for example when a surviving projection is known, declared, and policy-retained. Conversely, undeclared residue is both residual lifecycle state and a hard-gate failure.
+
+## Independent observation
+
+The composition does not trust the purge to report its own success. The `independently_observed_residual_count` comes from `ProjectionGovernor.sweep(set())`, which deliberately supplies no declaration exemptions. It therefore re-derives all surviving content-bearing residue from the retained projection graph.
+
+`measure_deletion_completeness()` rejects a partition that claims surviving declared or undeclared residue the independent sweep did not observe. A receipt cannot simply announce residue and have the measurement believe it.
+
+## Executed scenarios
+
+`../../../reference/tests/test_deletion_completeness_evidence.py` executes three paths.
+
+### Declared residual
+
+A transitive deletion is authorized and committed, but one content-bearing projection is retained by policy. The independent sweep observes the survivor.
+
+Expected public result:
+
+```text
+independently_observed_residual_count = 1
+total_residual_count                  = 1
+undeclared_residual_count             = 0
+hard_gate_passed                      = true
+lifecycle_satisfaction                = residual
+```
+
+### Undeclared residual
+
+A deliberately broken one-hop derived purge follows an authorized canonical deletion. A second-hop projection survives without being declared. The independent sweep catches it.
+
+Expected public result:
+
+```text
+independently_observed_residual_count = 1
+undeclared_residual_count             = 1
+hard_gate_passed                      = false
+lifecycle_satisfaction                = residual
+```
+
+This is the adversarial proof that the sweep can fail.
+
+### Zero residue
+
+The normal P4 transitive purge reaches the entire derivation closure and the independent sweep finds no surviving content-bearing projection.
+
+Expected public result:
+
+```text
+independently_observed_residual_count = 0
+total_residual_count                  = 0
+undeclared_residual_count             = 0
+hard_gate_passed                      = true
+lifecycle_satisfaction                = satisfied
+```
+
+## Portable binding
+
+Each scenario builds a P4.5a portable governance object whose:
+
+```text
+memory_action       = permanent_deletion
+governance          = committed
+after_state_ref     = sha256(public measurement)
+lifecycle_result    = derived measurement lifecycle
+canonical_receipt   = content-addressed canonical decision receipt
+action_ref          = scenario-specific runtime action reference
+```
+
+The signed portable evidence remains verifiable against the canonical receipt and an independently observed runtime action.
+
+The chain also records the exact Agent Memory commit SHA used to execute the scenario. CI passes the pull-request head SHA or push SHA explicitly rather than relying on a branch name.
+
+## Privacy boundary
+
+The public chain intentionally excludes:
+
+- deleted memory content;
+- canonical memory identifiers;
+- projection identifiers;
+- hidden reasoning;
+- full canonical receipts.
+
+Internal identifiers are required to execute a residue graph, but they are converted to counts and content-addressed references before the chain is serialized. The executable report fails if its known private fixture content or internal projection identifiers appear in the public JSON.
+
+## Machine-readable report
+
+`../../../reference/run_deletion_completeness.py` emits all three scenarios as JSON. CI runs:
+
+```bash
+python reference/run_deletion_completeness.py \
+  --agent-memory-commit <exact-40-hex-commit> \
+  --output deletion-completeness.json
+```
+
+and uploads that JSON as a workflow artifact.
+
+The report is evidence, not a conformance declaration. It records the exact source commit, scenario measurements, signed P4.5a objects, and their content-addressed references.
+
+## What this closes
+
+This slice supplies executable evidence for the #63 lifecycle gate:
+
+- P4 deletion completeness is exercised with residual and zero-residue outcomes;
+- the independent sweep detects a surviving projection;
+- the clean transitive purge demonstrates zero residual;
+- signed portable evidence distinguishes the outcomes without deleted memory content.
+
+It also covers both declared-residual and undeclared-residual negative cases, rather than treating every non-zero residue as the same governance condition.
+
+## What remains separate
+
+This composition does not prove:
+
+- that a remote storage provider actually erased physical media;
+- that an undeclared projection can always be discovered if it was never represented in the declaration/sweep surface;
+- production key custody or trust discovery;
+- upstream AgenTrust integration acceptance;
+- AGT runtime-enforcement composition;
+- ADR-020, ADR-021, or ADR-022 acceptance.
+
+The declaration surface remains load-bearing. A sweep cannot find state the system has no observability path to inspect, which is why undeclared-state discovery outside the modeled projection universe remains an explicit limitation rather than a magical guarantee.

--- a/reference/agentmem_ref/deletion_completeness.py
+++ b/reference/agentmem_ref/deletion_completeness.py
@@ -1,0 +1,175 @@
+"""Compose P4 deletion-residue measurements into P4.5 portable evidence.
+
+P4 proves whether derived state survived a governed deletion. P4.5 proves that a
+content-free third party can distinguish those lifecycle outcomes without
+receiving the deleted memory. This module is the explicit seam between them.
+
+The public measurement intentionally carries counts and cryptographic references,
+not projection identifiers or memory content. Internal residue identifiers remain
+available to the local sweep and receipt-generation path but are not serialized
+into the portable chain.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from . import residue
+from .portable_evidence import IssuerKey, sha256_ref, issue_evidence
+
+PROFILE = "agent-memory-deletion-completeness-chain"
+VERSION = "1.0.0"
+
+
+@dataclass(frozen=True)
+class DeletionCompletenessMeasurement:
+    """Content-free lifecycle measurement derived from the P4 residue partition."""
+
+    purged_count: int
+    declared_residual_controlled_count: int
+    declared_residual_uncontrollable_count: int
+    undeclared_residual_count: int
+    independently_observed_residual_count: int
+
+    @property
+    def lifecycle_satisfaction(self) -> str:
+        return "satisfied" if self.total_residual_count == 0 else "residual"
+
+    @property
+    def hard_gate_passed(self) -> bool:
+        return self.undeclared_residual_count == 0
+
+    @property
+    def total_residual_count(self) -> int:
+        return (
+            self.declared_residual_controlled_count
+            + self.declared_residual_uncontrollable_count
+            + self.undeclared_residual_count
+        )
+
+    def as_public_summary(self) -> dict:
+        return {
+            "purged_count": self.purged_count,
+            "declared_residual_controlled_count": self.declared_residual_controlled_count,
+            "declared_residual_uncontrollable_count": self.declared_residual_uncontrollable_count,
+            "undeclared_residual_count": self.undeclared_residual_count,
+            "independently_observed_residual_count": self.independently_observed_residual_count,
+            "total_residual_count": self.total_residual_count,
+            "hard_gate_passed": self.hard_gate_passed,
+            "lifecycle_satisfaction": self.lifecycle_satisfaction,
+        }
+
+
+def measure_deletion_completeness(
+    buckets: Mapping[str, Sequence[str]],
+    independently_observed_residual: Sequence[str],
+) -> DeletionCompletenessMeasurement:
+    """Derive a public lifecycle measurement from actual P4 residue evidence.
+
+    `independently_observed_residual` is intentionally supplied from an
+    independent sweep that ignores the purge's own declaration list. This makes
+    it possible to prove that surviving content existed even when the deletion
+    receipt correctly declared that residue.
+    """
+    required = {
+        residue.PURGED,
+        residue.DECLARED_CONTROLLED,
+        residue.DECLARED_UNCONTROLLABLE,
+        residue.UNDECLARED,
+    }
+    missing = required.difference(buckets)
+    if missing:
+        raise ValueError(f"residue partition missing buckets: {sorted(missing)}")
+
+    values: dict[str, tuple[str, ...]] = {}
+    for name in required:
+        items = tuple(buckets[name])
+        if any(not isinstance(item, str) or not item for item in items):
+            raise ValueError(f"residue bucket {name} contains a non-string identifier")
+        if len(items) != len(set(items)):
+            raise ValueError(f"residue bucket {name} contains duplicate identifiers")
+        values[name] = items
+
+    observed = tuple(independently_observed_residual)
+    if any(not isinstance(item, str) or not item for item in observed):
+        raise ValueError("independent residue sweep contains a non-string identifier")
+    if len(observed) != len(set(observed)):
+        raise ValueError("independent residue sweep contains duplicate identifiers")
+
+    declared_or_undeclared = (
+        set(values[residue.DECLARED_CONTROLLED])
+        | set(values[residue.DECLARED_UNCONTROLLABLE])
+        | set(values[residue.UNDECLARED])
+    )
+    if not declared_or_undeclared.issubset(set(observed)):
+        raise ValueError("public residue partition claims survivors the independent sweep did not observe")
+
+    return DeletionCompletenessMeasurement(
+        purged_count=len(values[residue.PURGED]),
+        declared_residual_controlled_count=len(values[residue.DECLARED_CONTROLLED]),
+        declared_residual_uncontrollable_count=len(values[residue.DECLARED_UNCONTROLLABLE]),
+        undeclared_residual_count=len(values[residue.UNDECLARED]),
+        independently_observed_residual_count=len(observed),
+    )
+
+
+def build_deletion_completeness_chain(
+    canonical_receipt: Mapping[str, object],
+    measurement: DeletionCompletenessMeasurement,
+    *,
+    agent_memory_commit: str,
+    issuer_id: str,
+    issuer_key: IssuerKey,
+    issued_at: str,
+    action_ref: str,
+    policy_ref: str,
+    authority_state_ref: str,
+    decision_time: str,
+    scope_ref: str,
+    before_state_ref: str,
+    source_domain_ref: str | None = None,
+    destination_domain_ref: str | None = None,
+    domain_authorization_state_ref: str | None = None,
+) -> dict:
+    """Bind an actual residue measurement to signed P4.5 portable evidence."""
+    if len(agent_memory_commit) != 40 or any(c not in "0123456789abcdef" for c in agent_memory_commit):
+        raise ValueError("agent_memory_commit must be an exact lowercase 40-hex commit SHA")
+
+    selected_action = canonical_receipt.get("selected_action")
+    if selected_action != "permanent_deletion":
+        raise ValueError("deletion completeness requires a canonical permanent_deletion receipt")
+
+    summary = measurement.as_public_summary()
+    summary_ref = sha256_ref(summary)
+    portable = issue_evidence(
+        canonical_receipt,
+        issuer_id=issuer_id,
+        key=issuer_key,
+        issued_at=issued_at,
+        action_ref=action_ref,
+        memory_action="permanent_deletion",
+        governance_disposition="committed",
+        policy_ref=policy_ref,
+        authority_state_ref=authority_state_ref,
+        decision_time=decision_time,
+        scope_ref=scope_ref,
+        before_state_ref=before_state_ref,
+        after_state_ref=summary_ref,
+        lifecycle_result=measurement.lifecycle_satisfaction,
+        source_domain_ref=source_domain_ref,
+        destination_domain_ref=destination_domain_ref,
+        domain_authorization_state_ref=domain_authorization_state_ref,
+    )
+
+    return {
+        "profile": PROFILE,
+        "version": VERSION,
+        "agent_memory_commit": agent_memory_commit,
+        "canonical_receipt_ref": portable["canonical_receipt_ref"],
+        "action_ref": action_ref,
+        "measurement_ref": summary_ref,
+        "measurement": summary,
+        "portable_evidence_ref": sha256_ref(portable),
+        "portable_evidence": portable,
+    }

--- a/reference/run_deletion_completeness.py
+++ b/reference/run_deletion_completeness.py
@@ -1,0 +1,204 @@
+"""Emit composed P4 -> P4.5 deletion-completeness evidence for CI/audit.
+
+The output contains only public, content-free evidence chains. Internal memory
+content and projection identifiers are used to execute the residue model but are
+never serialized.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref import policy, projections, receipts, residue  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter  # noqa: E402
+from agentmem_ref.deletion_completeness import (  # noqa: E402
+    build_deletion_completeness_chain,
+    measure_deletion_completeness,
+)
+from agentmem_ref.portable_evidence import IssuerKey  # noqa: E402
+from agentmem_ref.projection_governance import ProjectionGovernor  # noqa: E402
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+TENANT = "tenant:opaque:deletion-evidence"
+SOURCE = "memory:internal:alpha"
+ISSUER = "issuer:deletion-completeness-reference"
+KEY = IssuerKey(
+    issuer_id=ISSUER,
+    key_id="key-p45-lifecycle-report",
+    private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(97, 129))),
+    valid_from="2026-08-01T00:00:00Z",
+    valid_until="2026-08-31T23:59:59Z",
+)
+
+
+def _seed_proposal() -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id="prop-seed-report",
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference=SOURCE,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("ev:seed",),
+        tenant_ref=TENANT,
+    )
+
+
+def _delete_proposal(proposal_id: str) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=proposal_id,
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference=SOURCE,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="permanent_deletion",
+        current_strength="reinforced",
+        proposed_strength="removed",
+        downstream_authority=policy.A1,
+        reversibility="irreversible",
+        risk_class="low",
+        evidence_refs=("ev:deletion-request",),
+        tenant_ref=TENANT,
+        approval_refs=("approval:data-protection-officer",),
+        review_satisfied=True,
+    )
+
+
+def _governor() -> ProjectionGovernor:
+    adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), TENANT, Clock())
+    gov = ProjectionGovernor(adapter)
+    adapter.commit_proposal(_seed_proposal(), "private memory content not emitted")
+    gov.declare(
+        "internal:summary:one",
+        (SOURCE,),
+        projections.ESTIMATOR_MEDIATED,
+        projections.RECOVERABLE_CONTENT,
+        projections.APPROXIMABLE,
+        TENANT,
+    )
+    gov.declare(
+        "internal:summary:two",
+        ("internal:summary:one",),
+        projections.ESTIMATOR_MEDIATED,
+        projections.RECOVERABLE_CONTENT,
+        projections.APPROXIMABLE,
+        TENANT,
+    )
+    return gov
+
+
+def _chain(receipt: dict, measurement, commit: str, action_ref: str) -> dict:
+    return build_deletion_completeness_chain(
+        receipt,
+        measurement,
+        agent_memory_commit=commit,
+        issuer_id=ISSUER,
+        issuer_key=KEY,
+        issued_at="2026-08-11T21:40:02Z",
+        action_ref=action_ref,
+        policy_ref="policy:pama-2026-08",
+        authority_state_ref="authority:rev-41",
+        decision_time="2026-08-11T21:40:01Z",
+        scope_ref="scope:opaque:deletion-report",
+        before_state_ref="sha256:" + "6" * 64,
+        source_domain_ref="domain:opaque:source",
+        destination_domain_ref="domain:opaque:deleted",
+    )
+
+
+def _declared_residual(commit: str) -> dict:
+    gov = _governor()
+    result = gov.purge(
+        _delete_proposal("prop-report-declared"),
+        SOURCE,
+        retained_by_policy={"internal:summary:two"},
+    )
+    measurement = measure_deletion_completeness(result.buckets, gov.sweep(set()))
+    return _chain(result.receipt, measurement, commit, "action:delete:declared-residual")
+
+
+def _undeclared_residual(commit: str) -> dict:
+    gov = _governor()
+    delete = _delete_proposal("prop-report-undeclared")
+    decision = policy.evaluate(delete)
+    receipt = receipts.build_receipt(
+        receipt_id="receipt:delete:undeclared-report",
+        proposal=delete,
+        decision=decision,
+        selected_action="permanent_deletion",
+        selection_mode="deterministic",
+        timestamp="2026-08-11T21:40:01Z",
+        before_state="v1",
+        after_state="v1",
+    )
+    one_hop = residue.ResiduePlan(purged=["internal:summary:one"])
+    residue.apply_purge(gov.store, one_hop, gov._purged)
+    gov._purged.add(SOURCE)
+    buckets = residue.partition(gov.store, gov.view(), one_hop)
+    measurement = measure_deletion_completeness(buckets, gov.sweep(set()))
+    return _chain(receipt, measurement, commit, "action:delete:undeclared-residual")
+
+
+def _satisfied(commit: str) -> dict:
+    gov = _governor()
+    result = gov.purge(_delete_proposal("prop-report-clean"), SOURCE)
+    measurement = measure_deletion_completeness(result.buckets, gov.sweep(set()))
+    return _chain(result.receipt, measurement, commit, "action:delete:zero-residue")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = {
+        "report_type": "agent-memory-deletion-completeness-report",
+        "version": "1.0.0",
+        "agent_memory_commit": args.agent_memory_commit,
+        "scenarios": {
+            "declared_residual": _declared_residual(args.agent_memory_commit),
+            "undeclared_residual": _undeclared_residual(args.agent_memory_commit),
+            "zero_residue": _satisfied(args.agent_memory_commit),
+        },
+    }
+
+    if report["scenarios"]["declared_residual"]["measurement"]["lifecycle_satisfaction"] != "residual":
+        raise AssertionError("declared residual scenario did not remain residual")
+    if report["scenarios"]["undeclared_residual"]["measurement"]["hard_gate_passed"]:
+        raise AssertionError("undeclared residue scenario did not fail the hard gate")
+    if report["scenarios"]["zero_residue"]["measurement"]["lifecycle_satisfaction"] != "satisfied":
+        raise AssertionError("zero-residue scenario did not satisfy lifecycle")
+
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if any(secret in rendered for secret in (
+        "private memory content",
+        "internal:summary:one",
+        "internal:summary:two",
+        SOURCE,
+    )):
+        raise AssertionError("public deletion-completeness report leaked internal identifiers/content")
+
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_deletion_completeness_evidence.py
+++ b/reference/tests/test_deletion_completeness_evidence.py
@@ -1,0 +1,256 @@
+"""Compose actual P4 residue outcomes into P4.5 portable lifecycle evidence."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+import jsonschema
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from referencing import Registry, Resource
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy, projections, receipts, residue  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter  # noqa: E402
+from agentmem_ref.deletion_completeness import (  # noqa: E402
+    build_deletion_completeness_chain,
+    measure_deletion_completeness,
+)
+from agentmem_ref.portable_evidence import (  # noqa: E402
+    IssuerKey,
+    RuntimeObservation,
+    verify_evidence,
+)
+from agentmem_ref.projection_governance import ProjectionGovernor  # noqa: E402
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+TENANT = "tenant-a"
+SOURCE = "mem:alpha"
+COMMIT = "a" * 40
+ISSUER = "issuer:deletion-completeness-reference"
+KEY = IssuerKey(
+    issuer_id=ISSUER,
+    key_id="key-p45-lifecycle",
+    private_key=Ed25519PrivateKey.from_private_bytes(bytes(range(65, 97))),
+    valid_from="2026-08-01T00:00:00Z",
+    valid_until="2026-08-31T23:59:59Z",
+)
+
+
+def proposal(**overrides) -> policy.Proposal:
+    base = dict(
+        proposal_id="prop-delete",
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference=SOURCE,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="permanent_deletion",
+        current_strength="reinforced",
+        proposed_strength="removed",
+        downstream_authority=policy.A1,
+        reversibility="irreversible",
+        risk_class="low",
+        evidence_refs=("ev:deletion-request",),
+        tenant_ref=TENANT,
+        approval_refs=("approval:data-protection-officer",),
+        review_satisfied=True,
+    )
+    base.update(overrides)
+    return policy.Proposal(**base)
+
+
+def make_governor() -> ProjectionGovernor:
+    adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), TENANT, Clock())
+    gov = ProjectionGovernor(adapter)
+    adapter.commit_proposal(
+        policy.Proposal(
+            proposal_id="prop-seed",
+            actor_id="agent:planner",
+            charter_version="charter-1",
+            target_reference=SOURCE,
+            target_class=policy.M2,
+            scope=TENANT,
+            operation="promotion",
+            current_strength="reinforced",
+            proposed_strength="promoted",
+            downstream_authority=policy.A1,
+            reversibility="reversible",
+            risk_class="low",
+            evidence_refs=("ev:seed",),
+            tenant_ref=TENANT,
+        ),
+        "deleted-memory-content-that-must-never-enter-portable-evidence",
+    )
+    gov.declare(
+        "summary:one",
+        (SOURCE,),
+        projections.ESTIMATOR_MEDIATED,
+        projections.RECOVERABLE_CONTENT,
+        projections.APPROXIMABLE,
+        TENANT,
+    )
+    gov.declare(
+        "summary:two",
+        ("summary:one",),
+        projections.ESTIMATOR_MEDIATED,
+        projections.RECOVERABLE_CONTENT,
+        projections.APPROXIMABLE,
+        TENANT,
+    )
+    return gov
+
+
+def chain_for(receipt: dict, measurement, action_ref: str) -> dict:
+    return build_deletion_completeness_chain(
+        receipt,
+        measurement,
+        agent_memory_commit=COMMIT,
+        issuer_id=ISSUER,
+        issuer_key=KEY,
+        issued_at="2026-08-11T21:30:02Z",
+        action_ref=action_ref,
+        policy_ref="policy:pama-2026-08",
+        authority_state_ref="authority:rev-40",
+        decision_time="2026-08-11T21:30:01Z",
+        scope_ref="scope:opaque:deletion-completeness",
+        before_state_ref="sha256:" + "5" * 64,
+        source_domain_ref="domain:opaque:project-a",
+        destination_domain_ref="domain:opaque:deleted",
+    )
+
+
+class DeletionCompletenessEvidenceTests(unittest.TestCase):
+    def _verify_chain(self, receipt: dict, chain: dict) -> dict:
+        trust = KEY.trust_key()
+        return verify_evidence(
+            chain["portable_evidence"],
+            {(trust.issuer_id, trust.key_id): trust},
+            canonical_receipt=receipt,
+            runtime=RuntimeObservation(
+                action_ref=chain["action_ref"],
+                execution_time="2026-08-11T21:30:03Z",
+                authority_valid_at_execution=True,
+            ),
+        )
+
+    def test_declared_residual_is_observed_and_portably_reported(self):
+        gov = make_governor()
+        result = gov.purge(proposal(), SOURCE, retained_by_policy={"summary:two"})
+        self.assertTrue(result.committed)
+
+        observed = gov.sweep(set())
+        self.assertEqual(observed, ["summary:two"])
+        measurement = measure_deletion_completeness(result.buckets, observed)
+        self.assertTrue(measurement.hard_gate_passed)
+        self.assertEqual(measurement.total_residual_count, 1)
+        self.assertEqual(measurement.lifecycle_satisfaction, "residual")
+
+        chain = chain_for(result.receipt, measurement, "action:delete:declared-residual")
+        verified = self._verify_chain(result.receipt, chain)
+        self.assertEqual(verified["evidence_integrity"], "valid")
+        self.assertEqual(verified["runtime_execution"], "executed_as_authorized")
+        self.assertEqual(verified["lifecycle_satisfaction"], "residual")
+        self.assertEqual(chain["measurement"]["independently_observed_residual_count"], 1)
+
+    def test_undeclared_residue_hard_gate_failure_is_portably_reported(self):
+        gov = make_governor()
+        delete = proposal(proposal_id="prop-delete-partial")
+        decision = policy.evaluate(delete)
+        self.assertIn("permanent_deletion", decision.permitted_actions)
+        canonical_receipt = receipts.build_receipt(
+            receipt_id="receipt:delete:partial",
+            proposal=delete,
+            decision=decision,
+            selected_action="permanent_deletion",
+            selection_mode="deterministic",
+            timestamp="2026-08-11T21:30:01Z",
+            before_state="v1",
+            after_state="v1",
+        )
+
+        # Deliberately broken one-hop derived purge after an authorized canonical
+        # delete. The independent sweep must expose the transitive survivor.
+        one_hop = residue.ResiduePlan(purged=["summary:one"])
+        residue.apply_purge(gov.store, one_hop, gov._purged)
+        gov._purged.add(SOURCE)
+        buckets = residue.partition(gov.store, gov.view(), one_hop)
+        observed = gov.sweep(set())
+        self.assertEqual(buckets[residue.UNDECLARED], ["summary:two"])
+        self.assertEqual(observed, ["summary:two"])
+
+        measurement = measure_deletion_completeness(buckets, observed)
+        self.assertFalse(measurement.hard_gate_passed)
+        self.assertEqual(measurement.undeclared_residual_count, 1)
+        self.assertEqual(measurement.lifecycle_satisfaction, "residual")
+
+        chain = chain_for(canonical_receipt, measurement, "action:delete:undeclared-residual")
+        verified = self._verify_chain(canonical_receipt, chain)
+        self.assertEqual(verified["evidence_integrity"], "valid")
+        self.assertEqual(verified["lifecycle_satisfaction"], "residual")
+        self.assertFalse(chain["measurement"]["hard_gate_passed"])
+
+    def test_transitive_purge_zero_residue_is_portably_satisfied(self):
+        gov = make_governor()
+        result = gov.purge(proposal(proposal_id="prop-delete-clean"), SOURCE)
+        self.assertTrue(result.committed)
+        self.assertTrue(result.hard_gate_passed)
+
+        observed = gov.sweep(set())
+        self.assertEqual(observed, [])
+        measurement = measure_deletion_completeness(result.buckets, observed)
+        self.assertEqual(measurement.total_residual_count, 0)
+        self.assertEqual(measurement.lifecycle_satisfaction, "satisfied")
+
+        chain = chain_for(result.receipt, measurement, "action:delete:zero-residue")
+        verified = self._verify_chain(result.receipt, chain)
+        self.assertEqual(verified["evidence_integrity"], "valid")
+        self.assertEqual(verified["runtime_execution"], "executed_as_authorized")
+        self.assertEqual(verified["lifecycle_satisfaction"], "satisfied")
+        self.assertEqual(chain["measurement"]["independently_observed_residual_count"], 0)
+
+    def test_public_chains_exclude_memory_and_projection_identifiers(self):
+        gov = make_governor()
+        result = gov.purge(proposal(), SOURCE, retained_by_policy={"summary:two"})
+        measurement = measure_deletion_completeness(result.buckets, gov.sweep(set()))
+        chain = chain_for(result.receipt, measurement, "action:delete:privacy")
+
+        rendered = json.dumps(chain, sort_keys=True)
+        self.assertNotIn("deleted-memory-content", rendered)
+        self.assertNotIn("summary:one", rendered)
+        self.assertNotIn("summary:two", rendered)
+        self.assertNotIn(SOURCE, rendered)
+
+    def test_chain_and_embedded_portable_evidence_validate(self):
+        gov = make_governor()
+        result = gov.purge(proposal(proposal_id="prop-delete-schema"), SOURCE)
+        measurement = measure_deletion_completeness(result.buckets, gov.sweep(set()))
+        chain = chain_for(result.receipt, measurement, "action:delete:schema")
+
+        root = Path(__file__).resolve().parents[2]
+        schema_dir = root / "schemas"
+        chain_schema = json.loads((schema_dir / "deletion-completeness-chain.schema.json").read_text())
+        portable_schema = json.loads((schema_dir / "portable-governance-evidence.schema.json").read_text())
+        registry = Registry().with_resource(
+            portable_schema["$id"],
+            Resource.from_contents(portable_schema),
+        )
+        jsonschema.Draft202012Validator(chain_schema, registry=registry).validate(chain)
+        jsonschema.Draft202012Validator(portable_schema).validate(chain["portable_evidence"])
+
+    def test_measurement_rejects_a_partition_not_supported_by_independent_sweep(self):
+        buckets = {
+            residue.PURGED: [],
+            residue.DECLARED_CONTROLLED: ["projection:claimed"],
+            residue.DECLARED_UNCONTROLLABLE: [],
+            residue.UNDECLARED: [],
+        }
+        with self.assertRaises(ValueError):
+            measure_deletion_completeness(buckets, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/deletion-completeness-chain.schema.json
+++ b/schemas/deletion-completeness-chain.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mythologiq-labs-llc.github.io/agent-memory/schemas/deletion-completeness-chain.schema.json",
+  "title": "Agent Memory Deletion Completeness Evidence Chain",
+  "description": "Content-free composition of a P4 residue measurement with signed P4.5 portable governance evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "profile",
+    "version",
+    "agent_memory_commit",
+    "canonical_receipt_ref",
+    "action_ref",
+    "measurement_ref",
+    "measurement",
+    "portable_evidence_ref",
+    "portable_evidence"
+  ],
+  "properties": {
+    "profile": {"const": "agent-memory-deletion-completeness-chain"},
+    "version": {"const": "1.0.0"},
+    "agent_memory_commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "canonical_receipt_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "action_ref": {"type": "string", "minLength": 1},
+    "measurement_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "portable_evidence_ref": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "measurement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "purged_count",
+        "declared_residual_controlled_count",
+        "declared_residual_uncontrollable_count",
+        "undeclared_residual_count",
+        "independently_observed_residual_count",
+        "total_residual_count",
+        "hard_gate_passed",
+        "lifecycle_satisfaction"
+      ],
+      "properties": {
+        "purged_count": {"type": "integer", "minimum": 0},
+        "declared_residual_controlled_count": {"type": "integer", "minimum": 0},
+        "declared_residual_uncontrollable_count": {"type": "integer", "minimum": 0},
+        "undeclared_residual_count": {"type": "integer", "minimum": 0},
+        "independently_observed_residual_count": {"type": "integer", "minimum": 0},
+        "total_residual_count": {"type": "integer", "minimum": 0},
+        "hard_gate_passed": {"type": "boolean"},
+        "lifecycle_satisfaction": {"enum": ["satisfied", "residual"]}
+      }
+    },
+    "portable_evidence": {
+      "$ref": "portable-governance-evidence.schema.json"
+    }
+  }
+}


### PR DESCRIPTION
## Objective

Close the remaining #63 lifecycle-evidence seam by deriving P4.5 portable lifecycle outcomes from the actual P4 residue partition and independent sweep, rather than testing residue and portable lifecycle semantics only in adjacent suites.

## What this adds

- `reference/agentmem_ref/deletion_completeness.py`
- `reference/tests/test_deletion_completeness_evidence.py`
- `reference/run_deletion_completeness.py`
- `schemas/deletion-completeness-chain.schema.json`
- `docs/programs/runtime-evidence/deletion-completeness-evidence.md`
- CI emission/upload of exact-commit machine-readable deletion evidence

## Executed lifecycle states

### Declared residual

A governed deletion commits while one content-bearing projection is retained by policy. The independent sweep observes the survivor.

Expected:

```text
residual count = 1
undeclared residual = 0
hard gate = pass
lifecycle = residual
```

### Undeclared residual

A deliberately broken one-hop derived purge follows an authorized canonical deletion. The independent sweep catches the transitive survivor.

Expected:

```text
residual count = 1
undeclared residual = 1
hard gate = fail
lifecycle = residual
```

### Zero residue

The normal transitive purge reaches the full derivation closure and the independent sweep is empty.

Expected:

```text
residual count = 0
undeclared residual = 0
hard gate = pass
lifecycle = satisfied
```

## Portable binding

Each actual P4 measurement drives a signed P4.5a evidence object:

```text
memory_action = permanent_deletion
governance = committed
after_state_ref = sha256(content-free measurement)
lifecycle_result = derived from residue counts
```

The public chain contains counts and cryptographic references, not deleted memory or projection identifiers.

## Independent-sweep requirement

The public measurement is not allowed to believe the purge's report blindly. `measure_deletion_completeness()` rejects a residue partition that claims surviving state the independent sweep did not observe.

## Reproducibility

CI passes the exact pull-request head SHA or push SHA to `reference/run_deletion_completeness.py` and uploads `deletion-completeness.json` as a workflow artifact. This makes the evidence commit-specific rather than branch-relative.

## Claim boundary

This does not claim physical-media erasure, omniscient discovery of unmodeled state, ADR acceptance, or a higher conformance level. It closes the modeled deletion-completeness lifecycle gate by making the P4 -> P4.5 derivation explicit and executable.

Advances #63 and #46 without auto-closing either until all acceptance criteria are reconciled.