### PR TITLE
Docs: accept ADR-020 on executable runtime evidence

### DIFF
--- a/docs/adr/ADR-020-probabilistic-discovery-deterministic-governance.md
+++ b/docs/adr/ADR-020-probabilistic-discovery-deterministic-governance.md
@@ -243,7 +243,7 @@ ADR-020 was accepted only after the repository accumulated executable evidence f
 13. at least one implementation is mapped end-to-end from estimate -> governance -> action set -> commit
 14. at least one adversarial challenge causes a documented boundary, correction, or rejection rather than being ignored
 
-The acceptance audit is recorded in [`../audits/governed-uncertainty/09-adr-020-runtime-evidence-acceptance.md`](../audits/governed-uncertainty/09-adr-020-runtime-evidence-acceptance.md). Runtime evidence includes the pinned real-substrate governed adapter, stochastic containment, concurrency conflict evidence, deletion-completeness evidence, the P5 security scorecard, the P6 Mem0 comparator, and portable/external action-evidence negative paths.
+The acceptance audit is recorded in [`../audits/governed-uncertainty/09-adr-020-runtime-evidence-acceptance-audit.md`](../audits/governed-uncertainty/09-adr-020-runtime-evidence-acceptance-audit.md). Runtime evidence includes the pinned real-substrate governed adapter, stochastic containment, concurrency conflict evidence, deletion-completeness evidence, the P5 security scorecard, the P6 Mem0 comparator, and portable/external action-evidence negative paths.
 
 Acceptance is a **doctrine-maturity decision**, not a claim that the narrow reference adapter satisfies every cumulative Agent Memory conformance level or that every production implementation conforms.
 

--- a/docs/adr/ADR-020-probabilistic-discovery-deterministic-governance.md
+++ b/docs/adr/ADR-020-probabilistic-discovery-deterministic-governance.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -26,7 +26,7 @@ Memory also contains consequences too important to delegate directly to uncertai
 
 A binary choice between "deterministic memory" and "probabilistic memory" is therefore insufficient.
 
-## Decision candidate
+## Decision
 
 Adopt a **governed uncertainty** architecture:
 
@@ -224,9 +224,9 @@ Rejected as insufficient because thresholds can be miscalibrated, brittle, domai
 
 Rejected as a default because it creates a human bottleneck and prevents useful autonomous low-risk adaptation.
 
-## Validation required before acceptance
+## Acceptance evidence
 
-This ADR MUST remain Proposed until the repository has executable evidence proving at least:
+ADR-020 was accepted only after the repository accumulated executable evidence for all fourteen required boundaries:
 
 1. high-confidence false memory cannot self-promote
 2. high-relevance wrong-tenant memory cannot enter context
@@ -243,12 +243,17 @@ This ADR MUST remain Proposed until the repository has executable evidence provi
 13. at least one implementation is mapped end-to-end from estimate -> governance -> action set -> commit
 14. at least one adversarial challenge causes a documented boundary, correction, or rejection rather than being ignored
 
+The acceptance audit is recorded in [`../audits/governed-uncertainty/09-adr-020-runtime-evidence-acceptance.md`](../audits/governed-uncertainty/09-adr-020-runtime-evidence-acceptance.md). Runtime evidence includes the pinned real-substrate governed adapter, stochastic containment, concurrency conflict evidence, deletion-completeness evidence, the P5 security scorecard, the P6 Mem0 comparator, and portable/external action-evidence negative paths.
+
+Acceptance is a **doctrine-maturity decision**, not a claim that the narrow reference adapter satisfies every cumulative Agent Memory conformance level or that every production implementation conforms.
+
 Canonical evidence locations:
 
 - [`../06-conformance-test-plan.md`](../06-conformance-test-plan.md)
 - [`../24-determinism-probability-and-governed-uncertainty.md`](../24-determinism-probability-and-governed-uncertainty.md)
 - [`../25-governed-uncertainty-documentation-conformance-audit.md`](../25-governed-uncertainty-documentation-conformance-audit.md)
 - [`../audits/governed-uncertainty/`](../audits/governed-uncertainty/)
+- [`../programs/runtime-evidence/`](../programs/runtime-evidence/)
 
 ## Open questions
 
@@ -262,11 +267,11 @@ Canonical evidence locations:
 
 ## Research posture
 
-The decision should be challenged using freely inspectable research where practical, implementation evidence, adversarial fixtures, and negative results.
+The decision should continue to be challenged using freely inspectable research where practical, implementation evidence, adversarial fixtures, and negative results.
 
 Citation count is not confidence.
 
-## Doctrine candidate
+## Doctrine
 
 The system may be uncertain about what is true.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,15 +25,12 @@ Implementation maturity is tracked separately through documentation, fixtures, c
 ## Current doctrine state
 
 ```text
-ADR-001 through ADR-019: Accepted
-ADR-020: Proposed
+ADR-001 through ADR-020: Accepted
 ADR-021: Proposed
 ADR-022: Accepted
 ```
 
-ADRs 001-019 and ADR-022 have their required canonical doctrine contracts and, where specified, repository-level schema/fixture evidence.
-
-ADR-020 remains deliberately different. It requires **runtime end-to-end evidence**, not merely documentation or fixture structure.
+ADRs 001-020 and ADR-022 have satisfied their respective doctrine-maturity gates. ADR-020 is deliberately stronger than documentation-only acceptance: it required executable end-to-end runtime evidence and adversarial negative paths before acceptance.
 
 ADR-021 proposes the interoperability boundary for **portable memory-governance evidence**. It keeps Agent Memory authoritative for memory semantics, PAMA, lifecycle obligations, and canonical decision receipts while allowing external trust systems such as AgenTrust to verify and correlate evidence without redefining those semantics.
 
@@ -54,9 +51,9 @@ If an ADR explicitly requires stronger evidence before acceptance, that requirem
 
 ## Governed uncertainty
 
-[`ADR-020`](ADR-020-probabilistic-discovery-deterministic-governance.md) is intentionally still **Proposed**.
+[`ADR-020`](ADR-020-probabilistic-discovery-deterministic-governance.md) is **Accepted**.
 
-Its acceptance requires at least one real implementation mapped and tested end to end across:
+Its acceptance required at least one real implementation mapped and tested end to end across:
 
 ```text
 estimate / proposal
@@ -66,9 +63,9 @@ estimate / proposal
   -> committed consequence
 ```
 
-It also requires repeated behavioral evidence for stochastic containment, cross-scope recall, concurrency, deletion residue, and related adversarial cases.
+The repository now has executable evidence for stochastic containment, cross-scope recall, concurrency conflict handling, deletion residue and transitive deletion behavior, reconstructable receipts, adversarial boundary enforcement, and a pinned real-substrate path. The P10 acceptance audit maps all fourteen ADR-020 gates to current evidence.
 
-The repository now has machine-readable schemas and fixture definitions for those cases, but fixture validity is not runtime proof.
+Acceptance does not upgrade the narrow reference adapter to a higher cumulative conformance level. Doctrine maturity and implementation conformance remain separate claims.
 
 ## Portable memory-governance evidence
 

--- a/docs/programs/runtime-evidence/README.md
+++ b/docs/programs/runtime-evidence/README.md
@@ -4,9 +4,9 @@
 
 Move Agent Memory from a **doctrine-validated** reference architecture to an **implementation-evidenced** one.
 
-Everything in the doctrine tree is currently supported by internal coherence: schemas that validate, fixtures that are structurally sound, ADRs that agree with the documents they govern. That is necessary and it is not proof. This program exists to test whether the architecture's boundaries survive real substrates, real workloads, adversarial cases, portability pressure, observability requirements, and cost.
+Everything in the doctrine tree is supported by internal coherence: schemas that validate, fixtures that are structurally sound, and ADRs that agree with the documents they govern. This program exists because coherence is necessary and still is not proof. It tests whether the architecture's boundaries survive real substrates, real workloads, adversarial cases, portability pressure, observability requirements, and cost.
 
-> ADR-020 remains Proposed until runtime evidence, not prose, earns acceptance.
+> ADR-020 is Accepted on the executable evidence mapped by the P10 acceptance audit. That doctrine decision does not imply cumulative implementation conformance or universal production proof.
 
 The live backlog and workstream detail are tracked in the program issue. This document is the durable in-repo statement of the program's rules: what counts as evidence, how comparators are used, and what the program is not allowed to do.
 
@@ -89,6 +89,7 @@ Documents are added when their slice is ready to execute, not in advance. A dire
 | [`concurrency-conflict-evidence.md`](concurrency-conflict-evidence.md) | concurrency behavior | conflicting proposals from one prior state are revalidated at commit; stale second write is deferred and conflict evidence is emitted |
 | [`benchmark-security-scorecard.md`](benchmark-security-scorecard.md) | P5 benchmark/security matrix and harness | seven hard-gate security/governance metrics execute with explicit denominators and an exact-commit scorecard artifact; no scalar quality score |
 | [`mem0-adversarial-comparator.md`](mem0-adversarial-comparator.md) | P6 production-oriented adversarial comparator | pinned Mem0 OSS memory CRUD, scope, correction, deletion, history, and direct-ID behavior execute against local Qdrant/SQLite with external-model seams removed |
+| [`../audits/governed-uncertainty/09-adr-020-runtime-evidence-acceptance-audit.md`](../../audits/governed-uncertainty/09-adr-020-runtime-evidence-acceptance-audit.md) | P10 ADR-020 evidence review | all fourteen ADR-020 minimum evidence gates mapped to executable repository evidence; acceptance separated from cumulative conformance |
 
 ## Preconditions
 
@@ -102,7 +103,7 @@ External comparators do not require precondition 2. A comparator is measured, no
 
 ## Non-goals
 
-This program does not authorize replacing Agent Memory with any external system, vendor lock-in, treating emerging drafts as adopted standards, importing external schemas without semantic review, inventing a universal memory score, averaging critical governance failures into a passing aggregate, weakening scope, privacy, correction, or deletion semantics for implementation convenience, declaring governance runtime-proven because a schema validates, or accepting ADR-020 because a demonstration was persuasive once.
+This program does not authorize replacing Agent Memory with any external system, vendor lock-in, treating emerging drafts as adopted standards, importing external schemas without semantic review, inventing a universal memory score, averaging critical governance failures into a passing aggregate, weakening scope, privacy, correction, or deletion semantics for implementation convenience, or declaring cumulative implementation conformance merely because ADR-020 is accepted.
 
 ## Governing principle
 


### PR DESCRIPTION
Follows the exact-head-green P10 acceptance audit merged in #116.

This PR promotes ADR-020 from Proposed to Accepted based on the audited executable evidence surface.

Changes are intentionally limited to non-visual doctrine/status surfaces:
- ADR-020 status and decision wording
- ADR index/current doctrine state
- runtime-evidence program status and P10 audit registration

Acceptance basis includes the fourteen ADR-020 gates mapped in `docs/audits/governed-uncertainty/09-adr-020-runtime-evidence-acceptance-audit.md`, including real-substrate execution, stochastic containment, cross-scope admission, concurrency conflict handling, deletion residue, reconstructable receipts, and adversarial negative paths.

Important boundary: ADR acceptance is doctrine maturity. It does not raise the narrow reference adapter's cumulative conformance level or claim universal production conformance.

No visual, branding, logo, banner, Wiki Home, or visual-guide work is included.

Merge only after full exact-head validation and CodeQL succeed.