### PR TITLE
Reference: emit governed isolation-domain crossing receipts

### DIFF
--- a/reference/agentmem_ref/crossing.py
+++ b/reference/agentmem_ref/crossing.py
@@ -1,0 +1,162 @@
+"""Governed isolation-domain boundary crossings.
+
+Executable evidence toward proposed ADR-022. The operation that moves or makes
+memory influential across a logical boundary is recorded separately from the
+PAMA consequence class used to authorize the broadening.
+
+A valid receipt reconstructs a decision made under bound policy/state. It does
+not grant permanent permission for future crossings after membership,
+delegation, purpose, policy, or revocation state changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from . import policy, receipts
+
+CROSSING_OPERATIONS = frozenset(
+    {
+        "share",
+        "export",
+        "import",
+        "copy",
+        "promote_scope",
+        "summarize_for",
+        "derive_for",
+        "inherit",
+        "publish",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CrossingRequest:
+    operation: str
+    source_domain_refs: tuple[str, ...]
+    destination_domain_refs: tuple[str, ...]
+    actor: str
+    principal: str
+    purpose: str
+    representation_kind: str
+    source_refs: tuple[str, ...]
+    sensitivity_labels: tuple[str, ...] = ()
+    consent_ref: str = ""
+    delegation_ref: str = ""
+    membership_refs: tuple[str, ...] = ()
+    authority_refs: tuple[str, ...] = ()
+    policy_refs: tuple[str, ...] = ()
+    provenance_refs: tuple[str, ...] = ()
+    valid_until: str = ""
+    revocation_refs: tuple[str, ...] = ()
+    before_scope_refs: tuple[str, ...] = ()
+    after_scope_refs: tuple[str, ...] = ()
+    privacy_minimized: bool = False
+    redaction_ref: str = ""
+
+
+@dataclass(frozen=True)
+class CrossingResult:
+    decision: policy.Decision
+    receipt: dict
+    committed: bool
+    refusal: str | None = None
+
+
+def _outcome_for(decision: policy.Decision) -> tuple[str, bool]:
+    if decision.outcome in (policy.ALLOW, policy.ALLOW_WITH_LEDGER):
+        return "committed", True
+    if decision.outcome == policy.REQUIRE_REVIEW:
+        return "review_required", False
+    if decision.outcome == policy.REQUIRE_EXTERNAL_VERIFICATION:
+        return "verification_required", False
+    return "blocked", False
+
+
+def evaluate_crossing(
+    request: CrossingRequest,
+    proposal: policy.Proposal,
+    *,
+    receipt_id: str,
+    timestamp: str,
+    decision_receipt_ref: str = "",
+    ledger_ref: str = "",
+) -> CrossingResult:
+    """Evaluate and receipt one requested memory-boundary crossing.
+
+    `request.operation` describes the concrete transfer or influence operation.
+    `proposal.operation` must be `scope_expansion` because crossing to a broader
+    authority domain is the PAMA consequence under evaluation. This prevents a
+    caller from obtaining a weaker envelope by describing an export as a copy
+    or summary operation.
+    """
+    if request.operation not in CROSSING_OPERATIONS:
+        raise ValueError(f"unsupported crossing operation: {request.operation}")
+    if not request.source_domain_refs or not request.destination_domain_refs:
+        raise ValueError("crossing requires explicit source and destination domains")
+    if not request.source_refs:
+        raise ValueError("crossing requires at least one source memory or derivation ref")
+    if proposal.operation != "scope_expansion":
+        decision = policy.Decision(
+            outcome=policy.BLOCK,
+            permitted_actions=(),
+            prohibited_actions=(proposal.operation, "scope_expansion"),
+            reasons=("boundary crossing must be evaluated as scope_expansion",),
+        )
+    else:
+        decision = policy.evaluate(proposal)
+
+    outcome, committed = _outcome_for(decision)
+    representation = {
+        "kind": request.representation_kind,
+        "privacy_minimized": request.privacy_minimized,
+    }
+    if request.redaction_ref:
+        representation["redaction_ref"] = request.redaction_ref
+
+    document = {
+        "schema_version": "1.0.0",
+        "receipt_id": receipt_id,
+        "operation": request.operation,
+        "source_domain_refs": list(request.source_domain_refs),
+        "destination_domain_refs": list(request.destination_domain_refs),
+        "actor": request.actor,
+        "principal": request.principal,
+        "purpose": request.purpose,
+        "representation": representation,
+        "source_refs": list(request.source_refs),
+        "requested_consequence": "scope_expansion",
+        "pama_disposition": decision.outcome,
+        "policy_version": decision.policy_version,
+        "outcome": outcome,
+        "timestamp": timestamp,
+    }
+
+    optional_lists = (
+        ("membership_refs", request.membership_refs),
+        ("authority_refs", request.authority_refs),
+        ("policy_refs", request.policy_refs),
+        ("provenance_refs", request.provenance_refs),
+        ("revocation_refs", request.revocation_refs),
+        ("before_scope_refs", request.before_scope_refs),
+        ("after_scope_refs", request.after_scope_refs),
+    )
+    for key, values in optional_lists:
+        if values:
+            document[key] = list(values)
+    if request.sensitivity_labels:
+        document["sensitivity"] = {"labels": list(request.sensitivity_labels)}
+    if request.consent_ref:
+        document["consent_ref"] = request.consent_ref
+    if request.delegation_ref:
+        document["delegation_ref"] = request.delegation_ref
+    if request.valid_until:
+        document["valid_until"] = request.valid_until
+    if decision_receipt_ref:
+        document["decision_receipt_ref"] = decision_receipt_ref
+    if ledger_ref:
+        document["ledger_ref"] = ledger_ref
+
+    receipts.validate("boundary-crossing-receipt.schema.json", document)
+    refusal = None if committed else f"crossing not committed: {decision.outcome}"
+    return CrossingResult(decision=decision, receipt=document, committed=committed, refusal=refusal)

--- a/reference/tests/test_boundary_crossing.py
+++ b/reference/tests/test_boundary_crossing.py
@@ -1,0 +1,151 @@
+"""Executable boundary-crossing receipt evidence for proposed ADR-022."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+from agentmem_ref.crossing import CrossingRequest, evaluate_crossing  # noqa: E402
+
+
+def proposal(**overrides) -> policy.Proposal:
+    base = dict(
+        proposal_id="crossing-1",
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference="mem:security-summary",
+        target_class=policy.M4,
+        scope="tenant-a",
+        operation="scope_expansion",
+        current_strength="crystallized",
+        proposed_strength="crystallized",
+        downstream_authority=policy.A2,
+        reversibility="reversible",
+        risk_class="medium",
+        evidence_refs=("evidence:source-scope",),
+        tenant_ref="tenant-a",
+        purpose="security-review",
+    )
+    base.update(overrides)
+    return policy.Proposal(**base)
+
+
+def request(**overrides) -> CrossingRequest:
+    base = dict(
+        operation="share",
+        source_domain_refs=("domain:project-a",),
+        destination_domain_refs=("domain:shared-security",),
+        actor="agent:planner",
+        principal="user:alice",
+        purpose="security-review",
+        representation_kind="summary",
+        source_refs=("mem:security-summary",),
+        sensitivity_labels=("internal",),
+        membership_refs=("membership:shared-security",),
+        authority_refs=("authority:security-share",),
+        policy_refs=("policy:memory-scope",),
+        provenance_refs=("provenance:summary-build",),
+        before_scope_refs=("domain:project-a",),
+        after_scope_refs=("domain:shared-security",),
+    )
+    base.update(overrides)
+    return CrossingRequest(**base)
+
+
+class BoundaryCrossingTests(unittest.TestCase):
+    def test_unreviewed_scope_crossing_is_receipted_but_not_committed(self):
+        result = evaluate_crossing(
+            request(),
+            proposal(),
+            receipt_id="crossing:review-required",
+            timestamp="2026-08-11T20:00:00Z",
+        )
+
+        self.assertFalse(result.committed)
+        self.assertEqual(result.decision.outcome, policy.REQUIRE_REVIEW)
+        self.assertEqual(result.receipt["outcome"], "review_required")
+        self.assertEqual(result.receipt["source_domain_refs"], ["domain:project-a"])
+        self.assertEqual(result.receipt["destination_domain_refs"], ["domain:shared-security"])
+
+    def test_external_review_can_commit_crossing_without_changing_source_semantics(self):
+        result = evaluate_crossing(
+            request(),
+            proposal(
+                review_satisfied=True,
+                approval_refs=("approval:security-owner",),
+            ),
+            receipt_id="crossing:committed",
+            timestamp="2026-08-11T20:00:01Z",
+            decision_receipt_ref="decision:scope-expansion",
+            ledger_ref="ledger:crossing-1",
+        )
+
+        self.assertTrue(result.committed)
+        self.assertEqual(result.decision.outcome, policy.ALLOW_WITH_LEDGER)
+        self.assertEqual(result.receipt["outcome"], "committed")
+        self.assertEqual(result.receipt["pama_disposition"], "allow_with_ledger")
+        self.assertEqual(result.receipt["operation"], "share")
+        self.assertEqual(result.receipt["requested_consequence"], "scope_expansion")
+
+    def test_crossing_disguised_as_ordinary_operation_is_blocked(self):
+        result = evaluate_crossing(
+            request(operation="summarize_for"),
+            proposal(operation="promotion"),
+            receipt_id="crossing:disguised",
+            timestamp="2026-08-11T20:00:02Z",
+        )
+
+        self.assertFalse(result.committed)
+        self.assertEqual(result.decision.outcome, policy.BLOCK)
+        self.assertEqual(result.receipt["outcome"], "blocked")
+        self.assertIn("scope_expansion", result.decision.prohibited_actions)
+
+    def test_self_approval_blocks_crossing(self):
+        result = evaluate_crossing(
+            request(operation="export"),
+            proposal(
+                approves_own_authority=True,
+                review_satisfied=True,
+                approval_refs=("approval:self",),
+            ),
+            receipt_id="crossing:self-approved",
+            timestamp="2026-08-11T20:00:03Z",
+        )
+
+        self.assertFalse(result.committed)
+        self.assertEqual(result.decision.outcome, policy.BLOCK)
+        self.assertEqual(result.receipt["outcome"], "blocked")
+
+    def test_privacy_minimized_representation_does_not_self_authorize_export(self):
+        result = evaluate_crossing(
+            request(
+                operation="export",
+                destination_domain_refs=("domain:external-partner",),
+                privacy_minimized=True,
+                redaction_ref="redaction:approved-shape",
+            ),
+            proposal(),
+            receipt_id="crossing:minimized",
+            timestamp="2026-08-11T20:00:04Z",
+        )
+
+        self.assertFalse(result.committed)
+        self.assertTrue(result.receipt["representation"]["privacy_minimized"])
+        self.assertEqual(result.receipt["outcome"], "review_required")
+
+    def test_crossing_requires_explicit_source_and_destination_domains(self):
+        with self.assertRaises(ValueError):
+            evaluate_crossing(
+                request(destination_domain_refs=()),
+                proposal(),
+                receipt_id="crossing:missing-domain",
+                timestamp="2026-08-11T20:00:05Z",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Advances #68 by making the boundary-crossing receipt schema executable in the reference implementation.

## Changes

Adds `reference/agentmem_ref/crossing.py`:

- keeps the concrete transfer/influence operation (`share`, `export`, `summarize_for`, etc.) separate from the PAMA consequence class used to authorize it
- requires explicit source and destination domain refs plus source memory/derivation refs
- requires a crossing to be evaluated as `scope_expansion`; relabeling it as ordinary promotion/derivation fails closed
- binds actor, principal, purpose, representation, sensitivity, membership, authority, policy, provenance, expiry/revocation, and before/after scope evidence where supplied
- validates every emitted record against `boundary-crossing-receipt.schema.json`
- preserves review/verification/block outcomes as valid negative receipts rather than pretending every receipt means a committed crossing

## Tests

Adds executable cases proving:

- unreviewed crossing is receipted as `review_required` and not committed
- externally reviewed crossing may commit as `allow_with_ledger`
- crossing disguised as an ordinary operation is blocked
- self-approved crossing is blocked
- privacy-minimized/redacted representation does not self-authorize export
- source/destination domains must be explicit

## Maturity boundary

ADR-022 remains **Proposed**. This PR establishes executable crossing-receipt evidence, but shared-memory protocol reconciliation, isolation observability integration, and final acceptance audit still remain.

Merge only after exact-head full repository validation succeeds.