### PR TITLE
Reference: enforce shared-domain membership at recall

### DIFF
--- a/fixtures/shared-space-non-member-recall.json
+++ b/fixtures/shared-space-non-member-recall.json
@@ -1,0 +1,88 @@
+{
+  "fixture_id": "shared-space-non-member-recall",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "A same-tenant principal retrieves a semantically relevant memory from a shared memory domain but is not a current member. Membership is required for eligibility and the candidate must be blocked from context admission.",
+  "expected_behavior": {
+    "candidate_generated": true,
+    "recall_admitted": false,
+    "tenant_match": true,
+    "shared_domain_match": true,
+    "membership_active": false,
+    "membership_boundary_enforced": true
+  },
+  "governed_uncertainty": {
+    "requested_action": "admit_to_context",
+    "permitted_actions": [
+      "block_recall",
+      "report_scope_mismatch"
+    ],
+    "prohibited_actions": [
+      "admit_to_context"
+    ],
+    "selected_action": "block_recall",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "shared_memory_is_governed_domain",
+      "membership_not_equal_recall_admission",
+      "non_member_shared_recall_blocked",
+      "relevance_not_equal_permission",
+      "prohibited_action_not_selected"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:shared-security-memory",
+    "type": "fact",
+    "state": "crystallized",
+    "scope": {
+      "owner_principal": "team:security",
+      "origin_actor": "agent:security",
+      "tenant": "tenant-A",
+      "purpose": "security-review",
+      "isolation_domain_refs": [
+        "domain:shared-security"
+      ],
+      "primary_isolation_domain_ref": "domain:shared-security",
+      "shared_memory_domain_refs": [
+        "domain:shared-security"
+      ],
+      "domain_membership_refs": [
+        "membership:shared-security:requester:revoked"
+      ]
+    },
+    "provenance": {
+      "origin": "synthetic shared-space memory",
+      "observer": "agent:security",
+      "method": "governed shared write",
+      "timestamp": "2026-08-11T00:00:00Z"
+    },
+    "evidence": [
+      {
+        "id": "evidence:shared-space-perfect-match",
+        "kind": "semantic_retrieval",
+        "ref": "fixture://shared-space/semantic-score/1.0",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.92,
+      "calibrated": true,
+      "durability_dimensions": [
+        "governed_shared_memory"
+      ]
+    },
+    "authority": {
+      "pama_outcome": "block",
+      "risk_class": "high",
+      "permitted_actions": [
+        "block_recall",
+        "report_scope_mismatch"
+      ],
+      "prohibited_actions": [
+        "admit_to_context"
+      ],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-11T00:00:00Z"
+  }
+}

--- a/reference/agentmem_ref/adapter.py
+++ b/reference/agentmem_ref/adapter.py
@@ -95,6 +95,7 @@ class RecallContext:
     """
 
     target_domain_refs: tuple[str, ...]
+    principal_ref: str = ""
     project_ref: str = ""
     task_ref: str = ""
     purpose: str = ""
@@ -120,7 +121,21 @@ class GovernedMemoryAdapter:
         self._disputed: set[str] = set()
         self._tombstones: dict[str, dict] = {}
         self._fact_scope: dict[str, dict] = {}
+        self._shared_domain_members: dict[str, set[str]] = {}
         self.events: list[dict] = []
+
+    # -- isolation-domain administration -------------------------------
+
+    def set_shared_domain_members(self, domain_ref: str, members: tuple[str, ...]) -> None:
+        """Replace current membership for a governed shared-memory domain.
+
+        This is a narrow reference seam, not a complete membership service.
+        Recall always consults the current set so revocation affects subsequent
+        admission without rewriting the retained memory itself.
+        """
+        if not domain_ref:
+            raise ValueError("shared domain requires a stable domain ref")
+        self._shared_domain_members[domain_ref] = set(members)
 
     # -- write path -----------------------------------------------------
 
@@ -263,9 +278,10 @@ class GovernedMemoryAdapter:
         """Retrieve candidates, then admit only what current authority allows.
 
         Tenant partitioning is enforced before retrieval. Logical isolation
-        domains, project, and task are evaluated at admission because the
-        in-memory substrate is trusted to return same-tenant candidates for
-        policy evaluation. Candidate presence never creates admission rights.
+        domains, shared-space membership, project, and task are evaluated at
+        admission because the in-memory substrate is trusted to return
+        same-tenant candidates for policy evaluation. Candidate presence and
+        shared-space membership remain distinct from admission authority.
         """
         context = context or RecallContext(target_domain_refs=(self._tenant,))
         result = AdmissionResult()
@@ -294,8 +310,20 @@ class GovernedMemoryAdapter:
 
         memory_domains = set(scope["domain_refs"])
         target_domains = set(context.target_domain_refs)
-        if not target_domains or not memory_domains.intersection(target_domains):
+        matching_domains = memory_domains.intersection(target_domains)
+        if not target_domains or not matching_domains:
             return "isolation_domain_mismatch"
+
+        # A shared domain is still an isolation boundary. If all matching
+        # routes are governed shared spaces, at least one must currently admit
+        # the requesting principal as a member. Membership is necessary but
+        # not sufficient; project/task/purpose gates continue below.
+        shared_matches = {domain for domain in matching_domains if domain in self._shared_domain_members}
+        if shared_matches == matching_domains:
+            if not context.principal_ref:
+                return "shared_space_membership_unresolved"
+            if not any(context.principal_ref in self._shared_domain_members[domain] for domain in shared_matches):
+                return "shared_space_non_member"
 
         memory_project = scope.get("project_ref", "")
         if memory_project and context.project_ref != memory_project:

--- a/reference/tests/test_shared_domain_membership.py
+++ b/reference/tests/test_shared_domain_membership.py
@@ -1,0 +1,108 @@
+"""Executable shared-domain membership evidence for proposed ADR-022."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext  # noqa: E402
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+TENANT = "tenant-a"
+SHARED = "domain:shared-security"
+ALICE = "user:alice"
+BOB = "user:bob"
+
+
+def shared_proposal() -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id="proposal:shared-memory",
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference="mem:shared-security-procedure",
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("evidence:shared-source",),
+        tenant_ref=TENANT,
+        purpose="security-review",
+        isolation_domain_refs=(SHARED,),
+    )
+
+
+class SharedDomainMembershipTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), tenant=TENANT, clock=Clock())
+        committed = self.adapter.commit_proposal(shared_proposal(), "shared credential rotation guidance")
+        self.assertTrue(committed.committed)
+        self.fact_uuid = committed.fact_uuid
+        self.adapter.set_shared_domain_members(SHARED, (ALICE,))
+
+    def test_current_member_is_eligible_for_normal_admission_checks(self):
+        recall = self.adapter.governed_recall(
+            "shared credential rotation guidance",
+            RecallContext(target_domain_refs=(SHARED,), principal_ref=ALICE, purpose="security-review"),
+        )
+
+        self.assertIn(self.fact_uuid, recall.candidates)
+        self.assertIn(self.fact_uuid, recall.admitted)
+
+    def test_non_member_is_candidate_but_blocked(self):
+        recall = self.adapter.governed_recall(
+            "shared credential rotation guidance",
+            RecallContext(target_domain_refs=(SHARED,), principal_ref=BOB, purpose="security-review"),
+        )
+
+        self.assertIn(self.fact_uuid, recall.candidates)
+        self.assertNotIn(self.fact_uuid, recall.admitted)
+        self.assertEqual(recall.refusals[self.fact_uuid], "shared_space_non_member")
+
+    def test_unresolved_membership_fails_closed(self):
+        recall = self.adapter.governed_recall(
+            "shared credential rotation guidance",
+            RecallContext(target_domain_refs=(SHARED,), purpose="security-review"),
+        )
+
+        self.assertIn(self.fact_uuid, recall.candidates)
+        self.assertNotIn(self.fact_uuid, recall.admitted)
+        self.assertEqual(recall.refusals[self.fact_uuid], "shared_space_membership_unresolved")
+
+    def test_revocation_changes_subsequent_admission_without_rewriting_memory(self):
+        before = self.adapter.governed_recall(
+            "shared credential rotation guidance",
+            RecallContext(target_domain_refs=(SHARED,), principal_ref=ALICE, purpose="security-review"),
+        )
+        self.assertIn(self.fact_uuid, before.admitted)
+
+        self.adapter.set_shared_domain_members(SHARED, ())
+
+        after = self.adapter.governed_recall(
+            "shared credential rotation guidance",
+            RecallContext(target_domain_refs=(SHARED,), principal_ref=ALICE, purpose="security-review"),
+        )
+        self.assertIn(self.fact_uuid, after.candidates)
+        self.assertNotIn(self.fact_uuid, after.admitted)
+        self.assertEqual(after.refusals[self.fact_uuid], "shared_space_non_member")
+
+    def test_membership_does_not_override_wrong_target_domain(self):
+        recall = self.adapter.governed_recall(
+            "shared credential rotation guidance",
+            RecallContext(target_domain_refs=("domain:project-private",), principal_ref=ALICE, purpose="security-review"),
+        )
+
+        self.assertIn(self.fact_uuid, recall.candidates)
+        self.assertNotIn(self.fact_uuid, recall.admitted)
+        self.assertEqual(recall.refusals[self.fact_uuid], "isolation_domain_mismatch")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the remaining explicit ADR-022 acceptance-evidence gap for shared-memory membership versus non-member recall.

## Changes

- extends `RecallContext` with the accountable/requesting principal
- adds a narrow current-membership registry for governed shared-memory domains in the reference adapter
- evaluates shared-domain membership after logical-domain matching and before admission
- fails closed when shared-space membership cannot be resolved
- allows membership revocation to affect subsequent recall without rewriting the retained memory
- preserves the separate project/task/admission gates: membership is necessary where applicable, never sufficient

## Executable evidence

Adds `reference/tests/test_shared_domain_membership.py` proving:

- a current member may proceed through normal admission
- a same-tenant non-member remains a candidate but is blocked
- unresolved membership fails closed
- revocation blocks subsequent admission without deleting or rewriting the memory
- membership does not override a wrong target domain

Adds permanent conformance fixture `fixtures/shared-space-non-member-recall.json` with the explicit invariants:

- shared memory is a governed domain
- membership != recall admission
- relevance != permission
- non-member shared recall is blocked

## Maturity boundary

ADR-022 remains **Proposed** in this PR. After exact-head validation and merge, its own acceptance-evidence list can be audited against current `main`; status should change only in a separate evidence-backed decision.

Merge only after exact-head full repository validation succeeds.