### PR TITLE
P5: add benchmark and security scorecard harness

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -55,6 +55,21 @@ jobs:
           path: concurrency-evidence.json
           if-no-files-found: error
 
+      - name: Emit P5 benchmark security scorecard
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_benchmark_security.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output benchmark-security.json
+
+      - name: Upload P5 benchmark security scorecard
+        uses: actions/upload-artifact@v4
+        with:
+          name: p5-benchmark-security-scorecard
+          path: benchmark-security.json
+          if-no-files-found: error
+
       - name: Emit deletion-completeness evidence
         env:
           AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -114,6 +129,7 @@ jobs:
           docs/programs/runtime-evidence/trace-action-evidence.md
           docs/programs/runtime-evidence/deletion-completeness-evidence.md
           docs/programs/runtime-evidence/concurrency-conflict-evidence.md
+          docs/programs/runtime-evidence/benchmark-security-scorecard.md
           reference/README.md
 
       - name: Validate GitHub Wiki source links
@@ -139,9 +155,10 @@ jobs:
             echo "python scripts/validate_doctrine_boundaries.py"
             echo "python -m unittest discover -s reference/tests -t reference"
             echo "python reference/run_concurrency_evidence.py --agent-memory-commit <exact-40-hex-commit> --output concurrency-evidence.json"
+            echo "python reference/run_benchmark_security.py --agent-memory-commit <exact-40-hex-commit> --output benchmark-security.json"
             echo "python reference/run_deletion_completeness.py --agent-memory-commit <exact-40-hex-commit> --output deletion-completeness.json"
             echo "python -m venv /tmp/agent-memory-p45c-cmcp && /tmp/agent-memory-p45c-cmcp/bin/python -m pip install cmcp-runtime==0.4.0 agentrust-trace==0.8.0 agent-manifest==0.11.0 rfc8785==0.1.4 && PYTHONPATH=reference /tmp/agent-memory-p45c-cmcp/bin/python reference/run_trace_cmcp_comparator.py"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md docs/programs/runtime-evidence/deletion-completeness-evidence.md docs/programs/runtime-evidence/concurrency-conflict-evidence.md reference/README.md"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md docs/programs/runtime-evidence/deletion-completeness-evidence.md docs/programs/runtime-evidence/concurrency-conflict-evidence.md docs/programs/runtime-evidence/benchmark-security-scorecard.md reference/README.md"
             echo "python scripts/validate_wiki_links.py wiki-src"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'

--- a/docs/programs/runtime-evidence/README.md
+++ b/docs/programs/runtime-evidence/README.md
@@ -86,6 +86,8 @@ Documents are added when their slice is ready to execute, not in advance. A dire
 | [`agent-manifest-correlation.md`](agent-manifest-correlation.md) | P4.5b Agent Manifest memory checkpoint correlation | pinned external comparator executed; a checkpoint built from a test log containing `DEL` remains distinct from Agent Memory lifecycle satisfaction |
 | [`trace-action-evidence.md`](trace-action-evidence.md) | P4.5c TRACE/cMCP action-evidence binding | content-free action receipt adapter plus released cMCP verifier comparator; TRACE receipt state remains separate from Agent Memory governance and lifecycle |
 | [`deletion-completeness-evidence.md`](deletion-completeness-evidence.md) | P4 -> P4.5 deletion lifecycle composition | declared residual, undeclared hard-gate failure, and zero-residue success drive signed portable lifecycle evidence and an exact-commit JSON report |
+| [`concurrency-conflict-evidence.md`](concurrency-conflict-evidence.md) | concurrency behavior | conflicting proposals from one prior state are revalidated at commit; stale second write is deferred and conflict evidence is emitted |
+| [`benchmark-security-scorecard.md`](benchmark-security-scorecard.md) | P5 benchmark/security matrix and harness | seven hard-gate security/governance metrics execute with explicit denominators and an exact-commit scorecard artifact; no scalar quality score |
 
 ## Preconditions
 

--- a/docs/programs/runtime-evidence/benchmark-security-scorecard.md
+++ b/docs/programs/runtime-evidence/benchmark-security-scorecard.md
@@ -1,0 +1,174 @@
+# P5 benchmark and security scorecard
+
+P5 converts the hard-invariant rules in [`../../32-memory-quality-metrics.md`](../../32-memory-quality-metrics.md) into an executable scorecard for the Agent Memory reference governed adapter.
+
+This is a benchmark harness, not a universal memory score.
+
+## Why this slice exists
+
+The repository already has many executable negative paths, but isolated tests do not by themselves provide a benchmark-shaped answer to a basic question:
+
+> Across a defined workload, which governance/security boundaries were exercised, what were their denominators, and did any disqualifying failure occur?
+
+The P5 scorecard answers that without averaging critical failures into a friendly aggregate.
+
+```text
+hard invariant gates      pass/fail, un-averageable
+        |
+        +-- cross-scope admission
+        +-- blocked-action escape
+        +-- authority from confidence
+        +-- stochastic action-set escape
+        +-- stale-authorization rejection
+        +-- silent concurrent overwrite
+        +-- undeclared deletion residue
+```
+
+The only aggregate verdict is `hard_gates_passed`. It means every named gate passed. It is not a quality score.
+
+## Executed cases
+
+### Cross-scope admission
+
+The permissive substrate is seeded with a foreign-tenant fact that an unfiltered substrate query can see. Governed recall is then executed through the adapter for another tenant.
+
+Metric:
+
+```text
+cross_scope_admission_rate = admitted foreign candidates / substrate-visible foreign candidates
+required: 0
+```
+
+The denominator is therefore not manufactured from an empty workload. The benchmark first proves that the underlying substrate exposes a cross-scope candidate when called permissively, then measures whether the governed boundary admits it.
+
+### Blocked-action escape
+
+Three consequential operations are attempted without the authority required to commit them:
+
+- high-risk policy mutation;
+- critical scope expansion;
+- irreversible permanent deletion without completed review.
+
+Metric:
+
+```text
+blocked_action_escape_rate = escaped blocked attempts / blocked attempts
+required: 0
+```
+
+An escape includes committing the requested operation, selecting the prohibited operation, or reaching a substrate fact write.
+
+### Authority from confidence
+
+Two otherwise-identical high-risk durable proposals are executed with estimator confidence `0.99` and `0.01`.
+
+The outcome and permitted/prohibited action sets must remain identical, and the high-confidence proposal must not acquire commit authority.
+
+Metric:
+
+```text
+authority_from_confidence_count
+required: 0
+```
+
+Confidence remains evidence input. It is not authority.
+
+### Stochastic action-set containment
+
+The stochastic selector is exercised across a configurable number of seeded trials. Each selected action must remain inside the governance envelope.
+
+Metric:
+
+```text
+stochastic_action_set_violation_rate = escapes / stochastic trials
+required: 0
+```
+
+The trials are reproducible by seed, but identical selected actions are not required. The invariant is containment.
+
+### Stale authorization rejection
+
+A first mutation advances canonical state from `v0` to `v1`. A second proposal still bound to `v0` attempts to commit.
+
+Metric:
+
+```text
+stale_authorization_rejection_rate = correctly rejected stale attempts / stale attempts
+required: 1
+```
+
+This metric is intentionally separate from concurrent conflict behavior. A system can reject one stale write path while still mishandling multi-writer conflict semantics elsewhere.
+
+### Concurrent silent overwrite
+
+P5 reuses the executable concurrency evidence introduced in PR #80. Two incompatible proposals originate from the same prior state. The later stale proposal must be refused and the conflict must remain reconstructable.
+
+Metric:
+
+```text
+silent_overwrite_rate = silent last-writer-wins outcomes / conflict scenarios
+required: 0
+```
+
+### Clean deletion residue
+
+A canonical memory with a two-hop derived chain is permanently deleted through the governed projection path. The transitive purge and independent residue gate must report zero undeclared survivors.
+
+Metric:
+
+```text
+deletion_residue_rate = undeclared residual projections / derived projections under test
+required: 0
+```
+
+The separate deletion-completeness evidence remains the stronger adversarial proof that a deliberately broken one-hop purge is detected. P5 does not duplicate that fixture merely to inflate its case count.
+
+## Machine-readable output
+
+Run locally:
+
+```bash
+python reference/run_benchmark_security.py \
+  --agent-memory-commit <exact-40-hex-commit> \
+  --output benchmark-security.json
+```
+
+The result conforms to [`../../../schemas/benchmark-security-report.schema.json`](../../../schemas/benchmark-security-report.schema.json) and records:
+
+- exact Agent Memory commit;
+- adapter, doctrine, and policy versions;
+- sample counts;
+- each case numerator and denominator;
+- metric values;
+- each hard-gate rule and observed value;
+- the aggregate boolean `hard_gates_passed`;
+- explicit limitations.
+
+CI emits the same report at the exact PR head or merge commit and uploads it as an artifact.
+
+## Negative testing of the benchmark itself
+
+The harness is not trusted merely because it emits JSON. Its unit tests mutate each zero-tolerance metric to a failing value and verify that the overall hard-gate verdict becomes false. The stale-authorization gate is separately tested to fail when rejection coverage drops below 100%.
+
+This prevents a later scorecard refactor from quietly converting a hard invariant into a weighted or averaged metric.
+
+## Scope and limitations
+
+This P5 slice demonstrates security/governance benchmark behavior for the reference governed adapter and the already-mapped substrate boundary.
+
+It does **not** establish:
+
+- production workload performance;
+- task-success improvement;
+- long-horizon memory utility;
+- latency, storage, token, or cost efficiency;
+- exhaustive poisoning or extraction red-team coverage;
+- production memory-layer comparison;
+- a higher conformance level;
+- ADR-020 acceptance.
+
+P6 is the intended production-oriented adversarial comparator expansion. P8 and P9 own telemetry and systems/economic characterization respectively.
+
+## Governing rule
+
+> A benchmark that can average away an authority escape, cross-scope admission, or undeclared deletion residue is measuring the wrong thing.

--- a/reference/agentmem_ref/benchmark_security.py
+++ b/reference/agentmem_ref/benchmark_security.py
@@ -1,0 +1,367 @@
+"""P5 benchmark/security scorecard for the Agent Memory reference runtime.
+
+This module operationalizes the hard-gate rules in
+``docs/32-memory-quality-metrics.md``. It intentionally emits a scorecard, not
+a universal quality score. Critical governance failures are disqualifying and
+cannot be averaged away by successful cases elsewhere.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from . import policy, projections, receipts
+from .adapter import Clock, GovernedMemoryAdapter, StochasticSelector
+from .concurrency_evidence import run_concurrency_evidence
+from .projection_governance import ProjectionGovernor
+from .substrate import Fact, InMemoryTemporalGraph
+
+ADAPTER_VERSION = "0.1.0"
+DOCTRINE_VERSION = "v0.3"
+TENANT = "tenant-a"
+OTHER_TENANT = "tenant-b"
+
+
+def _proposal(**overrides) -> policy.Proposal:
+    values = dict(
+        proposal_id="bench-prop",
+        actor_id="agent:benchmark",
+        charter_version="charter-1",
+        target_reference="mem:benchmark",
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("ev:benchmark",),
+        tenant_ref=TENANT,
+        purpose="p5-security-benchmark",
+    )
+    values.update(overrides)
+    return policy.Proposal(**values)
+
+
+def _cross_scope_case() -> dict:
+    substrate = InMemoryTemporalGraph()
+    substrate.write_fact(
+        Fact(
+            uuid="foreign-benchmark-fact",
+            fact_text="benchmark secret token",
+            group_id=OTHER_TENANT,
+            created_at="2026-01-01T00:00:00Z",
+        )
+    )
+    unfiltered = substrate.search("benchmark secret")
+    foreign_candidates = [fact.uuid for fact, _ in unfiltered if fact.group_id == OTHER_TENANT]
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    governed = adapter.governed_recall("benchmark secret")
+    admitted_foreign = [ref for ref in governed.admitted if ref in foreign_candidates]
+    numerator = len(admitted_foreign)
+    denominator = len(foreign_candidates)
+    return {
+        "metric": "cross_scope_admission_rate",
+        "numerator": numerator,
+        "denominator": denominator,
+        "value": numerator / max(denominator, 1),
+        "passed": denominator > 0 and numerator == 0,
+        "details": {
+            "substrate_exposed_cross_scope_candidates": denominator,
+            "adapter_admitted_cross_scope_candidates": numerator,
+        },
+    }
+
+
+def _blocked_action_case() -> dict:
+    attempts = [
+        _proposal(
+            proposal_id="bench-policy-mutation",
+            operation="policy_mutation",
+            target_class=policy.M5,
+            downstream_authority=policy.A5,
+            risk_class="high",
+        ),
+        _proposal(
+            proposal_id="bench-scope-expansion",
+            operation="scope_expansion",
+            target_class=policy.M5,
+            downstream_authority=policy.A5,
+            risk_class="critical",
+        ),
+        _proposal(
+            proposal_id="bench-permanent-delete",
+            operation="permanent_deletion",
+            reversibility="irreversible",
+            risk_class="low",
+        ),
+    ]
+    escapes = 0
+    observations: list[dict] = []
+    for proposal in attempts:
+        substrate = InMemoryTemporalGraph()
+        adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+        result = adapter.commit_proposal(proposal, "blocked benchmark payload")
+        writes = [entry for entry in substrate.write_log if entry[0] == "write_fact"]
+        escaped = result.committed or result.receipt["selected_action"] == proposal.operation or bool(writes)
+        escapes += int(escaped)
+        observations.append(
+            {
+                "proposal_id": proposal.proposal_id,
+                "requested_action": proposal.operation,
+                "decision": result.decision.outcome,
+                "selected_action": result.receipt["selected_action"],
+                "committed": result.committed,
+                "substrate_writes": len(writes),
+            }
+        )
+    return {
+        "metric": "blocked_action_escape_rate",
+        "numerator": escapes,
+        "denominator": len(attempts),
+        "value": escapes / len(attempts),
+        "passed": escapes == 0,
+        "details": {"attempts": observations},
+    }
+
+
+def _confidence_authority_case() -> dict:
+    common = dict(target_class=policy.M4, risk_class="high", operation="promotion")
+    high_adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), tenant=TENANT, clock=Clock())
+    low_adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), tenant=TENANT, clock=Clock())
+    high = high_adapter.commit_proposal(
+        _proposal(proposal_id="bench-confidence-high", confidence=0.99, **common),
+        "high confidence claim",
+    )
+    low = low_adapter.commit_proposal(
+        _proposal(proposal_id="bench-confidence-low", confidence=0.01, **common),
+        "low confidence claim",
+    )
+    authority_created = int(
+        high.committed
+        or high.decision.outcome != low.decision.outcome
+        or high.decision.permitted_actions != low.decision.permitted_actions
+        or high.decision.prohibited_actions != low.decision.prohibited_actions
+    )
+    return {
+        "metric": "authority_from_confidence_count",
+        "numerator": authority_created,
+        "denominator": 2,
+        "value": authority_created,
+        "passed": authority_created == 0,
+        "details": {
+            "high_confidence": 0.99,
+            "low_confidence": 0.01,
+            "high_outcome": high.decision.outcome,
+            "low_outcome": low.decision.outcome,
+            "high_committed": high.committed,
+            "low_committed": low.committed,
+        },
+    }
+
+
+def _stochastic_case(trials: int) -> dict:
+    if trials <= 0:
+        raise ValueError("stochastic_trials must be positive")
+    escapes = 0
+    observed: set[str] = set()
+    proposal = _proposal(
+        proposal_id="bench-stochastic",
+        target_class=policy.M4,
+        operation="crystallization",
+        proposed_strength="canonical",
+        risk_class="high",
+    )
+    for seed in range(trials):
+        adapter = GovernedMemoryAdapter(
+            InMemoryTemporalGraph(), tenant=TENANT, clock=Clock(), selector=StochasticSelector(seed)
+        )
+        result = adapter.commit_proposal(proposal, "stochastic benchmark claim")
+        selected = result.receipt["selected_action"]
+        observed.add(selected)
+        if selected not in result.decision.permitted_actions or adapter.containment_violations:
+            escapes += 1
+    return {
+        "metric": "stochastic_action_set_violation_rate",
+        "numerator": escapes,
+        "denominator": trials,
+        "value": escapes / trials,
+        "passed": escapes == 0,
+        "details": {"distinct_selected_actions": sorted(observed)},
+    }
+
+
+def _stale_authorization_case() -> dict:
+    adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), tenant=TENANT, clock=Clock())
+    first = adapter.commit_proposal(_proposal(proposal_id="bench-stale-seed"), "first state")
+    stale = adapter.commit_proposal(
+        _proposal(proposal_id="bench-stale-attempt", state_snapshot="v0"),
+        "stale second state",
+    )
+    rejected = int(
+        first.committed
+        and not stale.committed
+        and stale.refusal == "stale_authorization"
+        and stale.receipt["selected_action"] == "defer"
+        and stale.receipt["before_state"] == "v1"
+        and stale.receipt["after_state"] == "v1"
+    )
+    return {
+        "metric": "stale_authorization_rejection_rate",
+        "numerator": rejected,
+        "denominator": 1,
+        "value": float(rejected),
+        "passed": rejected == 1,
+        "details": {
+            "requested_state": stale.receipt["state_snapshot"],
+            "observed_state": stale.receipt["before_state"],
+            "selected_action": stale.receipt["selected_action"],
+            "refusal": stale.refusal,
+        },
+    }
+
+
+def _concurrency_case(agent_memory_commit: str) -> dict:
+    evidence = run_concurrency_evidence(agent_memory_commit)
+    silent_overwrite = int(evidence["observed_behavior"]["silent_last_writer_wins"])
+    return {
+        "metric": "silent_overwrite_rate",
+        "numerator": silent_overwrite,
+        "denominator": 1,
+        "value": float(silent_overwrite),
+        "passed": evidence["passed"] and silent_overwrite == 0,
+        "details": {
+            "fixture_id": evidence["fixture_id"],
+            "conflict_recorded": evidence["observed_behavior"]["conflict_recorded"],
+            "state_version_revalidated": evidence["observed_behavior"]["state_version_revalidated"],
+            "substrate_write_count": evidence["outcomes"]["substrate_write_count"],
+        },
+    }
+
+
+def _clean_deletion_case() -> dict:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    governor = ProjectionGovernor(adapter)
+    source = "mem:benchmark-delete"
+    adapter.commit_proposal(
+        _proposal(proposal_id="bench-delete-seed", target_reference=source),
+        "deletion benchmark source",
+    )
+    governor.declare(
+        "bench:summary:1",
+        (source,),
+        projections.ESTIMATOR_MEDIATED,
+        projections.RECOVERABLE_CONTENT,
+        projections.APPROXIMABLE,
+        TENANT,
+    )
+    governor.declare(
+        "bench:summary:2",
+        ("bench:summary:1",),
+        projections.ESTIMATOR_MEDIATED,
+        projections.RECOVERABLE_CONTENT,
+        projections.APPROXIMABLE,
+        TENANT,
+    )
+    result = governor.purge(
+        _proposal(
+            proposal_id="bench-delete-clean",
+            target_reference=source,
+            operation="permanent_deletion",
+            proposed_strength="removed",
+            reversibility="irreversible",
+            approval_refs=("approval:benchmark",),
+            review_satisfied=True,
+        ),
+        source,
+    )
+    undeclared = len(result.undeclared)
+    derived_total = 2
+    return {
+        "metric": "deletion_residue_rate",
+        "numerator": undeclared,
+        "denominator": derived_total,
+        "value": undeclared / derived_total,
+        "passed": result.hard_gate_passed and undeclared == 0,
+        "details": {
+            "hard_gate_passed": result.hard_gate_passed,
+            "residue_buckets": {name: len(values) for name, values in result.buckets.items()},
+        },
+    }
+
+
+_HARD_GATE_RULES = {
+    "cross_scope_admission_rate": ("== 0", lambda value: value == 0),
+    "blocked_action_escape_rate": ("== 0", lambda value: value == 0),
+    "stochastic_action_set_violation_rate": ("== 0", lambda value: value == 0),
+    "authority_from_confidence_count": ("== 0", lambda value: value == 0),
+    "silent_overwrite_rate": ("== 0", lambda value: value == 0),
+    "deletion_residue_rate": ("== 0", lambda value: value == 0),
+    "stale_authorization_rejection_rate": ("== 1", lambda value: value == 1),
+}
+
+
+def evaluate_hard_gates(metrics: dict) -> list[dict]:
+    """Evaluate disqualifying metrics without weighting or averaging them."""
+    gates: list[dict] = []
+    for metric, (rule, predicate) in _HARD_GATE_RULES.items():
+        if metric not in metrics:
+            raise ValueError(f"missing hard-gate metric: {metric}")
+        observed = metrics[metric]
+        gates.append({"metric": metric, "rule": rule, "observed": observed, "passed": bool(predicate(observed))})
+    return gates
+
+
+def build_report(agent_memory_commit: str, stochastic_trials: int = 200) -> dict:
+    commit = agent_memory_commit.lower()
+    if len(commit) != 40 or any(ch not in "0123456789abcdef" for ch in commit):
+        raise ValueError("agent_memory_commit must be an exact 40-hex commit")
+
+    cases = {
+        "cross_scope_admission": _cross_scope_case(),
+        "blocked_action_escape": _blocked_action_case(),
+        "authority_from_confidence": _confidence_authority_case(),
+        "stochastic_action_set_containment": _stochastic_case(stochastic_trials),
+        "stale_authorization": _stale_authorization_case(),
+        "concurrent_conflict": _concurrency_case(commit),
+        "clean_deletion_residue": _clean_deletion_case(),
+    }
+    metrics = {case["metric"]: case["value"] for case in cases.values()}
+    gates = evaluate_hard_gates(metrics)
+    report = {
+        "report_type": "agent-memory-p5-benchmark-security-scorecard",
+        "version": "1.0.0",
+        "agent_memory_commit": commit,
+        "implementation": "agent-memory reference governed adapter",
+        "adapter_version": ADAPTER_VERSION,
+        "doctrine_version": DOCTRINE_VERSION,
+        "policy_version": policy.POLICY_VERSION,
+        "sample_counts": {
+            "security_cases": len(cases),
+            "blocked_action_attempts": cases["blocked_action_escape"]["denominator"],
+            "stochastic_trials": stochastic_trials,
+        },
+        "metrics": metrics,
+        "hard_gates": gates,
+        "hard_gates_passed": all(gate["passed"] for gate in gates) and all(case["passed"] for case in cases.values()),
+        "cases": cases,
+        "known_limits": [
+            "The scorecard exercises the reference governed adapter and its modeled/embedded test substrate boundaries; it is not a production deployment benchmark.",
+            "The clean deletion case measures zero undeclared residue. The separate deletion-completeness artifact remains the adversarial proof that deliberately broken purge is detected.",
+            "No task-success, latency, token-cost, extraction-red-team, poisoning-persistence, or long-horizon utility claim is made in this slice.",
+            "No scalar quality score is emitted; hard invariant failures remain disqualifying and un-averageable.",
+        ],
+    }
+    receipts.validate("benchmark-security-report.schema.json", report)
+    return report
+
+
+def with_metric(report: dict, metric: str, value: float | int) -> dict:
+    """Test helper: copy a report and re-evaluate gates after one metric changes."""
+    mutated = deepcopy(report)
+    mutated["metrics"][metric] = value
+    mutated["hard_gates"] = evaluate_hard_gates(mutated["metrics"])
+    mutated["hard_gates_passed"] = all(gate["passed"] for gate in mutated["hard_gates"])
+    return mutated

--- a/reference/run_benchmark_security.py
+++ b/reference/run_benchmark_security.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Emit the P5 benchmark/security scorecard for CI and audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.benchmark_security import build_report  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--stochastic-trials", type=int, default=200)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = build_report(args.agent_memory_commit, stochastic_trials=args.stochastic_trials)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report["hard_gates_passed"]:
+        failed = [gate["metric"] for gate in report["hard_gates"] if not gate["passed"]]
+        print(f"P5 hard gate failed: {failed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_benchmark_security.py
+++ b/reference/tests/test_benchmark_security.py
@@ -1,0 +1,76 @@
+"""Tests for the P5 benchmark/security scorecard."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.benchmark_security import build_report, with_metric  # noqa: E402
+
+COMMIT = "1" * 40
+
+
+class BenchmarkSecurityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.report = build_report(COMMIT, stochastic_trials=40)
+
+    def test_scorecard_passes_without_scalar_quality_score(self):
+        self.assertTrue(self.report["hard_gates_passed"])
+        self.assertNotIn("score", self.report)
+        self.assertNotIn("quality_score", self.report)
+        self.assertEqual(len(self.report["hard_gates"]), 7)
+
+    def test_all_cases_have_explicit_nonzero_denominators(self):
+        for name, case in self.report["cases"].items():
+            with self.subTest(case=name):
+                self.assertGreater(case["denominator"], 0)
+                self.assertGreaterEqual(case["numerator"], 0)
+
+    def test_zero_tolerance_gates_cannot_be_averaged_away(self):
+        zero_tolerance = [
+            "cross_scope_admission_rate",
+            "blocked_action_escape_rate",
+            "authority_from_confidence_count",
+            "stochastic_action_set_violation_rate",
+            "silent_overwrite_rate",
+            "deletion_residue_rate",
+        ]
+        for metric in zero_tolerance:
+            with self.subTest(metric=metric):
+                mutated = with_metric(self.report, metric, 1)
+                self.assertFalse(mutated["hard_gates_passed"])
+                gate = next(item for item in mutated["hard_gates"] if item["metric"] == metric)
+                self.assertFalse(gate["passed"])
+
+    def test_stale_authorization_gate_requires_complete_rejection(self):
+        mutated = with_metric(self.report, "stale_authorization_rejection_rate", 0)
+        self.assertFalse(mutated["hard_gates_passed"])
+        gate = next(
+            item for item in mutated["hard_gates"]
+            if item["metric"] == "stale_authorization_rejection_rate"
+        )
+        self.assertEqual(gate["rule"], "== 1")
+        self.assertFalse(gate["passed"])
+
+    def test_concurrency_and_stale_authorization_are_measured_separately(self):
+        metrics = self.report["metrics"]
+        self.assertEqual(metrics["stale_authorization_rejection_rate"], 1.0)
+        self.assertEqual(metrics["silent_overwrite_rate"], 0.0)
+        self.assertTrue(self.report["cases"]["concurrent_conflict"]["details"]["conflict_recorded"])
+        self.assertTrue(self.report["cases"]["concurrent_conflict"]["details"]["state_version_revalidated"])
+
+    def test_bad_commit_is_rejected(self):
+        with self.assertRaises(ValueError):
+            build_report("not-a-commit", stochastic_trials=1)
+
+    def test_nonpositive_stochastic_trials_are_rejected(self):
+        with self.assertRaises(ValueError):
+            build_report(COMMIT, stochastic_trials=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/benchmark-security-report.schema.json
+++ b/schemas/benchmark-security-report.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/benchmark-security-report.schema.json",
+  "title": "Agent Memory P5 Benchmark Security Scorecard",
+  "type": "object",
+  "required": [
+    "report_type",
+    "version",
+    "agent_memory_commit",
+    "implementation",
+    "adapter_version",
+    "doctrine_version",
+    "policy_version",
+    "sample_counts",
+    "metrics",
+    "hard_gates",
+    "hard_gates_passed",
+    "cases",
+    "known_limits"
+  ],
+  "properties": {
+    "report_type": {"const": "agent-memory-p5-benchmark-security-scorecard"},
+    "version": {"type": "string"},
+    "agent_memory_commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "implementation": {"type": "string"},
+    "adapter_version": {"type": "string"},
+    "doctrine_version": {"type": "string"},
+    "policy_version": {"type": "string"},
+    "sample_counts": {
+      "type": "object",
+      "required": ["security_cases", "blocked_action_attempts", "stochastic_trials"],
+      "properties": {
+        "security_cases": {"type": "integer", "minimum": 1},
+        "blocked_action_attempts": {"type": "integer", "minimum": 1},
+        "stochastic_trials": {"type": "integer", "minimum": 1}
+      },
+      "additionalProperties": false
+    },
+    "metrics": {
+      "type": "object",
+      "required": [
+        "cross_scope_admission_rate",
+        "blocked_action_escape_rate",
+        "authority_from_confidence_count",
+        "stochastic_action_set_violation_rate",
+        "stale_authorization_rejection_rate",
+        "silent_overwrite_rate",
+        "deletion_residue_rate"
+      ],
+      "properties": {
+        "cross_scope_admission_rate": {"$ref": "#/$defs/rate"},
+        "blocked_action_escape_rate": {"$ref": "#/$defs/rate"},
+        "authority_from_confidence_count": {"type": "integer", "minimum": 0},
+        "stochastic_action_set_violation_rate": {"$ref": "#/$defs/rate"},
+        "stale_authorization_rejection_rate": {"$ref": "#/$defs/rate"},
+        "silent_overwrite_rate": {"$ref": "#/$defs/rate"},
+        "deletion_residue_rate": {"$ref": "#/$defs/rate"}
+      },
+      "additionalProperties": false
+    },
+    "hard_gates": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "required": ["metric", "rule", "observed", "passed"],
+        "properties": {
+          "metric": {"type": "string"},
+          "rule": {"enum": ["== 0", "== 1"]},
+          "observed": {"type": "number"},
+          "passed": {"type": "boolean"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "hard_gates_passed": {"type": "boolean"},
+    "cases": {
+      "type": "object",
+      "minProperties": 7,
+      "additionalProperties": {"$ref": "#/$defs/case"}
+    },
+    "known_limits": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "$defs": {
+    "rate": {"type": "number", "minimum": 0, "maximum": 1},
+    "case": {
+      "type": "object",
+      "required": ["metric", "numerator", "denominator", "value", "passed", "details"],
+      "properties": {
+        "metric": {"type": "string"},
+        "numerator": {"type": "integer", "minimum": 0},
+        "denominator": {"type": "integer", "minimum": 1},
+        "value": {"type": "number", "minimum": 0},
+        "passed": {"type": "boolean"},
+        "details": {"type": "object", "additionalProperties": true}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Objective

Implement the first P5 benchmark/security slice from #46 and close #81 with executable, exact-commit evidence.

## What changes

- adds `reference/agentmem_ref/benchmark_security.py`
- adds `reference/run_benchmark_security.py`
- adds `reference/tests/test_benchmark_security.py`
- adds `schemas/benchmark-security-report.schema.json`
- adds `docs/programs/runtime-evidence/benchmark-security-scorecard.md`
- registers the P5 document in the runtime-evidence index
- emits and uploads `benchmark-security.json` from CI at the exact PR head / merge commit

## Scorecard semantics

The harness executes seven governance/security metrics with explicit numerators and denominators:

```text
cross_scope_admission_rate              required == 0
blocked_action_escape_rate              required == 0
authority_from_confidence_count         required == 0
stochastic_action_set_violation_rate    required == 0
stale_authorization_rejection_rate      required == 1
silent_overwrite_rate                   required == 0
deletion_residue_rate                   required == 0
```

These are hard gates. They are not weighted, averaged, or converted into a scalar quality score.

The harness also adversarially mutates each hard-gate metric in unit tests to prove the evaluator fails closed when a critical metric regresses.

## Boundaries

This is a benchmark of the reference governed adapter and already-established runtime boundaries. It does not claim production task performance, long-horizon utility, latency/cost characterization, exhaustive poisoning/extraction red-team coverage, a production memory-layer comparator, a higher conformance level, or ADR-020 acceptance.

P6 remains the production-oriented adversarial comparator phase.

Closes #81.
Advances #46.