### PR TITLE
Runtime: add P8 privacy-minimized telemetry projection

### DIFF
--- a/docs/programs/runtime-evidence/telemetry-minimization.md
+++ b/docs/programs/runtime-evidence/telemetry-minimization.md
@@ -1,0 +1,93 @@
+# P8 Telemetry Interoperability Without Shadow Memory
+
+## Purpose
+
+Make Agent Memory operationally observable without copying governed memory into a less-governed telemetry backend.
+
+Canonical audit events remain the reconstructable evidence surface. Telemetry is a deliberately lossy derived projection used for correlation, health, and operational analysis.
+
+The governing risk is **shadow memory**: raw memory content, prompts, summaries, evidence payloads, identities, or authority context copied into logs/traces/metrics where retention, access, deletion, and lifecycle controls are weaker than the memory system they observe.
+
+## V1 minimization profile
+
+`reference/agentmem_ref/telemetry.py` projects schema-valid `memory-audit-event` records into `telemetry-projection.schema.json`.
+
+The projection is strict allowlist, not denylist.
+
+Allowed directly:
+
+- event family and event schema version;
+- component name;
+- timestamp;
+- booleans indicating whether payload, signal, or authority context existed;
+- count of sensitivity labels, without the labels themselves.
+
+Potentially identifying or cross-linkable values are emitted only as keyed HMAC-SHA256 references:
+
+- event id;
+- memory id;
+- actor;
+- principal;
+- correlation and causation ids;
+- policy version;
+- receipt and ledger references.
+
+The HMAC key is local configuration and is not emitted. Different telemetry domains may use different keys so opaque identifiers do not automatically become globally linkable pseudonyms.
+
+Explicitly absent from the projection:
+
+- `payload` contents;
+- memory text or prompt content;
+- raw actor/principal/memory identifiers;
+- raw sensitivity labels;
+- signal values and uncertainty bodies;
+- estimator details;
+- authority refs;
+- permitted/prohibited/selected action names;
+- raw receipt or ledger identifiers.
+
+## Semantics
+
+```text
+canonical audit event  -> authoritative reconstruction evidence
+telemetry projection   -> minimized operational correlation only
+```
+
+A valid telemetry span does not prove a memory mutation was authorized, correct, complete, or successfully forgotten. Operators must resolve the canonical receipt/audit path under normal access controls when deeper evidence is required.
+
+Telemetry retention must be governed independently. Pseudonymization reduces disclosure risk but does not make telemetry non-sensitive or exempt it from retention/deletion policy.
+
+## Interoperability posture
+
+The V1 shape uses primitive span-style attributes that can be mapped into common observability systems, but this slice does not claim formal OpenTelemetry semantic-convention adoption or require an external telemetry SDK.
+
+That separation is intentional. Agent Memory defines the privacy/governance contract first. A later adapter may map this content-free shape into a specific telemetry transport without weakening it.
+
+## Validation
+
+`reference/tests/test_telemetry.py` injects a canonical audit event containing deliberately sensitive:
+
+- prompt and memory payloads;
+- credential-like content;
+- actor, principal, and memory identifiers;
+- sensitivity labels;
+- signal values and uncertainty notes;
+- authority refs and action names;
+- receipt and ledger ids.
+
+The serialized telemetry projection must contain none of those raw values. Tests also verify stable same-key correlation, cross-key unlinkability, schema validity, and minimum HMAC key strength.
+
+## Claim boundary
+
+P8 V1 demonstrates a local privacy-minimized telemetry seam. It does not claim:
+
+- that telemetry is anonymous;
+- that a telemetry backend satisfies Agent Memory retention or deletion requirements automatically;
+- that telemetry replaces canonical receipts or audit events;
+- formal compliance with any external observability standard;
+- production collector/exporter behavior;
+- any upstream submission or external repository change.
+
+## Next P8 slice
+
+The next useful evidence is retention/deletion behavior for telemetry itself: prove that correlation references can support operational reconstruction while telemetry records do not outlive the policy that permits them, and that deleting memory does not leave content-bearing telemetry residue merely because the telemetry system was classified as "observability."

--- a/reference/agentmem_ref/telemetry.py
+++ b/reference/agentmem_ref/telemetry.py
@@ -1,0 +1,69 @@
+"""Privacy-minimized telemetry projection for Agent Memory audit events.
+
+Canonical audit events remain the reconstructable evidence surface. Telemetry is
+an explicitly lossy derived projection for operational correlation. It carries
+no raw memory content and is not authoritative for memory semantics, lifecycle,
+or governance decisions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from . import receipts
+
+PROFILE = "agent-memory-telemetry-minimized"
+VERSION = "1.0.0"
+
+
+def _opaque_ref(key: bytes, value: str) -> str:
+    digest = hmac.new(key, value.encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"hmac-sha256:{digest}"
+
+
+class TelemetryProjector:
+    """Project a canonical audit event into a strict content-free span shape."""
+
+    def __init__(self, key: bytes) -> None:
+        if len(key) < 16:
+            raise ValueError("telemetry HMAC key must be at least 16 bytes")
+        self._key = key
+
+    def project(self, event: dict) -> dict:
+        receipts.validate("memory-audit-event.schema.json", event)
+
+        attrs: dict[str, object] = {
+            "am.event_ref": _opaque_ref(self._key, event["event_id"]),
+            "am.event_type": event["event_type"],
+            "am.event_version": event["event_version"],
+            "am.component": event["component"],
+            "am.payload_present": "payload" in event,
+            "am.signal_present": "signal" in event,
+            "am.authority_present": "authority" in event,
+            "am.sensitivity_count": len(event.get("sensitivity", ())),
+        }
+
+        for source_key, target_key in (
+            ("memory_id", "am.memory_ref"),
+            ("actor", "am.actor_ref"),
+            ("principal", "am.principal_ref"),
+            ("correlation_id", "am.correlation_ref"),
+            ("causation_id", "am.causation_ref"),
+            ("policy_version", "am.policy_ref"),
+            ("receipt_ref", "am.receipt_ref"),
+            ("ledger_ref", "am.ledger_ref"),
+        ):
+            value = event.get(source_key)
+            if isinstance(value, str) and value:
+                attrs[target_key] = _opaque_ref(self._key, value)
+
+        projection = {
+            "profile": PROFILE,
+            "version": VERSION,
+            "span_name": f"agent_memory.{event['event_type']}",
+            "timestamp": event["timestamp"],
+            "attributes": attrs,
+        }
+        receipts.validate("telemetry-projection.schema.json", projection)
+        return projection

--- a/reference/tests/test_telemetry.py
+++ b/reference/tests/test_telemetry.py
@@ -1,0 +1,113 @@
+"""P8 privacy-minimized telemetry projection tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.telemetry import TelemetryProjector  # noqa: E402
+
+
+class TelemetryProjectionTests(unittest.TestCase):
+    def setUp(self):
+        self.projector = TelemetryProjector(b"telemetry-test-key-32-bytes-long")
+        self.event = {
+            "schema_version": "1.0.0",
+            "event_id": "event:secret-decision-42",
+            "event_type": "memory.authority_decided",
+            "event_version": "1.0.0",
+            "timestamp": "2026-08-11T20:00:00Z",
+            "memory_id": "memory:user-alice-medical-secret",
+            "actor": "employee:alice@example.com",
+            "principal": "customer:patient-12345",
+            "component": "governed-adapter",
+            "correlation_id": "workflow:incident-red-team",
+            "causation_id": "event:private-cause",
+            "policy_version": "policy:prod-sensitive-v7",
+            "sensitivity": ["credential", "medical"],
+            "signal": {
+                "signal_type": "sensitivity",
+                "signal_semantics": "classifier_output",
+                "signal_value": "RAW-SECRET-SIGNAL-VALUE",
+                "estimator_id": "classifier:private",
+                "estimator_version": "v9",
+                "uncertainty": {"notes": "SECRET-UNCERTAINTY-NOTES"},
+            },
+            "authority": {
+                "authority_refs": ["authority:secret-admin-role"],
+                "permitted_actions": ["read_private_medical_memory"],
+                "prohibited_actions": ["export_raw_secret"],
+                "selected_action": "read_private_medical_memory",
+                "selection_mode": "deterministic",
+            },
+            "payload": {
+                "prompt": "TOP-SECRET-PROMPT-CONTENT",
+                "memory_text": "TOP-SECRET-MEMORY-CONTENT",
+                "credential": "password=hunter2",
+            },
+            "receipt_ref": "receipt:secret-42",
+            "ledger_ref": "ledger:secret-42",
+        }
+
+    def test_projection_contains_only_allowlisted_shape_and_opaque_refs(self):
+        projection = self.projector.project(self.event)
+        attrs = projection["attributes"]
+        self.assertEqual(projection["span_name"], "agent_memory.memory.authority_decided")
+        self.assertEqual(attrs["am.event_type"], "memory.authority_decided")
+        self.assertEqual(attrs["am.component"], "governed-adapter")
+        self.assertTrue(attrs["am.payload_present"])
+        self.assertTrue(attrs["am.signal_present"])
+        self.assertTrue(attrs["am.authority_present"])
+        self.assertEqual(attrs["am.sensitivity_count"], 2)
+        for key in (
+            "am.event_ref", "am.memory_ref", "am.actor_ref", "am.principal_ref",
+            "am.correlation_ref", "am.causation_ref", "am.policy_ref",
+            "am.receipt_ref", "am.ledger_ref",
+        ):
+            self.assertRegex(attrs[key], r"^hmac-sha256:[0-9a-f]{64}$")
+
+    def test_shadow_memory_content_does_not_survive_serialization(self):
+        serialized = json.dumps(self.projector.project(self.event), sort_keys=True)
+        forbidden = [
+            "TOP-SECRET-PROMPT-CONTENT",
+            "TOP-SECRET-MEMORY-CONTENT",
+            "password=hunter2",
+            "RAW-SECRET-SIGNAL-VALUE",
+            "SECRET-UNCERTAINTY-NOTES",
+            "memory:user-alice-medical-secret",
+            "employee:alice@example.com",
+            "customer:patient-12345",
+            "authority:secret-admin-role",
+            "read_private_medical_memory",
+            "export_raw_secret",
+            "receipt:secret-42",
+            "ledger:secret-42",
+            "credential",
+            "medical",
+        ]
+        for value in forbidden:
+            self.assertNotIn(value, serialized)
+
+    def test_same_identifier_correlates_under_same_key_without_revealing_raw_value(self):
+        first = self.projector.project(self.event)
+        second = self.projector.project(dict(self.event, event_id="event:other"))
+        self.assertEqual(first["attributes"]["am.memory_ref"], second["attributes"]["am.memory_ref"])
+        self.assertNotEqual(first["attributes"]["am.event_ref"], second["attributes"]["am.event_ref"])
+
+    def test_different_telemetry_keys_break_cross-domain_linkability(self):
+        first = self.projector.project(self.event)
+        other = TelemetryProjector(b"different-telemetry-key-32-bytes").project(self.event)
+        self.assertNotEqual(first["attributes"]["am.memory_ref"], other["attributes"]["am.memory_ref"])
+        self.assertNotEqual(first["attributes"]["am.principal_ref"], other["attributes"]["am.principal_ref"])
+
+    def test_short_hmac_key_is_rejected(self):
+        with self.assertRaises(ValueError):
+            TelemetryProjector(b"too-short")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_telemetry.py
+++ b/reference/tests/test_telemetry.py
@@ -98,7 +98,7 @@ class TelemetryProjectionTests(unittest.TestCase):
         self.assertEqual(first["attributes"]["am.memory_ref"], second["attributes"]["am.memory_ref"])
         self.assertNotEqual(first["attributes"]["am.event_ref"], second["attributes"]["am.event_ref"])
 
-    def test_different_telemetry_keys_break_cross-domain_linkability(self):
+    def test_different_telemetry_keys_break_cross_domain_linkability(self):
         first = self.projector.project(self.event)
         other = TelemetryProjector(b"different-telemetry-key-32-bytes").project(self.event)
         self.assertNotEqual(first["attributes"]["am.memory_ref"], other["attributes"]["am.memory_ref"])

--- a/schemas/telemetry-projection.schema.json
+++ b/schemas/telemetry-projection.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/telemetry-projection.schema.json",
+  "title": "Agent Memory Privacy-Minimized Telemetry Projection",
+  "description": "Content-free projection of a canonical memory audit event for external observability systems. Raw memory, actor, principal, payload, signal values, uncertainty, and authority-reference bodies are intentionally excluded.",
+  "type": "object",
+  "required": ["profile", "version", "span_name", "timestamp", "attributes"],
+  "properties": {
+    "profile": {"const": "agent-memory-telemetry-minimized"},
+    "version": {"const": "1.0.0"},
+    "span_name": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "attributes": {
+      "type": "object",
+      "required": ["am.event_ref", "am.event_type", "am.event_version", "am.component", "am.payload_present", "am.signal_present", "am.authority_present", "am.sensitivity_count"],
+      "properties": {
+        "am.event_ref": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"},
+        "am.event_type": {"type": "string", "minLength": 1},
+        "am.event_version": {"type": "string", "minLength": 1},
+        "am.component": {"type": "string", "minLength": 1},
+        "am.memory_ref": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"},
+        "am.actor_ref": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"},
+        "am.principal_ref": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"},
+        "am.correlation_ref": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"},
+        "am.causation_ref": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"},
+        "am.policy_ref": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"},
+        "am.receipt_ref": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"},
+        "am.ledger_ref": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"},
+        "am.payload_present": {"type": "boolean"},
+        "am.signal_present": {"type": "boolean"},
+        "am.authority_present": {"type": "boolean"},
+        "am.sensitivity_count": {"type": "integer", "minimum": 0}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Implements the first local P8 telemetry-interoperability slice under #46.

The goal is operational correlation without creating a shadow memory store in telemetry.

This PR:
- adds a strict allowlisted telemetry projection schema
- projects canonical memory audit events into primitive span-style attributes
- uses keyed HMAC-SHA256 references for memory, actor, principal, workflow, policy, receipt, and ledger identifiers
- emits event family/component/timestamp plus only presence/count metadata for potentially sensitive audit fields
- excludes raw payloads, memory text/prompts, sensitivity labels, signal values/uncertainty bodies, authority refs/action names, and raw identifiers
- tests deliberately sensitive payloads to prove those values do not survive serialized telemetry
- verifies same-key correlation and different-key unlinkability

Canonical audit events remain authoritative reconstruction evidence. Telemetry is an explicitly lossy derived projection.

No formal OpenTelemetry semantic-convention claim, no production collector claim, and no upstream submissions or external-repository writes.

Merge only after full exact-head validation and CodeQL succeed.