### PR TITLE
Runtime: add rotation-safe P8 telemetry retention

### DIFF
--- a/docs/programs/runtime-evidence/telemetry-minimization.md
+++ b/docs/programs/runtime-evidence/telemetry-minimization.md
@@ -34,6 +34,8 @@ Potentially identifying or cross-linkable values are emitted only as keyed HMAC-
 
 The HMAC key is local configuration and is not emitted. Different telemetry domains may use different keys so opaque identifiers do not automatically become globally linkable pseudonyms.
 
+Each projection also carries a non-secret `key_id` identifying the HMAC key generation. The identifier exists for retention/deletion accounting and is not an authority or trust signal.
+
 Explicitly absent from the projection:
 
 - `payload` contents;
@@ -46,48 +48,95 @@ Explicitly absent from the projection:
 - permitted/prohibited/selected action names;
 - raw receipt or ledger identifiers.
 
+## V2 retention and deletion
+
+`reference/agentmem_ref/telemetry_retention.py` treats minimized telemetry as governed derived state rather than an indefinite logging exemption.
+
+The local reference store persists only:
+
+- the validated telemetry projection;
+- an expiry timestamp.
+
+It does **not** persist the raw memory id or HMAC key used to create the projection.
+
+### Expiry
+
+Every stored projection has an explicit `expires_at`. `purge_expired()` removes records whose retention window has ended without needing to recover any source memory content.
+
+### Memory-targeted purge
+
+For deletion obligations, the raw memory id is supplied transiently to `purge_memory()`. The store receives the currently retained telemetry projectors, indexed by `key_id`, and recomputes the target's opaque `am.memory_ref` under each available HMAC key generation.
+
+This supports key rotation without making older telemetry unreachable for deletion:
+
+```text
+raw memory id
+  -> ref under telemetry-2026-07
+  -> ref under telemetry-2026-08
+  -> ...
+  -> purge every matching retained projection
+```
+
+The raw memory id and HMAC keys are not added to telemetry storage as a side effect of deletion.
+
+### Missing key generations fail closed
+
+If retained telemetry contains a `key_id` for which the deletion process no longer has the HMAC key, those records cannot be tested for membership in the target memory's telemetry closure.
+
+The result is therefore:
+
+```text
+unresolved key generation -> purge complete = false
+```
+
+Losing a pseudonymization key is not treated as proof that old telemetry no longer represents the deleted memory.
+
+This is intentionally conservative. Operators may later satisfy the obligation through expiry, deletion of the unresolved telemetry partition, restored key custody, or other independently verified remediation. The local reference does not invent a success verdict.
+
 ## Semantics
 
 ```text
 canonical audit event  -> authoritative reconstruction evidence
 telemetry projection   -> minimized operational correlation only
+telemetry purge         -> deletion of that derived observability state only
 ```
 
-A valid telemetry span does not prove a memory mutation was authorized, correct, complete, or successfully forgotten. Operators must resolve the canonical receipt/audit path under normal access controls when deeper evidence is required.
+A valid telemetry span does not prove a memory mutation was authorized, correct, complete, or successfully forgotten. Likewise, a successful telemetry purge does not by itself prove canonical memory forgetting completeness. It closes only the telemetry portion of the derived-state obligation.
 
-Telemetry retention must be governed independently. Pseudonymization reduces disclosure risk but does not make telemetry non-sensitive or exempt it from retention/deletion policy.
+Telemetry retention must be governed independently. Pseudonymization reduces disclosure risk but does not make telemetry anonymous, non-sensitive, or exempt from retention/deletion policy.
 
 ## Interoperability posture
 
-The V1 shape uses primitive span-style attributes that can be mapped into common observability systems, but this slice does not claim formal OpenTelemetry semantic-convention adoption or require an external telemetry SDK.
+The V1/V2 shape uses primitive span-style attributes that can be mapped into common observability systems, but these slices do not claim formal OpenTelemetry semantic-convention adoption or require an external telemetry SDK.
 
 That separation is intentional. Agent Memory defines the privacy/governance contract first. A later adapter may map this content-free shape into a specific telemetry transport without weakening it.
 
 ## Validation
 
-`reference/tests/test_telemetry.py` injects a canonical audit event containing deliberately sensitive:
+`reference/tests/test_telemetry.py` injects a canonical audit event containing deliberately sensitive prompt/memory payloads, credential-like content, raw identities, sensitivity labels, signal/uncertainty details, authority/action names, and receipt/ledger ids. The serialized projection must contain none of those raw values.
 
-- prompt and memory payloads;
-- credential-like content;
-- actor, principal, and memory identifiers;
-- sensitivity labels;
-- signal values and uncertainty notes;
-- authority refs and action names;
-- receipt and ledger ids.
+`reference/tests/test_telemetry_retention.py` verifies:
 
-The serialized telemetry projection must contain none of those raw values. Tests also verify stable same-key correlation, cross-key unlinkability, schema validity, and minimum HMAC key strength.
+- targeted purge removes only the requested memory's telemetry;
+- one memory emitted under multiple HMAC key generations is purged across all known generations;
+- a missing retired key generation makes the result explicitly incomplete;
+- expiry removes records without source-memory lookup;
+- stored telemetry contains neither raw memory identifiers nor HMAC key material.
 
 ## Claim boundary
 
-P8 V1 demonstrates a local privacy-minimized telemetry seam. It does not claim:
+P8 V1/V2 demonstrate a local privacy-minimized telemetry seam and rotation-aware retention/deletion behavior. They do not claim:
 
 - that telemetry is anonymous;
-- that a telemetry backend satisfies Agent Memory retention or deletion requirements automatically;
+- that a production telemetry backend automatically satisfies these requirements;
 - that telemetry replaces canonical receipts or audit events;
 - formal compliance with any external observability standard;
 - production collector/exporter behavior;
+- that telemetry purge alone satisfies overall memory forgetting completeness;
 - any upstream submission or external repository change.
 
-## Next P8 slice
+## P8 posture
 
-The next useful evidence is retention/deletion behavior for telemetry itself: prove that correlation references can support operational reconstruction while telemetry records do not outlive the policy that permits them, and that deleting memory does not leave content-bearing telemetry residue merely because the telemetry system was classified as "observability."
+The core local P8 risk is now executable on both sides of the lifecycle: content is minimized before telemetry emission, and retained pseudonymous telemetry can expire or be targeted for deletion across known key rotations without converting missing keys into a false success claim.
+
+Further production work may test a concrete collector/storage backend, but that is a deployment-specific evidence extension rather than a reason to weaken the local minimization and retention contract.

--- a/reference/agentmem_ref/telemetry.py
+++ b/reference/agentmem_ref/telemetry.py
@@ -25,10 +25,19 @@ def _opaque_ref(key: bytes, value: str) -> str:
 class TelemetryProjector:
     """Project a canonical audit event into a strict content-free span shape."""
 
-    def __init__(self, key: bytes) -> None:
+    def __init__(self, key: bytes, key_id: str = "local") -> None:
         if len(key) < 16:
             raise ValueError("telemetry HMAC key must be at least 16 bytes")
+        if not key_id:
+            raise ValueError("telemetry key_id must be non-empty")
         self._key = key
+        self.key_id = key_id
+
+    def memory_ref(self, memory_id: str) -> str:
+        """Resolve one raw memory id into this key generation's opaque reference."""
+        if not memory_id:
+            raise ValueError("memory_id must be non-empty")
+        return _opaque_ref(self._key, memory_id)
 
     def project(self, event: dict) -> dict:
         receipts.validate("memory-audit-event.schema.json", event)
@@ -61,6 +70,7 @@ class TelemetryProjector:
         projection = {
             "profile": PROFILE,
             "version": VERSION,
+            "key_id": self.key_id,
             "span_name": f"agent_memory.{event['event_type']}",
             "timestamp": event["timestamp"],
             "attributes": attrs,

--- a/reference/agentmem_ref/telemetry_retention.py
+++ b/reference/agentmem_ref/telemetry_retention.py
@@ -1,0 +1,106 @@
+"""Governed local retention for privacy-minimized telemetry projections.
+
+Telemetry is derived operational state. This store never retains raw memory ids
+or HMAC keys. Deletion receives the raw memory id transiently and resolves it
+against every available telemetry key generation.
+
+If retained projections use a key generation that is no longer available, a
+memory-targeted purge is explicitly incomplete. Losing the key does not turn
+unsearchable pseudonymous state into proof of deletion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from . import receipts
+from .telemetry import TelemetryProjector
+
+
+@dataclass(frozen=True)
+class TelemetryRecord:
+    projection: dict
+    expires_at: str
+
+
+@dataclass(frozen=True)
+class TelemetryPurgeResult:
+    removed_count: int
+    unresolved_key_ids: tuple[str, ...]
+    complete: bool
+
+
+class TelemetryStore:
+    """In-memory reference store for minimized telemetry plus expiry metadata."""
+
+    def __init__(self) -> None:
+        self._records: list[TelemetryRecord] = []
+
+    def append(self, projection: dict, *, expires_at: str) -> None:
+        receipts.validate("telemetry-projection.schema.json", projection)
+        _parse_time(expires_at)
+        self._records.append(TelemetryRecord(projection=projection.copy(), expires_at=expires_at))
+
+    def records(self) -> tuple[TelemetryRecord, ...]:
+        return tuple(self._records)
+
+    def purge_expired(self, *, now: str) -> int:
+        cutoff = _parse_time(now)
+        retained: list[TelemetryRecord] = []
+        removed = 0
+        for record in self._records:
+            if _parse_time(record.expires_at) <= cutoff:
+                removed += 1
+            else:
+                retained.append(record)
+        self._records = retained
+        return removed
+
+    def purge_memory(
+        self,
+        memory_id: str,
+        *,
+        projectors: dict[str, TelemetryProjector],
+    ) -> TelemetryPurgeResult:
+        """Remove projections linked to one memory across every known key generation.
+
+        Any retained key generation for which no projector is supplied makes the
+        result incomplete because those records cannot be tested for membership
+        in the target memory's telemetry closure.
+        """
+        if not memory_id:
+            raise ValueError("memory_id must be non-empty")
+
+        retained_key_ids = {record.projection["key_id"] for record in self._records}
+        unresolved = tuple(sorted(retained_key_ids - set(projectors)))
+        expected_refs = {
+            key_id: projector.memory_ref(memory_id)
+            for key_id, projector in projectors.items()
+        }
+
+        retained: list[TelemetryRecord] = []
+        removed = 0
+        for record in self._records:
+            key_id = record.projection["key_id"]
+            expected = expected_refs.get(key_id)
+            memory_ref = record.projection["attributes"].get("am.memory_ref")
+            if expected is not None and memory_ref == expected:
+                removed += 1
+            else:
+                retained.append(record)
+        self._records = retained
+
+        return TelemetryPurgeResult(
+            removed_count=removed,
+            unresolved_key_ids=unresolved,
+            complete=not unresolved,
+        )
+
+
+def _parse_time(value: str) -> datetime:
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        raise ValueError("telemetry retention timestamps must include timezone")
+    return parsed.astimezone(timezone.utc)

--- a/reference/tests/test_telemetry_retention.py
+++ b/reference/tests/test_telemetry_retention.py
@@ -1,0 +1,106 @@
+"""P8 telemetry retention, expiry, and rotation-safe deletion tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.telemetry import TelemetryProjector  # noqa: E402
+from agentmem_ref.telemetry_retention import TelemetryStore  # noqa: E402
+
+
+def event(event_id: str, memory_id: str, timestamp: str = "2026-08-11T20:00:00Z") -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "event_id": event_id,
+        "event_type": "memory.recalled",
+        "event_version": "1.0.0",
+        "timestamp": timestamp,
+        "memory_id": memory_id,
+        "component": "runtime-memory",
+        "correlation_id": f"workflow:{event_id}",
+        "payload": {"content": f"SECRET:{memory_id}"},
+    }
+
+
+class TelemetryRetentionTests(unittest.TestCase):
+    def setUp(self):
+        self.old = TelemetryProjector(b"old-telemetry-key-material-0001", key_id="telemetry-2026-07")
+        self.new = TelemetryProjector(b"new-telemetry-key-material-0002", key_id="telemetry-2026-08")
+
+    def test_targeted_purge_removes_only_requested_memory(self):
+        store = TelemetryStore()
+        store.append(self.new.project(event("evt-a", "mem:a")), expires_at="2026-09-01T00:00:00Z")
+        store.append(self.new.project(event("evt-b", "mem:b")), expires_at="2026-09-01T00:00:00Z")
+
+        result = store.purge_memory("mem:a", projectors={self.new.key_id: self.new})
+
+        self.assertTrue(result.complete)
+        self.assertEqual(result.removed_count, 1)
+        remaining = store.records()
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0].projection["attributes"]["am.memory_ref"], self.new.memory_ref("mem:b"))
+
+    def test_key_rotation_purge_removes_same_memory_from_all_known_generations(self):
+        store = TelemetryStore()
+        store.append(self.old.project(event("evt-old", "mem:a")), expires_at="2026-09-01T00:00:00Z")
+        store.append(self.new.project(event("evt-new", "mem:a")), expires_at="2026-09-01T00:00:00Z")
+        store.append(self.old.project(event("evt-other", "mem:b")), expires_at="2026-09-01T00:00:00Z")
+
+        result = store.purge_memory(
+            "mem:a",
+            projectors={self.old.key_id: self.old, self.new.key_id: self.new},
+        )
+
+        self.assertTrue(result.complete)
+        self.assertEqual(result.removed_count, 2)
+        self.assertEqual(len(store.records()), 1)
+        self.assertEqual(store.records()[0].projection["key_id"], self.old.key_id)
+
+    def test_missing_retired_key_generation_makes_purge_incomplete(self):
+        store = TelemetryStore()
+        store.append(self.old.project(event("evt-old", "mem:a")), expires_at="2026-09-01T00:00:00Z")
+        store.append(self.new.project(event("evt-new", "mem:a")), expires_at="2026-09-01T00:00:00Z")
+
+        result = store.purge_memory("mem:a", projectors={self.new.key_id: self.new})
+
+        self.assertFalse(result.complete)
+        self.assertEqual(result.removed_count, 1)
+        self.assertEqual(result.unresolved_key_ids, (self.old.key_id,))
+        self.assertEqual(len(store.records()), 1)
+        self.assertEqual(store.records()[0].projection["key_id"], self.old.key_id)
+
+    def test_expiry_removes_records_without_memory_lookup(self):
+        store = TelemetryStore()
+        store.append(self.new.project(event("evt-expired", "mem:a")), expires_at="2026-08-11T21:00:00Z")
+        store.append(self.new.project(event("evt-live", "mem:b")), expires_at="2026-08-13T00:00:00Z")
+
+        removed = store.purge_expired(now="2026-08-12T00:00:00Z")
+
+        self.assertEqual(removed, 1)
+        self.assertEqual(len(store.records()), 1)
+
+    def test_store_contains_no_raw_memory_id_or_hmac_key_material(self):
+        store = TelemetryStore()
+        projection = self.new.project(event("evt-secret", "mem:secret-user-record"))
+        store.append(projection, expires_at="2026-09-01T00:00:00Z")
+
+        serialized = json.dumps(
+            [
+                {"projection": record.projection, "expires_at": record.expires_at}
+                for record in store.records()
+            ],
+            sort_keys=True,
+        )
+        self.assertNotIn("mem:secret-user-record", serialized)
+        self.assertNotIn("SECRET:mem:secret-user-record", serialized)
+        self.assertNotIn("new-telemetry-key-material-0002", serialized)
+        self.assertIn(self.new.key_id, serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/telemetry-projection.schema.json
+++ b/schemas/telemetry-projection.schema.json
@@ -4,10 +4,15 @@
   "title": "Agent Memory Privacy-Minimized Telemetry Projection",
   "description": "Content-free projection of a canonical memory audit event for external observability systems. Raw memory, actor, principal, payload, signal values, uncertainty, and authority-reference bodies are intentionally excluded.",
   "type": "object",
-  "required": ["profile", "version", "span_name", "timestamp", "attributes"],
+  "required": ["profile", "version", "key_id", "span_name", "timestamp", "attributes"],
   "properties": {
     "profile": {"const": "agent-memory-telemetry-minimized"},
     "version": {"const": "1.0.0"},
+    "key_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Non-secret identifier for the HMAC key generation used to create opaque telemetry references. The key itself is never emitted."
+    },
     "span_name": {"type": "string", "minLength": 1},
     "timestamp": {"type": "string", "format": "date-time"},
     "attributes": {


### PR DESCRIPTION
Extends local P8 telemetry evidence under #46 from emission minimization into retention/deletion behavior.

This PR:
- binds each privacy-minimized telemetry projection to a non-secret HMAC `key_id`
- adds a local telemetry retention store that persists only minimized projections plus explicit expiry metadata
- never stores raw memory ids or HMAC keys
- supports targeted memory purge across multiple known HMAC key generations
- fails closed when retained telemetry references a key generation unavailable to the deletion process
- exposes `complete=false` plus unresolved key ids rather than treating key loss as proof of deletion
- supports independent expiry-based purge
- tests selective purge, rotation-safe purge, missing-key incompleteness, expiry, and absence of raw memory/key material in stored records

Claim boundary: telemetry remains derived operational state. Successful telemetry purge closes only that observability residue surface and does not by itself prove overall memory forgetting completeness.

No formal OpenTelemetry claim, no production collector/backend claim, and no upstream submissions or external-repository writes.

Merge only after full exact-head validation and CodeQL succeed.