### PR TITLE
Reference: enforce derived-scope and scope-promotion governance

### DIFF
--- a/fixtures/same-agent-cross-project-isolation.json
+++ b/fixtures/same-agent-cross-project-isolation.json
@@ -1,0 +1,83 @@
+{
+  "fixture_id": "same-agent-cross-project-isolation",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "The same agent and tenant request a semantically perfect memory from a different project isolation domain. Candidate discovery may occur in a trusted substrate, but recall admission must be blocked.",
+  "expected_behavior": {
+    "candidate_generated": true,
+    "recall_admitted": false,
+    "same_agent": true,
+    "tenant_match": true,
+    "isolation_domain_match": false,
+    "project_boundary_enforced": true
+  },
+  "governed_uncertainty": {
+    "requested_action": "admit_to_context",
+    "permitted_actions": [
+      "block_recall",
+      "report_scope_mismatch"
+    ],
+    "prohibited_actions": [
+      "admit_to_context"
+    ],
+    "selected_action": "block_recall",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "same_agent_not_equal_same_memory_scope",
+      "relevance_not_equal_permission",
+      "cross_project_admission_blocked",
+      "prohibited_action_not_selected"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:project-a-security-memory",
+    "type": "fact",
+    "state": "crystallized",
+    "scope": {
+      "owner_principal": "user:alice",
+      "origin_actor": "agent:planner",
+      "tenant": "tenant-A",
+      "project": "project-A",
+      "task": "task-security-review",
+      "purpose": "security-review",
+      "isolation_domain_refs": [
+        "domain:project-A"
+      ],
+      "primary_isolation_domain_ref": "domain:project-A"
+    },
+    "provenance": {
+      "origin": "synthetic project-A memory",
+      "observer": "agent:planner",
+      "method": "governed write",
+      "timestamp": "2026-08-11T00:00:00Z"
+    },
+    "evidence": [
+      {
+        "id": "evidence:semantic-perfect-match",
+        "kind": "semantic_retrieval",
+        "ref": "fixture://semantic-score/1.0",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.95,
+      "calibrated": true,
+      "durability_dimensions": [
+        "verified_project_a_memory"
+      ]
+    },
+    "authority": {
+      "pama_outcome": "block",
+      "risk_class": "high",
+      "permitted_actions": [
+        "block_recall",
+        "report_scope_mismatch"
+      ],
+      "prohibited_actions": [
+        "admit_to_context"
+      ],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-11T00:00:00Z"
+  }
+}

--- a/fixtures/same-agent-cross-task-isolation.json
+++ b/fixtures/same-agent-cross-task-isolation.json
@@ -1,0 +1,84 @@
+{
+  "fixture_id": "same-agent-cross-task-isolation",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "The same agent, tenant, project, and logical domain request a memory bound to a different task. The memory remains a candidate but must not enter the new task context.",
+  "expected_behavior": {
+    "candidate_generated": true,
+    "recall_admitted": false,
+    "same_agent": true,
+    "tenant_match": true,
+    "project_match": true,
+    "task_match": false,
+    "task_boundary_enforced": true
+  },
+  "governed_uncertainty": {
+    "requested_action": "admit_to_context",
+    "permitted_actions": [
+      "block_recall",
+      "report_scope_mismatch"
+    ],
+    "prohibited_actions": [
+      "admit_to_context"
+    ],
+    "selected_action": "block_recall",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "same_agent_not_equal_same_memory_scope",
+      "same_project_not_equal_same_task",
+      "task_switch_does_not_carry_context_authority",
+      "prohibited_action_not_selected"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:project-a-task-one-memory",
+    "type": "fact",
+    "state": "crystallized",
+    "scope": {
+      "owner_principal": "user:alice",
+      "origin_actor": "agent:planner",
+      "tenant": "tenant-A",
+      "project": "project-A",
+      "task": "task-1",
+      "purpose": "assistance",
+      "isolation_domain_refs": [
+        "domain:project-A"
+      ],
+      "primary_isolation_domain_ref": "domain:project-A"
+    },
+    "provenance": {
+      "origin": "synthetic task-1 memory",
+      "observer": "agent:planner",
+      "method": "governed write",
+      "timestamp": "2026-08-11T00:00:00Z"
+    },
+    "evidence": [
+      {
+        "id": "evidence:task-memory",
+        "kind": "direct_record",
+        "ref": "fixture://task-1/memory",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.9,
+      "calibrated": true,
+      "durability_dimensions": [
+        "task_local"
+      ]
+    },
+    "authority": {
+      "pama_outcome": "block",
+      "risk_class": "medium",
+      "permitted_actions": [
+        "block_recall",
+        "report_scope_mismatch"
+      ],
+      "prohibited_actions": [
+        "admit_to_context"
+      ],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-11T00:00:00Z"
+  }
+}

--- a/fixtures/unauthorized-scope-promotion.json
+++ b/fixtures/unauthorized-scope-promotion.json
@@ -1,0 +1,91 @@
+{
+  "fixture_id": "unauthorized-scope-promotion",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "A derived memory attempts to broaden from a shared-security domain to an external audience without external approval. Derivation cannot manufacture scope-expansion authority.",
+  "expected_behavior": {
+    "scope_broadening_detected": true,
+    "mutation_committed": false,
+    "review_required": true,
+    "self_authorization_allowed": false
+  },
+  "governed_uncertainty": {
+    "requested_action": "scope_expansion",
+    "permitted_actions": [
+      "enter_pending_verification",
+      "collect_more_evidence",
+      "defer"
+    ],
+    "prohibited_actions": [
+      "scope_expansion"
+    ],
+    "selected_action": "defer",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "derivation_not_equal_authority_laundering",
+      "source_authorized_not_equal_destination_authorized",
+      "scope_expansion_requires_governance",
+      "prohibited_action_not_selected"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:derived-security-summary",
+    "type": "summary",
+    "state": "candidate",
+    "scope": {
+      "owner_principal": "team:security",
+      "origin_actor": "agent:planner",
+      "tenant": "tenant-A",
+      "purpose": "security-review",
+      "isolation_domain_refs": [
+        "domain:shared-security"
+      ],
+      "source_isolation_domain_refs": [
+        "domain:project-A",
+        "domain:project-B"
+      ],
+      "allowed_destinations": [
+        "domain:shared-security"
+      ]
+    },
+    "provenance": {
+      "origin": "synthetic multi-source summary",
+      "observer": "agent:planner",
+      "method": "derived summary",
+      "timestamp": "2026-08-11T00:00:00Z",
+      "derived_from": [
+        "uor:test:project-a-source",
+        "uor:test:project-b-source"
+      ]
+    },
+    "evidence": [
+      {
+        "id": "evidence:scope-basis",
+        "kind": "scope_derivation",
+        "ref": "fixture://derived-scope/intersection",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.88,
+      "calibrated": true,
+      "durability_dimensions": [
+        "derived_shared_security"
+      ]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "permitted_actions": [
+        "enter_pending_verification",
+        "collect_more_evidence",
+        "defer"
+      ],
+      "prohibited_actions": [
+        "scope_expansion"
+      ],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-11T00:00:00Z"
+  }
+}

--- a/reference/agentmem_ref/scope_governance.py
+++ b/reference/agentmem_ref/scope_governance.py
@@ -1,0 +1,110 @@
+"""Isolation-domain scope propagation for derived memory.
+
+Executable evidence toward proposed ADR-022. A transform may change
+representation but does not erase source authority constraints.
+
+The safe default is:
+
+    derived audience <= intersection(source audiences)
+    derived purpose  <= intersection(source purposes)
+    derived restrictions >= union(source restrictions)
+
+An empty compatible audience or purpose is not silently widened. It is a hard
+failure that requires a separate governed scope-promotion decision.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import policy
+
+
+class ScopeConflict(ValueError):
+    """Raised when source scopes have no compatible derived authority."""
+
+
+@dataclass(frozen=True)
+class SourceScope:
+    source_ref: str
+    domain_refs: frozenset[str]
+    allowed_audiences: frozenset[str]
+    allowed_purposes: frozenset[str]
+    restrictions: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class DerivedScope:
+    source_refs: tuple[str, ...]
+    domain_refs: frozenset[str]
+    allowed_audiences: frozenset[str]
+    allowed_purposes: frozenset[str]
+    restrictions: frozenset[str]
+
+
+def derive_scope(sources: tuple[SourceScope, ...]) -> DerivedScope:
+    """Compute the default scope a derivation may inherit without promotion."""
+    if not sources:
+        raise ScopeConflict("derived scope requires at least one source")
+
+    domains = set(sources[0].domain_refs)
+    audiences = set(sources[0].allowed_audiences)
+    purposes = set(sources[0].allowed_purposes)
+    restrictions: set[str] = set()
+
+    for source in sources:
+        domains.intersection_update(source.domain_refs)
+        audiences.intersection_update(source.allowed_audiences)
+        purposes.intersection_update(source.allowed_purposes)
+        restrictions.update(source.restrictions)
+
+    if not domains:
+        raise ScopeConflict("source isolation domains have no compatible intersection")
+    if not audiences:
+        raise ScopeConflict("source audiences have no compatible intersection")
+    if not purposes:
+        raise ScopeConflict("source purposes have no compatible intersection")
+
+    return DerivedScope(
+        source_refs=tuple(source.source_ref for source in sources),
+        domain_refs=frozenset(domains),
+        allowed_audiences=frozenset(audiences),
+        allowed_purposes=frozenset(purposes),
+        restrictions=frozenset(restrictions),
+    )
+
+
+def scope_broadens(inherited: DerivedScope, requested: DerivedScope) -> bool:
+    """Return True when requested scope would weaken any inherited constraint."""
+    return (
+        not requested.domain_refs.issubset(inherited.domain_refs)
+        or not requested.allowed_audiences.issubset(inherited.allowed_audiences)
+        or not requested.allowed_purposes.issubset(inherited.allowed_purposes)
+        or not requested.restrictions.issuperset(inherited.restrictions)
+    )
+
+
+def evaluate_scope_promotion(proposal: policy.Proposal, inherited: DerivedScope, requested: DerivedScope) -> policy.Decision:
+    """Evaluate intentional broadening through PAMA rather than derivation logic.
+
+    A non-broadening request needs no scope-expansion authority. A broadening
+    request must be represented as `scope_expansion`; callers cannot relabel it
+    as a harmless transform to obtain a weaker envelope.
+    """
+    if not scope_broadens(inherited, requested):
+        return policy.Decision(
+            outcome=policy.ALLOW,
+            permitted_actions=("retain_inherited_scope",),
+            prohibited_actions=(),
+            reasons=("requested scope does not broaden inherited constraints",),
+        )
+
+    if proposal.operation != "scope_expansion":
+        return policy.Decision(
+            outcome=policy.BLOCK,
+            permitted_actions=(),
+            prohibited_actions=(proposal.operation, "scope_expansion"),
+            reasons=("scope broadening must be evaluated as scope_expansion",),
+        )
+
+    return policy.evaluate(proposal)

--- a/reference/tests/test_scope_governance.py
+++ b/reference/tests/test_scope_governance.py
@@ -1,0 +1,169 @@
+"""Executable derived-scope and scope-promotion evidence for ADR-022."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+from agentmem_ref.scope_governance import (  # noqa: E402
+    DerivedScope,
+    ScopeConflict,
+    SourceScope,
+    derive_scope,
+    evaluate_scope_promotion,
+    scope_broadens,
+)
+
+
+def promotion_proposal(**overrides) -> policy.Proposal:
+    base = dict(
+        proposal_id="scope-promotion-1",
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference="mem:derived",
+        target_class=policy.M4,
+        scope="tenant-a",
+        operation="scope_expansion",
+        current_strength="reinforced",
+        proposed_strength="reinforced",
+        downstream_authority=policy.A2,
+        reversibility="reversible",
+        risk_class="medium",
+        evidence_refs=("scope:source-a", "scope:source-b"),
+        tenant_ref="tenant-a",
+        purpose="assistance",
+    )
+    base.update(overrides)
+    return policy.Proposal(**base)
+
+
+class ScopeGovernanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.a = SourceScope(
+            source_ref="mem:a",
+            domain_refs=frozenset({"domain:project-a", "domain:shared-security"}),
+            allowed_audiences=frozenset({"team:security", "agent:planner"}),
+            allowed_purposes=frozenset({"security-review", "incident-response"}),
+            restrictions=frozenset({"no-external-export"}),
+        )
+        self.b = SourceScope(
+            source_ref="mem:b",
+            domain_refs=frozenset({"domain:shared-security", "domain:project-b"}),
+            allowed_audiences=frozenset({"team:security", "agent:auditor"}),
+            allowed_purposes=frozenset({"security-review"}),
+            restrictions=frozenset({"retain-provenance"}),
+        )
+
+    def test_multi_source_derivation_intersects_authority_and_unions_restrictions(self):
+        derived = derive_scope((self.a, self.b))
+
+        self.assertEqual(derived.domain_refs, frozenset({"domain:shared-security"}))
+        self.assertEqual(derived.allowed_audiences, frozenset({"team:security"}))
+        self.assertEqual(derived.allowed_purposes, frozenset({"security-review"}))
+        self.assertEqual(
+            derived.restrictions,
+            frozenset({"no-external-export", "retain-provenance"}),
+        )
+
+    def test_incompatible_sources_fail_closed_instead_of_selecting_broadest_scope(self):
+        private = SourceScope(
+            source_ref="mem:private",
+            domain_refs=frozenset({"domain:private"}),
+            allowed_audiences=frozenset({"user:alice"}),
+            allowed_purposes=frozenset({"personal"}),
+        )
+        public = SourceScope(
+            source_ref="mem:public",
+            domain_refs=frozenset({"domain:public"}),
+            allowed_audiences=frozenset({"public"}),
+            allowed_purposes=frozenset({"publication"}),
+        )
+
+        with self.assertRaises(ScopeConflict):
+            derive_scope((private, public))
+
+    def test_summary_does_not_erase_source_restrictions(self):
+        inherited = derive_scope((self.a, self.b))
+        requested = DerivedScope(
+            source_refs=inherited.source_refs,
+            domain_refs=inherited.domain_refs,
+            allowed_audiences=inherited.allowed_audiences,
+            allowed_purposes=inherited.allowed_purposes,
+            restrictions=frozenset(),
+        )
+
+        self.assertTrue(scope_broadens(inherited, requested))
+
+    def test_broadening_disguised_as_derivation_is_blocked(self):
+        inherited = derive_scope((self.a, self.b))
+        requested = DerivedScope(
+            source_refs=inherited.source_refs,
+            domain_refs=inherited.domain_refs | {"domain:public"},
+            allowed_audiences=inherited.allowed_audiences | {"public"},
+            allowed_purposes=inherited.allowed_purposes,
+            restrictions=inherited.restrictions,
+        )
+        mislabeled = promotion_proposal(operation="promotion")
+
+        decision = evaluate_scope_promotion(mislabeled, inherited, requested)
+
+        self.assertEqual(decision.outcome, policy.BLOCK)
+        self.assertIn("scope_expansion", decision.prohibited_actions)
+
+    def test_unauthorized_scope_promotion_cannot_commit_by_default(self):
+        inherited = derive_scope((self.a, self.b))
+        requested = DerivedScope(
+            source_refs=inherited.source_refs,
+            domain_refs=inherited.domain_refs | {"domain:external"},
+            allowed_audiences=inherited.allowed_audiences | {"partner:external"},
+            allowed_purposes=inherited.allowed_purposes,
+            restrictions=inherited.restrictions,
+        )
+
+        decision = evaluate_scope_promotion(promotion_proposal(), inherited, requested)
+
+        self.assertEqual(decision.outcome, policy.REQUIRE_REVIEW)
+        self.assertIn("scope_expansion", decision.prohibited_actions)
+        self.assertNotIn("scope_expansion", decision.permitted_actions)
+
+    def test_self_approved_scope_promotion_is_absorbing_block(self):
+        inherited = derive_scope((self.a, self.b))
+        requested = DerivedScope(
+            source_refs=inherited.source_refs,
+            domain_refs=inherited.domain_refs | {"domain:external"},
+            allowed_audiences=inherited.allowed_audiences | {"partner:external"},
+            allowed_purposes=inherited.allowed_purposes,
+            restrictions=inherited.restrictions,
+        )
+
+        decision = evaluate_scope_promotion(
+            promotion_proposal(approves_own_authority=True),
+            inherited,
+            requested,
+        )
+
+        self.assertEqual(decision.outcome, policy.BLOCK)
+        self.assertEqual(decision.permitted_actions, ())
+
+    def test_narrower_derived_scope_does_not_require_scope_expansion(self):
+        inherited = derive_scope((self.a, self.b))
+        requested = DerivedScope(
+            source_refs=inherited.source_refs,
+            domain_refs=inherited.domain_refs,
+            allowed_audiences=inherited.allowed_audiences,
+            allowed_purposes=inherited.allowed_purposes,
+            restrictions=inherited.restrictions | {"no-copy"},
+        )
+
+        decision = evaluate_scope_promotion(promotion_proposal(), inherited, requested)
+
+        self.assertEqual(decision.outcome, policy.ALLOW)
+        self.assertEqual(decision.permitted_actions, ("retain_inherited_scope",))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Advances #68 with executable derived-scope propagation and the critical unauthorized scope-promotion fixtures.

## Executable scope propagation

Adds `reference/agentmem_ref/scope_governance.py` with the default ADR-022 candidate rule:

- derived domains <= intersection(source domains)
- derived audiences <= intersection(source audiences)
- derived purposes <= intersection(source purposes)
- derived restrictions >= union(source restrictions)
- empty compatible intersections fail closed rather than selecting the broadest source
- removing inherited restrictions counts as broadening
- intentional broadening must be evaluated as `scope_expansion` through PAMA
- relabeling a broadening operation as ordinary promotion/derivation is blocked

## Tests

Adds executable evidence that:

- multi-source scope derives the compatible intersection and accumulated restrictions
- incompatible source scopes fail closed
- summaries do not erase source restrictions
- disguised scope broadening is blocked
- unauthorized scope expansion remains prohibited pending review
- self-approved scope expansion is an absorbing block
- narrowing scope does not require scope-expansion authority

## Critical conformance fixtures

Adds:

- `same-agent-cross-project-isolation.json`
- `same-agent-cross-task-isolation.json`
- `unauthorized-scope-promotion.json`

These complement the executable recall-isolation tests merged in #106 and make the acceptance-critical cases permanent corpus members.

## Maturity boundary

ADR-022 remains **Proposed**. This PR does not yet reconcile the shared-memory protocol, emit executable boundary-crossing receipts, complete observability integration, or establish production/runtime isolation beyond the reference evidence.

Merge only after exact-head full repository validation succeeds.