### PR TITLE
Runtime: complete P9 systems and economic characterization

### DIFF
--- a/.github/workflows/p9-systems-characterization.yml
+++ b/.github/workflows/p9-systems-characterization.yml
@@ -1,0 +1,54 @@
+name: P9 Systems Characterization
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  characterize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Execute P9 characterization tests
+        run: python -m unittest reference.tests.test_systems_characterization
+
+      - name: Emit exact-head P9 characterization
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_systems_characterization.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --sizes 10,100,500
+          --repeats 5
+          --output systems-characterization.json
+
+      - name: Upload P9 characterization evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: p9-systems-economic-characterization
+          path: systems-characterization.json
+          if-no-files-found: error
+
+      - name: Publish P9 summary
+        if: always()
+        run: |
+          {
+            echo "## P9 systems/economic characterization"
+            echo ""
+            echo "Portable gates use structural work only. Runner timing is observational and non-gating."
+            echo ""
+            echo '```'
+            echo "python -m unittest reference.tests.test_systems_characterization"
+            echo "python reference/run_systems_characterization.py --agent-memory-commit <exact-40-hex-commit> --sizes 10,100,500 --repeats 5 --output systems-characterization.json"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/p9-systems-characterization.yml
+++ b/.github/workflows/p9-systems-characterization.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install P9 validation dependency
+        run: python -m pip install --disable-pip-version-check jsonschema==4.26.0
+
       - name: Execute P9 characterization tests
         run: python -m unittest reference.tests.test_systems_characterization
 
@@ -48,6 +51,7 @@ jobs:
             echo "Portable gates use structural work only. Runner timing is observational and non-gating."
             echo ""
             echo '```'
+            echo "python -m pip install jsonschema==4.26.0"
             echo "python -m unittest reference.tests.test_systems_characterization"
             echo "python reference/run_systems_characterization.py --agent-memory-commit <exact-40-hex-commit> --sizes 10,100,500 --repeats 5 --output systems-characterization.json"
             echo '```'

--- a/docs/programs/runtime-evidence/systems-economic-characterization.md
+++ b/docs/programs/runtime-evidence/systems-economic-characterization.md
@@ -1,0 +1,128 @@
+# P9 Systems and Economic Characterization
+
+## Purpose
+
+Characterize the operational cost shape of the Agent Memory reference runtime without turning performance or cost into authority.
+
+P9 answers a narrower question than conformance:
+
+> What work does the reference implementation perform as retained state, recall candidate volume, and derived-state closure grow?
+
+It does **not** answer whether a memory operation is authorized. PAMA, lifecycle, scope, deletion, and recall rules remain authoritative regardless of whether a faster implementation exists.
+
+## Evidence surface
+
+`reference/run_systems_characterization.py` executes a provider-neutral characterization and emits an exact-commit JSON artifact.
+
+The report separates two classes of evidence.
+
+### Deterministic structural cost
+
+These measurements are portable enough to compare across runs because they describe work performed rather than wall-clock speed:
+
+- audit-event and decision-receipt amplification for one governed canonical mutation;
+- serialized governance-evidence bytes emitted by that mutation;
+- recall candidate count as retained facts increase;
+- derivation-closure size and required projection purge operations as projection depth increases.
+
+### Environment-specific timing
+
+The same executed paths record minimum, median, and maximum `perf_counter_ns` observations across repeated samples.
+
+Timing is deliberately **non-gating**. The artifact records Python implementation/version, platform, and machine architecture because CI runner speed is not reproducible enough to become a conformance threshold.
+
+```text
+lower latency != more authority
+higher cost    != governance failure
+faster recall  != permission to admit
+cheaper write  != permission to persist
+```
+
+## Default workload
+
+The CI characterization uses workload sizes:
+
+```text
+10 -> 100 -> 500
+```
+
+with five timing samples per measured path.
+
+The workload is intentionally small enough to execute on every validation run while still exposing growth shape. It is not a production capacity benchmark.
+
+## Characterized paths
+
+### Governed write amplification
+
+One successful governed canonical mutation is executed through the normal adapter path.
+
+The report records:
+
+- canonical mutations;
+- audit events;
+- decision receipts;
+- evidence records per canonical mutation;
+- serialized receipt bytes;
+- serialized audit-event bytes;
+- total serialized governance-evidence bytes.
+
+This measures the explicit governance overhead the reference path chooses to retain for reconstructability. It is not a claim that every implementation must use the same encoding or storage layout.
+
+### Recall scaling
+
+For each workload size, the local reference substrate is populated with same-tenant facts and a governed recall is executed.
+
+The report records retained fact count, candidate count, admitted count, and observational latency.
+
+For this reference substrate, candidate work grows with the scanned retained set. P9 records that fact rather than disguising the in-memory reference adapter as an optimized production retrieval engine.
+
+### Deletion propagation scaling
+
+For each workload size, a deterministic chain of declared tier-3 projections is created from one canonical root. The existing transitive derivation-closure algorithm is executed.
+
+The report records projection depth, closure nodes, required projection purge operations, and observational latency.
+
+The structural invariant is important: deletion work follows the reachable derived-state closure. A cheaper implementation may improve traversal mechanics, but it may not obtain the savings by silently skipping reachable residue.
+
+## CI gates
+
+P9 fails CI only for structural contradictions, such as:
+
+- candidate count no longer matching the controlled retained-set workload;
+- transitive closure failing to include every declared projection in the controlled chain;
+- structural work not increasing when the controlled workload increases;
+- malformed exact-commit or workload parameters.
+
+Latency values never fail CI merely for being slow.
+
+## Economic interpretation
+
+The P9 artifact intentionally reports provider-neutral work units and bytes rather than dollars.
+
+Dollar cost depends on deployment choices that this repository does not control, including database engine, storage class, compute architecture, cloud region, retention period, indexing strategy, observability backend, and vendor pricing.
+
+A deployment may map the structural measurements to its own unit economics later. That mapping is operational evidence, not Agent Memory doctrine.
+
+## Claim boundary
+
+P9 demonstrates systems/economic characterization of the **reference runtime** and its implemented algorithms. It does not establish:
+
+- universal production throughput or latency;
+- a service-level objective;
+- cloud or hardware pricing;
+- maximum supported memory volume;
+- superiority over an external memory product;
+- permission to weaken governance for performance;
+- a new conformance level.
+
+## Reproduction
+
+```bash
+python reference/run_systems_characterization.py \
+  --agent-memory-commit <exact-40-hex-commit> \
+  --sizes 10,100,500 \
+  --repeats 5 \
+  --output systems-characterization.json
+```
+
+The generated JSON artifact is uploaded by `Validate Doctrine Evidence` for exact-head inspection.

--- a/reference/agentmem_ref/systems_characterization.py
+++ b/reference/agentmem_ref/systems_characterization.py
@@ -1,0 +1,228 @@
+"""P9 systems/economic characterization for the Agent Memory reference runtime.
+
+The characterization deliberately separates portable structural cost from
+machine-local timing. Operation counts, evidence amplification, candidate
+counts, and derivation closure sizes are deterministic properties of the
+executed reference paths. Latency is observational only and must never become
+an authority signal, a governance threshold, or a conformance gate.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import statistics
+import sys
+import time
+from dataclasses import asdict, dataclass
+
+from . import policy
+from .adapter import Clock, GovernedMemoryAdapter
+from .projections import (
+    DERIVED_CONTENT,
+    DETERMINISTIC,
+    REPRODUCIBLE,
+    Projection,
+    ProjectionStore,
+)
+from .substrate import Fact, InMemoryTemporalGraph
+
+TENANT = "tenant:p9"
+
+
+@dataclass(frozen=True)
+class TimingSummary:
+    samples: int
+    minimum_ns: int
+    median_ns: int
+    maximum_ns: int
+
+
+def _timed(operation, repeats: int) -> TimingSummary:
+    samples: list[int] = []
+    for _ in range(repeats):
+        started = time.perf_counter_ns()
+        operation()
+        samples.append(time.perf_counter_ns() - started)
+    return TimingSummary(
+        samples=len(samples),
+        minimum_ns=min(samples),
+        median_ns=int(statistics.median(samples)),
+        maximum_ns=max(samples),
+    )
+
+
+def _proposal(proposal_id: str, target_reference: str) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=proposal_id,
+        actor_id="agent:p9-characterizer",
+        charter_version="charter:p9",
+        target_reference=target_reference,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("evidence:p9",),
+        estimator_refs=("estimator:p9",),
+        estimator_versions=("1",),
+        confidence=0.8,
+        tenant_ref=TENANT,
+        purpose="systems_characterization",
+    )
+
+
+def characterize_write_amplification() -> dict:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    result = adapter.commit_proposal(
+        _proposal("proposal:p9-write", "memory:p9-write"),
+        "P9 canonical write characterization",
+    )
+    if not result.committed:
+        raise RuntimeError("P9 write characterization path did not commit")
+
+    receipt_bytes = len(json.dumps(result.receipt, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    event_bytes = sum(
+        len(json.dumps(event, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        for event in result.events
+    )
+    return {
+        "canonical_mutations": 1,
+        "audit_events": len(result.events),
+        "decision_receipts": 1,
+        "evidence_records_per_canonical_mutation": len(result.events) + 1,
+        "serialized_receipt_bytes": receipt_bytes,
+        "serialized_event_bytes": event_bytes,
+        "serialized_evidence_bytes": receipt_bytes + event_bytes,
+    }
+
+
+def _seed_substrate(size: int) -> tuple[InMemoryTemporalGraph, GovernedMemoryAdapter]:
+    substrate = InMemoryTemporalGraph()
+    for index in range(size):
+        substrate.write_fact(
+            Fact(
+                uuid=f"fact:p9:{index}",
+                fact_text=f"systems characterization token-{index}",
+                group_id=TENANT,
+                created_at="2026-01-01T00:00:00Z",
+            )
+        )
+    return substrate, GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+
+
+def characterize_recall(size: int, repeats: int) -> dict:
+    _, adapter = _seed_substrate(size)
+    latest = None
+
+    def run() -> None:
+        nonlocal latest
+        latest = adapter.governed_recall("systems characterization")
+
+    timing = _timed(run, repeats)
+    assert latest is not None
+    return {
+        "retained_facts": size,
+        "candidate_count": len(latest.candidates),
+        "admitted_count": len(latest.admitted),
+        "timing": asdict(timing),
+    }
+
+
+def _projection_chain(size: int) -> ProjectionStore:
+    store = ProjectionStore()
+    source = "memory:p9-root"
+    for index in range(size):
+        projection_id = f"projection:p9:{index}"
+        store.declare(
+            Projection(
+                projection_id=projection_id,
+                basis=((source, 1),),
+                transform=DETERMINISTIC,
+                content_class=DERIVED_CONTENT,
+                rebuild=REPRODUCIBLE,
+                scope=TENANT,
+            )
+        )
+        source = projection_id
+    return store
+
+
+def characterize_deletion_closure(size: int, repeats: int) -> dict:
+    store = _projection_chain(size)
+    latest = None
+
+    def run() -> None:
+        nonlocal latest
+        latest = store.derivation_closure("memory:p9-root")
+
+    timing = _timed(run, repeats)
+    assert latest is not None
+    return {
+        "projection_depth": size,
+        "closure_nodes": len(latest),
+        "required_projection_purge_operations": len(latest),
+        "timing": asdict(timing),
+    }
+
+
+def build_report(agent_memory_commit: str, sizes: tuple[int, ...] = (10, 100, 500), repeats: int = 5) -> dict:
+    if len(agent_memory_commit) != 40:
+        raise ValueError("agent_memory_commit must be an exact 40-character commit SHA")
+    if not sizes or any(size <= 0 for size in sizes):
+        raise ValueError("sizes must contain positive integers")
+    if tuple(sorted(set(sizes))) != sizes:
+        raise ValueError("sizes must be unique and strictly increasing")
+    if repeats < 1:
+        raise ValueError("repeats must be positive")
+
+    recall = [characterize_recall(size, repeats) for size in sizes]
+    deletion = [characterize_deletion_closure(size, repeats) for size in sizes]
+
+    structural_invariants = {
+        "recall_candidate_count_matches_retained_facts": all(
+            row["candidate_count"] == row["retained_facts"] for row in recall
+        ),
+        "deletion_closure_matches_projection_depth": all(
+            row["closure_nodes"] == row["projection_depth"] for row in deletion
+        ),
+        "structural_work_grows_with_workload": all(
+            recall[index]["candidate_count"] < recall[index + 1]["candidate_count"]
+            and deletion[index]["closure_nodes"] < deletion[index + 1]["closure_nodes"]
+            for index in range(len(sizes) - 1)
+        ),
+    }
+
+    return {
+        "profile": "agent-memory-p9-systems-characterization",
+        "version": "1.0.0",
+        "agent_memory_commit": agent_memory_commit,
+        "runner": {
+            "python": sys.version.split()[0],
+            "implementation": platform.python_implementation(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+        },
+        "method": {
+            "sizes": list(sizes),
+            "timing_repeats": repeats,
+            "latency_is_observational_only": True,
+            "latency_is_not_a_conformance_gate": True,
+            "cost_units_are_provider_neutral": True,
+        },
+        "write_amplification": characterize_write_amplification(),
+        "recall_scaling": recall,
+        "deletion_propagation_scaling": deletion,
+        "structural_invariants": structural_invariants,
+        "structural_invariants_passed": all(structural_invariants.values()),
+        "claim_boundary": [
+            "reference-runtime characterization, not universal production performance",
+            "timing values are runner-specific observations",
+            "cost and efficiency do not create memory authority",
+            "no external provider pricing or hardware cost claim",
+        ],
+    }

--- a/reference/run_systems_characterization.py
+++ b/reference/run_systems_characterization.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Emit P9 systems/economic characterization evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.systems_characterization import build_report  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--sizes", default="10,100,500")
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    sizes = tuple(int(value.strip()) for value in args.sizes.split(",") if value.strip())
+    report = build_report(args.agent_memory_commit, sizes=sizes, repeats=args.repeats)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report["structural_invariants_passed"]:
+        failed = [name for name, passed in report["structural_invariants"].items() if not passed]
+        print(f"P9 structural characterization invariant failed: {failed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_systems_characterization.py
+++ b/reference/tests/test_systems_characterization.py
@@ -1,0 +1,57 @@
+"""P9 systems/economic characterization tests."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.systems_characterization import build_report  # noqa: E402
+
+
+class SystemsCharacterizationTests(unittest.TestCase):
+    def test_report_preserves_structural_and_timing_boundaries(self):
+        report = build_report("a" * 40, sizes=(5, 20), repeats=2)
+
+        self.assertEqual(report["profile"], "agent-memory-p9-systems-characterization")
+        self.assertTrue(report["structural_invariants_passed"])
+        self.assertTrue(report["method"]["latency_is_observational_only"])
+        self.assertTrue(report["method"]["latency_is_not_a_conformance_gate"])
+        self.assertTrue(report["method"]["cost_units_are_provider_neutral"])
+
+        write = report["write_amplification"]
+        self.assertEqual(write["canonical_mutations"], 1)
+        self.assertEqual(write["audit_events"], 4)
+        self.assertEqual(write["decision_receipts"], 1)
+        self.assertEqual(write["evidence_records_per_canonical_mutation"], 5)
+        self.assertGreater(write["serialized_evidence_bytes"], 0)
+
+        self.assertEqual(
+            [row["candidate_count"] for row in report["recall_scaling"]],
+            [5, 20],
+        )
+        self.assertEqual(
+            [row["closure_nodes"] for row in report["deletion_propagation_scaling"]],
+            [5, 20],
+        )
+        for family in ("recall_scaling", "deletion_propagation_scaling"):
+            for row in report[family]:
+                self.assertEqual(row["timing"]["samples"], 2)
+                self.assertGreaterEqual(row["timing"]["minimum_ns"], 0)
+                self.assertGreaterEqual(row["timing"]["maximum_ns"], row["timing"]["minimum_ns"])
+
+    def test_exact_commit_and_workload_shape_fail_closed(self):
+        with self.assertRaises(ValueError):
+            build_report("short")
+        with self.assertRaises(ValueError):
+            build_report("a" * 40, sizes=(10, 10))
+        with self.assertRaises(ValueError):
+            build_report("a" * 40, sizes=(20, 10))
+        with self.assertRaises(ValueError):
+            build_report("a" * 40, repeats=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Completes the P9 systems/economic characterization slice under #46.

This PR adds a provider-neutral characterization of the Agent Memory reference runtime that keeps operational cost separate from governance authority.

It adds:
- deterministic structural measurements for governed-write evidence amplification
- serialized governance-evidence byte counts
- recall candidate/admission scaling across controlled retained-set sizes
- transitive deletion/derived-projection closure scaling
- runner-specific min/median/max timing observations that are explicitly non-gating
- exact Python/platform/machine metadata for timing interpretation
- structural invariants that fail CI when the controlled workload or transitive-closure behavior contradicts the expected executed path
- an exact-head JSON artifact uploaded by a dedicated P9 CI workflow
- documentation defining economic interpretation and claim boundaries

Default CI workload: 10, 100, and 500 units with five timing samples per path.

Important boundaries:
- latency/cost never create authority
- timing is observational, not a conformance threshold
- provider-neutral work units are reported instead of invented dollar costs
- this is reference-runtime characterization, not universal production throughput/SLO evidence
- no upstream submissions or external-repository writes

Merge only after exact-head Validate Doctrine Evidence, P9 Systems Characterization, and CodeQL all succeed.