### PR TITLE
Docs: add V1 visual decision-flow guide and Wiki navigation

### DIFF
--- a/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
+++ b/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
@@ -21,8 +21,12 @@ saturation != confidence
 saturation != authority
 relevance != permission
 certification != permanence forever
-proposal != commit
+staleness != falsity
+supersession != correction
+delete operation != forgetting completeness
 retrieval != recall admission
+same agent != same memory scope
+proposal != commit
 ```
 
 When a visual and a canonical document appear to differ, **the canonical document governs**. Open an issue rather than treating the picture as an independent policy source.
@@ -97,6 +101,8 @@ Candidate generation may be probabilistic. Admission is governed. Ranking occurs
 
 ## What comes next
 
-The immediate visual core above does **not** complete the full initiative. The next stable visual work under issue #73 covers temporal correction/supersession and deletion completeness/derived-state propagation. Emerging isolation-domain and portable-evidence visuals must follow the maturity of their governing ADRs and executable evidence rather than anticipating it.
+The immediate visual core above does **not** complete the full initiative. The next stable visual work under issue #73 covers temporal correction/supersession and deletion completeness/derived-state propagation.
 
-This page will remain an index into those stable visual explanations as they land.
+[ADR-021](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md) and [ADR-022](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-022-memory-isolation-domains-and-controlled-boundary-crossing.md) remain **Proposed**. V1 does not contain a visual that finalizes either boundary. Isolation-domain visuals must follow ADR-022's doctrine maturity, and portable-evidence visuals must follow ADR-021's executable interoperability evidence rather than inventing a wire model visually. A diagram does not raise an ADR status, conformance level, or runtime-evidence claim.
+
+This page will remain an index into stable visual explanations as they land.

--- a/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
+++ b/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
@@ -1,0 +1,102 @@
+# Decision Flows and Memory Lifecycle
+
+This page is a **visual map of existing Agent Memory doctrine**. It is not a new doctrine source, decision table, runtime guarantee, or substitute for the canonical numbered documentation.
+
+Use each diagram to answer one architectural question, then follow the canonical source link when implementation or conformance depends on the exact contract.
+
+| Principal question | Visual | Canonical source |
+|---|---|---|
+| How can retained state strengthen, weaken, be disputed, corrected, reconciled, or pruned? | [Lifecycle state map](#1-memory-lifecycle-state-map) | [`docs/02-lifecycle-state-machine.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/02-lifecycle-state-machine.md) |
+| Which signals strengthen or weaken persistence without creating authority? | [Strength and stability](#2-strength-and-stability-dynamics) | [`docs/03-scoring-and-decay.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/03-scoring-and-decay.md) |
+| What authority outcome is allowed for a proposed mutation? | [PAMA decision flow](#3-pama-mutation-authority-decision-flow) | [`docs/pama/README.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/pama/README.md) |
+| Which retrieved candidates may enter active context, and under what treatment? | [Governed recall](#4-governed-recall-pipeline) | [`docs/26-governed-recall-planner.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/26-governed-recall-planner.md) |
+
+## Reading rule
+
+The diagrams deliberately preserve distinctions that are easy to destroy through visual simplification:
+
+```text
+confidence != truth
+saturation != confidence
+saturation != authority
+relevance != permission
+certification != permanence forever
+proposal != commit
+retrieval != recall admission
+```
+
+When a visual and a canonical document appear to differ, **the canonical document governs**. Open an issue rather than treating the picture as an independent policy source.
+
+## 1. Memory lifecycle state map
+
+**Question:** How can retained state strengthen, weaken, be disputed, corrected, reconciled, or pruned?
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/lifecycle-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/lifecycle-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/lifecycle-flow-light.svg" alt="Agent Memory lifecycle state map showing strengthening and promotion, demotion, dispute, correction, reconciliation, pruning, and the separation between transition proposal and committed state" width="100%">
+  </picture>
+</p>
+
+Not every memory traverses every state. `Crystallized` is durable under current evidence and policy, not eternal. `Pruned` removes memory from active recall or durable lifecycle consideration according to policy and does not necessarily mean physical deletion.
+
+**Readable Wiki context:** [Lifecycle and Forgetting](Lifecycle-and-Forgetting)  
+**Canonical contract:** [`docs/02-lifecycle-state-machine.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/02-lifecycle-state-machine.md)
+
+## 2. Strength and stability dynamics
+
+**Question:** Which signals strengthen or weaken a memory's case for persistence without creating authority?
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/strength-stability-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/strength-stability-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/strength-stability-flow-light.svg" alt="Agent Memory strength and stability map separating evidence confidence, source trust, saturation, contradiction pressure, certification, lifecycle stability, and PAMA authority" width="100%">
+  </picture>
+</p>
+
+Evidence, verification, corroboration, meaningful reuse, and stable provenance can strengthen the case for persistence. Contradiction, expiry, invalidation, uncertainty, and drift can weaken it. Neither direction grants authority to promote, share, execute, or delete. Exact operating thresholds remain calibrated implementation choices rather than doctrine.
+
+**Readable Wiki context:** [Core Concepts](Core-Concepts)  
+**Canonical contracts:** [`docs/03-scoring-and-decay.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/03-scoring-and-decay.md) · [`docs/16-source-trust-and-reputation.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/16-source-trust-and-reputation.md) · [`docs/04-governance-and-pama.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/04-governance-and-pama.md)
+
+## 3. PAMA mutation-authority decision flow
+
+**Question:** What authority outcome is allowed for a proposed mutation?
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/pama-decision-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/pama-decision-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/pama-decision-flow-light.svg" alt="PAMA mutation authority decision flow showing proposal classification, authority floors, policy modifiers, outcome resolution, permitted action set construction, and commit or deferral with evidence" width="100%">
+  </picture>
+</p>
+
+PAMA is multidimensional governance, not a single memory-quality score. Target class, lifecycle strength, requested operation, downstream authority, consequence, actor, evidence, uncertainty, and policy remain distinct. Confidence or saturation can contribute evidence but cannot expand an otherwise prohibited authority envelope.
+
+**Readable Wiki context:** [PAMA](PAMA)  
+**Canonical contracts:** [`docs/pama/README.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/pama/README.md) · [`docs/33-pama-decision-table.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/33-pama-decision-table.md) · [ADR-004](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-004-pama-controls-mutation-authority.md)
+
+## 4. Governed recall pipeline
+
+**Question:** Which retrieved candidates may enter active context, and under what treatment?
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/governed-recall-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/governed-recall-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/governed-recall-flow-light.svg" alt="Governed recall pipeline showing request resolution, candidate generation and normalization, recall admission, ranking only among admitted candidates, composition risk, context budgeting, governed assembly, and recall explanation" width="100%">
+  </picture>
+</p>
+
+Candidate generation may be probabilistic. Admission is governed. Ranking occurs only among admitted candidates, composition has its own policy boundary, and context budgeting cannot discard required governance state. A stronger retrieval score never reopens a blocked candidate.
+
+**Readable Wiki context:** [Implementation Guide](Implementation-Guide)  
+**Canonical contract:** [`docs/26-governed-recall-planner.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/26-governed-recall-planner.md) · [ADR-013](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-013-governed-recall-planner-is-required.md)
+
+## What comes next
+
+The immediate visual core above does **not** complete the full initiative. The next stable visual work under issue #73 covers temporal correction/supersession and deletion completeness/derived-state propagation. Emerging isolation-domain and portable-evidence visuals must follow the maturity of their governing ADRs and executable evidence rather than anticipating it.
+
+This page will remain an index into those stable visual explanations as they land.

--- a/wiki-src/Home.md
+++ b/wiki-src/Home.md
@@ -18,6 +18,7 @@ Agent Memory asks a larger question than _“how do we retrieve old context?”_
 
 | I want to... | Start here |
 |---|---|
+| Follow the architecture through focused visual decision flows | **[Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle)** |
 | Understand the architecture quickly | **[Getting Started](Getting-Started)** |
 | Learn the core vocabulary and invariants | **[Core Concepts](Core-Concepts)** |
 | Understand adaptive authority | **[PAMA](PAMA)** |

--- a/wiki-src/_Sidebar.md
+++ b/wiki-src/_Sidebar.md
@@ -7,6 +7,7 @@
 - [Glossary](Glossary)
 
 **Architecture**
+- [Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle)
 - [PAMA](PAMA)
 - [Lifecycle and Forgetting](Lifecycle-and-Forgetting)
 - [Canonical and Derived State](Canonical-and-Derived-State)


### PR DESCRIPTION
Advances #73 with the final V1 navigation slice. This PR does not complete the full issue; V2 acceptance work remains.

## Scope

- adds `wiki-src/Decision-Flows-and-Memory-Lifecycle.md` as a reader-oriented visual map of the four stable V1 diagrams
- adds the visual guide under the Wiki Architecture sidebar
- adds a direct visual-guide path from Wiki Home
- keeps each diagram centered on one principal architectural question
- links every visual back to its readable Wiki context and canonical numbered docs/accepted ADRs

## Doctrine boundary

The new page explicitly states that it is an explanatory map, not a doctrine source, decision table, runtime guarantee, conformance claim, or replacement for canonical documentation.

It preserves the visual separations required by #73:

- confidence != truth
- saturation != confidence
- saturation != authority
- relevance != permission
- certification != permanence forever
- staleness != falsity
- supersession != correction
- delete operation != forgetting completeness
- retrieval != recall admission
- same agent != same memory scope
- proposal != commit

No new states, scores, thresholds, transition rules, policy outcomes, authority rules, or runtime claims are introduced.

ADR-021 and ADR-022 remain **Proposed**. This V1 slice does not finalize either emerging boundary, raise conformance, or alter ADR maturity.

## Accessibility / mobile

The page reuses the already-validated 540px-wide paired light/dark assets. Every embed has useful alt text, a nearby text summary, and canonical links. Meaning remains labeled in text rather than color alone.

## Remaining issue scope

#73 remains open after this V1 increment. Its initiative-level acceptance criteria still require, at minimum, the V2 temporal correction/supersession visual and deletion-completeness/derived-state propagation visual before closure can be considered.