### PR TITLE
Docs: add V2 executable scenario walkthroughs

### DIFF
--- a/assets/diagrams/scenario-walkthroughs-flow-light.svg
+++ b/assets/diagrams/scenario-walkthroughs-flow-light.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="540" height="1060" viewBox="0 0 540 1060" role="img" aria-labelledby="title desc">
+  <title id="title">Three governed Agent Memory scenario walkthroughs</title>
+  <desc id="desc">A vertical set of three executable scenario walkthroughs: a well-supported memory is routed through governance into pending verification rather than self-promoted; a highly confident and saturated false claim is blocked from crystallization and routed to external verification or dispute; and deleting a raw record while a derived summary survives prevents any claim of complete forgetting.</desc>
+  <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7.5" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L8,3 z" fill="#57606a"/></marker></defs>
+  <rect x="1" y="1" width="538" height="1058" rx="18" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="28" y="42" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="24" font-weight="700">Doctrine under pressure: three executable walkthroughs</text>
+  <text x="28" y="68" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Each path maps to an existing conformance fixture. Example flow does not create new policy.</text>
+
+  <text x="28" y="112" fill="#1a7f37" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">01  SUPPORTED MEMORY STILL REQUIRES GOVERNANCE</text>
+  <rect x="28" y="128" width="484" height="246" rx="12" fill="#f3fff5" stroke="#1a7f37"/>
+  <text x="48" y="158" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Corroboration + cross-reference + meaningful reuse</text>
+  <line x1="270" y1="170" x2="270" y2="190" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="214" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">estimator proposes promotion</text>
+  <line x1="270" y1="226" x2="270" y2="246" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="270" text-anchor="middle" fill="#8250df" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">PAMA permits: pending verification / more evidence / defer</text>
+  <line x1="270" y1="282" x2="270" y2="302" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="326" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">selected action → pending verification → receipt</text>
+  <text x="48" y="354" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Strength supports a proposal. It does not authorize crystallization.</text>
+
+  <text x="28" y="422" fill="#cf222e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">02  FALSEHOOD CAN BECOME STRONG WITHOUT BECOMING TRUE</text>
+  <rect x="28" y="438" width="484" height="246" rx="12" fill="#fff5f5" stroke="#cf222e"/>
+  <text x="48" y="468" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">false claim · confidence 0.99 · saturation 0.97</text>
+  <line x1="270" y1="480" x2="270" y2="500" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="524" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">requests durable crystallization</text>
+  <line x1="270" y1="536" x2="270" y2="556" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="580" text-anchor="middle" fill="#cf222e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">crystallize is prohibited</text>
+  <line x1="270" y1="592" x2="270" y2="612" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="636" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">external verification or dispute</text>
+  <text x="48" y="664" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">confidence != truth · saturation != confidence · saturation != authority</text>
+
+  <text x="28" y="732" fill="#0969da" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">03  RECORD DELETION CAN FAIL THE FORGETTING OUTCOME</text>
+  <rect x="28" y="748" width="484" height="246" rx="12" fill="#f6f8fa" stroke="#0969da"/>
+  <text x="48" y="778" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">raw record deleted</text>
+  <line x1="270" y1="790" x2="270" y2="810" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="834" text-anchor="middle" fill="#cf222e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">derived summary still holds recoverable content</text>
+  <line x1="270" y1="846" x2="270" y2="866" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="890" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">full deletion claim remains prohibited</text>
+  <line x1="270" y1="902" x2="270" y2="922" stroke="#57606a" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="946" text-anchor="middle" fill="#24292f" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">continue dependency purge + report residue + verify</text>
+  <text x="48" y="974" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">delete operation != forgetting completeness</text>
+
+  <rect x="28" y="1016" width="484" height="28" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="270" y="1035" text-anchor="middle" fill="#57606a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11">Fixtures: governed-promotion-audit-trace · high-confidence-false-promotion · deletion-residue</text>
+</svg>

--- a/assets/diagrams/scenario-walkthroughs-flow.svg
+++ b/assets/diagrams/scenario-walkthroughs-flow.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="540" height="1060" viewBox="0 0 540 1060" role="img" aria-labelledby="title desc">
+  <title id="title">Three governed Agent Memory scenario walkthroughs</title>
+  <desc id="desc">A vertical set of three executable scenario walkthroughs: a well-supported memory is routed through governance into pending verification rather than self-promoted; a highly confident and saturated false claim is blocked from crystallization and routed to external verification or dispute; and deleting a raw record while a derived summary survives prevents any claim of complete forgetting.</desc>
+  <defs><marker id="arrow" markerWidth="9" markerHeight="9" refX="7.5" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L8,3 z" fill="#8b949e"/></marker></defs>
+  <rect x="1" y="1" width="538" height="1058" rx="18" fill="#0d1117" stroke="#30363d"/>
+  <text x="28" y="42" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="24" font-weight="700">Doctrine under pressure: three executable walkthroughs</text>
+  <text x="28" y="68" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13">Each path maps to an existing conformance fixture. Example flow does not create new policy.</text>
+
+  <text x="28" y="112" fill="#7ee787" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">01  SUPPORTED MEMORY STILL REQUIRES GOVERNANCE</text>
+  <rect x="28" y="128" width="484" height="246" rx="12" fill="#122019" stroke="#3fb950"/>
+  <text x="48" y="158" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">Corroboration + cross-reference + meaningful reuse</text>
+  <line x1="270" y1="170" x2="270" y2="190" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="214" text-anchor="middle" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">estimator proposes promotion</text>
+  <line x1="270" y1="226" x2="270" y2="246" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="270" text-anchor="middle" fill="#d2a8ff" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">PAMA permits: pending verification / more evidence / defer</text>
+  <line x1="270" y1="282" x2="270" y2="302" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="326" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">selected action → pending verification → receipt</text>
+  <text x="48" y="354" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">Strength supports a proposal. It does not authorize crystallization.</text>
+
+  <text x="28" y="422" fill="#ff7b72" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">02  FALSEHOOD CAN BECOME STRONG WITHOUT BECOMING TRUE</text>
+  <rect x="28" y="438" width="484" height="246" rx="12" fill="#251719" stroke="#f85149"/>
+  <text x="48" y="468" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">false claim · confidence 0.99 · saturation 0.97</text>
+  <line x1="270" y1="480" x2="270" y2="500" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="524" text-anchor="middle" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">requests durable crystallization</text>
+  <line x1="270" y1="536" x2="270" y2="556" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="580" text-anchor="middle" fill="#ff7b72" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">crystallize is prohibited</text>
+  <line x1="270" y1="592" x2="270" y2="612" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="636" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">external verification or dispute</text>
+  <text x="48" y="664" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">confidence != truth · saturation != confidence · saturation != authority</text>
+
+  <text x="28" y="732" fill="#79c0ff" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700">03  RECORD DELETION CAN FAIL THE FORGETTING OUTCOME</text>
+  <rect x="28" y="748" width="484" height="246" rx="12" fill="#161b22" stroke="#388bfd"/>
+  <text x="48" y="778" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="15" font-weight="700">raw record deleted</text>
+  <line x1="270" y1="790" x2="270" y2="810" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="834" text-anchor="middle" fill="#ff7b72" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14" font-weight="700">derived summary still holds recoverable content</text>
+  <line x1="270" y1="846" x2="270" y2="866" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="890" text-anchor="middle" fill="#c9d1d9" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">full deletion claim remains prohibited</text>
+  <line x1="270" y1="902" x2="270" y2="922" stroke="#8b949e" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="946" text-anchor="middle" fill="#f0f6fc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="14">continue dependency purge + report residue + verify</text>
+  <text x="48" y="974" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12">delete operation != forgetting completeness</text>
+
+  <rect x="28" y="1016" width="484" height="28" rx="8" fill="#161b22" stroke="#30363d"/>
+  <text x="270" y="1035" text-anchor="middle" fill="#8b949e" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11">Fixtures: governed-promotion-audit-trace · high-confidence-false-promotion · deletion-residue</text>
+</svg>

--- a/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
+++ b/wiki-src/Decision-Flows-and-Memory-Lifecycle.md
@@ -12,6 +12,7 @@ Use each diagram to answer one architectural question, then follow the canonical
 | Which retrieved candidates may enter active context, and under what treatment? | [Governed recall](#4-governed-recall-pipeline) | [`docs/26-governed-recall-planner.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/26-governed-recall-planner.md) |
 | How should readers distinguish supersession, correction, dispute, and staleness across time? | [Temporal change](#5-temporal-change-correction-and-supersession) | [`docs/18-temporal-causality-layer.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/18-temporal-causality-layer.md) |
 | Why can a successful delete operation still leave memory behind? | [Deletion completeness](#6-deletion-completeness-and-derived-state-propagation) | [`docs/28-retention-deletion-and-tombstones.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/28-retention-deletion-and-tombstones.md) |
+| What do these governance boundaries look like in executable cases? | [Scenario walkthroughs](#7-executable-scenario-walkthroughs) | [Conformance fixtures](https://github.com/MythologIQ-Labs-LLC/agent-memory/tree/main/fixtures) |
 
 ## Reading rule
 
@@ -136,9 +137,25 @@ Canonical deletion doctrine requires propagation through known derivation relati
 **Canonical contract:** [`docs/28-retention-deletion-and-tombstones.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/28-retention-deletion-and-tombstones.md) · [`docs/31-recovery-rollback-and-replay.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/31-recovery-rollback-and-replay.md)  
 **Executed design evidence:** [`docs/programs/runtime-evidence/canonical-and-derived-state.md`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/programs/runtime-evidence/canonical-and-derived-state.md)
 
+## 7. Executable scenario walkthroughs
+
+**Question:** What do these boundaries look like when the repository's fixtures exercise them?
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/scenario-walkthroughs-flow.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/scenario-walkthroughs-flow-light.svg">
+    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/scenario-walkthroughs-flow-light.svg" alt="Three governed-memory scenarios showing a supported memory entering pending verification rather than self-promoting, a highly confident false claim blocked from crystallization, and a raw deletion failing the forgetting outcome because derived residue survives" width="100%">
+  </picture>
+</p>
+
+These are not hypothetical new policies. They are reader-oriented projections of existing conformance fixtures. [`governed-promotion-audit-trace.json`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/fixtures/governed-promotion-audit-trace.json) shows corroboration, cross-reference, reuse, proposal, authority resolution, a selected permitted action, committed `pending_verification`, and a reconstructable receipt. [`high-confidence-false-promotion.json`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/fixtures/high-confidence-false-promotion.json) demonstrates that confidence `0.99` and saturation `0.97` still do not permit crystallization of a false claim. [`deletion-residue.json`](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/fixtures/deletion-residue.json) demonstrates that a deleted raw record plus surviving derived content forbids a full-deletion claim and requires continued dependency handling and verification.
+
+The scenario set deliberately does **not** visualize cross-project isolation as settled behavior. The repository already has recall and tenant-scope negative cases, but issue #73 separately binds the isolation-domain visualization to ADR-022 maturity. Scenario convenience does not get to bypass that boundary.
+
 ## What comes next
 
-The remaining V2 work under issue #73 is the first scenario walkthrough set and then a local acceptance-criteria audit.
+The stable V1/V2 visual core and first executable scenario set are now represented. The next step under issue #73 is a local acceptance-criteria audit against the merged repository and published Wiki before deciding what remains open.
 
 [ADR-021](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md) and [ADR-022](https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/adr/ADR-022-memory-isolation-domains-and-controlled-boundary-crossing.md) remain **Proposed**. This visual guide does not contain a visual that finalizes either boundary. Isolation-domain visuals must follow ADR-022's doctrine maturity, and portable-evidence visuals must follow ADR-021's executable interoperability evidence rather than inventing a wire model visually. A diagram does not raise an ADR status, conformance level, or runtime-evidence claim.
 


### PR DESCRIPTION
Superseded by PR #97, which merged the same scenario walkthrough slice onto the same `a040551220094105165d47f4bde1a3589359e1ef` baseline while this PR's exact-head CI was running.

Verification before closing this duplicate:
- #97 head: `7553e47c82a3a2f65d1351176c2186c1d73b258d`
- #97 `Validate Doctrine Evidence` run #445: success at that exact head
- #97 merge commit: `e835b0d579ee07bb322b5f87c0e748fbc7f9ae3b`
- the merged assets use the same blob identities as this replayed slice (`scenario-walkthroughs-flow-light.svg` = `b33ad212...`; the paired dark asset and visual-guide content are likewise the intended scenario set)

No duplicate merge is necessary.