### PR TITLE
Reference: enforce isolation domains in governed recall

### DIFF
--- a/reference/agentmem_ref/adapter.py
+++ b/reference/agentmem_ref/adapter.py
@@ -86,6 +86,20 @@ class AdmissionResult:
     refusals: dict[str, str] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class RecallContext:
+    """Authority context for one governed recall request.
+
+    Domain refs are logical authority boundaries. They are not storage
+    partitions and their tuple order does not imply hierarchy.
+    """
+
+    target_domain_refs: tuple[str, ...]
+    project_ref: str = ""
+    task_ref: str = ""
+    purpose: str = ""
+
+
 class GovernedMemoryAdapter:
     """Wraps a permissive substrate in the governance it does not provide."""
 
@@ -105,6 +119,7 @@ class GovernedMemoryAdapter:
         self._state_version: dict[str, int] = {}
         self._disputed: set[str] = set()
         self._tombstones: dict[str, dict] = {}
+        self._fact_scope: dict[str, dict] = {}
         self.events: list[dict] = []
 
     # -- write path -----------------------------------------------------
@@ -232,28 +247,38 @@ class GovernedMemoryAdapter:
                 created_at=self._clock.now(),
             )
         )
+        domain_refs = tuple(proposal.isolation_domain_refs) or ((proposal.scope,) if proposal.scope else (self._tenant,))
+        self._fact_scope[uuid] = {
+            "domain_refs": domain_refs,
+            "project_ref": proposal.project_ref,
+            "task_ref": proposal.task_ref,
+            "purpose": proposal.purpose,
+        }
         self._state_version[proposal.target_reference] = self._state_version.get(proposal.target_reference, 0) + 1
         return uuid
 
     # -- read path ------------------------------------------------------
 
-    def governed_recall(self, query: str) -> AdmissionResult:
-        """Retrieve candidates, then admit only what policy allows.
+    def governed_recall(self, query: str, context: RecallContext | None = None) -> AdmissionResult:
+        """Retrieve candidates, then admit only what current authority allows.
 
-        The partition filter is always passed explicitly. The substrate's
-        unfiltered default is never reachable through this adapter.
+        Tenant partitioning is enforced before retrieval. Logical isolation
+        domains, project, and task are evaluated at admission because the
+        in-memory substrate is trusted to return same-tenant candidates for
+        policy evaluation. Candidate presence never creates admission rights.
         """
+        context = context or RecallContext(target_domain_refs=(self._tenant,))
         result = AdmissionResult()
         for fact, _score in self._substrate.search(query, group_ids=[self._tenant]):
             result.candidates.append(fact.uuid)
-            refusal = self._admission_refusal(fact)
+            refusal = self._admission_refusal(fact, context)
             if refusal:
                 result.refusals[fact.uuid] = refusal
             else:
                 result.admitted.append(fact.uuid)
         return result
 
-    def _admission_refusal(self, fact: Fact) -> str | None:
+    def _admission_refusal(self, fact: Fact, context: RecallContext) -> str | None:
         if fact.group_id != self._tenant:
             return "out_of_scope"
         if fact.uuid in self._tombstones:
@@ -262,6 +287,24 @@ class GovernedMemoryAdapter:
             return "superseded_not_current"
         if fact.uuid in self._disputed:
             return "disputed"
+
+        scope = self._fact_scope.get(fact.uuid)
+        if scope is None:
+            return None
+
+        memory_domains = set(scope["domain_refs"])
+        target_domains = set(context.target_domain_refs)
+        if not target_domains or not memory_domains.intersection(target_domains):
+            return "isolation_domain_mismatch"
+
+        memory_project = scope.get("project_ref", "")
+        if memory_project and context.project_ref != memory_project:
+            return "project_scope_mismatch"
+
+        memory_task = scope.get("task_ref", "")
+        if memory_task and context.task_ref != memory_task:
+            return "task_scope_mismatch"
+
         return None
 
     def mark_disputed(self, fact_uuid: str) -> None:

--- a/reference/agentmem_ref/policy.py
+++ b/reference/agentmem_ref/policy.py
@@ -119,6 +119,9 @@ class Proposal:
     state_snapshot: str = ""
     tenant_ref: str = ""
     purpose: str = ""
+    isolation_domain_refs: tuple[str, ...] = ()
+    project_ref: str = ""
+    task_ref: str = ""
 
 
 @dataclass(frozen=True)

--- a/reference/tests/test_isolation_domains.py
+++ b/reference/tests/test_isolation_domains.py
@@ -1,0 +1,146 @@
+"""Executable isolation-domain recall evidence for proposed ADR-022.
+
+These tests deliberately use one adapter, one agent identity, one tenant, and
+one physical substrate. The only changing boundary is logical memory scope.
+That is the property #68 needs to make load-bearing.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext  # noqa: E402
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+TENANT = "tenant-a"
+AGENT = "agent:planner"
+DOMAIN_A = "domain:project-a"
+DOMAIN_B = "domain:project-b"
+
+
+def proposal(reference: str, domain: str, project: str, task: str) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=f"proposal:{reference}",
+        actor_id=AGENT,
+        charter_version="charter-1",
+        target_reference=reference,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("evidence:source",),
+        tenant_ref=TENANT,
+        purpose="assistance",
+        isolation_domain_refs=(domain,),
+        project_ref=project,
+        task_ref=task,
+    )
+
+
+class IsolationDomainRecallTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.substrate = InMemoryTemporalGraph()
+        self.adapter = GovernedMemoryAdapter(self.substrate, tenant=TENANT, clock=Clock())
+
+    def _commit(self, reference: str, domain: str, project: str, task: str):
+        result = self.adapter.commit_proposal(
+            proposal(reference, domain, project, task),
+            "deployment credential rotation procedure",
+        )
+        self.assertTrue(result.committed)
+        return result.fact_uuid
+
+    def test_matching_domain_project_and_task_is_admitted(self):
+        fact_uuid = self._commit("mem:a1", DOMAIN_A, "project-a", "task-1")
+
+        recall = self.adapter.governed_recall(
+            "deployment credential rotation procedure",
+            RecallContext(
+                target_domain_refs=(DOMAIN_A,),
+                project_ref="project-a",
+                task_ref="task-1",
+                purpose="assistance",
+            ),
+        )
+
+        self.assertIn(fact_uuid, recall.candidates)
+        self.assertIn(fact_uuid, recall.admitted)
+
+    def test_same_agent_same_tenant_wrong_project_is_blocked(self):
+        fact_uuid = self._commit("mem:a2", DOMAIN_A, "project-a", "task-1")
+
+        # Same adapter == same agent/runtime identity; same tenant and same
+        # physical store. Semantic match remains exact enough to be a candidate.
+        recall = self.adapter.governed_recall(
+            "deployment credential rotation procedure",
+            RecallContext(
+                target_domain_refs=(DOMAIN_B,),
+                project_ref="project-b",
+                task_ref="task-1",
+                purpose="assistance",
+            ),
+        )
+
+        self.assertIn(fact_uuid, recall.candidates)
+        self.assertNotIn(fact_uuid, recall.admitted)
+        self.assertEqual(recall.refusals[fact_uuid], "isolation_domain_mismatch")
+
+    def test_same_agent_same_project_wrong_task_is_blocked(self):
+        fact_uuid = self._commit("mem:a3", DOMAIN_A, "project-a", "task-1")
+
+        recall = self.adapter.governed_recall(
+            "deployment credential rotation procedure",
+            RecallContext(
+                target_domain_refs=(DOMAIN_A,),
+                project_ref="project-a",
+                task_ref="task-2",
+                purpose="assistance",
+            ),
+        )
+
+        self.assertIn(fact_uuid, recall.candidates)
+        self.assertNotIn(fact_uuid, recall.admitted)
+        self.assertEqual(recall.refusals[fact_uuid], "task_scope_mismatch")
+
+    def test_task_switch_does_not_carry_prior_context_authority(self):
+        fact_uuid = self._commit("mem:a4", DOMAIN_A, "project-a", "task-1")
+
+        first = self.adapter.governed_recall(
+            "deployment credential rotation procedure",
+            RecallContext((DOMAIN_A,), project_ref="project-a", task_ref="task-1"),
+        )
+        self.assertIn(fact_uuid, first.admitted)
+
+        switched = self.adapter.governed_recall(
+            "deployment credential rotation procedure",
+            RecallContext((DOMAIN_B,), project_ref="project-b", task_ref="task-9"),
+        )
+
+        self.assertIn(fact_uuid, switched.candidates)
+        self.assertNotIn(fact_uuid, switched.admitted)
+        self.assertEqual(switched.refusals[fact_uuid], "isolation_domain_mismatch")
+
+    def test_unresolved_target_domain_fails_closed_for_scoped_memory(self):
+        fact_uuid = self._commit("mem:a5", DOMAIN_A, "project-a", "task-1")
+
+        recall = self.adapter.governed_recall(
+            "deployment credential rotation procedure",
+            RecallContext(target_domain_refs=(), project_ref="project-a", task_ref="task-1"),
+        )
+
+        self.assertIn(fact_uuid, recall.candidates)
+        self.assertNotIn(fact_uuid, recall.admitted)
+        self.assertEqual(recall.refusals[fact_uuid], "isolation_domain_mismatch")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Advances #68 Work Package C with executable same-agent project/task isolation in the governed reference adapter.

## Changes

- adds additive isolation context to reference proposals: logical domain refs, project ref, task ref
- adds `RecallContext` to governed recall with explicit target domain, project, task, and purpose context
- preserves tenant pre-filtering before retrieval
- records logical scope bindings when a governed write commits
- evaluates logical domain/project/task mismatch at recall admission
- fails closed when a scoped memory is recalled without a resolvable target domain
- keeps candidate generation distinct from admission: same-tenant cross-domain matches may remain candidates in the trusted reference substrate but cannot enter active context

## Executable negative paths

`reference/tests/test_isolation_domains.py` proves within one adapter/agent, one tenant, and one physical store:

1. matching domain/project/task is admitted
2. same-agent wrong-project memory is a candidate but blocked
3. same-agent same-project wrong-task memory is a candidate but blocked
4. switching task/project context does not carry prior-context recall authority
5. unresolved target domain fails closed for explicitly scoped memory

This is deliberately evidence toward **Proposed ADR-022**. It does not accept the ADR, establish all #68 fixtures, reconcile shared-memory protocol semantics, or claim production isolation.

Merge only after exact-head full repository validation succeeds.