### PR TITLE
Runtime: prove P7 propagation across two governed stores

### DIFF
--- a/docs/programs/runtime-evidence/governed-interchange.md
+++ b/docs/programs/runtime-evidence/governed-interchange.md
@@ -4,10 +4,11 @@
 
 Exercise the Agent Memory Profile 6 seam without defining a transport standard or making any upstream submission.
 
-The local evidence now asks two questions:
+The local evidence asks three progressively stronger questions:
 
 1. can one governed system export memory to another without losing ownership, provenance, lifecycle, sensitivity, scope provenance, or receiver-local authorization;
-2. can later source correction, supersession, revocation, or deletion obligations remain visible without turning the sender into a remote mutation authority over the receiver?
+2. can later source correction, supersession, revocation, or deletion obligations remain visible without turning the sender into a remote mutation authority over the receiver;
+3. can the receiver actually execute those locally authorized consequences against its own store and prove deletion completeness with the existing P4 residue machinery?
 
 External projects are not modified, asked to adopt the contract, or treated as implementation dependencies.
 
@@ -15,7 +16,7 @@ External projects are not modified, asked to adopt the contract, or treated as i
 
 The reference path under `reference/agentmem_ref/interchange.py` enforces:
 
-1. sender export requires a schema-valid memory and a **committed governed boundary-crossing receipt**;
+1. sender export requires a schema-valid memory and a committed governed boundary-crossing receipt;
 2. the crossing receipt must bind the exported memory id;
 3. cross-system export requires explicit ownership and source isolation-domain bindings;
 4. sender-side authorization travels with the bundle as evidence, not as receiver permission;
@@ -23,62 +24,53 @@ The reference path under `reference/agentmem_ref/interchange.py` enforces:
 6. an ownership conflict fails closed before admission;
 7. successful import preserves stable identity, lifecycle state, provenance, sensitivity, and owner;
 8. successful import binds the receiving isolation domain while retaining source-domain provenance;
-9. the imported memory records the **receiver's** authority envelope, not the sender's authority refs.
+9. the imported memory records the receiver's authority envelope, not the sender's authority refs.
 
-The companion fixture `fixtures/cross-system-authority-conflict.json` makes the missing authority-conflict case from `docs/35-interoperability-profiles.md` permanent in the conformance corpus.
+The companion fixture `fixtures/cross-system-authority-conflict.json` makes the authority-conflict case from `docs/35-interoperability-profiles.md` permanent in the conformance corpus.
 
 ## V2: lifecycle-obligation continuity
 
-A successful import now also emits a local `InterchangeLink` binding the imported memory to:
+A successful import emits a local `InterchangeLink` binding the imported memory to source system, receiver system, source crossing receipt, source isolation domains, and receiver isolation domain.
 
-- source system;
-- receiver system;
-- source crossing receipt;
-- source isolation domains;
-- receiver isolation domain.
+A later `SourceLifecycleNotice` may report correction, supersession, revocation, or deletion. The notice is evidence of a source-side lifecycle change, not permission to mutate receiver state. The receiver verifies identity/source linkage, maps the notice to a local consequence, and evaluates that consequence under current receiver PAMA policy and authority. Unresolved review leaves local state untouched.
 
-A later `SourceLifecycleNotice` may report correction, supersession, revocation, or deletion. The notice is **evidence of a source-side lifecycle change**, not permission to mutate receiver state.
+## V3: two-store correction and deletion propagation
 
-The receiver therefore:
+`reference/agentmem_ref/interchange_propagation.py` composes the notice contract with two existing first-party mechanisms rather than creating an interoperability shortcut:
 
-1. verifies memory identity and the linked source system;
-2. requires source evidence references;
-3. maps deletion to a local `permanent_deletion` consequence and other lifecycle changes to local `correction`;
-4. evaluates that consequence under the receiver's current PAMA policy and authority;
-5. leaves local memory untouched while review or verification is still required;
-6. only after receiver-local authorization schedules a local correction or deletion workflow.
+- receiver correction uses `GovernedMemoryAdapter.commit_proposal(operation="correction")`, emits the normal decision receipt, writes replacement state in the receiver's own store, and then marks the prior receiver fact superseded rather than erasing history;
+- receiver deletion uses `GovernedMemoryAdapter.governed_delete(operation="permanent_deletion")`, then runs the existing P4 projection purge plan, independent residue sweep, four-way residue partition, and `DeletionCompletenessMeasurement`.
 
-Even an authorized notice handler does not directly purge or rewrite the local memory object in this slice. It schedules the local consequence so the existing correction/deletion machinery remains authoritative for actual mutation and forgetting completeness.
+The executable test uses two separate `InMemoryTemporalGraph` stores and two separate governed adapters. A sender-side correction/deletion receipt becomes notice evidence. The receiver still makes and receipts its own local decision.
+
+The deletion path has both a clean case and an adversarial late-projection case. In the adversarial case, a receiver-side content-bearing projection appears after purge traversal. The independent sweep must classify it as `undeclared_residual`; therefore:
+
+```text
+valid receiver deletion receipt
+        !=
+receiver forgetting completeness
+```
+
+until the independent sweep reports zero residual state.
 
 ## Evidence boundary
 
-This demonstrates local executable interoperability behavior. It does **not** claim:
+This demonstrates local executable interoperability behavior. It does not claim a universal interchange wire format, Profile 6 conformance for the entire reference adapter, automatic trust of imported memory, transfer of ownership/certification/mutation authority, production transport security, or adoption by any external project.
 
-- a universal interchange wire format;
-- Profile 6 conformance for the entire reference adapter;
-- automatic trust of imported memory;
-- transfer of ownership, certification, mutation, correction, or deletion authority;
-- proof that remote deletion automatically satisfies local forgetting completeness;
-- production transport security;
-- upstream acceptance by Agent Manifest, TRACE/cMCP, Mem0, Graphiti, AgenTrust, or any other project.
-
-The sender's `allow` authorizes the sender's own export. A later sender notice makes an obligation visible. The receiver still owns every local admission and consequence decision.
+No upstream PR, issue, comment, patch, or submission is part of P7.
 
 ## Validation
 
-`reference/tests/test_interchange.py` covers:
+`reference/tests/test_interchange.py` covers authority and lifecycle-notice boundaries. `reference/tests/test_interchange_propagation.py` covers:
 
-- refusal to export without a committed sender crossing;
-- refusal to inherit sender authority at the receiver;
-- fail-closed ownership conflict;
-- successful locally authorized import with semantic preservation and receiving-domain rebinding;
-- deletion notice held pending local governance;
-- locally authorized deletion notice scheduling a local deletion workflow without silently deleting state;
-- correction notice requiring receiver-local correction authority;
-- rejection of lifecycle notices from an unlinked source system.
+- correction across two concrete local stores with receiver-local PAMA and receipt evidence;
+- prior receiver state retained as superseded rather than silently overwritten;
+- receiver-local permanent deletion after source deletion evidence;
+- clean deletion with zero undeclared residue and satisfied lifecycle measurement;
+- late receiver projection detected as undeclared residue, preventing a false forgetting claim.
 
-Repository CI runs these tests through the existing reference governed-adapter validation path together with fixture/schema/doctrine validation.
+Repository CI executes these alongside the existing fixture/schema/doctrine, P4 deletion-completeness, comparator, real-substrate, and conformance paths.
 
-## Remaining P7 work
+## Remaining P7 posture
 
-The strongest remaining Profile 6 gap is end-to-end **actual correction/deletion propagation evidence** across two concrete local stores, including receipt linkage and deletion-residue accounting on the receiving side. That work must reuse the existing canonical correction and deletion-completeness machinery rather than creating a special interoperability shortcut.
+V1-V3 establish the local reference mechanics for governed import, authority conflict, lifecycle continuity, and actual correction/deletion propagation with residue accounting. This is substantial Profile 6 evidence, but a full Profile 6 claim remains cumulative and must still satisfy the complete profile prerequisites and declared fixture scope rather than being inferred from these slices alone.

--- a/reference/agentmem_ref/interchange_propagation.py
+++ b/reference/agentmem_ref/interchange_propagation.py
@@ -1,0 +1,122 @@
+"""Receiver-local execution of cross-system correction and deletion obligations.
+
+P7 notices are evidence, not remote commands. This module composes the notice
+contract with the existing governed adapter and P4 projection/residue machinery
+so a receiver can prove what happened to its own retained copy.
+
+No transport or external project semantics are defined here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import residue
+from .adapter import CommitResult, GovernedMemoryAdapter
+from .deletion_completeness import DeletionCompletenessMeasurement, measure_deletion_completeness
+from .projections import CanonicalView, Projection, ProjectionStore, RESIDUAL
+from .substrate import TemporalGraphPort
+from . import policy
+
+
+@dataclass(frozen=True)
+class CorrectionPropagationResult:
+    commit: CommitResult
+    superseded_fact_uuid: str
+    replacement_fact_uuid: str | None
+
+
+@dataclass(frozen=True)
+class DeletionPropagationResult:
+    commit: CommitResult
+    buckets: dict[str, list[str]]
+    independently_observed_residual: tuple[str, ...]
+    measurement: DeletionCompletenessMeasurement
+
+
+def apply_receiver_correction(
+    adapter: GovernedMemoryAdapter,
+    substrate: TemporalGraphPort,
+    *,
+    proposal: policy.Proposal,
+    superseded_fact_uuid: str,
+    corrected_text: str,
+    invalid_at: str,
+) -> CorrectionPropagationResult:
+    """Commit a receiver-local correction and supersede, rather than erase, old state."""
+    if proposal.operation != "correction":
+        raise ValueError("receiver correction propagation requires operation=correction")
+
+    commit = adapter.commit_proposal(proposal, corrected_text)
+    replacement = commit.fact_uuid if commit.committed else None
+    if commit.committed:
+        substrate.invalidate_fact(superseded_fact_uuid, invalid_at=invalid_at, expired_at=invalid_at)
+
+    return CorrectionPropagationResult(
+        commit=commit,
+        superseded_fact_uuid=superseded_fact_uuid,
+        replacement_fact_uuid=replacement,
+    )
+
+
+def apply_receiver_deletion(
+    adapter: GovernedMemoryAdapter,
+    projections: ProjectionStore,
+    *,
+    proposal: policy.Proposal,
+    fact_uuid: str,
+    retained_by_policy: set[str] | None = None,
+    late_projections: tuple[Projection, ...] = (),
+) -> DeletionPropagationResult:
+    """Execute receiver-local deletion and independently measure retained residue.
+
+    The purge plan is intentionally computed before `late_projections` are
+    declared. Tests use that seam to model state created after traversal or
+    omitted from the deletion plan. The independent sweep must discover it as
+    undeclared residue rather than trusting the deletion receipt's optimism.
+    """
+    if proposal.operation != "permanent_deletion":
+        raise ValueError("receiver deletion propagation requires permanent_deletion")
+
+    plan = residue.plan_purge(projections, proposal.target_reference, retained_by_policy)
+    commit = adapter.governed_delete(
+        proposal,
+        fact_uuid,
+        derived_refs=tuple(sorted(plan.declared)),
+    )
+
+    if not commit.committed:
+        empty = {
+            residue.PURGED: [],
+            residue.DECLARED_CONTROLLED: [],
+            residue.DECLARED_UNCONTROLLABLE: [],
+            residue.UNDECLARED: [],
+        }
+        measurement = measure_deletion_completeness(empty, ())
+        return DeletionPropagationResult(commit, empty, (), measurement)
+
+    # Simulate declarations that arrived after traversal or were omitted from
+    # the purge plan. A trustworthy independent sweep must still catch them.
+    for projection in late_projections:
+        projections.declare(projection)
+
+    purged_projection_ids: set[str] = set()
+    residue.apply_purge(projections, plan, purged_projection_ids)
+
+    view = CanonicalView(
+        versions={proposal.target_reference: adapter.state_version(proposal.target_reference)},
+        tombstoned=adapter.tombstoned_ids(),
+        purged=purged_projection_ids,
+    )
+    buckets = residue.partition(projections, view, plan)
+    observed = tuple(
+        sorted(
+            {
+                projection.projection_id
+                for projection in projections.all_versions()
+                if projection.is_content_bearing and projections.freshness(projection, view) == RESIDUAL
+            }
+        )
+    )
+    measurement = measure_deletion_completeness(buckets, observed)
+    return DeletionPropagationResult(commit, buckets, observed, measurement)

--- a/reference/tests/test_interchange_propagation.py
+++ b/reference/tests/test_interchange_propagation.py
@@ -1,0 +1,249 @@
+"""P7 correction/deletion propagation across two concrete local stores."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy, residue  # noqa: E402
+from agentmem_ref.adapter import GovernedMemoryAdapter  # noqa: E402
+from agentmem_ref.interchange import (  # noqa: E402
+    NOTICE_CORRECTION,
+    NOTICE_DELETION,
+    SourceLifecycleNotice,
+    evaluate_source_notice,
+)
+from agentmem_ref.interchange_propagation import (  # noqa: E402
+    apply_receiver_correction,
+    apply_receiver_deletion,
+)
+from agentmem_ref.projections import (  # noqa: E402
+    DETERMINISTIC,
+    DERIVED_CONTENT,
+    REPRODUCIBLE,
+    Projection,
+    ProjectionStore,
+)
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+MEMORY_ID = "mem:two-store-decision"
+
+
+def proposal(
+    *,
+    actor: str,
+    operation: str,
+    tenant: str,
+    state_snapshot: str = "",
+    review: bool = True,
+) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=f"{actor}:{operation}",
+        actor_id=actor,
+        charter_version="charter-1",
+        target_reference=MEMORY_ID,
+        target_class=policy.M4,
+        scope=tenant,
+        operation=operation,
+        current_strength="crystallized",
+        proposed_strength="crystallized",
+        downstream_authority=policy.A2,
+        reversibility="irreversible" if operation == "permanent_deletion" else "reversible",
+        risk_class="medium",
+        evidence_refs=(f"evidence:{operation}",),
+        review_satisfied=review,
+        approval_refs=(f"approval:{tenant}",) if review else (),
+        state_snapshot=state_snapshot,
+        tenant_ref=tenant,
+        isolation_domain_refs=(f"domain:{tenant}",),
+    )
+
+
+def link():
+    from agentmem_ref.interchange import InterchangeLink
+
+    return InterchangeLink(
+        memory_id=MEMORY_ID,
+        source_system="system-a",
+        receiver_system="system-b",
+        source_crossing_receipt_ref="crossing:export",
+        source_domain_refs=("domain:tenant-a",),
+        receiver_domain_ref="domain:tenant-b",
+    )
+
+
+def imported_memory() -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "id": MEMORY_ID,
+        "type": "decision",
+        "state": "crystallized",
+        "scope": {
+            "owner_principal": "user:alice",
+            "tenant": "tenant-b",
+            "isolation_domain_refs": ["domain:tenant-b"],
+            "source_isolation_domain_refs": ["domain:tenant-a"],
+        },
+        "provenance": {
+            "origin": "system-a",
+            "observer": "agent:source",
+            "method": "governed interchange",
+            "timestamp": "2026-08-11T20:00:00Z",
+        },
+        "evidence": [{"id": "evidence:import", "kind": "interchange", "ref": "crossing:export", "confidence": 1.0}],
+        "saturation": {"sigma": 0.9, "calibrated": True, "durability_dimensions": ["decision"]},
+        "authority": {"pama_outcome": "allow_with_ledger", "risk_class": "medium"},
+        "created_at": "2026-08-11T20:00:00Z",
+    }
+
+
+class TwoStorePropagationTests(unittest.TestCase):
+    def setUp(self):
+        self.sender_store = InMemoryTemporalGraph()
+        self.receiver_store = InMemoryTemporalGraph()
+        self.sender = GovernedMemoryAdapter(self.sender_store, "tenant-a")
+        self.receiver = GovernedMemoryAdapter(self.receiver_store, "tenant-b")
+
+        sender_initial = self.sender.commit_proposal(
+            proposal(actor="agent:source", operation="promotion", tenant="tenant-a"),
+            "original governed decision",
+        )
+        receiver_initial = self.receiver.commit_proposal(
+            proposal(actor="agent:receiver", operation="promotion", tenant="tenant-b"),
+            "original governed decision",
+        )
+        self.assertTrue(sender_initial.committed)
+        self.assertTrue(receiver_initial.committed)
+        assert sender_initial.fact_uuid and receiver_initial.fact_uuid
+        self.sender_fact = sender_initial.fact_uuid
+        self.receiver_fact = receiver_initial.fact_uuid
+
+    def test_correction_propagates_as_receiver_local_governed_supersession(self):
+        sender_correction = self.sender.commit_proposal(
+            proposal(actor="agent:source", operation="correction", tenant="tenant-a"),
+            "corrected governed decision",
+        )
+        self.assertTrue(sender_correction.committed)
+
+        notice = SourceLifecycleNotice(
+            "notice:correction",
+            "system-a",
+            MEMORY_ID,
+            NOTICE_CORRECTION,
+            (sender_correction.receipt["receipt_id"],),
+            source_state="corrected",
+            source_receipt_ref=sender_correction.receipt["receipt_id"],
+        )
+        receiver_correction_proposal = proposal(actor="agent:receiver", operation="correction", tenant="tenant-b")
+        notice_result = evaluate_source_notice(
+            imported_memory(),
+            link(),
+            notice,
+            receiver_proposal=receiver_correction_proposal,
+        )
+        self.assertEqual(notice_result.local_action, "schedule_local_correction")
+
+        propagated = apply_receiver_correction(
+            self.receiver,
+            self.receiver_store,
+            proposal=receiver_correction_proposal,
+            superseded_fact_uuid=self.receiver_fact,
+            corrected_text="corrected governed decision",
+            invalid_at="2026-08-11T21:00:00Z",
+        )
+        self.assertTrue(propagated.commit.committed)
+        self.assertIsNotNone(propagated.replacement_fact_uuid)
+        old = self.receiver_store.get_fact(self.receiver_fact)
+        self.assertIsNotNone(old)
+        assert old is not None
+        self.assertTrue(old.is_event_invalid)
+        self.assertIsNotNone(self.receiver_store.get_fact(propagated.replacement_fact_uuid))
+        self.assertEqual(propagated.commit.receipt["selected_action"], "correction")
+
+    def test_clean_receiver_deletion_reuses_p4_residue_measurement(self):
+        projections = ProjectionStore()
+        projections.declare(
+            Projection(
+                projection_id="receiver:index",
+                basis=((MEMORY_ID, self.receiver.state_version(MEMORY_ID)),),
+                transform=DETERMINISTIC,
+                content_class=DERIVED_CONTENT,
+                rebuild=REPRODUCIBLE,
+                scope="tenant-b",
+            )
+        )
+
+        sender_delete = self.sender.governed_delete(
+            proposal(actor="agent:source", operation="permanent_deletion", tenant="tenant-a"),
+            self.sender_fact,
+        )
+        self.assertTrue(sender_delete.committed)
+
+        receiver_delete_proposal = proposal(actor="agent:receiver", operation="permanent_deletion", tenant="tenant-b")
+        notice_result = evaluate_source_notice(
+            imported_memory(),
+            link(),
+            SourceLifecycleNotice(
+                "notice:delete", "system-a", MEMORY_ID, NOTICE_DELETION,
+                (sender_delete.receipt["receipt_id"],), source_receipt_ref=sender_delete.receipt["receipt_id"],
+            ),
+            receiver_proposal=receiver_delete_proposal,
+        )
+        self.assertEqual(notice_result.local_action, "schedule_local_deletion")
+
+        propagated = apply_receiver_deletion(
+            self.receiver,
+            projections,
+            proposal=receiver_delete_proposal,
+            fact_uuid=self.receiver_fact,
+        )
+        self.assertTrue(propagated.commit.committed)
+        self.assertIsNone(self.receiver_store.get_fact(self.receiver_fact))
+        self.assertIsNotNone(self.receiver.tombstone(self.receiver_fact))
+        self.assertEqual(propagated.buckets[residue.UNDECLARED], [])
+        self.assertTrue(propagated.measurement.hard_gate_passed)
+        self.assertEqual(propagated.measurement.lifecycle_satisfaction, "satisfied")
+
+    def test_late_receiver_projection_prevents_false_forgetting_claim(self):
+        projections = ProjectionStore()
+        projections.declare(
+            Projection(
+                projection_id="receiver:known-index",
+                basis=((MEMORY_ID, self.receiver.state_version(MEMORY_ID)),),
+                transform=DETERMINISTIC,
+                content_class=DERIVED_CONTENT,
+                rebuild=REPRODUCIBLE,
+                scope="tenant-b",
+            )
+        )
+        late = Projection(
+            projection_id="receiver:late-cache",
+            basis=((MEMORY_ID, self.receiver.state_version(MEMORY_ID)),),
+            transform=DETERMINISTIC,
+            content_class=DERIVED_CONTENT,
+            rebuild=REPRODUCIBLE,
+            scope="tenant-b",
+            note="declared after purge traversal to model hidden/late receiver residue",
+        )
+
+        receiver_delete_proposal = proposal(actor="agent:receiver", operation="permanent_deletion", tenant="tenant-b")
+        propagated = apply_receiver_deletion(
+            self.receiver,
+            projections,
+            proposal=receiver_delete_proposal,
+            fact_uuid=self.receiver_fact,
+            late_projections=(late,),
+        )
+
+        self.assertTrue(propagated.commit.committed)
+        self.assertEqual(propagated.buckets[residue.UNDECLARED], ["receiver:late-cache"])
+        self.assertEqual(propagated.independently_observed_residual, ("receiver:late-cache",))
+        self.assertFalse(propagated.measurement.hard_gate_passed)
+        self.assertEqual(propagated.measurement.lifecycle_satisfaction, "residual")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_interchange_propagation.py
+++ b/reference/tests/test_interchange_propagation.py
@@ -40,6 +40,12 @@ def proposal(
     state_snapshot: str = "",
     review: bool = True,
 ) -> policy.Proposal:
+    strength = {
+        "promotion": ("reinforced", "canonical"),
+        "correction": ("canonical", "canonical"),
+        "permanent_deletion": ("canonical", "not_applicable"),
+    }
+    current_strength, proposed_strength = strength[operation]
     return policy.Proposal(
         proposal_id=f"{actor}:{operation}",
         actor_id=actor,
@@ -48,8 +54,8 @@ def proposal(
         target_class=policy.M4,
         scope=tenant,
         operation=operation,
-        current_strength="crystallized",
-        proposed_strength="crystallized",
+        current_strength=current_strength,
+        proposed_strength=proposed_strength,
         downstream_authority=policy.A2,
         reversibility="irreversible" if operation == "permanent_deletion" else "reversible",
         risk_class="medium",


### PR DESCRIPTION
Completes the next local P7 evidence slice under #46 without any upstream submission.

This PR executes correction and deletion consequences across two separate local `InMemoryTemporalGraph` stores, each behind its own `GovernedMemoryAdapter`.

It reuses existing Agent Memory mechanisms rather than inventing an interchange shortcut:
- correction runs through receiver-local PAMA and `commit_proposal(operation="correction")`, emits a normal receipt, writes replacement receiver state, and supersedes the prior receiver fact rather than erasing history
- deletion runs through receiver-local `governed_delete(operation="permanent_deletion")`
- receiver deletion then reuses the P4 projection purge, independent sweep, four-way residue partition, and `DeletionCompletenessMeasurement`
- a clean receiver deletion reaches zero undeclared residue
- an adversarial projection appearing after purge traversal is independently detected as `undeclared_residual`, preventing a false forgetting-completeness claim

Claim boundary: local reference/runtime evidence only. No universal transport claim, no automatic remote authority, no full Profile 6 claim, and no writes/submissions to external repositories.

Merge only after full exact-head validation and CodeQL succeed.