### PR TITLE
Runtime: add P7 governed cross-system interchange evidence

### DIFF
--- a/docs/programs/runtime-evidence/governed-interchange.md
+++ b/docs/programs/runtime-evidence/governed-interchange.md
@@ -1,0 +1,56 @@
+# P7 Governed Interchange Evidence
+
+## Purpose
+
+Exercise the Agent Memory Profile 6 seam without defining a transport standard or making any upstream submission.
+
+The question is deliberately narrow:
+
+> Can one governed system export memory to another without losing ownership, provenance, lifecycle, sensitivity, scope provenance, or the requirement for receiver-local authorization?
+
+This slice is local reference evidence only. External projects are not modified, asked to adopt the contract, or treated as implementation dependencies.
+
+## Executed contract
+
+The reference path under `reference/agentmem_ref/interchange.py` enforces:
+
+1. sender export requires a schema-valid memory and a **committed governed boundary-crossing receipt**;
+2. the crossing receipt must bind the exported memory id;
+3. cross-system export requires explicit ownership and source isolation-domain bindings;
+4. sender-side authorization travels with the bundle as evidence, not as receiver permission;
+5. the receiver must evaluate a local `scope_expansion` proposal through its own PAMA path;
+6. an ownership conflict fails closed before admission;
+7. successful import preserves stable identity, lifecycle state, provenance, sensitivity, and owner;
+8. successful import binds the receiving isolation domain while retaining source-domain provenance;
+9. the imported memory records the **receiver's** authority envelope, not the sender's authority refs.
+
+The companion fixture `fixtures/cross-system-authority-conflict.json` makes the missing authority-conflict case from `docs/35-interoperability-profiles.md` permanent in the conformance corpus.
+
+## Evidence boundary
+
+This demonstrates a local executable interoperability contract. It does **not** claim:
+
+- a universal interchange wire format;
+- Profile 6 conformance for the entire reference adapter;
+- automatic trust of imported memory;
+- transfer of ownership, certification, or mutation authority;
+- deletion propagation to an actual remote deployment;
+- production transport security;
+- upstream acceptance by Agent Manifest, TRACE/cMCP, Mem0, Graphiti, AgenTrust, or any other project.
+
+The sender's `allow` means only that the sender authorized its own export. The receiver still owns its admission and consequence decision.
+
+## Validation
+
+`reference/tests/test_interchange.py` covers:
+
+- refusal to export without a committed sender crossing;
+- refusal to inherit sender authority at the receiver;
+- fail-closed ownership conflict;
+- successful locally authorized import with semantic preservation and receiving-domain rebinding.
+
+Repository CI runs these tests through the existing reference governed-adapter validation path together with fixture/schema/doctrine validation.
+
+## Next P7 slice
+
+The next meaningful P7 work is deletion/correction continuity across the exchange boundary: prove that an exported copy retains enough source identity and lifecycle linkage for a later correction, supersession, revocation, or deletion obligation to be recognized and governed by the receiver without granting the sender unilateral mutation authority over the receiver's store.

--- a/fixtures/cross-system-authority-conflict.json
+++ b/fixtures/cross-system-authority-conflict.json
@@ -1,0 +1,65 @@
+{
+  "fixture_id": "cross-system-authority-conflict",
+  "fixture_version": "1.0.0",
+  "class": "interoperability",
+  "description": "A receiving system is offered a governed memory whose sender-side export was authorized, but the receiver asserts a conflicting owner or attempts to reuse sender authority as local permission.",
+  "expected_behavior": {
+    "sender_allow_becomes_receiver_allow": false,
+    "ownership_conflict_fails_closed": true,
+    "receiver_reauthorizes_locally": true,
+    "source_scope_and_provenance_survive": true
+  },
+  "governed_uncertainty": {
+    "requested_action": "scope_expansion",
+    "permitted_actions": ["enter_pending_verification", "collect_more_evidence", "defer"],
+    "prohibited_actions": ["silent_authority_import", "ownership_rewrite"],
+    "selected_action": "enter_pending_verification",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "authority_does_not_transit_seams",
+      "ownership_is_preserved_across_exchange",
+      "receiver_runs_local_governance",
+      "scope_provenance_survives_import"
+    ]
+  },
+  "memory_unit": {
+    "id": "mem:cross-system-authority-conflict",
+    "type": "decision",
+    "state": "crystallized",
+    "scope": {
+      "owner_principal": "user:alice",
+      "tenant": "tenant-a",
+      "project": "project-a",
+      "purpose": "security-review",
+      "isolation_domain_refs": ["domain:project-a"],
+      "primary_isolation_domain_ref": "domain:project-a"
+    },
+    "provenance": {
+      "origin": "synthetic interoperability fixture",
+      "observer": "system-a",
+      "method": "governed export/import authority conflict",
+      "timestamp": "2026-08-11T20:00:00Z"
+    },
+    "evidence": [
+      {
+        "id": "evidence:sender-export-receipt",
+        "kind": "boundary_crossing_receipt",
+        "ref": "fixture://sender/export/receipt",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.95,
+      "calibrated": true,
+      "durability_dimensions": ["certified_decision"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "permitted_actions": ["enter_pending_verification", "collect_more_evidence", "defer"],
+      "prohibited_actions": ["silent_authority_import", "ownership_rewrite"],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-11T20:00:00Z"
+  }
+}

--- a/reference/agentmem_ref/interchange.py
+++ b/reference/agentmem_ref/interchange.py
@@ -1,0 +1,142 @@
+"""Local reference evidence for governed cross-system memory interchange.
+
+This module does not define a transport standard and does not import another
+project's authority semantics. It exercises Agent Memory's own Profile 6 seam:
+
+- sender export requires a committed governed boundary crossing;
+- the memory's identity, provenance, lifecycle, sensitivity, ownership, and
+  source-domain scope survive export;
+- sender authority travels as evidence, never as receiver permission;
+- the receiver evaluates its own PAMA authority before admitting the import;
+- ownership conflicts fail closed;
+- successful imports bind a receiving isolation domain while retaining source
+  domain provenance.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+
+from . import policy, receipts
+
+
+@dataclass(frozen=True)
+class ExportBundle:
+    sender_system: str
+    receiver_system: str
+    memory: dict
+    crossing_receipt: dict
+    sender_authority_evidence: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    decision: policy.Decision
+    admitted: bool
+    memory: dict | None
+    refusal: str | None = None
+
+
+def build_export_bundle(
+    memory: dict,
+    *,
+    sender_system: str,
+    receiver_system: str,
+    crossing_receipt: dict,
+) -> ExportBundle:
+    """Build an export only from a schema-valid memory and committed crossing."""
+    receipts.validate("memory-unit.schema.json", memory)
+    receipts.validate("boundary-crossing-receipt.schema.json", crossing_receipt)
+
+    if crossing_receipt.get("outcome") != "committed":
+        raise ValueError("memory export requires a committed governed crossing")
+    if memory["id"] not in crossing_receipt.get("source_refs", ()):
+        raise ValueError("crossing receipt does not bind the exported memory")
+
+    scope = memory.get("scope") or {}
+    if not scope.get("owner_principal"):
+        raise ValueError("cross-system export requires an explicit owner_principal")
+    if not scope.get("isolation_domain_refs"):
+        raise ValueError("cross-system export requires explicit source isolation domains")
+
+    evidence = []
+    for key in ("decision_receipt_ref", "ledger_ref"):
+        value = crossing_receipt.get(key)
+        if value:
+            evidence.append(value)
+    evidence.append(crossing_receipt["receipt_id"])
+
+    return ExportBundle(
+        sender_system=sender_system,
+        receiver_system=receiver_system,
+        memory=deepcopy(memory),
+        crossing_receipt=deepcopy(crossing_receipt),
+        sender_authority_evidence=tuple(evidence),
+    )
+
+
+def import_bundle(
+    bundle: ExportBundle,
+    *,
+    receiver_domain_ref: str,
+    receiver_proposal: policy.Proposal,
+    expected_owner_principal: str | None = None,
+) -> ImportResult:
+    """Evaluate one import under receiver-local authority.
+
+    The sender's crossing receipt is evidence that the sender authorized an
+    export. It is never reused as the receiver's allow decision.
+    """
+    source = deepcopy(bundle.memory)
+    receipts.validate("memory-unit.schema.json", source)
+
+    source_scope = source.get("scope") or {}
+    owner = source_scope.get("owner_principal")
+    if expected_owner_principal is not None and owner != expected_owner_principal:
+        decision = policy.Decision(
+            outcome=policy.BLOCK,
+            permitted_actions=(),
+            prohibited_actions=("scope_expansion",),
+            reasons=("cross-system ownership conflict",),
+        )
+        return ImportResult(decision, False, None, "ownership_conflict")
+
+    if receiver_proposal.target_reference != source["id"]:
+        raise ValueError("receiver proposal must bind the imported memory id")
+    if receiver_proposal.operation != "scope_expansion":
+        decision = policy.Decision(
+            outcome=policy.BLOCK,
+            permitted_actions=(),
+            prohibited_actions=(receiver_proposal.operation, "scope_expansion"),
+            reasons=("cross-system import must be evaluated as scope_expansion",),
+        )
+        return ImportResult(decision, False, None, "receiver_reauthorization_required")
+
+    decision = policy.evaluate(receiver_proposal)
+    if decision.outcome not in (policy.ALLOW, policy.ALLOW_WITH_LEDGER):
+        return ImportResult(decision, False, None, f"receiver_{decision.outcome}")
+
+    source_domains = tuple(source_scope.get("isolation_domain_refs", ()))
+    inherited_sources = tuple(source_scope.get("source_isolation_domain_refs", ()))
+    all_sources = list(dict.fromkeys((*source_domains, *inherited_sources)))
+
+    imported = deepcopy(source)
+    imported["acquisition_mode"] = "imported"
+    imported_scope = deepcopy(source_scope)
+    imported_scope["primary_isolation_domain_ref"] = receiver_domain_ref
+    imported_scope["isolation_domain_refs"] = [receiver_domain_ref]
+    imported_scope["source_isolation_domain_refs"] = all_sources
+    imported["scope"] = imported_scope
+    imported["authority"] = {
+        "pama_outcome": decision.outcome,
+        "risk_class": receiver_proposal.risk_class,
+        "policy_version": decision.policy_version,
+        "authority_refs": list(receiver_proposal.approval_refs),
+        "permitted_actions": list(decision.permitted_actions),
+        "prohibited_actions": list(decision.prohibited_actions),
+        "selection_mode": "deterministic",
+    }
+
+    receipts.validate("memory-unit.schema.json", imported)
+    return ImportResult(decision, True, imported)

--- a/reference/tests/test_interchange.py
+++ b/reference/tests/test_interchange.py
@@ -1,0 +1,203 @@
+"""Executable P7 governed memory interchange evidence."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+from agentmem_ref.crossing import CrossingRequest, evaluate_crossing  # noqa: E402
+from agentmem_ref.interchange import build_export_bundle, import_bundle  # noqa: E402
+
+
+def memory_unit() -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "id": "mem:portable-decision",
+        "type": "decision",
+        "state": "crystallized",
+        "scope": {
+            "owner_principal": "user:alice",
+            "tenant": "tenant-a",
+            "project": "project-a",
+            "purpose": "security-review",
+            "isolation_domain_refs": ["domain:project-a"],
+            "primary_isolation_domain_ref": "domain:project-a",
+        },
+        "sensitivity": {"labels": ["internal"]},
+        "provenance": {
+            "origin": "system-a",
+            "observer": "agent:planner",
+            "method": "governed decision",
+            "timestamp": "2026-08-11T20:00:00Z",
+            "source_refs": ["evidence:decision-source"],
+        },
+        "evidence": [
+            {
+                "id": "evidence:decision-source",
+                "kind": "decision_record",
+                "ref": "local://decision/42",
+                "confidence": 1.0,
+            }
+        ],
+        "saturation": {
+            "sigma": 0.95,
+            "calibrated": True,
+            "durability_dimensions": ["certified_decision"],
+        },
+        "authority": {
+            "pama_outcome": "allow_with_ledger",
+            "risk_class": "medium",
+            "policy_version": "sender-policy-7",
+            "authority_refs": ["authority:sender"],
+            "permitted_actions": ["retain"],
+            "prohibited_actions": [],
+            "selection_mode": "deterministic",
+        },
+        "created_at": "2026-08-11T20:00:00Z",
+    }
+
+
+def crossing(*, reviewed: bool) -> dict:
+    request = CrossingRequest(
+        operation="export",
+        source_domain_refs=("domain:project-a",),
+        destination_domain_refs=("domain:system-b-import",),
+        actor="agent:planner",
+        principal="user:alice",
+        purpose="security-review",
+        representation_kind="canonical_memory",
+        source_refs=("mem:portable-decision",),
+        authority_refs=("authority:sender",),
+        policy_refs=("policy:sender-export",),
+        provenance_refs=("evidence:decision-source",),
+        before_scope_refs=("domain:project-a",),
+        after_scope_refs=("domain:system-b-import",),
+    )
+    proposal = policy.Proposal(
+        proposal_id="sender-export",
+        actor_id="agent:planner",
+        charter_version="charter-a",
+        target_reference="mem:portable-decision",
+        target_class=policy.M4,
+        scope="tenant-a",
+        operation="scope_expansion",
+        current_strength="crystallized",
+        proposed_strength="crystallized",
+        downstream_authority=policy.A2,
+        reversibility="reversible",
+        risk_class="medium",
+        evidence_refs=("evidence:decision-source",),
+        review_satisfied=reviewed,
+        approval_refs=("approval:sender-security-owner",) if reviewed else (),
+    )
+    return evaluate_crossing(
+        request,
+        proposal,
+        receipt_id="crossing:sender-export",
+        timestamp="2026-08-11T20:01:00Z",
+        decision_receipt_ref="decision:sender-export",
+        ledger_ref="ledger:sender-export",
+    ).receipt
+
+
+def receiver_proposal(*, reviewed: bool = True, owner_conflict: bool = False) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id="receiver-import",
+        actor_id="agent:receiver",
+        charter_version="charter-b",
+        target_reference="mem:portable-decision",
+        target_class=policy.M4,
+        scope="tenant-b",
+        operation="scope_expansion",
+        current_strength="crystallized",
+        proposed_strength="crystallized",
+        downstream_authority=policy.A2,
+        reversibility="reversible",
+        risk_class="medium",
+        evidence_refs=("crossing:sender-export",),
+        review_satisfied=reviewed,
+        approval_refs=("approval:receiver-security-owner",) if reviewed else (),
+        actor_authority_resolved=not owner_conflict,
+    )
+
+
+class InterchangeTests(unittest.TestCase):
+    def test_export_requires_committed_sender_crossing(self):
+        with self.assertRaises(ValueError):
+            build_export_bundle(
+                memory_unit(),
+                sender_system="system-a",
+                receiver_system="system-b",
+                crossing_receipt=crossing(reviewed=False),
+            )
+
+    def test_receiver_does_not_inherit_sender_allow(self):
+        bundle = build_export_bundle(
+            memory_unit(),
+            sender_system="system-a",
+            receiver_system="system-b",
+            crossing_receipt=crossing(reviewed=True),
+        )
+        result = import_bundle(
+            bundle,
+            receiver_domain_ref="domain:system-b-import",
+            receiver_proposal=receiver_proposal(reviewed=False),
+            expected_owner_principal="user:alice",
+        )
+        self.assertFalse(result.admitted)
+        self.assertEqual(result.decision.outcome, policy.REQUIRE_REVIEW)
+        self.assertIsNone(result.memory)
+
+    def test_ownership_conflict_fails_closed(self):
+        bundle = build_export_bundle(
+            memory_unit(),
+            sender_system="system-a",
+            receiver_system="system-b",
+            crossing_receipt=crossing(reviewed=True),
+        )
+        result = import_bundle(
+            bundle,
+            receiver_domain_ref="domain:system-b-import",
+            receiver_proposal=receiver_proposal(),
+            expected_owner_principal="user:bob",
+        )
+        self.assertFalse(result.admitted)
+        self.assertEqual(result.decision.outcome, policy.BLOCK)
+        self.assertEqual(result.refusal, "ownership_conflict")
+
+    def test_successful_import_preserves_semantics_and_rebinds_local_scope(self):
+        original = memory_unit()
+        bundle = build_export_bundle(
+            original,
+            sender_system="system-a",
+            receiver_system="system-b",
+            crossing_receipt=crossing(reviewed=True),
+        )
+        result = import_bundle(
+            bundle,
+            receiver_domain_ref="domain:system-b-import",
+            receiver_proposal=receiver_proposal(),
+            expected_owner_principal="user:alice",
+        )
+
+        self.assertTrue(result.admitted)
+        imported = result.memory
+        assert imported is not None
+        self.assertEqual(imported["id"], original["id"])
+        self.assertEqual(imported["state"], original["state"])
+        self.assertEqual(imported["provenance"], original["provenance"])
+        self.assertEqual(imported["sensitivity"], original["sensitivity"])
+        self.assertEqual(imported["scope"]["owner_principal"], "user:alice")
+        self.assertEqual(imported["scope"]["isolation_domain_refs"], ["domain:system-b-import"])
+        self.assertEqual(imported["scope"]["source_isolation_domain_refs"], ["domain:project-a"])
+        self.assertEqual(imported["authority"]["authority_refs"], ["approval:receiver-security-owner"])
+        self.assertNotIn("authority:sender", imported["authority"]["authority_refs"])
+        self.assertEqual(bundle.sender_authority_evidence[-1], "crossing:sender-export")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the first executable P7 interchange slice under #46, entirely within this repository.

Scope:
- adds a local reference interchange seam requiring a committed sender-side governed crossing
- preserves memory identity, provenance, lifecycle, sensitivity, owner, and source-domain scope across export/import
- treats sender authority as evidence only, never receiver permission
- requires receiver-local PAMA re-authorization before import admission
- fails closed on ownership conflict
- binds successful imports to the receiving isolation domain while preserving source-domain provenance
- adds the previously missing `cross-system-authority-conflict` fixture
- records the P7 evidence boundary and next slice in runtime-evidence docs

Explicit boundary: no upstream PRs, issues, comments, patches, or submissions to external repositories. No external project is asked to adopt this contract. This does not claim universal transport interoperability or full Profile 6 conformance.

Merge only after exact-head full validation and CodeQL succeed.