### PR TITLE
Runtime: govern P7 correction and deletion continuity

### DIFF
--- a/docs/programs/runtime-evidence/governed-interchange.md
+++ b/docs/programs/runtime-evidence/governed-interchange.md
@@ -4,13 +4,14 @@
 
 Exercise the Agent Memory Profile 6 seam without defining a transport standard or making any upstream submission.
 
-The question is deliberately narrow:
+The local evidence now asks two questions:
 
-> Can one governed system export memory to another without losing ownership, provenance, lifecycle, sensitivity, scope provenance, or the requirement for receiver-local authorization?
+1. can one governed system export memory to another without losing ownership, provenance, lifecycle, sensitivity, scope provenance, or receiver-local authorization;
+2. can later source correction, supersession, revocation, or deletion obligations remain visible without turning the sender into a remote mutation authority over the receiver?
 
-This slice is local reference evidence only. External projects are not modified, asked to adopt the contract, or treated as implementation dependencies.
+External projects are not modified, asked to adopt the contract, or treated as implementation dependencies.
 
-## Executed contract
+## V1: governed export and import
 
 The reference path under `reference/agentmem_ref/interchange.py` enforces:
 
@@ -18,7 +19,7 @@ The reference path under `reference/agentmem_ref/interchange.py` enforces:
 2. the crossing receipt must bind the exported memory id;
 3. cross-system export requires explicit ownership and source isolation-domain bindings;
 4. sender-side authorization travels with the bundle as evidence, not as receiver permission;
-5. the receiver must evaluate a local `scope_expansion` proposal through its own PAMA path;
+5. the receiver evaluates a local `scope_expansion` proposal through its own PAMA path;
 6. an ownership conflict fails closed before admission;
 7. successful import preserves stable identity, lifecycle state, provenance, sensitivity, and owner;
 8. successful import binds the receiving isolation domain while retaining source-domain provenance;
@@ -26,19 +27,42 @@ The reference path under `reference/agentmem_ref/interchange.py` enforces:
 
 The companion fixture `fixtures/cross-system-authority-conflict.json` makes the missing authority-conflict case from `docs/35-interoperability-profiles.md` permanent in the conformance corpus.
 
+## V2: lifecycle-obligation continuity
+
+A successful import now also emits a local `InterchangeLink` binding the imported memory to:
+
+- source system;
+- receiver system;
+- source crossing receipt;
+- source isolation domains;
+- receiver isolation domain.
+
+A later `SourceLifecycleNotice` may report correction, supersession, revocation, or deletion. The notice is **evidence of a source-side lifecycle change**, not permission to mutate receiver state.
+
+The receiver therefore:
+
+1. verifies memory identity and the linked source system;
+2. requires source evidence references;
+3. maps deletion to a local `permanent_deletion` consequence and other lifecycle changes to local `correction`;
+4. evaluates that consequence under the receiver's current PAMA policy and authority;
+5. leaves local memory untouched while review or verification is still required;
+6. only after receiver-local authorization schedules a local correction or deletion workflow.
+
+Even an authorized notice handler does not directly purge or rewrite the local memory object in this slice. It schedules the local consequence so the existing correction/deletion machinery remains authoritative for actual mutation and forgetting completeness.
+
 ## Evidence boundary
 
-This demonstrates a local executable interoperability contract. It does **not** claim:
+This demonstrates local executable interoperability behavior. It does **not** claim:
 
 - a universal interchange wire format;
 - Profile 6 conformance for the entire reference adapter;
 - automatic trust of imported memory;
-- transfer of ownership, certification, or mutation authority;
-- deletion propagation to an actual remote deployment;
+- transfer of ownership, certification, mutation, correction, or deletion authority;
+- proof that remote deletion automatically satisfies local forgetting completeness;
 - production transport security;
 - upstream acceptance by Agent Manifest, TRACE/cMCP, Mem0, Graphiti, AgenTrust, or any other project.
 
-The sender's `allow` means only that the sender authorized its own export. The receiver still owns its admission and consequence decision.
+The sender's `allow` authorizes the sender's own export. A later sender notice makes an obligation visible. The receiver still owns every local admission and consequence decision.
 
 ## Validation
 
@@ -47,10 +71,14 @@ The sender's `allow` means only that the sender authorized its own export. The r
 - refusal to export without a committed sender crossing;
 - refusal to inherit sender authority at the receiver;
 - fail-closed ownership conflict;
-- successful locally authorized import with semantic preservation and receiving-domain rebinding.
+- successful locally authorized import with semantic preservation and receiving-domain rebinding;
+- deletion notice held pending local governance;
+- locally authorized deletion notice scheduling a local deletion workflow without silently deleting state;
+- correction notice requiring receiver-local correction authority;
+- rejection of lifecycle notices from an unlinked source system.
 
 Repository CI runs these tests through the existing reference governed-adapter validation path together with fixture/schema/doctrine validation.
 
-## Next P7 slice
+## Remaining P7 work
 
-The next meaningful P7 work is deletion/correction continuity across the exchange boundary: prove that an exported copy retains enough source identity and lifecycle linkage for a later correction, supersession, revocation, or deletion obligation to be recognized and governed by the receiver without granting the sender unilateral mutation authority over the receiver's store.
+The strongest remaining Profile 6 gap is end-to-end **actual correction/deletion propagation evidence** across two concrete local stores, including receipt linkage and deletion-residue accounting on the receiving side. That work must reuse the existing canonical correction and deletion-completeness machinery rather than creating a special interoperability shortcut.

--- a/reference/agentmem_ref/interchange.py
+++ b/reference/agentmem_ref/interchange.py
@@ -4,13 +4,15 @@ This module does not define a transport standard and does not import another
 project's authority semantics. It exercises Agent Memory's own Profile 6 seam:
 
 - sender export requires a committed governed boundary crossing;
-- the memory's identity, provenance, lifecycle, sensitivity, ownership, and
-  source-domain scope survive export;
+- memory identity, provenance, lifecycle, sensitivity, ownership, and source
+  domain scope survive export;
 - sender authority travels as evidence, never as receiver permission;
-- the receiver evaluates its own PAMA authority before admitting the import;
+- the receiver evaluates its own PAMA authority before admitting an import;
 - ownership conflicts fail closed;
 - successful imports bind a receiving isolation domain while retaining source
-  domain provenance.
+  domain provenance;
+- later source correction/deletion notices remain evidence until receiver-local
+  governance authorizes a local consequence.
 """
 
 from __future__ import annotations
@@ -19,6 +21,12 @@ from copy import deepcopy
 from dataclasses import dataclass
 
 from . import policy, receipts
+
+NOTICE_CORRECTION = "correction"
+NOTICE_SUPERSESSION = "supersession"
+NOTICE_REVOCATION = "revocation"
+NOTICE_DELETION = "deletion"
+NOTICE_KINDS = frozenset({NOTICE_CORRECTION, NOTICE_SUPERSESSION, NOTICE_REVOCATION, NOTICE_DELETION})
 
 
 @dataclass(frozen=True)
@@ -31,10 +39,40 @@ class ExportBundle:
 
 
 @dataclass(frozen=True)
+class InterchangeLink:
+    memory_id: str
+    source_system: str
+    receiver_system: str
+    source_crossing_receipt_ref: str
+    source_domain_refs: tuple[str, ...]
+    receiver_domain_ref: str
+
+
+@dataclass(frozen=True)
 class ImportResult:
     decision: policy.Decision
     admitted: bool
     memory: dict | None
+    refusal: str | None = None
+    link: InterchangeLink | None = None
+
+
+@dataclass(frozen=True)
+class SourceLifecycleNotice:
+    notice_id: str
+    source_system: str
+    memory_id: str
+    kind: str
+    evidence_refs: tuple[str, ...]
+    source_state: str = ""
+    source_receipt_ref: str = ""
+
+
+@dataclass(frozen=True)
+class NoticeResult:
+    decision: policy.Decision
+    recognized: bool
+    local_action: str
     refusal: str | None = None
 
 
@@ -139,4 +177,65 @@ def import_bundle(
     }
 
     receipts.validate("memory-unit.schema.json", imported)
-    return ImportResult(decision, True, imported)
+    link = InterchangeLink(
+        memory_id=source["id"],
+        source_system=bundle.sender_system,
+        receiver_system=bundle.receiver_system,
+        source_crossing_receipt_ref=bundle.crossing_receipt["receipt_id"],
+        source_domain_refs=tuple(all_sources),
+        receiver_domain_ref=receiver_domain_ref,
+    )
+    return ImportResult(decision, True, imported, link=link)
+
+
+def evaluate_source_notice(
+    imported_memory: dict,
+    link: InterchangeLink,
+    notice: SourceLifecycleNotice,
+    *,
+    receiver_proposal: policy.Proposal,
+) -> NoticeResult:
+    """Recognize a source lifecycle change without importing remote authority.
+
+    A notice may make a local correction/deletion obligation visible. It never
+    directly changes or deletes receiver state. The receiver evaluates the
+    corresponding local consequence under its own current policy and authority.
+    """
+    receipts.validate("memory-unit.schema.json", imported_memory)
+    if notice.kind not in NOTICE_KINDS:
+        raise ValueError(f"unsupported lifecycle notice: {notice.kind}")
+    if not notice.evidence_refs:
+        raise ValueError("source lifecycle notice requires evidence refs")
+    if imported_memory["id"] != link.memory_id or notice.memory_id != link.memory_id:
+        return NoticeResult(
+            policy.Decision(policy.BLOCK, (), ("correction", "permanent_deletion"), ("notice memory identity mismatch",)),
+            False,
+            "none",
+            "identity_mismatch",
+        )
+    if notice.source_system != link.source_system:
+        return NoticeResult(
+            policy.Decision(policy.BLOCK, (), ("correction", "permanent_deletion"), ("notice source system mismatch",)),
+            False,
+            "none",
+            "source_system_mismatch",
+        )
+
+    expected_operation = "permanent_deletion" if notice.kind == NOTICE_DELETION else "correction"
+    if receiver_proposal.target_reference != link.memory_id:
+        raise ValueError("receiver notice proposal must bind the imported memory id")
+    if receiver_proposal.operation != expected_operation:
+        decision = policy.Decision(
+            outcome=policy.BLOCK,
+            permitted_actions=(),
+            prohibited_actions=(receiver_proposal.operation, expected_operation),
+            reasons=("source lifecycle notice mapped to wrong local consequence",),
+        )
+        return NoticeResult(decision, True, "none", "wrong_local_consequence")
+
+    decision = policy.evaluate(receiver_proposal)
+    if decision.outcome not in (policy.ALLOW, policy.ALLOW_WITH_LEDGER):
+        return NoticeResult(decision, True, "pending_local_governance", f"receiver_{decision.outcome}")
+
+    action = "schedule_local_deletion" if notice.kind == NOTICE_DELETION else "schedule_local_correction"
+    return NoticeResult(decision, True, action)

--- a/reference/tests/test_interchange.py
+++ b/reference/tests/test_interchange.py
@@ -10,7 +10,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from agentmem_ref import policy  # noqa: E402
 from agentmem_ref.crossing import CrossingRequest, evaluate_crossing  # noqa: E402
-from agentmem_ref.interchange import build_export_bundle, import_bundle  # noqa: E402
+from agentmem_ref.interchange import (  # noqa: E402
+    NOTICE_CORRECTION,
+    NOTICE_DELETION,
+    SourceLifecycleNotice,
+    build_export_bundle,
+    evaluate_source_notice,
+    import_bundle,
+)
 
 
 def memory_unit() -> dict:
@@ -35,19 +42,8 @@ def memory_unit() -> dict:
             "timestamp": "2026-08-11T20:00:00Z",
             "source_refs": ["evidence:decision-source"],
         },
-        "evidence": [
-            {
-                "id": "evidence:decision-source",
-                "kind": "decision_record",
-                "ref": "local://decision/42",
-                "confidence": 1.0,
-            }
-        ],
-        "saturation": {
-            "sigma": 0.95,
-            "calibrated": True,
-            "durability_dimensions": ["certified_decision"],
-        },
+        "evidence": [{"id": "evidence:decision-source", "kind": "decision_record", "ref": "local://decision/42", "confidence": 1.0}],
+        "saturation": {"sigma": 0.95, "calibrated": True, "durability_dimensions": ["certified_decision"]},
         "authority": {
             "pama_outcome": "allow_with_ledger",
             "risk_class": "medium",
@@ -78,115 +74,69 @@ def crossing(*, reviewed: bool) -> dict:
         after_scope_refs=("domain:system-b-import",),
     )
     proposal = policy.Proposal(
-        proposal_id="sender-export",
-        actor_id="agent:planner",
-        charter_version="charter-a",
-        target_reference="mem:portable-decision",
-        target_class=policy.M4,
-        scope="tenant-a",
-        operation="scope_expansion",
-        current_strength="crystallized",
-        proposed_strength="crystallized",
-        downstream_authority=policy.A2,
-        reversibility="reversible",
-        risk_class="medium",
-        evidence_refs=("evidence:decision-source",),
-        review_satisfied=reviewed,
+        proposal_id="sender-export", actor_id="agent:planner", charter_version="charter-a",
+        target_reference="mem:portable-decision", target_class=policy.M4, scope="tenant-a",
+        operation="scope_expansion", current_strength="crystallized", proposed_strength="crystallized",
+        downstream_authority=policy.A2, reversibility="reversible", risk_class="medium",
+        evidence_refs=("evidence:decision-source",), review_satisfied=reviewed,
         approval_refs=("approval:sender-security-owner",) if reviewed else (),
     )
     return evaluate_crossing(
-        request,
-        proposal,
-        receipt_id="crossing:sender-export",
-        timestamp="2026-08-11T20:01:00Z",
-        decision_receipt_ref="decision:sender-export",
-        ledger_ref="ledger:sender-export",
+        request, proposal, receipt_id="crossing:sender-export", timestamp="2026-08-11T20:01:00Z",
+        decision_receipt_ref="decision:sender-export", ledger_ref="ledger:sender-export",
     ).receipt
 
 
-def receiver_proposal(*, reviewed: bool = True, owner_conflict: bool = False) -> policy.Proposal:
+def receiver_proposal(*, reviewed: bool = True) -> policy.Proposal:
     return policy.Proposal(
-        proposal_id="receiver-import",
-        actor_id="agent:receiver",
-        charter_version="charter-b",
-        target_reference="mem:portable-decision",
-        target_class=policy.M4,
-        scope="tenant-b",
-        operation="scope_expansion",
-        current_strength="crystallized",
-        proposed_strength="crystallized",
-        downstream_authority=policy.A2,
-        reversibility="reversible",
-        risk_class="medium",
-        evidence_refs=("crossing:sender-export",),
-        review_satisfied=reviewed,
+        proposal_id="receiver-import", actor_id="agent:receiver", charter_version="charter-b",
+        target_reference="mem:portable-decision", target_class=policy.M4, scope="tenant-b",
+        operation="scope_expansion", current_strength="crystallized", proposed_strength="crystallized",
+        downstream_authority=policy.A2, reversibility="reversible", risk_class="medium",
+        evidence_refs=("crossing:sender-export",), review_satisfied=reviewed,
         approval_refs=("approval:receiver-security-owner",) if reviewed else (),
-        actor_authority_resolved=not owner_conflict,
+    )
+
+
+def notice_proposal(operation: str, *, reviewed: bool) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=f"receiver-{operation}", actor_id="agent:receiver", charter_version="charter-b",
+        target_reference="mem:portable-decision", target_class=policy.M4, scope="tenant-b",
+        operation=operation, current_strength="crystallized", proposed_strength="corrected",
+        downstream_authority=policy.A2, reversibility="reversible", risk_class="medium",
+        evidence_refs=("notice:source-change",), review_satisfied=reviewed,
+        approval_refs=("approval:receiver-security-owner",) if reviewed else (),
     )
 
 
 class InterchangeTests(unittest.TestCase):
+    def imported(self):
+        bundle = build_export_bundle(memory_unit(), sender_system="system-a", receiver_system="system-b", crossing_receipt=crossing(reviewed=True))
+        result = import_bundle(bundle, receiver_domain_ref="domain:system-b-import", receiver_proposal=receiver_proposal(), expected_owner_principal="user:alice")
+        self.assertTrue(result.admitted)
+        self.assertIsNotNone(result.memory)
+        self.assertIsNotNone(result.link)
+        return result.memory, result.link
+
     def test_export_requires_committed_sender_crossing(self):
         with self.assertRaises(ValueError):
-            build_export_bundle(
-                memory_unit(),
-                sender_system="system-a",
-                receiver_system="system-b",
-                crossing_receipt=crossing(reviewed=False),
-            )
+            build_export_bundle(memory_unit(), sender_system="system-a", receiver_system="system-b", crossing_receipt=crossing(reviewed=False))
 
     def test_receiver_does_not_inherit_sender_allow(self):
-        bundle = build_export_bundle(
-            memory_unit(),
-            sender_system="system-a",
-            receiver_system="system-b",
-            crossing_receipt=crossing(reviewed=True),
-        )
-        result = import_bundle(
-            bundle,
-            receiver_domain_ref="domain:system-b-import",
-            receiver_proposal=receiver_proposal(reviewed=False),
-            expected_owner_principal="user:alice",
-        )
+        bundle = build_export_bundle(memory_unit(), sender_system="system-a", receiver_system="system-b", crossing_receipt=crossing(reviewed=True))
+        result = import_bundle(bundle, receiver_domain_ref="domain:system-b-import", receiver_proposal=receiver_proposal(reviewed=False), expected_owner_principal="user:alice")
         self.assertFalse(result.admitted)
         self.assertEqual(result.decision.outcome, policy.REQUIRE_REVIEW)
-        self.assertIsNone(result.memory)
 
     def test_ownership_conflict_fails_closed(self):
-        bundle = build_export_bundle(
-            memory_unit(),
-            sender_system="system-a",
-            receiver_system="system-b",
-            crossing_receipt=crossing(reviewed=True),
-        )
-        result = import_bundle(
-            bundle,
-            receiver_domain_ref="domain:system-b-import",
-            receiver_proposal=receiver_proposal(),
-            expected_owner_principal="user:bob",
-        )
+        bundle = build_export_bundle(memory_unit(), sender_system="system-a", receiver_system="system-b", crossing_receipt=crossing(reviewed=True))
+        result = import_bundle(bundle, receiver_domain_ref="domain:system-b-import", receiver_proposal=receiver_proposal(), expected_owner_principal="user:bob")
         self.assertFalse(result.admitted)
-        self.assertEqual(result.decision.outcome, policy.BLOCK)
         self.assertEqual(result.refusal, "ownership_conflict")
 
     def test_successful_import_preserves_semantics_and_rebinds_local_scope(self):
         original = memory_unit()
-        bundle = build_export_bundle(
-            original,
-            sender_system="system-a",
-            receiver_system="system-b",
-            crossing_receipt=crossing(reviewed=True),
-        )
-        result = import_bundle(
-            bundle,
-            receiver_domain_ref="domain:system-b-import",
-            receiver_proposal=receiver_proposal(),
-            expected_owner_principal="user:alice",
-        )
-
-        self.assertTrue(result.admitted)
-        imported = result.memory
-        assert imported is not None
+        imported, link = self.imported()
         self.assertEqual(imported["id"], original["id"])
         self.assertEqual(imported["state"], original["state"])
         self.assertEqual(imported["provenance"], original["provenance"])
@@ -194,9 +144,51 @@ class InterchangeTests(unittest.TestCase):
         self.assertEqual(imported["scope"]["owner_principal"], "user:alice")
         self.assertEqual(imported["scope"]["isolation_domain_refs"], ["domain:system-b-import"])
         self.assertEqual(imported["scope"]["source_isolation_domain_refs"], ["domain:project-a"])
-        self.assertEqual(imported["authority"]["authority_refs"], ["approval:receiver-security-owner"])
-        self.assertNotIn("authority:sender", imported["authority"]["authority_refs"])
-        self.assertEqual(bundle.sender_authority_evidence[-1], "crossing:sender-export")
+        self.assertEqual(link.source_system, "system-a")
+
+    def test_source_deletion_notice_does_not_delete_without_local_authority(self):
+        imported, link = self.imported()
+        before = dict(imported)
+        result = evaluate_source_notice(
+            imported, link,
+            SourceLifecycleNotice("notice:delete", "system-a", imported["id"], NOTICE_DELETION, ("receipt:source-delete",), source_state="tombstoned"),
+            receiver_proposal=notice_proposal("permanent_deletion", reviewed=False),
+        )
+        self.assertTrue(result.recognized)
+        self.assertFalse(result.local_action == "schedule_local_deletion")
+        self.assertEqual(result.local_action, "pending_local_governance")
+        self.assertEqual(imported, before)
+
+    def test_locally_authorized_deletion_notice_schedules_local_deletion_only(self):
+        imported, link = self.imported()
+        result = evaluate_source_notice(
+            imported, link,
+            SourceLifecycleNotice("notice:delete", "system-a", imported["id"], NOTICE_DELETION, ("receipt:source-delete",)),
+            receiver_proposal=notice_proposal("permanent_deletion", reviewed=True),
+        )
+        self.assertEqual(result.decision.outcome, policy.ALLOW_WITH_LEDGER)
+        self.assertEqual(result.local_action, "schedule_local_deletion")
+        self.assertEqual(imported["state"], "crystallized")
+
+    def test_correction_notice_requires_receiver_local_correction_authority(self):
+        imported, link = self.imported()
+        result = evaluate_source_notice(
+            imported, link,
+            SourceLifecycleNotice("notice:correction", "system-a", imported["id"], NOTICE_CORRECTION, ("receipt:source-correction",), source_state="corrected"),
+            receiver_proposal=notice_proposal("correction", reviewed=False),
+        )
+        self.assertEqual(result.local_action, "pending_local_governance")
+        self.assertEqual(result.decision.outcome, policy.REQUIRE_REVIEW)
+
+    def test_notice_from_unlinked_system_is_rejected(self):
+        imported, link = self.imported()
+        result = evaluate_source_notice(
+            imported, link,
+            SourceLifecycleNotice("notice:spoof", "system-c", imported["id"], NOTICE_DELETION, ("receipt:fake",)),
+            receiver_proposal=notice_proposal("permanent_deletion", reviewed=True),
+        )
+        self.assertFalse(result.recognized)
+        self.assertEqual(result.refusal, "source_system_mismatch")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extends local P7 interchange evidence under #46.

This slice keeps source lifecycle changes visible without importing remote authority:
- successful imports retain an explicit local interchange link to source system, crossing receipt, source domains, and receiver domain
- correction/supersession/revocation/deletion notices require source identity and evidence
- deletion notices map to receiver-local `permanent_deletion`; other lifecycle notices map to receiver-local `correction`
- every consequence is re-evaluated under current receiver PAMA authority
- unreviewed notices leave local memory untouched and pending local governance
- even authorized notices schedule the existing local correction/deletion workflow rather than directly rewriting or purging state
- notices from an unlinked source system fail closed

No upstream submissions or external-repository writes. No universal transport claim. No full Profile 6 conformance claim.

Merge only after exact-head full validation and CodeQL succeed.