### PR TITLE
Schema: represent isolation domains and governed crossings

### DIFF
--- a/schemas/boundary-crossing-receipt.schema.json
+++ b/schemas/boundary-crossing-receipt.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/boundary-crossing-receipt.schema.json",
+  "title": "Agent Memory Boundary Crossing Receipt",
+  "description": "Reconstructable evidence for a governed memory-isolation-domain crossing. This schema is evidence toward proposed ADR-022 and does not accept the ADR or make a valid receipt permanently authorize future crossings.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "operation",
+    "source_domain_refs",
+    "destination_domain_refs",
+    "actor",
+    "principal",
+    "purpose",
+    "representation",
+    "source_refs",
+    "pama_disposition",
+    "policy_version",
+    "outcome",
+    "timestamp"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "minLength": 1 },
+    "receipt_id": { "type": "string", "minLength": 1 },
+    "operation": {
+      "type": "string",
+      "enum": [
+        "share",
+        "export",
+        "import",
+        "copy",
+        "promote_scope",
+        "summarize_for",
+        "derive_for",
+        "inherit",
+        "publish"
+      ]
+    },
+    "source_domain_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "destination_domain_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "actor": { "type": "string", "minLength": 1 },
+    "principal": { "type": "string", "minLength": 1 },
+    "purpose": { "type": "string", "minLength": 1 },
+    "representation": {
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "content_ref": { "type": "string" },
+        "privacy_minimized": { "type": "boolean" },
+        "redaction_ref": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "source_refs": {
+      "type": "array",
+      "description": "Memory, derivation, or governed projection references that are materially involved in the crossing.",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "sensitivity": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "classification_ref": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "consent_ref": { "type": "string" },
+    "delegation_ref": { "type": "string" },
+    "membership_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "requested_consequence": { "type": "string" },
+    "pama_disposition": {
+      "type": "string",
+      "enum": [
+        "allow",
+        "allow_with_ledger",
+        "require_review",
+        "require_external_verification",
+        "abstain",
+        "quarantine",
+        "collect_more_evidence",
+        "block"
+      ]
+    },
+    "authority_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "policy_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "policy_version": { "type": "string", "minLength": 1 },
+    "provenance_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "valid_until": { "type": "string", "format": "date-time" },
+    "revocation_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["committed", "deferred", "review_required", "verification_required", "blocked"]
+    },
+    "before_scope_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "after_scope_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "decision_receipt_ref": { "type": "string" },
+    "ledger_ref": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "outcome": { "const": "committed" } },
+        "required": ["outcome"]
+      },
+      "then": {
+        "properties": {
+          "pama_disposition": {
+            "enum": ["allow", "allow_with_ledger"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "outcome": { "const": "blocked" } },
+        "required": ["outcome"]
+      },
+      "then": {
+        "properties": {
+          "pama_disposition": {
+            "enum": ["block", "abstain", "quarantine"]
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/schemas/memory-unit.schema.json
+++ b/schemas/memory-unit.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/memory-unit.schema.json",
   "title": "Agent Memory Unit",
-  "description": "Doctrine-level memory unit schema. New governed-uncertainty fields are additive for backward compatibility with early fixtures.",
+  "description": "Doctrine-level memory unit schema. New governed-uncertainty and isolation-domain fields are additive for backward compatibility with early fixtures.",
   "type": "object",
   "required": [
     "id",
@@ -285,12 +285,51 @@
         "origin_actor": { "type": "string" },
         "tenant": { "type": "string" },
         "organization": { "type": "string" },
+        "workspace": { "type": "string" },
         "project": { "type": "string" },
         "repository": { "type": "string" },
+        "task": { "type": "string" },
+        "session": { "type": "string" },
         "purpose": { "type": "string" },
         "consent_state": { "type": "string" },
         "delegation_ref": { "type": "string" },
-        "valid_until": { "type": "string", "format": "date-time" }
+        "valid_until": { "type": "string", "format": "date-time" },
+        "allowed_destinations": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "revocation_ref": { "type": "string" },
+        "isolation_domain_refs": {
+          "type": "array",
+          "description": "Logical authority-domain identifiers that currently govern this memory. Order does not imply hierarchy.",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "primary_isolation_domain_ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional primary domain for implementations that need one routing anchor. It does not make other bound domains subordinate."
+        },
+        "source_isolation_domain_refs": {
+          "type": "array",
+          "description": "Source-domain provenance relevant to inherited or derived scope constraints.",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "shared_memory_domain_refs": {
+          "type": "array",
+          "description": "Governed shared-memory domains in which this memory is eligible. Membership alone does not imply recall, mutation, export, or re-sharing authority.",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "domain_membership_refs": {
+          "type": "array",
+          "description": "References to current membership or authorization state used to evaluate domain access.",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
Advances #68 Work Package B against the canonical isolation-domain contract merged in #104.

## Changes

- extends `schemas/memory-unit.schema.json` additively with explicit isolation-domain bindings inside the existing `scope` seam
  - workspace / task / session
  - allowed destinations and revocation reference
  - logical isolation-domain refs with no implied hierarchy
  - optional primary routing anchor without making other domains subordinate
  - source-domain provenance for inherited/derived state
  - governed shared-memory domain refs
  - current membership/authorization refs
- adds `schemas/boundary-crossing-receipt.schema.json`
  - source and destination domain bindings
  - crossing operation
  - actor / principal / purpose / representation
  - source memory or derivation refs
  - sensitivity / consent / delegation / membership evidence
  - PAMA disposition, authority and policy refs
  - provenance, expiry/revocation, outcome, before/after scope, timestamp
  - basic consistency constraints between committed/blocked outcomes and PAMA dispositions

## Compatibility and doctrine boundaries

- all new memory-unit scope fields are optional so existing fixtures remain backward compatible
- no fixed tenant -> project -> task hierarchy is encoded
- `primary_isolation_domain_ref` is explicitly a routing anchor, not a semantic parent
- shared-memory membership does not imply recall, mutation, export, or re-sharing permission
- receipt validity does not create permanent future authorization
- ADR-022 remains **Proposed**
- no conformance level or runtime-isolation claim is raised

## Remaining #68 work

This establishes machine-readable domain state and a crossing receipt shape. Recall/context isolation, derived-scope executable fixtures, shared-memory protocol reconciliation, observability integration, and the critical adversarial fixtures still remain.

Merge only after exact-head repository validation succeeds.