### PR TITLE
Docs: refine Wiki home page

### DIFF
--- a/wiki-src/Home.md
+++ b/wiki-src/Home.md
@@ -37,16 +37,12 @@ The governing idea is compact:
 
 ## Start with what you need
 
-| If you want to... | Start here | Why |
-|---|---|---|
-| **Understand Agent Memory quickly** | **[Getting Started](Getting-Started)** | The shortest guided introduction to the architecture and vocabulary. |
-| **See the architecture visually** | **[Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle)** | Lifecycle, PAMA, recall, correction, deletion, isolation, and evidence flows in one visual guide. |
-| **Understand the core doctrine** | **[Core Concepts](Core-Concepts)** | The invariants and distinctions the rest of the architecture preserves. |
-| **Implement a memory system** | **[Implementation Guide](Implementation-Guide)** | A practical path from doctrine to components, adapters, governance, and evidence. |
-| **Evaluate security and isolation** | **[Security and Privacy](Security-and-Privacy)** | Scope, tenancy, isolation domains, leakage, sensitivity, and deletion boundaries. |
-| **Evaluate what is actually proven** | **[Conformance and Evidence](Conformance-and-Evidence)** → **[Runtime Evidence](Runtime-Evidence)** | Separates documentation, fixtures, executable evidence, and cumulative conformance claims. |
-| **Understand PAMA** | **[PAMA](PAMA)** | The native doctrine for proportional mutation authority and bounded consequence. |
-| **Trace research and influences** | **[Research and Sources](Research-and-Sources)** → **[Aligned Projects & Intellectual Lineage](Aligned-Projects-and-Intellectual-Lineage)** | Supporting and challenging evidence, provenance, and external architectural lineage. |
+- **New to Agent Memory?** Start with **[Getting Started](Getting-Started)**, then **[Core Concepts](Core-Concepts)** for the vocabulary and invariants the architecture preserves.
+- **Want the architecture in pictures?** Open **[Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle)** for lifecycle, PAMA, recall, correction, deletion, isolation, and evidence flows.
+- **Implementing a memory system?** Use the **[Implementation Guide](Implementation-Guide)**, then move into **[PAMA](PAMA)**, **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)**, and **[Canonical and Derived State](Canonical-and-Derived-State)** as needed.
+- **Reviewing security or isolation?** Start with **[Security and Privacy](Security-and-Privacy)** for scope, tenancy, isolation domains, sensitivity, leakage, and deletion boundaries.
+- **Checking what is actually proven?** Read **[Conformance and Evidence](Conformance-and-Evidence)** first, then **[Runtime Evidence](Runtime-Evidence)** for what has actually executed.
+- **Researching the foundations or influences?** Use **[Research and Sources](Research-and-Sources)** and **[Aligned Projects & Intellectual Lineage](Aligned-Projects-and-Intellectual-Lineage)**.
 
 ## Why retrieval alone is not enough
 

--- a/wiki-src/Home.md
+++ b/wiki-src/Home.md
@@ -4,9 +4,15 @@
 
 # Agent Memory
 
-**A field guide to governed memory for autonomous and agentic systems.**
+**A reference architecture for governed memory in autonomous and agentic systems.**
 
-Agent Memory is about more than retrieving old context. It defines what becomes memory, what remains uncertain, what may influence future behavior, who may change durable state, and how retained state can be corrected or forgotten.
+Agent Memory is about retained state that can influence future behavior without quietly acquiring truth, scope, permanence, or authority it has not earned.
+
+It separates uncertain interpretation from governed consequence, preserves why state changed, and treats correction, isolation, and forgetting as first-class architectural responsibilities rather than cleanup work.
+
+> **Agentic memory is retained state that can alter an agent's future interpretation, reasoning, planning, tool use, action, or adaptation across a meaningful persistence boundary.**
+
+## The architecture in one view
 
 <p align="center">
   <picture>
@@ -16,111 +22,112 @@ Agent Memory is about more than retrieving old context. It defines what becomes 
   </picture>
 </p>
 
-> **Agentic memory is retained state that can alter an agent's future interpretation, reasoning, planning, tool use, action, or adaptation across a meaningful persistence boundary.**
+The loop is intentionally split into responsibilities that many memory systems blur together:
 
-## Visual architecture at a glance
+1. **Interpret.** Experience becomes evidence, provenance, uncertainty, and a proposal.
+2. **Govern.** PAMA resolves what consequences are permitted under current policy, scope, authority, and state.
+3. **Commit.** A permitted consequence becomes explicit retained state with reconstructable evidence.
+4. **Recall.** Retrieval creates candidates; governance decides what may enter active context.
+5. **Revise or forget.** Correction, supersession, staleness, deletion, and residual derived state remain distinct and auditable.
 
-The Wiki now includes a reusable visual layer for the consequential paths that used to require reconstructing the architecture from prose. These diagrams are explanatory only. Canonical numbered docs and Accepted ADRs remain authoritative.
-
-### Memory lifecycle
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/lifecycle-flow.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/lifecycle-flow-light.svg">
-    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/lifecycle-flow-light.svg" alt="Agent Memory lifecycle state map showing strengthening and promotion, demotion, dispute, correction, reconciliation, pruning, and the separation between transition proposal and committed state" width="100%">
-  </picture>
-</p>
-
-A memory may strengthen, weaken, become disputed, be corrected, be reconciled, or be pruned without collapsing those events into one generic confidence score. **[Open the full lifecycle explanation](Lifecycle-and-Forgetting)**.
-
-### Isolation-domain crossing
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/isolation-domain-crossing.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/isolation-domain-crossing-light.svg">
-    <img src="https://raw.githubusercontent.com/MythologIQ-Labs-LLC/agent-memory/main/assets/diagrams/isolation-domain-crossing-light.svg" alt="Agent Memory isolation-domain crossing flow showing separate project and task domains within one physical store, domain authorization, PAMA evaluation, blocked and permitted crossing paths, and a reconstructable boundary-crossing receipt" width="100%">
-  </picture>
-</p>
-
-Semantic relevance cannot authorize a scope crossing. The same agent can operate in multiple projects, tasks, or shared spaces while those memories remain governed by different authority boundaries. **[Open the security and isolation explanation](Security-and-Privacy)**.
-
-For the complete set, including strength/stability, PAMA, governed recall, temporal correction, deletion completeness, scenarios, and portable evidence, use **[Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle)**.
-
-## Start with the question you have
-
-**I want the architecture in pictures.**  
-Start with **[Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle)**. It is the visual map for lifecycle, strength/stability, PAMA, recall, temporal correction, deletion completeness, executable scenarios, isolation boundaries, and evidence boundaries.
-
-**I am new to Agent Memory.**  
-Read **[Getting Started](Getting-Started)**, then **[Core Concepts](Core-Concepts)** for the vocabulary and invariants that the diagrams preserve.
-
-**I am implementing a memory system.**  
-Use the **[Implementation Guide](Implementation-Guide)**, then **[PAMA](PAMA)**, **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)**, and **[Canonical and Derived State](Canonical-and-Derived-State)** for the consequential boundaries.
-
-**I am evaluating whether a claim is actually proven.**  
-Use **[Conformance and Evidence](Conformance-and-Evidence)** for the evidence ladder and **[Runtime Evidence](Runtime-Evidence)** for what has actually executed.
-
-## Follow the architecture
-
-1. **Observe and estimate.** Experience becomes evidence, provenance, uncertainty, and a proposal. See **[Core Concepts](Core-Concepts)**.
-2. **Govern consequences.** PAMA resolves what actions are permitted. Evidence may strengthen a proposal; it does not manufacture authority. See **[PAMA](PAMA)**.
-3. **Commit explicit state.** A permitted consequence becomes retained state with reconstructable evidence. See **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)**.
-4. **Recall through admission.** Retrieval creates candidates; governance decides what may enter active context. See **[Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle#4-governed-recall-pipeline)**.
-5. **Correct, supersede, or forget.** Historical truth, correction, staleness, supersession, deletion, and residue remain distinct. See **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)** and **[Canonical and Derived State](Canonical-and-Derived-State)**.
-6. **Cross scope deliberately.** Same-agent relevance does not authorize movement among isolation domains; controlled crossing resolves current scope authority and PAMA before admission or export. See **[Security and Privacy](Security-and-Privacy)**.
-7. **Verify without inflating claims.** Runtime and portable evidence can prove specific relationships and outcomes without becoming semantic authority. See **[Runtime Evidence](Runtime-Evidence)**.
-
-The core separations are deliberately simple to state and expensive to violate:
-
-```text
-confidence != truth
-saturation != authority
-relevance != permission
-proposal != commit
-retrieval != recall admission
-same agent != same memory scope
-staleness != falsity
-delete operation != forgetting completeness
-```
-
-For the complete visual set and nearby canonical-source links, use **[Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle)**.
-
-## What makes the architecture different
-
-Agent Memory separates four jobs that are often collapsed into one opaque score:
-
-- **Epistemics** estimates relevance, trust, contradiction, sensitivity, utility, staleness, and other uncertain properties.
-- **Governance** determines which consequences are allowed under current policy, scope, authority, and state.
-- **Commit** applies an explicit state transition and emits reconstructable evidence.
-- **Recall** admits retained state into active context only when relevance and authorization both permit it.
+The governing idea is compact:
 
 > **Probabilistic epistemics. Governed consequences.**  
 > **Uncertainty may propose. Authority constrains.**
 
+## Start with what you need
+
+| If you want to... | Start here | Why |
+|---|---|---|
+| **Understand Agent Memory quickly** | **[Getting Started](Getting-Started)** | The shortest guided introduction to the architecture and vocabulary. |
+| **See the architecture visually** | **[Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle)** | Lifecycle, PAMA, recall, correction, deletion, isolation, and evidence flows in one visual guide. |
+| **Understand the core doctrine** | **[Core Concepts](Core-Concepts)** | The invariants and distinctions the rest of the architecture preserves. |
+| **Implement a memory system** | **[Implementation Guide](Implementation-Guide)** | A practical path from doctrine to components, adapters, governance, and evidence. |
+| **Evaluate security and isolation** | **[Security and Privacy](Security-and-Privacy)** | Scope, tenancy, isolation domains, leakage, sensitivity, and deletion boundaries. |
+| **Evaluate what is actually proven** | **[Conformance and Evidence](Conformance-and-Evidence)** → **[Runtime Evidence](Runtime-Evidence)** | Separates documentation, fixtures, executable evidence, and cumulative conformance claims. |
+| **Understand PAMA** | **[PAMA](PAMA)** | The native doctrine for proportional mutation authority and bounded consequence. |
+| **Trace research and influences** | **[Research and Sources](Research-and-Sources)** → **[Aligned Projects & Intellectual Lineage](Aligned-Projects-and-Intellectual-Lineage)** | Supporting and challenging evidence, provenance, and external architectural lineage. |
+
+## Why retrieval alone is not enough
+
+A retrieval system can answer **what looks relevant**. A governed memory architecture must also answer:
+
+- Should this state have been retained at all?
+- Is it still current, merely historically true, disputed, or superseded?
+- Does it belong to this user, task, project, tenant, or shared domain?
+- Is the source trustworthy in this scope?
+- May the memory enter the current context?
+- May an agent change durable or shared state because of it?
+- Can the resulting consequence be reconstructed later?
+- Can the memory be corrected without destroying history?
+- Can a deletion request reach summaries, indexes, caches, graph edges, and other derived state?
+
+That is the boundary Agent Memory is designed to make explicit.
+
+## The separations that matter
+
+The architecture resists convenient equivalences that become expensive failure modes later:
+
+```text
+identity       != truth
+confidence     != authority
+saturation     != truth
+relevance      != permission
+retrieval      != recall admission
+proposal       != commit
+same agent     != same memory scope
+staleness      != falsity
+supersession   != correction
+delete action  != forgetting completeness
+```
+
+These are not slogans pasted over a storage layer. They determine where evidence, policy, scope, lifecycle, and authority must remain independently inspectable.
+
+## Four jobs that should not collapse into one score
+
+**Epistemics** estimates uncertain properties such as relevance, trust, contradiction, sensitivity, utility, and staleness.
+
+**Governance** determines which consequences are allowed under current authority, policy, scope, and state.
+
+**Commit** applies an explicit state transition and emits evidence sufficient to reconstruct why it happened.
+
+**Recall** admits retained state into active context only when relevance and authorization both permit it.
+
+A model may be highly confident and still be wrong. A memory may be highly reinforced and still be unauthorized. A retrieval result may be highly relevant and still belong to another scope. Agent Memory keeps those possibilities representable instead of averaging them into reassurance.
+
 ## Current maturity
 
-- **Canonical doctrine:** ADR-001 through ADR-019 and ADR-022 are Accepted.
-- **Emerging decisions:** ADR-020 and ADR-021 remain Proposed and keep their own evidence gates.
-- **Executed evidence:** the repository exercises a governed reference adapter, P4 deletion-completeness paths, and the P4.5 portable-governance-evidence chain with adversarial negative cases.
-- **Isolation boundary:** ADR-022 acceptance establishes the doctrine contract; #68 remains open for broader runtime and negative-path conformance work.
-- **Claim boundary:** those executions do not automatically raise a conformance level or accept another ADR.
+Agent Memory separates doctrine maturity from implementation evidence so that one cannot impersonate the other.
 
-See **[Architecture Decisions](Architecture-Decisions)** for doctrine maturity and **[Runtime Evidence](Runtime-Evidence)** for the executable evidence ledger.
+| Area | Current state |
+|---|---|
+| **Canonical doctrine** | ADR-001 through ADR-020 and ADR-022 are **Accepted**. |
+| **Portable governance evidence** | ADR-021 remains **Proposed** and independently maturity-gated. |
+| **Runtime evidence** | Executable reference paths cover governed mutation, stochastic containment, deletion completeness, concurrency conflict handling, portable evidence correlation, adversarial comparator behavior, and systems characterization. |
+| **ADR-020 evidence gate** | Satisfied through the repository's executable P10 acceptance audit. |
+| **Reference implementation** | A narrow evidence vehicle, not a claim of universal production readiness or higher cumulative conformance. |
+| **Conformance claims** | Governed separately from individual evidence slices. Passing a runtime experiment does not automatically raise a cumulative conformance level. |
 
-## Explore the rest
+See **[Architecture Decisions](Architecture-Decisions)** for doctrine status and **[Runtime Evidence](Runtime-Evidence)** for the executable evidence ledger.
 
-- **[Governed Uncertainty](Governed-Uncertainty)** for deterministic governance around probabilistic discovery
-- **[Security and Privacy](Security-and-Privacy)** for isolation domains, scope, deletion, and leakage risks
-- **[Research and Sources](Research-and-Sources)** for supporting and challenging research
-- **[Aligned Projects & Intellectual Lineage](Aligned-Projects-and-Intellectual-Lineage)** for external influences and architectural relationships
-- **[Contributing](Contributing)** for contribution rules
+## Explore the architecture
 
-## Canonical source
+- **[PAMA](PAMA)** for proportional mutation authority and consequence governance
+- **[Lifecycle and Forgetting](Lifecycle-and-Forgetting)** for strengthening, correction, dispute, pruning, and forgetting
+- **[Canonical and Derived State](Canonical-and-Derived-State)** for staleness, deletion propagation, residue, and rebuild authority
+- **[Governed Uncertainty](Governed-Uncertainty)** for deterministic boundaries around probabilistic discovery
+- **[Security and Privacy](Security-and-Privacy)** for isolation domains, scope, tenancy, sensitivity, and leakage risks
+- **[Decision Flows and Memory Lifecycle](Decision-Flows-and-Memory-Lifecycle)** for the complete visual architecture set
+- **[Glossary](Glossary)** when two familiar words turn out to mean inconveniently different things
 
-The Wiki is the readable navigation and explanation layer. The numbered repository documentation remains authoritative.
+## Canonical source and contribution path
 
-**Canonical repository:** https://github.com/MythologIQ-Labs-LLC/agent-memory  
-**Documentation index:** https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/README.md  
-**Architecture decisions:** https://github.com/MythologIQ-Labs-LLC/agent-memory/tree/main/docs/adr
+The Wiki is the reader-facing navigation and explanation layer. Canonical doctrine, schemas, fixtures, evidence, and ADR status live in the repository itself.
+
+- **Canonical repository:** https://github.com/MythologIQ-Labs-LLC/agent-memory
+- **Documentation index:** https://github.com/MythologIQ-Labs-LLC/agent-memory/blob/main/docs/README.md
+- **Architecture decisions:** https://github.com/MythologIQ-Labs-LLC/agent-memory/tree/main/docs/adr
+- **Runtime evidence program:** https://github.com/MythologIQ-Labs-LLC/agent-memory/tree/main/docs/programs/runtime-evidence
+- **Contributing:** **[Contributing](Contributing)**
+
+If a Wiki summary and a canonical repository source ever disagree, the canonical source wins. The useful response is to fix the Wiki, not to hold a committee meeting between two Markdown files.


### PR DESCRIPTION
Refines `wiki-src/Home.md` into a clearer reader-facing landing page without changing doctrine.

Key changes:
- tighten the opening thesis and explain the architecture in one view
- replace duplicated full-page visuals with one primary loop and route deeper visual detail to the dedicated flow page
- add intent-based navigation for new readers, implementers, security reviewers, evidence reviewers, and researchers
- sharpen the retrieval-vs-governed-memory distinction
- consolidate the core invariants and four non-collapsible responsibilities
- update the maturity snapshot to the current ADR state, including ADR-020 Accepted, ADR-021 Proposed, and ADR-022 Accepted
- preserve the Wiki as an explanation/navigation layer with canonical repository sources authoritative

No schema, fixture, runtime, ADR, or conformance semantics are changed. Merge only after exact-head validation succeeds.