### PR TITLE
P4.5 acceptance closeout: exercise authority revocation at execution

### DIFF
--- a/reference/tests/test_portable_evidence.py
+++ b/reference/tests/test_portable_evidence.py
@@ -292,6 +292,26 @@ class PortableEvidenceTests(unittest.TestCase):
         self.assertEqual(result["evidence_integrity"], "valid")
         self.assertEqual(result["runtime_execution"], "unverifiable")
 
+    def test_authority_revoked_between_decision_and_execution_is_unauthorized(self):
+        evidence = make_evidence()
+        result = verify_evidence(
+            evidence,
+            self.trust,
+            runtime=RuntimeObservation(
+                action_ref="action:delete:42",
+                execution_time="2026-08-11T18:00:02Z",
+                source_domain_ref="domain:opaque:project-a",
+                destination_domain_ref="domain:opaque:archive",
+                domain_authorization_state_ref="domain-auth:9",
+                authority_valid_at_execution=False,
+                domain_authorization_valid_at_execution=True,
+            ),
+        )
+        self.assertEqual(result["evidence_integrity"], "valid")
+        self.assertEqual(result["binding_failures"], [])
+        self.assertEqual(result["governance_disposition"], "committed")
+        self.assertEqual(result["runtime_execution"], "unauthorized_execution")
+
     def test_valid_denial_plus_runtime_action_is_unauthorized_execution(self):
         evidence = make_evidence(governance_disposition="denied", lifecycle_result="not_applicable")
         result = verify_evidence(


### PR DESCRIPTION
## Objective

Close the last locally identified negative-path test gap in #63 by explicitly exercising generic execution-time authority revocation as distinct from isolation-domain membership revocation.

## Why this is separate

P4.5 now models two independent continuity dimensions:

```text
generic actor/PAMA authority
domain membership / crossing authority
```

PR #78 added explicit tests for revoked shared-domain membership. The verifier already handled `authority_valid_at_execution=False`, but the #63 adversarial corpus calls out authority revoked between decision and execution as its own case. This PR makes that behavior executable rather than counting the domain-membership test twice.

## Vector

A signed decision is valid and `committed` at decision time. The observed action matches, domain membership remains valid, but generic authority is independently known to be revoked before execution.

Expected result:

```text
evidence_integrity = valid
governance_disposition = committed
runtime_execution = unauthorized_execution
binding_failures = []
```

The signature remains authentic historical evidence; execution-time authority truth is represented separately.

No production behavior or schema changes are introduced.