### PR TITLE
Docs: add V2 deletion completeness and derived-state propagation visual

### DIFF
--- a/assets/diagrams/deletion-propagation-flow-light.svg
+++ b/assets/diagrams/deletion-propagation-flow-light.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="540" height="1040" viewBox="0 0 540 1040" role="img" aria-labelledby="title desc">
+  <title id="title">Deletion completeness and derived-state propagation</title>
+  <desc id="desc">A vertical Agent Memory diagram showing canonical memory, governed derived memory, and projections, then separating correction propagation from deletion propagation. Correction makes dependent projections stale and routes rebuild or supersession through governance. Deletion traverses the transitive derivation closure, purges in-scope state, performs an independent residue sweep, and only satisfies the lifecycle when undeclared residue is zero. The P4 projection vocabulary shown is executed design evidence, not adopted doctrine.</desc>
+  <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7.5" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L8,3 z" fill="#57606a"/></marker></defs>
+  <rect x="1" y="1" width="538" height="1038" rx="18" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="28" y="40" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="23" font-weight="700">A successful delete is not yet complete forgetting</text>
+  <text x="28" y="65" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Canonical requirement plus executed P4 design evidence. Projection vocabulary is not ADR-adopted doctrine.</text>
+
+  <text x="28" y="105" fill="#0969da" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">01  THREE STATE TIERS</text>
+  <rect x="28" y="120" width="484" height="68" rx="11" fill="#f6f8fa" stroke="#0969da"/>
+  <text x="270" y="146" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Canonical memory unit</text>
+  <text x="270" y="168" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">identity · lifecycle · authority · provenance</text>
+  <line x1="270" y1="188" x2="270" y2="210" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="218" width="484" height="68" rx="11" fill="#f8f5ff" stroke="#8250df"/>
+  <text x="270" y="244" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Governed derived memory unit</text>
+  <text x="270" y="266" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">summary / semantic / procedural memory with derivation links</text>
+  <line x1="270" y1="286" x2="270" y2="308" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="316" width="484" height="86" rx="11" fill="#f3fff5" stroke="#1a7f37"/>
+  <text x="270" y="342" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Projection state</text>
+  <text x="270" y="366" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">embedding · index · cache · materialized view · summary projection</text>
+  <text x="270" y="388" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">not itself a memory unit; basis/dependency visibility is the residue problem</text>
+
+  <text x="28" y="448" fill="#8250df" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">02  CORRECTION PATH</text>
+  <rect x="28" y="463" width="484" height="112" rx="11" fill="#f8f5ff" stroke="#8250df"/>
+  <text x="48" y="492" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Source version changes → dependent projection becomes stale</text>
+  <text x="48" y="518" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">stale = source changed; content may be out of date</text>
+  <text x="48" y="544" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">rebuild/supersession is governed; estimator-mediated rebuild is a mutation</text>
+  <text x="48" y="564" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Correction preserves history unless privacy/deletion policy requires otherwise.</text>
+
+  <text x="28" y="621" fill="#cf222e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">03  DELETION PATH</text>
+  <rect x="28" y="636" width="484" height="58" rx="10" fill="#fff5f5" stroke="#cf222e"/>
+  <text x="270" y="661" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Source purged → traverse transitive derivation closure</text>
+  <text x="270" y="681" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">One-hop deletion is insufficient.</text>
+  <line x1="270" y1="694" x2="270" y2="716" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="724" width="484" height="58" rx="10" fill="#fff5f5" stroke="#cf222e"/>
+  <text x="270" y="749" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Purge in-scope dependents + report known residual copies</text>
+  <text x="270" y="769" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Uncontrollable copies are declared, not quietly omitted.</text>
+  <line x1="270" y1="782" x2="270" y2="804" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="812" width="484" height="58" rx="10" fill="#f6f8fa" stroke="#57606a"/>
+  <text x="270" y="837" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Independent residue sweep</text>
+  <text x="270" y="857" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Verification does not ask the purge process whether it succeeded.</text>
+
+  <path d="M270 870 V894 M270 894 H150 V914 M270 894 H390 V914" fill="none" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="922" width="230" height="76" rx="10" fill="#f3fff5" stroke="#1a7f37"/>
+  <text x="143" y="948" text-anchor="middle" fill="#1a7f37" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">undeclared residue = 0</text>
+  <text x="143" y="971" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">lifecycle outcome satisfied</text>
+  <text x="143" y="989" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11">subject to declared scope/outcome</text>
+  <rect x="282" y="922" width="230" height="76" rx="10" fill="#fff5f5" stroke="#cf222e"/>
+  <text x="397" y="948" text-anchor="middle" fill="#cf222e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">surviving undeclared residue</text>
+  <text x="397" y="971" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">lifecycle incomplete</text>
+  <text x="397" y="989" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11">delete operation != forgetting completeness</text>
+
+  <text x="270" y="1023" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">stale = source changed · residual = source was tombstoned/purged</text>
+</svg>

--- a/assets/diagrams/deletion-propagation-flow.svg
+++ b/assets/diagrams/deletion-propagation-flow.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="540" height="1040" viewBox="0 0 540 1040" role="img" aria-labelledby="title desc">
+  <title id="title">Deletion completeness and derived-state propagation</title>
+  <desc id="desc">A vertical Agent Memory diagram showing canonical memory, governed derived memory, and projections, then separating correction propagation from deletion propagation. Correction makes dependent projections stale and routes rebuild or supersession through governance. Deletion traverses the transitive derivation closure, purges in-scope state, performs an independent residue sweep, and only satisfies the lifecycle when undeclared residue is zero. The P4 projection vocabulary shown is executed design evidence, not adopted doctrine.</desc>
+  <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7.5" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L8,3 z" fill="#8b949e"/></marker></defs>
+  <rect x="1" y="1" width="538" height="1038" rx="18" fill="#0d1117" stroke="#30363d"/>
+  <text x="28" y="40" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="23" font-weight="700">A successful delete is not yet complete forgetting</text>
+  <text x="28" y="65" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Canonical requirement plus executed P4 design evidence. Projection vocabulary is not ADR-adopted doctrine.</text>
+
+  <text x="28" y="105" fill="#79c0ff" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">01  THREE STATE TIERS</text>
+  <rect x="28" y="120" width="484" height="68" rx="11" fill="#161b22" stroke="#388bfd"/>
+  <text x="270" y="146" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Canonical memory unit</text>
+  <text x="270" y="168" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">identity · lifecycle · authority · provenance</text>
+  <line x1="270" y1="188" x2="270" y2="210" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="218" width="484" height="68" rx="11" fill="#1c1628" stroke="#a371f7"/>
+  <text x="270" y="244" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Governed derived memory unit</text>
+  <text x="270" y="266" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">summary / semantic / procedural memory with derivation links</text>
+  <line x1="270" y1="286" x2="270" y2="308" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="316" width="484" height="86" rx="11" fill="#122019" stroke="#3fb950"/>
+  <text x="270" y="342" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="16" font-weight="700">Projection state</text>
+  <text x="270" y="366" text-anchor="middle" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">embedding · index · cache · materialized view · summary projection</text>
+  <text x="270" y="388" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">not itself a memory unit; basis/dependency visibility is the residue problem</text>
+
+  <text x="28" y="448" fill="#d2a8ff" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">02  CORRECTION PATH</text>
+  <rect x="28" y="463" width="484" height="112" rx="11" fill="#1c1628" stroke="#a371f7"/>
+  <text x="48" y="492" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Source version changes → dependent projection becomes stale</text>
+  <text x="48" y="518" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">stale = source changed; content may be out of date</text>
+  <text x="48" y="544" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">rebuild/supersession is governed; estimator-mediated rebuild is a mutation</text>
+  <text x="48" y="564" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Correction preserves history unless privacy/deletion policy requires otherwise.</text>
+
+  <text x="28" y="621" fill="#ff7b72" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">03  DELETION PATH</text>
+  <rect x="28" y="636" width="484" height="58" rx="10" fill="#251719" stroke="#f85149"/>
+  <text x="270" y="661" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Source purged → traverse transitive derivation closure</text>
+  <text x="270" y="681" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">One-hop deletion is insufficient.</text>
+  <line x1="270" y1="694" x2="270" y2="716" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="724" width="484" height="58" rx="10" fill="#251719" stroke="#f85149"/>
+  <text x="270" y="749" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Purge in-scope dependents + report known residual copies</text>
+  <text x="270" y="769" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Uncontrollable copies are declared, not quietly omitted.</text>
+  <line x1="270" y1="782" x2="270" y2="804" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="812" width="484" height="58" rx="10" fill="#161b22" stroke="#8b949e"/>
+  <text x="270" y="837" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Independent residue sweep</text>
+  <text x="270" y="857" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Verification does not ask the purge process whether it succeeded.</text>
+
+  <path d="M270 870 V894 M270 894 H150 V914 M270 894 H390 V914" fill="none" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="28" y="922" width="230" height="76" rx="10" fill="#122019" stroke="#3fb950"/>
+  <text x="143" y="948" text-anchor="middle" fill="#7ee787" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">undeclared residue = 0</text>
+  <text x="143" y="971" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">lifecycle outcome satisfied</text>
+  <text x="143" y="989" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11">subject to declared scope/outcome</text>
+  <rect x="282" y="922" width="230" height="76" rx="10" fill="#251719" stroke="#f85149"/>
+  <text x="397" y="948" text-anchor="middle" fill="#ff7b72" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">surviving undeclared residue</text>
+  <text x="397" y="971" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">lifecycle incomplete</text>
+  <text x="397" y="989" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11">delete operation != forgetting completeness</text>
+
+  <text x="270" y="1023" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">stale = source changed · residual = source was tombstoned/purged</text>
+</svg>

--- a/wiki-src/Canonical-and-Derived-State.md
+++ b/wiki-src/Canonical-and-Derived-State.md
@@ -8,6 +8,16 @@ Deleting a memory is easy. Proving it is gone is the hard part, and almost every
 
 A user asks for a record to be deleted. The record disappears. But a summary written from it still contains the content, an embedding built from it still encodes it, a search index still points at it, and a cached view still serves it. Each of those is a legitimate piece of engineering. Together they mean the deletion was a gesture. **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)** already says deletion must propagate through derived state. This page is about what that sentence has to mean before anyone can test it.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/deletion-propagation-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/deletion-propagation-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/deletion-propagation-flow-light.svg" alt="Deletion completeness diagram showing canonical memory, governed derived memory and projection state, then separating correction staleness from deletion residue, transitive purge, independent residue sweep, and lifecycle success only when undeclared residue is zero" width="100%">
+  </picture>
+</p>
+
+The canonical requirement is that deletion propagate through known derived state and that verification answer the requested forgetting outcome rather than merely report that one row disappeared. The three-tier projection vocabulary and the exact `stale`/`residual` relation shown here are **executed P4 design evidence, not adopted doctrine**. The diagram therefore explains the current tested design without raising ADR-020 status or turning implementation vocabulary into a new canonical contract. Its critical distinction remains: a changed source creates a correctness problem; a purged source can create prohibited residual content. A delete operation is not proof of forgetting completeness.
+
 ## Three tiers, not two
 
 "Canonical memory versus derived projections" sounds like one boundary. There are two, and the difference decides where the risk lives.

--- a/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
+++ b/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
@@ -11,6 +11,7 @@ Use each diagram to answer one architectural question, then follow the canonical
 | What authority outcome is allowed for a proposed mutation? | [PAMA decision flow](#3-pama-mutation-authority-decision-flow) | [`docs/pama/README.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/pama/README.md) |
 | Which retrieved candidates may enter active context, and under what treatment? | [Governed recall](#4-governed-recall-pipeline) | [`docs/26-governed-recall-planner.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/26-governed-recall-planner.md) |
 | How should readers distinguish supersession, correction, dispute, and staleness across time? | [Temporal change](#5-temporal-change-correction-and-supersession) | [`docs/18-temporal-causality-layer.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/18-temporal-causality-layer.md) |
+| Why can a successful delete operation still leave memory behind? | [Deletion completeness](#6-deletion-completeness-and-derived-state-propagation) | [`docs/28-retention-deletion-and-tombstones.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/28-retention-deletion-and-tombstones.md) |
 
 ## Reading rule
 
@@ -117,9 +118,27 @@ Supersession preserves a previously valid state while a newer state becomes curr
 **Readable Wiki context:** [Lifecycle and Forgetting](Lifecycle-and-Forgetting)  
 **Canonical contract:** [`docs/18-temporal-causality-layer.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/18-temporal-causality-layer.md) · [ADR-011](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-011-temporal-causality-is-required-for-memory-evolution.md)
 
+## 6. Deletion completeness and derived-state propagation
+
+**Question:** Why can a successful delete operation still leave memory behind?
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/deletion-propagation-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/deletion-propagation-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/deletion-propagation-flow-light.svg" alt="Deletion completeness diagram showing canonical memory, governed derived memory and projection state, correction staleness versus deletion residue, transitive purge, independent residue verification, and incomplete forgetting when undeclared residue survives" width="100%">
+  </picture>
+</p>
+
+Canonical deletion doctrine requires propagation through known derivation relationships and verification of the requested forgetting outcome. The diagram's three-tier projection vocabulary, transitive-closure mechanics, and `stale`/`residual` relation come from **executed P4 design evidence that is not ADR-adopted doctrine**. That distinction is deliberate. The tested design makes the key failure mode legible without pretending its supporting ADR has matured: source change creates staleness; source purge can create residual content; and a row-level delete cannot prove forgetting completeness.
+
+**Readable Wiki context:** [Lifecycle and Forgetting](Lifecycle-and-Forgetting) · [Canonical and Derived State](Canonical-and-Derived-State)  
+**Canonical contract:** [`docs/28-retention-deletion-and-tombstones.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/28-retention-deletion-and-tombstones.md) · [`docs/31-recovery-rollback-and-replay.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/31-recovery-rollback-and-replay.md)  
+**Executed design evidence:** [`docs/programs/runtime-evidence/canonical-and-derived-state.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/programs/runtime-evidence/canonical-and-derived-state.md)
+
 ## What comes next
 
-The remaining stable V2 visual work under issue #73 covers deletion completeness/derived-state propagation and the first scenario walkthroughs.
+The remaining V2 work under issue #73 is the first scenario walkthrough set and then a local acceptance-criteria audit.
 
 [ADR-021](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md) and [ADR-022](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-022-memory-isolation-domains-and-controlled-boundary-crossing.md) remain **Proposed**. This visual guide does not contain a visual that finalizes either boundary. Isolation-domain visuals must follow ADR-022's doctrine maturity, and portable-evidence visuals must follow ADR-021's executable interoperability evidence rather than inventing a wire model visually. A diagram does not raise an ADR status, conformance level, or runtime-evidence claim.
 

--- a/wiki-src/Lifecycle-and-Forgetting.md
+++ b/wiki-src/Lifecycle-and-Forgetting.md
@@ -108,6 +108,16 @@ residual  a source was purged      content may be prohibited
 
 Staleness may be repairable by recomputation. Residue is not: it is a governance problem, and only the deletion authority may resolve it. **[Canonical and Derived State](Canonical-and-Derived-State)** develops both, along with the case where correction and deletion give opposite instructions about the same superseded summary.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/deletion-propagation-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/deletion-propagation-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/deletion-propagation-flow-light.svg" alt="Deletion completeness diagram showing canonical memory, governed derived memory and projection state, correction staleness versus deletion residue, transitive purge, independent residue verification, and incomplete forgetting when undeclared residue survives" width="100%">
+  </picture>
+</p>
+
+The deletion requirement is canonical: verification must address the requested forgetting outcome and known derived state rather than merely prove that one storage row disappeared. The diagram's three-tier projection vocabulary and its exact P4 residue mechanics are **executed design evidence, not adopted doctrine**. That maturity boundary matters. A persuasive picture cannot accept ADR-020 for us. The useful operational distinction is still clear: source change creates staleness; source purge can create residual content; and a delete operation is not equivalent to demonstrated forgetting completeness.
+
 ## Correction is not erasure
 
 Agent Memory prefers preserved history over silent overwrite.


### PR DESCRIPTION
Advances #73 with the second V2 visual slice. This PR intentionally does **not** close #73.

## Scope

- adds paired light/dark `assets/diagrams/deletion-propagation-flow*.svg`
- embeds the visual in `Lifecycle and Forgetting`
- embeds the visual in `Canonical and Derived State`
- adds the visual to the reader-oriented visual guide

## Doctrine and maturity boundary

This slice deliberately separates canonical requirement from executed design evidence.

Canonical doctrine from `docs/28-retention-deletion-and-tombstones.md` / ADR-015 requires deletion propagation through known derivation relationships and verification of the requested forgetting outcome rather than merely proving one storage row disappeared.

The three-tier projection vocabulary, transitive-closure mechanics, independent residue sweep, and exact `stale`/`residual` relation shown in the visual come from the P4 runtime-evidence design. That design is implemented and exercised in CI, but **not ADR-adopted doctrine**. The diagram says so explicitly and does not raise ADR-020 status, conformance, or runtime guarantees.

Preserved distinctions:

- delete operation != forgetting completeness
- stale = source changed
- residual = source tombstoned/purged
- correction != deletion
- one-hop purge != demonstrated transitive deletion completeness
- purge self-report != independent residue verification
- estimator-mediated rebuild remains a governed mutation

## Accessibility / mobile

- matched 540px-wide vertical light/dark variants
- identical reader-facing semantics and geometry
- `<title>` and `<desc>` in both variants
- text labels accompany semantic color
- useful alt text on every embed
- nearby text fallback and source/maturity explanation

## Remaining issue scope

After this slice, the two V2 architecture visuals are present. #73 remains open for the first scenario walkthrough set and a local acceptance-criteria audit. ADR-021 and ADR-022 visual maturity remains untouched.