### PR TITLE
Govern AI-assisted contributions with bounded human delegation

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -135,6 +135,7 @@ jobs:
           python scripts/validate_markdown_links.py
           README.md
           CONTRIBUTING.md
+          GOVERNANCE.md
           docs/README.md
           docs/pama/README.md
           docs/04-governance-and-pama.md
@@ -142,6 +143,7 @@ jobs:
           docs/33-pama-decision-table.md
           docs/40-aligned-projects-and-intellectual-lineage.md
           docs/SOURCE_RIGHTS_POLICY.md
+          docs/policies/AI_ASSISTED_CONTRIBUTIONS.md
           docs/adr/README.md
           docs/27-schema-registry-and-type-evolution.md
           docs/32-memory-quality-metrics.md
@@ -185,7 +187,7 @@ jobs:
             echo "python -m venv /tmp/agent-memory-p6-mem0 && /tmp/agent-memory-p6-mem0/bin/python -m pip install mem0ai==2.0.18 jsonschema==4.26.0 && MEM0_TELEMETRY=false PYTHONPATH=reference /tmp/agent-memory-p6-mem0/bin/python reference/run_mem0_comparator.py --agent-memory-commit <exact-40-hex-commit> --output mem0-comparator.json"
             echo "python reference/run_deletion_completeness.py --agent-memory-commit <exact-40-hex-commit> --output deletion-completeness.json"
             echo "python -m venv /tmp/agent-memory-p45c-cmcp && /tmp/agent-memory-p45c-cmcp/bin/python -m pip install cmcp-runtime==0.4.0 agentrust-trace==0.8.0 agent-manifest==0.11.0 rfc8785==0.1.4 && PYTHONPATH=reference /tmp/agent-memory-p45c-cmcp/bin/python reference/run_trace_cmcp_comparator.py"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md docs/programs/runtime-evidence/deletion-completeness-evidence.md docs/programs/runtime-evidence/concurrency-conflict-evidence.md docs/programs/runtime-evidence/benchmark-security-scorecard.md docs/programs/runtime-evidence/mem0-adversarial-comparator.md reference/README.md"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md GOVERNANCE.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/policies/AI_ASSISTED_CONTRIBUTIONS.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md docs/programs/runtime-evidence/deletion-completeness-evidence.md docs/programs/runtime-evidence/concurrency-conflict-evidence.md docs/programs/runtime-evidence/benchmark-security-scorecard.md docs/programs/runtime-evidence/mem0-adversarial-comparator.md reference/README.md"
             echo "python scripts/validate_wiki_links.py wiki-src"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,24 @@ By intentionally submitting a contribution for inclusion in this repository, you
 
 Participation is also subject to the repository [Code of Conduct](CODE_OF_CONDUCT.md). Repository decision rights and doctrine-change rules are described in [GOVERNANCE.md](GOVERNANCE.md). Security-sensitive findings should follow [SECURITY.md](SECURITY.md) rather than being disclosed through an ordinary public issue.
 
+## AI-assisted development and accountable delegation
+
+Agent Memory permits and encourages AI-assisted development, including coding agents, AI editors, code generators, automated review tools, and authenticated repository connectors.
+
+The repository does not require contributors or maintainers to hand-write code or manually click every repository action. It requires accountable authority.
+
+The governing standard is [`docs/policies/AI_ASSISTED_CONTRIBUTIONS.md`](docs/policies/AI_ASSISTED_CONTRIBUTIONS.md).
+
+Its core rule is:
+
+> **AI-assisted development is allowed. Unbounded autonomous contribution is not accepted by default.**
+
+A responsible human owns the objective, material risk, repository authority, and resulting contribution. Repository actions may be performed by an agent when they are directly delegated in a bounded working session or allowed by a standing repository authorization.
+
+Direct delegation does not authorize unrelated upstream submissions, external-project comments, destructive administration, or expansion into work outside the stated scope.
+
+DCO is a planned provenance mechanism, not an invisible current gate. It becomes mandatory only when the repository explicitly activates and enforces it. See the policy and #85 for the organization rollout.
+
 ## Before contributing
 
 Start with:
@@ -18,7 +36,8 @@ Start with:
 4. [`docs/24-determinism-probability-and-governed-uncertainty.md`](docs/24-determinism-probability-and-governed-uncertainty.md)
 5. [`docs/adr/README.md`](docs/adr/README.md)
 6. [`docs/SOURCE_RIGHTS_POLICY.md`](docs/SOURCE_RIGHTS_POLICY.md)
-7. [`GOVERNANCE.md`](GOVERNANCE.md)
+7. [`docs/policies/AI_ASSISTED_CONTRIBUTIONS.md`](docs/policies/AI_ASSISTED_CONTRIBUTIONS.md)
+8. [`GOVERNANCE.md`](GOVERNANCE.md)
 
 Then read the specific doctrine document your change affects.
 
@@ -242,6 +261,8 @@ A pull request should state:
 - what the change proves
 - what remains unproven
 
+For a human-directed agent workflow, the PR should also make the material delegation or authorization boundary clear when it is relevant to understanding who exercised repository authority.
+
 Large research or runtime-evidence programs should be sliced into independently reviewable claims rather than merged as one heroic diff.
 
 ## Definition of done
@@ -254,6 +275,8 @@ A contribution is complete when:
 4. schemas/fixtures are updated when the contract changed
 5. source rights and attribution obligations are resolved for any material reuse
 6. validation passes
-7. the PR clearly states what was proven and what remains unproven
+7. repository authority for agent-executed actions is bounded and accountable where applicable
+8. any explicitly active provenance requirement is satisfied
+9. the PR clearly states what was proven and what remains unproven
 
 A green validator proves the repository evidence is structurally coherent. It does not absolve runtime systems from reality, which remains stubbornly outside JSON Schema's jurisdiction.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -10,6 +10,24 @@ The current repository maintainer and doctrine owner is **Kevin R. Knapp** (`@Kn
 
 PAMA is native Agent Memory doctrine authored by Kevin R. Knapp. External implementations may conform to, challenge, or extend the doctrine through the contribution process, but they do not acquire doctrine ownership by implementing it.
 
+## AI-assisted contribution authority
+
+Agent Memory adopts [`docs/policies/AI_ASSISTED_CONTRIBUTIONS.md`](docs/policies/AI_ASSISTED_CONTRIBUTIONS.md) as its repository policy for AI-assisted development and human-directed agent execution.
+
+The policy separates implementation method from repository authority:
+
+- coding agents and AI-assisted development are allowed;
+- contributors and maintainers are not required to hand-write code or manually perform every repository API action;
+- a responsible human remains accountable for the objective, material risk, and delegated authority;
+- authenticated agents may perform repository actions when directly delegated in a bounded working session or authorized by standing repository policy;
+- unbounded autonomous contribution is not accepted by default;
+- direct delegation inside Agent Memory does not create authority to act in external repositories;
+- upstream contribution rules control when they are stricter.
+
+Organization-wide inheritance is tracked separately in #85 and is not claimed merely because Agent Memory has adopted the local policy.
+
+DCO is not an active Agent Memory gate until explicit activation and enforcement are merged and discoverable.
+
 ## Decision classes
 
 Changes are reviewed according to their consequence.
@@ -94,8 +112,12 @@ A change is merge-ready when:
 2. affected doctrine and contracts are internally consistent;
 3. source provenance and reuse rights are resolved;
 4. tests/validators relevant to the change pass;
-5. the PR distinguishes what it proves from what remains unproven;
-6. material disagreement is either resolved or recorded rather than silently erased.
+5. repository authority for any agent-executed action is bounded and accountable;
+6. any explicitly active contribution-provenance requirement is satisfied;
+7. the PR distinguishes what it proves from what remains unproven;
+8. material disagreement is either resolved or recorded rather than silently erased.
+
+Where a task specifies exact-head validation, that validated head is the merge boundary. A later head must be revalidated rather than inheriting trust from an earlier result.
 
 ## Implementation neutrality
 
@@ -106,6 +128,8 @@ Conceptual adjacency does not create architectural ownership.
 ## Security-sensitive changes
 
 Security-sensitive findings should follow `SECURITY.md`. Do not force public disclosure merely to satisfy normal issue-tracking ceremony.
+
+AI assistance does not reduce the review bar for cryptography, authentication, authorization, policy enforcement, isolation boundaries, provenance, destructive lifecycle actions, or other security-sensitive surfaces. Independent validation is required when self-referential tests could mask an implementation error.
 
 ## Forks and derivative works
 

--- a/docs/policies/AI_ASSISTED_CONTRIBUTIONS.md
+++ b/docs/policies/AI_ASSISTED_CONTRIBUTIONS.md
@@ -1,0 +1,224 @@
+# MythologIQ Labs AI-Assisted Contribution Standard
+
+**Status:** Agent Memory repository policy; proposed MythologIQ Labs organization default
+
+**Organization rollout:** tracked in [#85](https://github.com/MythologIQ-Labs-LLC/agent-memory/issues/85)
+
+## Purpose
+
+MythologIQ Labs builds with coding agents and other AI-assisted development tools. Their use is permitted and encouraged when it improves implementation speed, validation coverage, accessibility, review quality, or evidence quality.
+
+The governing question is not who typed the code. It is who is accountable for the contribution and under what authority repository actions occur.
+
+> **AI-assisted development is allowed. Unbounded autonomous contribution is not accepted by default.**
+
+A responsible human must own the objective, material risk, repository authority, and resulting contribution. A repository may also explicitly authorize a bounded agent workflow when the scope, allowed actions, evidence requirements, and revocation boundary are clear.
+
+This policy is technology-neutral. It applies whether work is produced with a coding agent, IDE assistant, code generator, automated reviewer, or conventional hand-authored development.
+
+## Definitions
+
+### AI-assisted contribution
+
+A contribution is **AI-assisted** when a human contributor uses one or more AI tools to research, design, implement, test, refactor, document, review, or prepare a change while the human remains accountable for the result.
+
+The responsible human does not need to have typed every line.
+
+### Human-directed agent execution
+
+A workflow is **human-directed agent execution** when a responsible human explicitly delegates a bounded task or repository action to an agent and remains accountable for the delegation.
+
+Examples include asking an authenticated coding agent or connector to:
+
+- implement an issue with stated acceptance criteria;
+- create a branch or pull request for reviewed work;
+- run or inspect validation;
+- update an issue with verified results;
+- merge an exact validated head when the human has authorized that workflow.
+
+Human-directed agent execution is not treated as unbounded autonomous contribution merely because the agent performs the repository API call.
+
+### Autonomous contribution
+
+A contribution is **autonomous** when an agent acts as the effective contributor without a responsible human, without bounded delegated authority, or beyond the scope that a human or repository policy authorized.
+
+Examples include independently filing speculative issues, opening unsolicited pull requests, claiming work, approving changes, or merging outside a documented or directly delegated authority boundary.
+
+### Responsible human
+
+The **responsible human** owns the repository-facing consequence. That person must be able to explain the objective, material behavior, validation evidence, known limitations, and why the delegated authority was appropriate.
+
+## Allowed uses of AI development tools
+
+AI tools may be used for:
+
+- implementation and refactoring;
+- tests, fixtures, and adversarial vectors;
+- documentation and diagrams;
+- debugging and root-cause analysis;
+- code and security review;
+- standards and interoperability mapping;
+- migration planning;
+- dependency analysis;
+- benchmark and validation harnesses;
+- drafting commit messages, issues, pull-request descriptions, and review responses;
+- repository actions explicitly delegated by a responsible human or authorized by repository policy.
+
+Routine AI assistance does not require a disclosure label unless a repository-specific or upstream rule requires one.
+
+## Human accountability requirements
+
+For a substantive contribution, the responsible human must ensure that:
+
+1. **The objective is understood.** Scope, intended consequence, and acceptance boundary are clear.
+2. **Material behavior is reviewable.** The actual change and relevant evidence are available for inspection. Agent summaries are aids, not a substitute for repository evidence.
+3. **Material choices are defensible.** The responsible human can explain the important design decisions, tradeoffs, and known failure modes.
+4. **Evidence is verified.** Tests, validators, benchmarks, or independent checks appropriate to the risk have been run or inspected.
+5. **Provenance and rights are resolved.** Generated or reused code, documentation, diagrams, and other material must satisfy repository source-rights rules.
+6. **Repository authority is explicit.** An agent action must be directly delegated, permitted by a standing repository authorization, or performed by ordinary human submission.
+7. **The contribution is owned.** Bugs, security defects, misleading claims, provenance failures, and policy violations remain attributable to the responsible human and repository governance process.
+
+For security-sensitive or doctrine-changing work, direct inspection of the relevant diff and evidence is expected before final acceptance. Lower-risk mechanical work may use a lighter review path when repository policy permits it.
+
+## Repository-boundary rule
+
+Repository actions require authority, not ritual.
+
+A pull request, issue, review response, approval, or merge may occur through either of these paths:
+
+```text
+ordinary human submission
+
+or
+
+bounded human delegation / standing repository authorization
+  -> explicit scope
+  -> permitted repository actions
+  -> required validation
+  -> reviewable evidence
+  -> revocable authority
+```
+
+For Agent Memory, the maintainer may directly delegate repository actions to authenticated AI tools or connectors during an active working session. Such delegation is bounded by the stated task, issue or branch scope, repository governance, and any explicit merge gate such as exact-head CI validation.
+
+A general instruction to work on Agent Memory does not authorize unrelated upstream submissions, external-project comments, destructive repository administration, or expansion into a different issue or organization.
+
+Unattended or recurring agents require a standing repository authorization that identifies their allowed actions and oversight model.
+
+## Prohibited autonomous behavior by default
+
+Unless explicitly authorized, agents and bots must not:
+
+- open unsolicited pull requests or issues;
+- claim issues without a responsible human or standing authorization;
+- post unsolicited substantive review feedback to external contributors;
+- impersonate a human in maintainer discussions;
+- approve pull requests;
+- merge outside a delegated or standing merge authority;
+- manufacture stars, forks, issues, comments, or other synthetic community activity;
+- use AI generation to obscure unattributed derivative work or licensing conflicts;
+- treat access to one repository as authority to act in another.
+
+## DCO and contribution provenance
+
+MythologIQ Labs intends to use the Developer Certificate of Origin as the default provenance mechanism for public repositories that accept external code or specification contributions, unless a repository documents another contribution agreement.
+
+**DCO is not automatically active merely because this policy mentions it.** A repository must explicitly activate the requirement and should add automated enforcement at the same time so contributors are not governed by an invisible manual gate.
+
+Agent Memory does not claim DCO enforcement until that activation is merged and discoverable. The organization rollout and enforcement work are tracked in #85.
+
+When DCO is active, an agent must never invent or apply a human `Signed-off-by` certification without that person's authorization.
+
+## Security-sensitive changes
+
+AI assistance does not lower the review bar for security-sensitive work.
+
+Changes involving cryptography, authentication, authorization, policy enforcement, sandboxing, supply-chain controls, secrets handling, isolation boundaries, signing, provenance, or destructive lifecycle actions require heightened review.
+
+At minimum:
+
+- avoid self-referential validation where an implementation and its only test oracle share the same assumptions;
+- prefer independent vectors, reference implementations, or known-answer tests where available;
+- review dependencies and algorithms for invented packages, obsolete primitives, and insecure defaults;
+- do not place secrets, credentials, or restricted data into external tools without an approved handling basis;
+- state what the validation proves and what remains unproven.
+
+## Prior art, copyright, and licensing
+
+AI assistance does not erase provenance obligations.
+
+Contributors must:
+
+- identify and credit material prior art when work is substantially derived from an external source;
+- comply with the repository source-rights and attribution rules;
+- avoid copying or laundering incompatible third-party work through model output;
+- preserve required notices, licenses, and modification notices;
+- disclose uncertainty when origin or reuse rights cannot be established.
+
+When in doubt, prefer independent synthesis and explicit attribution.
+
+## Disclosure
+
+Routine AI assistance does not require disclosure merely because an AI tool participated.
+
+Disclosure is appropriate when:
+
+1. a repository or upstream project explicitly requires it;
+2. a standing autonomous agent authorization is material to understanding who exercised repository authority; or
+3. material generated content has not received the review required by the applicable repository policy, in which case the contribution is normally not merge-ready.
+
+Disclosure is not a substitute for accountability.
+
+## Authorizing repository agents and bots
+
+A standing authorization should document:
+
+- the bot or agent identity or class of authenticated tool;
+- the actions it may perform;
+- repository, branch, file, label, issue, or workflow scope where material;
+- required validation and review gates;
+- the human or governance role accountable for the authorization;
+- how the authorization can be revoked.
+
+Authorization is narrow. Permission to run CI does not imply permission to open PRs, review code, answer maintainers, merge changes, or act in external repositories.
+
+## Relationship to local and upstream rules
+
+This document is an Agent Memory repository policy and the proposed MythologIQ Labs organization default.
+
+Organization-wide inheritance is not claimed until the #85 rollout is actually complete.
+
+A repository may impose stricter requirements for security, regulatory, contractual, release, or standards reasons. Local rules may narrow automation privileges but should not silently weaken the human-accountability baseline.
+
+When contributing to an external project, that project's rules control the upstream submission. MythologIQ Labs policy never grants permission to bypass a stricter external contribution boundary.
+
+## Practical workflow
+
+A compliant agent-first workflow can be:
+
+```text
+human defines objective, scope, and acceptance boundary
+        |
+        v
+agent researches / implements / tests / reviews
+        |
+        v
+repository evidence and material diff remain inspectable
+        |
+        v
+human reviews directly or exercises an explicit bounded delegation path
+        |
+        v
+provenance, risk, and repository-specific gates are satisfied
+        |
+        v
+human or authorized agent performs the repository action
+        |
+        v
+exact required checks / approvals gate merge
+        |
+        v
+responsible human remains accountable for the consequence
+```
+
+The purpose of this standard is not to recreate manual coding or manual button-clicking as ceremony. It is to preserve accountable authority, reviewability, provenance, and maintainer trust while using modern coding agents as first-class development tools.


### PR DESCRIPTION
## Objective

Recover the genuinely stranded governance work from `governance/human-accountable-ai-contributions`, but rebase it onto current `main` and correct the parts that would otherwise overstate policy maturity or create an accidental human bottleneck.

Advances #85.

## What changed

- adds `docs/policies/AI_ASSISTED_CONTRIBUTIONS.md` as an **Agent Memory repository policy** and **proposed** MythologIQ Labs organization default;
- explicitly distinguishes human-directed bounded agent execution from unbounded autonomous contribution;
- permits authenticated agents/connectors to perform repository actions when directly delegated or covered by standing repository authorization;
- makes clear that Agent Memory delegation does not grant authority to act in external repositories;
- keeps stricter upstream contribution rules authoritative;
- stages DCO rather than silently activating it before automated enforcement exists;
- wires the policy into `CONTRIBUTING.md` and `GOVERNANCE.md`;
- makes exact-head validation an explicit merge boundary in repository governance;
- adds `GOVERNANCE.md` and the new policy to documentation-link validation.

## Why this differs from the stranded branch

The original unmerged branch called the policy an already-active organization default, required DCO immediately without enforcement, and implied ordinary agent workflows had to stop at a manual human PR-submission boundary.

Those claims did not match repository reality or #85's own rollout state. This PR preserves human accountability while allowing the repository's actual bounded, human-directed agent workflow.

## Boundaries

This does **not**:

- complete #85's organization-wide `.github` rollout;
- activate DCO enforcement;
- authorize unattended agents by default;
- authorize upstream/external repository actions;
- weaken exact-head CI, provenance, source-rights, or security review requirements;
- change Agent Memory doctrine or ADR maturity.

## Validation

The branch is one commit directly ahead of current `main` and changes exactly four files. Merge only after exact-head CI and CodeQL succeed.