### PR TITLE
Docs: add V2 temporal correction and supersession visual

### DIFF
--- a/assets/diagrams/temporal-correction-flow-light.svg
+++ b/assets/diagrams/temporal-correction-flow-light.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="540" height="960" viewBox="0 0 540 960" role="img" aria-labelledby="title desc">
+  <title id="title">Temporal change, correction, supersession, dispute, and staleness</title>
+  <desc id="desc">A vertical Agent Memory timeline distinguishing historically true state that is later superseded, wrong or incomplete state that is corrected, currently uncertain state that is disputed, and old but historically valid state that is stale for current-state recall. Historical records remain preserved and causal inference does not rewrite the event log.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="7.5" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L8,3 z" fill="#57606a"/></marker>
+  </defs>
+  <rect x="1" y="1" width="538" height="958" rx="18" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="28" y="42" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="24" font-weight="700">Temporal change is not one kind of replacement</text>
+  <text x="28" y="68" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Preserve what was true, what was wrong, what is uncertain, and what is merely old.</text>
+
+  <text x="28" y="108" fill="#0969da" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">01  SUPERSESSION</text>
+  <rect x="28" y="124" width="484" height="132" rx="12" fill="#f6f8fa" stroke="#0969da"/>
+  <text x="48" y="154" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Historically true → newer state applies later</text>
+  <text x="48" y="180" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">T1: endpoint = A</text>
+  <text x="48" y="204" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">T2: endpoint = B</text>
+  <text x="48" y="230" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">A remains historical state; B becomes current. Supersession != correction.</text>
+
+  <line x1="270" y1="256" x2="270" y2="282" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="28" y="314" fill="#8250df" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">02  CORRECTION</text>
+  <rect x="28" y="330" width="484" height="132" rx="12" fill="#f8f5ff" stroke="#8250df"/>
+  <text x="48" y="360" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Wrong or materially incomplete → corrected</text>
+  <text x="48" y="386" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Prior record was inaccurate within its claimed scope/time.</text>
+  <text x="48" y="412" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">New record preserves correction history and provenance.</text>
+  <text x="48" y="438" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Correction changes the claim; it does not silently erase the historical record.</text>
+
+  <line x1="270" y1="462" x2="270" y2="488" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="28" y="520" fill="#cf222e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">03  DISPUTE</text>
+  <rect x="28" y="536" width="484" height="132" rx="12" fill="#fff5f5" stroke="#cf222e"/>
+  <text x="48" y="566" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Currently uncertain → disputed</text>
+  <text x="48" y="592" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Conflicting evidence does not automatically select a winner.</text>
+  <text x="48" y="618" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Review, verification, or more evidence may be required.</text>
+  <text x="48" y="644" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Disputed state must not be silently treated as canonical truth.</text>
+
+  <line x1="270" y1="668" x2="270" y2="694" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="28" y="726" fill="#1a7f37" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">04  STALENESS</text>
+  <rect x="28" y="742" width="484" height="132" rx="12" fill="#f3fff5" stroke="#1a7f37"/>
+  <text x="48" y="772" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Old but historically valid → stale for current-state recall</text>
+  <text x="48" y="798" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Age or changed conditions can reduce current relevance.</text>
+  <text x="48" y="824" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Historical queries may still legitimately return the older state.</text>
+  <text x="48" y="850" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Staleness != falsity. Historically true != currently true.</text>
+
+  <rect x="28" y="898" width="484" height="38" rx="9" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="270" y="922" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Chronology may be exact. Causal attribution remains uncertain unless independently established.</text>
+</svg>

--- a/assets/diagrams/temporal-correction-flow.svg
+++ b/assets/diagrams/temporal-correction-flow.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="540" height="960" viewBox="0 0 540 960" role="img" aria-labelledby="title desc">
+  <title id="title">Temporal change, correction, supersession, dispute, and staleness</title>
+  <desc id="desc">A vertical Agent Memory timeline distinguishing historically true state that is later superseded, wrong or incomplete state that is corrected, currently uncertain state that is disputed, and old but historically valid state that is stale for current-state recall. Historical records remain preserved and causal inference does not rewrite the event log.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="7.5" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L8,3 z" fill="#8b949e"/></marker>
+  </defs>
+  <rect x="1" y="1" width="538" height="958" rx="18" fill="#0d1117" stroke="#30363d"/>
+  <text x="28" y="42" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="24" font-weight="700">Temporal change is not one kind of replacement</text>
+  <text x="28" y="68" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Preserve what was true, what was wrong, what is uncertain, and what is merely old.</text>
+
+  <text x="28" y="108" fill="#79c0ff" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">01  SUPERSESSION</text>
+  <rect x="28" y="124" width="484" height="132" rx="12" fill="#161b22" stroke="#388bfd"/>
+  <text x="48" y="154" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Historically true → newer state applies later</text>
+  <text x="48" y="180" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">T1: endpoint = A</text>
+  <text x="48" y="204" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">T2: endpoint = B</text>
+  <text x="48" y="230" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">A remains historical state; B becomes current. Supersession != correction.</text>
+
+  <line x1="270" y1="256" x2="270" y2="282" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="28" y="314" fill="#d2a8ff" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">02  CORRECTION</text>
+  <rect x="28" y="330" width="484" height="132" rx="12" fill="#1c1628" stroke="#a371f7"/>
+  <text x="48" y="360" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Wrong or materially incomplete → corrected</text>
+  <text x="48" y="386" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Prior record was inaccurate within its claimed scope/time.</text>
+  <text x="48" y="412" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">New record preserves correction history and provenance.</text>
+  <text x="48" y="438" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Correction changes the claim; it does not silently erase the historical record.</text>
+
+  <line x1="270" y1="462" x2="270" y2="488" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="28" y="520" fill="#ff7b72" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">03  DISPUTE</text>
+  <rect x="28" y="536" width="484" height="132" rx="12" fill="#251719" stroke="#f85149"/>
+  <text x="48" y="566" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Currently uncertain → disputed</text>
+  <text x="48" y="592" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Conflicting evidence does not automatically select a winner.</text>
+  <text x="48" y="618" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Review, verification, or more evidence may be required.</text>
+  <text x="48" y="644" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Disputed state must not be silently treated as canonical truth.</text>
+
+  <line x1="270" y1="668" x2="270" y2="694" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="28" y="726" fill="#7ee787" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">04  STALENESS</text>
+  <rect x="28" y="742" width="484" height="132" rx="12" fill="#122019" stroke="#3fb950"/>
+  <text x="48" y="772" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Old but historically valid → stale for current-state recall</text>
+  <text x="48" y="798" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Age or changed conditions can reduce current relevance.</text>
+  <text x="48" y="824" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">Historical queries may still legitimately return the older state.</text>
+  <text x="48" y="850" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Staleness != falsity. Historically true != currently true.</text>
+
+  <rect x="28" y="898" width="484" height="38" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="270" y="922" text-anchor="middle" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Chronology may be exact. Causal attribution remains uncertain unless independently established.</text>
+</svg>

--- a/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
+++ b/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
@@ -10,6 +10,7 @@ Use each diagram to answer one architectural question, then follow the canonical
 | Which signals strengthen or weaken persistence without creating authority? | [Strength and stability](#2-strength-and-stability-dynamics) | [`docs/03-scoring-and-decay.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/03-scoring-and-decay.md) |
 | What authority outcome is allowed for a proposed mutation? | [PAMA decision flow](#3-pama-mutation-authority-decision-flow) | [`docs/pama/README.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/pama/README.md) |
 | Which retrieved candidates may enter active context, and under what treatment? | [Governed recall](#4-governed-recall-pipeline) | [`docs/26-governed-recall-planner.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/26-governed-recall-planner.md) |
+| How should readers distinguish supersession, correction, dispute, and staleness across time? | [Temporal change](#5-temporal-change-correction-and-supersession) | [`docs/18-temporal-causality-layer.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/18-temporal-causality-layer.md) |
 
 ## Reading rule
 
@@ -99,10 +100,27 @@ Candidate generation may be probabilistic. Admission is governed. Ranking occurs
 **Readable Wiki context:** [Implementation Guide](Implementation-Guide)  
 **Canonical contract:** [`docs/26-governed-recall-planner.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/26-governed-recall-planner.md) · [ADR-013](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-013-governed-recall-planner-is-required.md)
 
+## 5. Temporal change, correction, and supersession
+
+**Question:** How should readers distinguish supersession, correction, dispute, and staleness across time?
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/temporal-correction-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/temporal-correction-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/temporal-correction-flow-light.svg" alt="Temporal change diagram distinguishing historically true state that is later superseded, wrong or incomplete state that is corrected, uncertain state that is disputed, and old but historically valid state that is stale for current-state recall" width="100%">
+  </picture>
+</p>
+
+Supersession preserves a previously valid state while a newer state becomes current. Correction records that an earlier claim was wrong or materially incomplete within its claimed scope or time. Dispute preserves unresolved uncertainty. Staleness can reduce current-state usefulness without converting historical truth into falsity. Exact chronology does not establish causality, and inferred causal links must not rewrite the historical event log.
+
+**Readable Wiki context:** [Lifecycle and Forgetting](Lifecycle-and-Forgetting)  
+**Canonical contract:** [`docs/18-temporal-causality-layer.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/18-temporal-causality-layer.md) · [ADR-011](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-011-temporal-causality-is-required-for-memory-evolution.md)
+
 ## What comes next
 
-The immediate visual core above does **not** complete the full initiative. The next stable visual work under issue #73 covers temporal correction/supersession and deletion completeness/derived-state propagation.
+The remaining stable V2 visual work under issue #73 covers deletion completeness/derived-state propagation and the first scenario walkthroughs.
 
-[ADR-021](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md) and [ADR-022](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-022-memory-isolation-domains-and-controlled-boundary-crossing.md) remain **Proposed**. V1 does not contain a visual that finalizes either boundary. Isolation-domain visuals must follow ADR-022's doctrine maturity, and portable-evidence visuals must follow ADR-021's executable interoperability evidence rather than inventing a wire model visually. A diagram does not raise an ADR status, conformance level, or runtime-evidence claim.
+[ADR-021](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md) and [ADR-022](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-022-memory-isolation-domains-and-controlled-boundary-crossing.md) remain **Proposed**. This visual guide does not contain a visual that finalizes either boundary. Isolation-domain visuals must follow ADR-022's doctrine maturity, and portable-evidence visuals must follow ADR-021's executable interoperability evidence rather than inventing a wire model visually. A diagram does not raise an ADR status, conformance level, or runtime-evidence claim.
 
 This page will remain an index into stable visual explanations as they land.

--- a/wiki-src/Lifecycle-and-Forgetting.md
+++ b/wiki-src/Lifecycle-and-Forgetting.md
@@ -120,9 +120,20 @@ historically true != currently true
 
 When evidence changes, the architecture should preserve what was known, what changed, why it changed, and which newer state supersedes the old one.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/temporal-correction-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/temporal-correction-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/temporal-correction-flow-light.svg" alt="Temporal change diagram distinguishing historically true state that is later superseded, wrong or incomplete state that is corrected, uncertain state that is disputed, and old but historically valid state that is stale for current-state recall" width="100%">
+  </picture>
+</p>
+
+The visual is an explanatory projection of the temporal-causality doctrine, not a replacement policy. Supersession means the older record was valid and a newer state applies later. Correction means the older record was wrong or materially incomplete within its claimed scope or time. Dispute preserves unresolved uncertainty rather than choosing a winner, while staleness can reduce current-state usefulness without making a historically valid record false. Chronology may be deterministic when the system has exact events and timestamps; causal attribution remains uncertain unless independently established.
+
 ## Canonical sources
 
 - Lifecycle state machine: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/02-lifecycle-state-machine.md
+- Temporal causality: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/18-temporal-causality-layer.md
 - Forgetting and consolidation: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/21-forgetting-consolidation-and-memory-metabolism.md
 - Retention, deletion, tombstones: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/28-retention-deletion-and-tombstones.md
 - Recovery and replay: https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/31-recovery-rollback-and-replay.md


### PR DESCRIPTION
Advances #73 with the first V2 mutation/history visual. This PR intentionally does **not** close #73.

## Scope

- adds paired light/dark `assets/diagrams/temporal-correction-flow*.svg`
- uses a 540px-wide vertical composition consistent with the V1 visual language
- embeds the visual in `wiki-src/Lifecycle-and-Forgetting.md`
- adds it to the visual-guide index in `wiki-src/Decision-Flows-and-Memory-Lifecycle.md`

## Doctrine trace

Every substantive visual claim is pinned to `docs/18-temporal-causality-layer.md` and accepted ADR-011.

The visual preserves these distinctions:

- historically true then superseded != corrected
- wrong or materially incomplete within claimed scope/time -> corrected
- unresolved conflicting evidence -> disputed rather than silently canonical
- old but historically valid -> stale for current-state recall without becoming false
- historically true != currently true
- exact chronology != established causality
- causal inference must not rewrite the historical event log

No new temporal states, causal authority, correction authority, timestamps, thresholds, retrieval policy, or conformance claims are introduced.

## Accessibility / mobile

- matched light/dark SVGs with identical reader-facing semantics and geometry
- 540px-wide vertical composition
- `<title>` and `<desc>` in both variants
- text labels accompany all semantic color usage
- useful embed alt text
- nearby textual explanation/fallback and direct canonical links

## Remaining issue scope

#73 remains open. V2 still requires deletion-completeness/derived-state propagation and first scenario walkthroughs before the issue-level acceptance criteria can be reassessed. ADR-021/ADR-022 visual maturity remains untouched.