### PR TITLE
P4.5: fail closed on cross-domain authorization continuity

### DIFF
--- a/docs/programs/runtime-evidence/portable-governance-evidence.md
+++ b/docs/programs/runtime-evidence/portable-governance-evidence.md
@@ -41,9 +41,10 @@ Therefore all of these are representable without contradiction:
 valid evidence + denied + unauthorized execution
 valid evidence + committed + executed as authorized + residual
 valid evidence + committed + executed as authorized + satisfied
+valid evidence + committed + revoked domain membership + unauthorized execution
 ```
 
-A valid signature never manufactures PAMA permission. A valid runtime action never proves lifecycle satisfaction.
+A valid signature never manufactures PAMA permission. A valid runtime action never proves lifecycle satisfaction. Generic actor/PAMA authority also never manufactures isolation-domain membership.
 
 ## Portable evidence v1
 
@@ -156,12 +157,26 @@ The reference verifier can compare signed evidence to independently observed run
 - authority-state reference
 - source isolation domain
 - destination isolation domain
+- domain-authorization-state reference
 - execution time
-- execution-time authority continuity
+- execution-time generic authority continuity
+- execution-time domain-membership/authorization continuity
 
-Wrong action catches replay against another execution. Wrong policy/authority references expose stale or mismatched decision state. Wrong domain catches an isolation-boundary mismatch without requiring raw domain contents. Execution before the signed decision is rejected.
+Wrong action catches replay against another execution. Wrong policy/authority references expose stale or mismatched decision state. Wrong source/destination domain catches isolation-boundary broadening or substitution without requiring raw domain contents. A stale domain-authorization-state reference exposes membership/state drift. Execution before the signed decision is rejected.
 
-If execution is observed but execution-time authority continuity is unknown, runtime authorization is reported as `unverifiable`, not optimistically permitted.
+Generic authority and domain authorization are intentionally separate. For a boundary-crossing action, `source_domain_ref != destination_domain_ref`, a verifier needs both the signed domain-authorization state and independent execution-time continuity evidence. If either is missing, `runtime_execution` is `unverifiable`, not optimistically permitted. If membership/authorization is independently known to be revoked or expired at execution, the evidence can remain cryptographically valid while `runtime_execution` becomes `unauthorized_execution`.
+
+This distinction lets a verifier truthfully represent:
+
+```text
+signature = valid
+decision-time governance = committed
+generic actor authority at execution = valid
+shared-domain membership at execution = revoked
+runtime execution = unauthorized_execution
+```
+
+No signature rewriting is needed. Historical evidence stays authentic while current authorization truth remains current.
 
 ## Machine-readable result taxonomy
 
@@ -178,7 +193,7 @@ If execution is observed but execution-time authority continuity is unknown, run
 }
 ```
 
-`binding_failures` is intentionally explicit because a verifier needs to distinguish tampering, unknown trust, replay, stale policy, stale authority, temporal mismatch, and wrong isolation domain rather than flattening them into the same red light.
+`binding_failures` is intentionally explicit because a verifier needs to distinguish tampering, unknown trust, replay, stale policy, stale authority, stale domain authorization, temporal mismatch, and wrong isolation domain rather than flattening them into the same red light.
 
 ## Executed vectors
 
@@ -195,8 +210,13 @@ If execution is observed but execution-time authority continuity is unknown, run
 - stale/wrong policy reference
 - stale/wrong authority-state reference
 - wrong source isolation domain
+- unauthorized destination-domain broadening
+- stale/wrong domain-authorization-state reference
+- revoked/expired shared-domain membership at execution
+- fail-closed cross-domain execution with missing membership continuity evidence
+- fail-closed cross-domain execution with no signed membership state
 - execution preceding the signed decision
-- fail-closed execution when authority continuity is unknown
+- fail-closed execution when generic authority continuity is unknown
 - valid denial plus unauthorized runtime execution
 - authorized deletion with residual lifecycle state
 - detached verification after canonical content is unavailable
@@ -214,7 +234,7 @@ python scripts/validate_schemas.py
 
 ## What this slice proves
 
-P4.5a now has an executable substrate-independent boundary for content-free, independently verifiable governance evidence. It demonstrates that Agent Memory can sign and independently check the binding among a canonical receipt reference, decision-time governance state, isolation-domain references, and a runtime action while preserving lifecycle outcome as a separate semantic dimension.
+P4.5a has an executable substrate-independent boundary for content-free, independently verifiable governance evidence. It demonstrates that Agent Memory can sign and independently check the binding among a canonical receipt reference, decision-time governance state, isolation-domain references, domain-authorization state, and a runtime action while preserving lifecycle outcome as a separate semantic dimension.
 
 The implementation also demonstrates the core deletion distinction:
 
@@ -224,16 +244,17 @@ valid evidence of authorized deletion != proof of forgetting
 
 A correctly signed, authorized, correctly executed delete may still carry `lifecycle_satisfaction = residual`.
 
+P4.5b Agent Manifest correlation, P4.5c TRACE/cMCP action evidence, and the P4-to-P4.5 deletion-completeness composition are documented separately in this runtime-evidence program and execute against this portable boundary.
+
 ## What remains unproven
 
-This slice does not yet prove:
+This slice does not prove:
 
-- Agent Manifest checkpoint/delta correlation (P4.5b)
-- TRACE/AgenTrust external action-evidence interoperability (P4.5c)
 - production key storage or remote trust-anchor discovery
-- external revocation infrastructure
-- multi-implementation interoperability
+- an online shared-domain membership/revocation service
+- multi-implementation interoperability outside the pinned comparators
 - runtime-enforcement composition with AGT or another policy peer
+- upstream AgenTrust integration acceptance
 - ADR acceptance or a higher conformance level
 
-Those remain later evidence gates rather than assumptions smuggled into a successful unit test.
+Those remain separate evidence gates rather than assumptions smuggled into a successful unit test.

--- a/docs/programs/runtime-evidence/trace-action-evidence.md
+++ b/docs/programs/runtime-evidence/trace-action-evidence.md
@@ -1,6 +1,6 @@
 # P4.5c TRACE-compatible external action evidence
 
-Status: **Executable interoperability evidence**. This slice maps P4.5a portable Agent Memory governance evidence into the existing AgenTrust external action-evidence surface without making TRACE or cMCP responsible for PAMA or memory lifecycle semantics.
+Status: **Executable interoperability evidence**. This slice maps P4.5a portable Agent Memory governance evidence into the existing AgenTrust external action-evidence surface without making TRACE or cMCP responsible for PAMA, isolation-domain membership, or memory lifecycle semantics.
 
 Parent implementation issue: #63.
 
@@ -56,12 +56,13 @@ The meanings remain separate:
 
 ```text
 TRACE/cMCP receipt integrity != PAMA permission
+TRACE/cMCP receipt integrity != isolation-domain membership
 external accepted outcome    != lifecycle satisfaction
 external rejected outcome    != malformed evidence
 valid action evidence         != physical completion
 ```
 
-Agent Memory remains authoritative for memory-action meaning, PAMA, canonical receipt semantics, isolation-domain meaning, correction/deletion obligations, residue, and lifecycle satisfaction.
+Agent Memory remains authoritative for memory-action meaning, PAMA, canonical receipt semantics, isolation-domain meaning and membership continuity, correction/deletion obligations, residue, and lifecycle satisfaction.
 
 ## Existing envelope, no new TRACE wire format
 
@@ -98,7 +99,8 @@ The detached payload is content-free:
   "execution_outcome": "accepted | rejected",
   "execution_time": "2026-08-11T21:00:03Z",
   "source_domain_ref": "<optional opaque reference>",
-  "destination_domain_ref": "<optional opaque reference>"
+  "destination_domain_ref": "<optional opaque reference>",
+  "domain_authorization_state_ref": "<optional opaque membership/authorization-state reference>"
 }
 ```
 
@@ -109,7 +111,7 @@ It intentionally excludes:
 - full canonical receipts;
 - PAMA policy contents;
 - tenant/project/domain display names when opaque references suffice;
-- a claim that TRACE understands Agent Memory lifecycle semantics.
+- a claim that TRACE understands Agent Memory authority or lifecycle semantics.
 
 ## Two canonicalization domains
 
@@ -142,9 +144,52 @@ The verifier also binds:
 - detached `portable_evidence_ref` to the supplied P4.5a evidence;
 - detached `canonical_receipt_ref` to the signed P4.5a receipt reference;
 - optional source/destination opaque domain references to the P4.5a scope;
+- optional opaque `domain_authorization_state_ref` to the P4.5a scope;
 - external execution time to the P4.5a decision-time ordering check.
 
-No external receipt is allowed to manufacture execution-time PAMA authority. When authority continuity is supplied, it remains an Agent Memory verifier input rather than a TRACE semantic.
+No external receipt is allowed to manufacture execution-time PAMA authority or isolation-domain membership. Those continuity facts remain Agent Memory verifier inputs rather than TRACE semantics.
+
+## Domain-authorization non-escalation
+
+A valid TRACE/cMCP receipt proves the configured action-evidence binding. It does not prove that the Agent Memory actor still held permission to cross a memory-domain boundary at execution time.
+
+For a signed cross-domain consequence, Agent Memory independently evaluates:
+
+```text
+source_domain_ref
+destination_domain_ref
+domain_authorization_state_ref
+domain_authorization_valid_at_execution
+```
+
+The executable paths distinguish:
+
+```text
+TRACE receipt = valid accepted
+Agent Memory evidence = valid
+domain membership at execution = valid
+runtime execution = executed_as_authorized
+```
+
+from:
+
+```text
+TRACE receipt = valid accepted
+Agent Memory evidence = valid
+domain membership at execution = revoked/expired
+runtime execution = unauthorized_execution
+```
+
+and from:
+
+```text
+TRACE receipt = valid accepted
+Agent Memory evidence = valid
+required domain-continuity evidence = missing
+runtime execution = unverifiable
+```
+
+This is intentional. Historical receipt authenticity does not need to be rewritten when authorization changes. The runtime result carries the current execution-time authority truth.
 
 ## TRACE result taxonomy
 
@@ -209,6 +254,7 @@ The isolated environment is intentional because the current cMCP/AGT dependency 
 - accepted external receipt plus lifecycle `residual`;
 - accepted external receipt plus lifecycle `satisfied`;
 - valid external rejection as negative evidence;
+- valid TRACE receipt plus revoked Agent Memory domain membership;
 - wrong `linked_call_id` replay;
 - wrong Agent Memory `action_ref` replay;
 - detached payload tampering;
@@ -216,6 +262,7 @@ The isolated environment is intentional because the current cMCP/AGT dependency 
 - unknown/untrusted external issuer;
 - missing required receipt;
 - isolation-domain mismatch;
+- domain-authorization-state mismatch;
 - schema validation;
 - absence of raw memory content;
 - exact reuse of the existing six-field cMCP envelope.
@@ -269,6 +316,7 @@ The evidence remains multi-dimensional:
 valid TRACE receipt + committed Agent Memory decision + lifecycle residual
 valid TRACE receipt + committed Agent Memory decision + lifecycle satisfied
 valid TRACE rejection + independently valid Agent Memory governance evidence
+valid TRACE receipt + revoked Agent Memory domain membership + unauthorized execution
 ```
 
 ## What remains unproven
@@ -278,6 +326,7 @@ This slice does not prove:
 - TRACE Trust Record hardware attestation of an Agent Memory process;
 - physical completion or functional-safety certification;
 - production issuer-key discovery or revocation infrastructure;
+- production isolation-domain membership discovery/revocation infrastructure;
 - upstream Community/Verified integration acceptance;
 - generic cross-organization trust-anchor discovery;
 - AGT/runtime-policy composition (optional P4.5d);

--- a/reference/agentmem_ref/portable_evidence.py
+++ b/reference/agentmem_ref/portable_evidence.py
@@ -132,7 +132,12 @@ def _usable_at(timestamp: str, valid_from: str, valid_until: str | None, revoked
 
 @dataclass(frozen=True)
 class RuntimeObservation:
-    """Optional execution-time facts supplied independently by a verifier."""
+    """Optional execution-time facts supplied independently by a verifier.
+
+    Generic actor/PAMA authority continuity and isolation-domain membership
+    continuity are separate facts. A verifier must not infer that one remained
+    valid merely because the other did.
+    """
 
     action_ref: str | None = None
     execution_time: str | None = None
@@ -140,7 +145,9 @@ class RuntimeObservation:
     authority_state_ref: str | None = None
     source_domain_ref: str | None = None
     destination_domain_ref: str | None = None
+    domain_authorization_state_ref: str | None = None
     authority_valid_at_execution: bool | None = None
+    domain_authorization_valid_at_execution: bool | None = None
 
 
 def issue_evidence(
@@ -292,6 +299,11 @@ def verify_evidence(
         (runtime.authority_state_ref, governance["authority_state_ref"], "stale_or_wrong_authority_state_ref"),
         (runtime.source_domain_ref, scope.get("source_domain_ref"), "wrong_source_domain"),
         (runtime.destination_domain_ref, scope.get("destination_domain_ref"), "wrong_destination_domain"),
+        (
+            runtime.domain_authorization_state_ref,
+            scope.get("domain_authorization_state_ref"),
+            "stale_or_wrong_domain_authorization_state_ref",
+        ),
     ):
         if observed is not None and observed != signed:
             failures.append(failure)
@@ -366,6 +378,18 @@ def _structural_failures(evidence: Mapping[str, object]) -> list[str]:
     return failures
 
 
+def _cross_domain(scope: Mapping[str, object]) -> bool:
+    source = scope.get("source_domain_ref")
+    destination = scope.get("destination_domain_ref")
+    return (
+        isinstance(source, str)
+        and isinstance(destination, str)
+        and bool(source)
+        and bool(destination)
+        and source != destination
+    )
+
+
 def _result(
     integrity: str,
     failures: list[str],
@@ -374,8 +398,11 @@ def _result(
     runtime: RuntimeObservation,
 ) -> dict:
     governance = evidence.get("governance") if isinstance(evidence.get("governance"), dict) else {}
+    scope = evidence.get("scope") if isinstance(evidence.get("scope"), dict) else {}
     disposition = governance.get("disposition", "unverifiable")
     lifecycle = evidence.get("lifecycle_result", "unverifiable")
+    cross_domain = _cross_domain(scope)
+    signed_domain_state = scope.get("domain_authorization_state_ref")
 
     if runtime.action_ref is None:
         execution = "not_executed"
@@ -385,7 +412,18 @@ def _result(
         execution = "unauthorized_execution"
     elif runtime.authority_valid_at_execution is False:
         execution = "unauthorized_execution"
+    elif cross_domain and runtime.domain_authorization_valid_at_execution is False:
+        execution = "unauthorized_execution"
     elif runtime.authority_valid_at_execution is None:
+        execution = "unverifiable"
+    elif cross_domain and (
+        not isinstance(signed_domain_state, str)
+        or not signed_domain_state
+        or runtime.domain_authorization_state_ref is None
+        or runtime.domain_authorization_valid_at_execution is None
+    ):
+        # A boundary-crossing action needs execution-time membership/authorization
+        # continuity. Absence of that evidence never becomes optimistic permission.
         execution = "unverifiable"
     elif integrity == INTEGRITY_VALID:
         execution = "executed_as_authorized"

--- a/reference/agentmem_ref/trace_action_evidence.py
+++ b/reference/agentmem_ref/trace_action_evidence.py
@@ -150,12 +150,7 @@ def issue_trace_action_evidence(
     execution_outcome: str,
     execution_time: str,
 ) -> dict:
-    """Issue a cMCP-compatible external execution-evidence envelope.
-
-    The detached payload carries only content-free Agent Memory references plus
-    opaque domain references already present in the signed P4.5a evidence. It
-    never copies raw memory or asks TRACE/cMCP to interpret PAMA.
-    """
+    """Issue a cMCP-compatible external execution-evidence envelope."""
     if execution_outcome not in _OUTCOMES:
         raise ValueError(f"unsupported external execution outcome: {execution_outcome}")
     if not isinstance(call_id, str) or not call_id:
@@ -181,7 +176,11 @@ def issue_trace_action_evidence(
         "execution_outcome": execution_outcome,
         "execution_time": execution_time,
     }
-    for name in ("source_domain_ref", "destination_domain_ref"):
+    for name in (
+        "source_domain_ref",
+        "destination_domain_ref",
+        "domain_authorization_state_ref",
+    ):
         value = scope.get(name)
         if value is not None:
             if not isinstance(value, str) or not value:
@@ -209,7 +208,11 @@ def _portable_scope_failures(payload: Mapping[str, object], portable_evidence: M
     if not isinstance(scope, Mapping):
         return ["portable_scope_missing"]
     failures: list[str] = []
-    for name in ("source_domain_ref", "destination_domain_ref"):
+    for name in (
+        "source_domain_ref",
+        "destination_domain_ref",
+        "domain_authorization_state_ref",
+    ):
         signed = scope.get(name)
         detached = payload.get(name)
         if signed != detached:
@@ -227,14 +230,9 @@ def verify_trace_action_evidence(
     observed_call_id: str | None = None,
     observed_action_ref: str | None = None,
     authority_valid_at_execution: bool | None = None,
+    domain_authorization_valid_at_execution: bool | None = None,
 ) -> dict:
-    """Verify TRACE/cMCP action evidence without importing Agent Memory semantics.
-
-    TRACE receipt validity, Agent Memory governance, runtime authorization, and
-    lifecycle satisfaction remain separate result dimensions. Unknown external
-    issuer trust is ``receipt_unverified`` rather than ``receipt_invalid`` when
-    every independently checkable binding still holds.
-    """
+    """Verify TRACE/cMCP action evidence without importing Agent Memory semantics."""
     if bundle is None:
         portable_result = verify_evidence(
             portable_evidence,
@@ -307,7 +305,7 @@ def verify_trace_action_evidence(
 
     try:
         expected_hash = detached_payload_hash(payload)
-    except Exception:  # rfc8785 exposes several canonicalization errors
+    except Exception:
         expected_hash = ""
         failures.append("detached_payload_canonicalization_failed")
     if envelope.get("evidence_hash") != expected_hash:
@@ -347,7 +345,13 @@ def verify_trace_action_evidence(
         destination_domain_ref=(
             str(payload.get("destination_domain_ref")) if payload.get("destination_domain_ref") is not None else None
         ),
+        domain_authorization_state_ref=(
+            str(payload.get("domain_authorization_state_ref"))
+            if payload.get("domain_authorization_state_ref") is not None
+            else None
+        ),
         authority_valid_at_execution=authority_valid_at_execution,
+        domain_authorization_valid_at_execution=domain_authorization_valid_at_execution,
     )
     portable_result = verify_evidence(
         portable_evidence,

--- a/reference/run_deletion_completeness.py
+++ b/reference/run_deletion_completeness.py
@@ -117,6 +117,7 @@ def _chain(receipt: dict, measurement, commit: str, action_ref: str) -> dict:
         before_state_ref="sha256:" + "6" * 64,
         source_domain_ref="domain:opaque:source",
         destination_domain_ref="domain:opaque:deleted",
+        domain_authorization_state_ref="domain-auth:deletion-report:41",
     )
 
 

--- a/reference/tests/test_deletion_completeness_evidence.py
+++ b/reference/tests/test_deletion_completeness_evidence.py
@@ -31,6 +31,7 @@ TENANT = "tenant-a"
 SOURCE = "mem:alpha"
 COMMIT = "a" * 40
 ISSUER = "issuer:deletion-completeness-reference"
+DOMAIN_AUTH_STATE = "domain-auth:deletion:40"
 KEY = IssuerKey(
     issuer_id=ISSUER,
     key_id="key-p45-lifecycle",
@@ -120,6 +121,7 @@ def chain_for(receipt: dict, measurement, action_ref: str) -> dict:
         before_state_ref="sha256:" + "5" * 64,
         source_domain_ref="domain:opaque:project-a",
         destination_domain_ref="domain:opaque:deleted",
+        domain_authorization_state_ref=DOMAIN_AUTH_STATE,
     )
 
 
@@ -133,7 +135,9 @@ class DeletionCompletenessEvidenceTests(unittest.TestCase):
             runtime=RuntimeObservation(
                 action_ref=chain["action_ref"],
                 execution_time="2026-08-11T21:30:03Z",
+                domain_authorization_state_ref=DOMAIN_AUTH_STATE,
                 authority_valid_at_execution=True,
+                domain_authorization_valid_at_execution=True,
             ),
         )
 
@@ -172,8 +176,6 @@ class DeletionCompletenessEvidenceTests(unittest.TestCase):
             after_state="v1",
         )
 
-        # Deliberately broken one-hop derived purge after an authorized canonical
-        # delete. The independent sweep must expose the transitive survivor.
         one_hop = residue.ResiduePlan(purged=["summary:one"])
         residue.apply_purge(gov.store, one_hop, gov._purged)
         gov._purged.add(SOURCE)

--- a/reference/tests/test_portable_evidence.py
+++ b/reference/tests/test_portable_evidence.py
@@ -96,7 +96,9 @@ class PortableEvidenceTests(unittest.TestCase):
                 authority_state_ref="authority:rev-12",
                 source_domain_ref="domain:opaque:project-a",
                 destination_domain_ref="domain:opaque:archive",
+                domain_authorization_state_ref="domain-auth:9",
                 authority_valid_at_execution=True,
+                domain_authorization_valid_at_execution=True,
             ),
         )
         self.assertEqual(result["evidence_integrity"], "valid")
@@ -172,6 +174,97 @@ class PortableEvidenceTests(unittest.TestCase):
         self.assertEqual(result["evidence_integrity"], "invalid")
         self.assertIn("wrong_source_domain", result["binding_failures"])
 
+    def test_unauthorized_scope_broadening_fails_destination_binding(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                source_domain_ref="domain:opaque:project-a",
+                destination_domain_ref="domain:opaque:organization-wide",
+                domain_authorization_state_ref="domain-auth:9",
+                authority_valid_at_execution=True,
+                domain_authorization_valid_at_execution=True,
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "invalid")
+        self.assertIn("wrong_destination_domain", result["binding_failures"])
+        self.assertEqual(result["runtime_execution"], "unverifiable")
+
+    def test_stale_domain_authorization_state_fails_binding(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                source_domain_ref="domain:opaque:project-a",
+                destination_domain_ref="domain:opaque:archive",
+                domain_authorization_state_ref="domain-auth:10",
+                authority_valid_at_execution=True,
+                domain_authorization_valid_at_execution=True,
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "invalid")
+        self.assertIn(
+            "stale_or_wrong_domain_authorization_state_ref",
+            result["binding_failures"],
+        )
+        self.assertEqual(result["runtime_execution"], "unverifiable")
+
+    def test_revoked_shared_domain_membership_makes_execution_unauthorized(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                execution_time="2026-08-11T18:00:02Z",
+                source_domain_ref="domain:opaque:project-a",
+                destination_domain_ref="domain:opaque:archive",
+                domain_authorization_state_ref="domain-auth:9",
+                authority_valid_at_execution=True,
+                domain_authorization_valid_at_execution=False,
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "valid")
+        self.assertEqual(result["binding_failures"], [])
+        self.assertEqual(result["runtime_execution"], "unauthorized_execution")
+
+    def test_cross_domain_execution_without_membership_continuity_is_unverifiable(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                execution_time="2026-08-11T18:00:02Z",
+                source_domain_ref="domain:opaque:project-a",
+                destination_domain_ref="domain:opaque:archive",
+                authority_valid_at_execution=True,
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "valid")
+        self.assertEqual(result["runtime_execution"], "unverifiable")
+
+    def test_cross_domain_execution_without_signed_membership_state_is_unverifiable(self):
+        evidence = make_evidence(domain_authorization_state_ref=None)
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                execution_time="2026-08-11T18:00:02Z",
+                source_domain_ref="domain:opaque:project-a",
+                destination_domain_ref="domain:opaque:archive",
+                authority_valid_at_execution=True,
+                domain_authorization_valid_at_execution=True,
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "valid")
+        self.assertEqual(result["runtime_execution"], "unverifiable")
+
     def test_execution_before_decision_fails_binding(self):
         evidence = make_evidence()
         result = verify_evidence(
@@ -215,7 +308,14 @@ class PortableEvidenceTests(unittest.TestCase):
         result = verify_evidence(
             evidence,
             self.trust,
-            runtime=RuntimeObservation(action_ref="action:delete:42", authority_valid_at_execution=True),
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                source_domain_ref="domain:opaque:project-a",
+                destination_domain_ref="domain:opaque:archive",
+                domain_authorization_state_ref="domain-auth:9",
+                authority_valid_at_execution=True,
+                domain_authorization_valid_at_execution=True,
+            ),
         )
         self.assertEqual(result["evidence_integrity"], "valid")
         self.assertEqual(result["runtime_execution"], "executed_as_authorized")

--- a/reference/tests/test_trace_action_evidence.py
+++ b/reference/tests/test_trace_action_evidence.py
@@ -31,6 +31,7 @@ from agentmem_ref.trace_action_evidence import (  # noqa: E402
 )
 
 AM_ISSUER = "issuer:agent-memory-reference"
+DOMAIN_AUTH_STATE = "domain-auth:trace:31"
 AM_KEY = IssuerKey(
     issuer_id=AM_ISSUER,
     key_id="am-key-2026-08",
@@ -82,6 +83,7 @@ class TraceActionEvidenceTests(unittest.TestCase):
             lifecycle_result=lifecycle,
             source_domain_ref="domain:opaque:project-a",
             destination_domain_ref="domain:opaque:deleted",
+            domain_authorization_state_ref=DOMAIN_AUTH_STATE,
         )
         return receipt, portable
 
@@ -106,6 +108,9 @@ class TraceActionEvidenceTests(unittest.TestCase):
             observed_call_id=kwargs.pop("observed_call_id", self.call_id),
             observed_action_ref=kwargs.pop("observed_action_ref", self.action_ref),
             authority_valid_at_execution=kwargs.pop("authority_valid_at_execution", True),
+            domain_authorization_valid_at_execution=kwargs.pop(
+                "domain_authorization_valid_at_execution", True
+            ),
             **kwargs,
         )
 
@@ -125,6 +130,7 @@ class TraceActionEvidenceTests(unittest.TestCase):
         self.assertEqual(result["agent_memory"]["governance_disposition"], "committed")
         self.assertEqual(result["agent_memory"]["runtime_execution"], "executed_as_authorized")
         self.assertEqual(result["agent_memory"]["lifecycle_satisfaction"], "residual")
+        self.assertEqual(bundle["detached_payload"]["domain_authorization_state_ref"], DOMAIN_AUTH_STATE)
 
     def test_same_action_receipt_can_preserve_satisfied_lifecycle(self):
         receipt, portable, bundle = self._bundle("satisfied", "accepted")
@@ -140,6 +146,19 @@ class TraceActionEvidenceTests(unittest.TestCase):
         self.assertEqual(result["external_execution_outcome"], "rejected")
         self.assertEqual(result["agent_memory"]["governance_disposition"], "committed")
         self.assertEqual(result["agent_memory"]["lifecycle_satisfaction"], "residual")
+
+    def test_valid_trace_receipt_does_not_override_revoked_domain_membership(self):
+        receipt, portable, bundle = self._bundle("residual", "accepted")
+        result = self._verify(
+            receipt,
+            portable,
+            bundle,
+            domain_authorization_valid_at_execution=False,
+        )
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_VALID_ACCEPTED)
+        self.assertEqual(result["trace_binding"], "valid")
+        self.assertEqual(result["agent_memory"]["evidence_integrity"], "valid")
+        self.assertEqual(result["agent_memory"]["runtime_execution"], "unauthorized_execution")
 
     def test_wrong_call_id_blocks_replay(self):
         receipt, portable, bundle = self._bundle()
@@ -183,11 +202,13 @@ class TraceActionEvidenceTests(unittest.TestCase):
             observed_call_id=self.call_id,
             observed_action_ref=self.action_ref,
             authority_valid_at_execution=True,
+            domain_authorization_valid_at_execution=True,
         )
         self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_UNVERIFIED)
         self.assertEqual(result["trace_binding"], "unverifiable")
         self.assertEqual(result["binding_failures"], [])
         self.assertEqual(result["agent_memory"]["evidence_integrity"], "valid")
+        self.assertEqual(result["agent_memory"]["runtime_execution"], "executed_as_authorized")
 
     def test_required_receipt_missing_is_distinct(self):
         receipt, portable = self._receipt_and_portable()
@@ -207,11 +228,19 @@ class TraceActionEvidenceTests(unittest.TestCase):
         bundle["external_execution_evidence"]["evidence_hash"] = detached_payload_hash(
             bundle["detached_payload"]
         )
-        # The issuer signature still commits the old hash, so this is both an envelope
-        # signature failure and a semantic domain-binding failure.
         result = self._verify(receipt, portable, bundle)
         self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_INVALID)
         self.assertIn("destination_domain_ref_mismatch", result["binding_failures"])
+
+    def test_domain_authorization_state_mismatch_is_detected(self):
+        receipt, portable, bundle = self._bundle()
+        bundle["detached_payload"]["domain_authorization_state_ref"] = "domain-auth:trace:wrong"
+        bundle["external_execution_evidence"]["evidence_hash"] = detached_payload_hash(
+            bundle["detached_payload"]
+        )
+        result = self._verify(receipt, portable, bundle)
+        self.assertEqual(result["trace_receipt_status"], TRACE_RECEIPT_INVALID)
+        self.assertIn("domain_authorization_state_ref_mismatch", result["binding_failures"])
 
     def test_bundle_is_content_free_and_schema_valid(self):
         _, _, bundle = self._bundle()

--- a/schemas/trace-action-evidence-bundle.schema.json
+++ b/schemas/trace-action-evidence-bundle.schema.json
@@ -48,7 +48,8 @@
         "execution_outcome": {"enum": ["accepted", "rejected"]},
         "execution_time": {"type": "string", "format": "date-time"},
         "source_domain_ref": {"type": "string", "minLength": 1},
-        "destination_domain_ref": {"type": "string", "minLength": 1}
+        "destination_domain_ref": {"type": "string", "minLength": 1},
+        "domain_authorization_state_ref": {"type": "string", "minLength": 1}
       }
     }
   }


### PR DESCRIPTION
## Objective

Close the remaining #63 cross-domain authority gap by independently checking domain-authorization state and execution-time membership continuity instead of treating generic PAMA/actor authority as sufficient for a boundary-crossing memory action.

## Problem

P4.5a already signed `domain_authorization_state_ref`, but `RuntimeObservation` did not expose or compare it. A verifier could therefore validate source/destination domains and generic authority while never establishing that shared-domain membership remained valid at execution time.

That is exactly the stale-membership failure #63 says must fail closed.

## New runtime facts

`RuntimeObservation` now carries:

```text
domain_authorization_state_ref
domain_authorization_valid_at_execution
```

These remain separate from:

```text
authority_state_ref
authority_valid_at_execution
```

Generic PAMA/actor authority and isolation-domain membership are not interchangeable.

## Behavior

For a cross-domain action (`source_domain_ref != destination_domain_ref`):

- wrong domain-authorization state reference -> evidence binding is invalid;
- domain membership revoked/expired before execution -> evidence can remain cryptographically valid, but runtime result is `unauthorized_execution`;
- missing signed or execution-time domain continuity evidence -> runtime result is `unverifiable`, never optimistic permission;
- unauthorized destination broadening -> binding failure;
- correct state + valid generic authority + valid domain authorization -> `executed_as_authorized`.

## TRACE/cMCP composition

P4.5c now carries the opaque `domain_authorization_state_ref` in its detached payload and binds it back to the signed P4.5a scope.

A valid TRACE action receipt does **not** override revoked Agent Memory domain membership. The executable vector demonstrates:

```text
TRACE receipt: valid accepted
Agent Memory evidence: valid
execution-time domain membership: revoked
Agent Memory runtime_execution: unauthorized_execution
```

This preserves the ownership boundary: TRACE proves the action receipt; Agent Memory decides whether the memory-domain consequence remained authorized.

## Deletion-completeness composition

The P4 -> P4.5 deletion chains now sign an opaque domain-authorization state and supply its execution-time continuity when asserting an authorized cross-domain deletion outcome.

## Adversarial vectors

- stale/wrong domain authorization state
- revoked shared-domain membership
- cross-domain execution with missing continuity evidence
- cross-domain evidence with no signed membership state
- destination-domain scope broadening
- valid TRACE receipt plus revoked Agent Memory domain membership
- TRACE detached domain-authorization-state mismatch

## Claim boundary

This does not invent a universal membership registry or revocation service. The verifier consumes independently supplied execution-time continuity facts and fails closed when they are absent. Production discovery remains a deployment concern.

Advances #63 and #46 without changing conformance level or ADR status.