### PR TITLE
Runtime: enforce explicit cross-domain composition policy

### DIFF
--- a/docs/audits/isolation/02-cross-domain-composition-evidence.md
+++ b/docs/audits/isolation/02-cross-domain-composition-evidence.md
@@ -1,0 +1,56 @@
+# Cross-Domain Composition Evidence
+
+## Question
+
+Can two memories that each pass governed recall still be refused when their **combination** violates an explicit policy constraint?
+
+## Doctrine under test
+
+Canonical doc 41 states that individual admission does not prove a combined context is safe. Domain provenance must survive long enough for a composition-risk gate to evaluate the set.
+
+This slice does not create a universal rule that different domains may never compose. That would convert one threat case into architecture law without evidence.
+
+Instead, `reference/agentmem_ref/composition.py` accepts explicit set-level constraints. A constraint names the domain combination that current policy forbids. The composition evaluator then verifies that every proposed memory already passed candidate-level admission, preserves domain provenance across the set, and fails closed when an explicit prohibited combination is present.
+
+## Research support
+
+The implementation direction is consistent with, but not defined by, established access-control and information-flow work:
+
+- NIST SP 800-162 evaluates authorization from attributes of the subject, object, requested operation, and environment against policy rather than treating prior access as universal permission.
+- NIST SP 800-207 rejects implicit trust from location and instead requires resource-specific access decisions.
+- Decentralized information-flow-control research demonstrates why locally permitted component operations still require enforcement of permitted flows across composed/distributed systems.
+
+References:
+
+- https://doi.org/10.6028/NIST.SP.800-162
+- https://doi.org/10.6028/NIST.SP.800-207
+- Zeldovich, Boyd-Wickizer, and Mazières, *Securing Distributed Systems with Information Flow Control*, NSDI 2008, https://www.usenix.org/conference/nsdi-08/securing-distributed-systems-information-flow-control
+
+These sources are research inputs. They do not become Agent Memory doctrine by citation.
+
+## Executable evidence
+
+`reference/tests/test_composition_gate.py` proves four boundaries:
+
+1. two memories from different logical project domains can each pass governed recall when the request context is authorized for both;
+2. an explicit set-level policy constraint can still block their combined context;
+3. absence of such a constraint does not cause the reference path to invent a blanket cross-domain prohibition;
+4. the composition stage cannot reintroduce a memory that recall did not admit, and unresolved domain provenance fails closed.
+
+The permanent fixture `fixtures/cross-domain-composition-risk.json` records the adversarial case from issue #68.
+
+## Claim boundary
+
+This is a local executable composition-policy seam, not a universal information-flow proof, noninterference proof, policy language, or full context-assembly subsystem.
+
+It establishes:
+
+```text
+individual_recall_admission
+!=
+composition_permission
+```
+
+when explicit policy says the combined set is prohibited.
+
+It does not claim that all cross-domain combinations are unsafe, that domain identity alone is enough to derive every composition policy, or that the reference adapter now satisfies a higher cumulative conformance level.

--- a/fixtures/cross-domain-composition-risk.json
+++ b/fixtures/cross-domain-composition-risk.json
@@ -1,0 +1,88 @@
+{
+  "fixture_id": "cross-domain-composition-risk",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "Two memories are individually admissible to the requesting context, but an explicit project-separation policy prohibits their combined admission. Candidate-level permission does not manufacture composition permission.",
+  "expected_behavior": {
+    "individual_recall_admitted": true,
+    "composition_admitted": false,
+    "composition_policy_enforced": true
+  },
+  "governed_uncertainty": {
+    "requested_action": "admit_composed_context",
+    "permitted_actions": [
+      "block_composition",
+      "narrow_context",
+      "defer"
+    ],
+    "prohibited_actions": [
+      "admit_composed_context"
+    ],
+    "selected_action": "block_composition",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "individual_admission_not_equal_composition_permission",
+      "domain_provenance_preserved_through_composition_gate",
+      "explicit_composition_constraint_enforced",
+      "prohibited_action_not_selected"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:cross-domain-composition-context",
+    "type": "summary",
+    "state": "candidate",
+    "scope": {
+      "owner_principal": "user:alice",
+      "origin_actor": "agent:planner",
+      "tenant": "tenant-a",
+      "purpose": "assistance",
+      "isolation_domain_refs": [
+        "domain:project-red",
+        "domain:project-blue"
+      ],
+      "source_isolation_domain_refs": [
+        "domain:project-red",
+        "domain:project-blue"
+      ]
+    },
+    "provenance": {
+      "origin": "synthetic composition proposal",
+      "observer": "context-assembler",
+      "method": "set-level composition",
+      "timestamp": "2026-08-12T00:00:00Z",
+      "derived_from": [
+        "uor:test:project-red-memory",
+        "uor:test:project-blue-memory"
+      ]
+    },
+    "evidence": [
+      {
+        "id": "evidence:composition-policy",
+        "kind": "policy_constraint",
+        "ref": "policy:separate-red-blue",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.8,
+      "calibrated": true,
+      "durability_dimensions": [
+        "composition_candidate"
+      ]
+    },
+    "authority": {
+      "pama_outcome": "block",
+      "risk_class": "high",
+      "permitted_actions": [
+        "block_composition",
+        "narrow_context",
+        "defer"
+      ],
+      "prohibited_actions": [
+        "admit_composed_context"
+      ],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-12T00:00:00Z"
+  }
+}

--- a/reference/agentmem_ref/composition.py
+++ b/reference/agentmem_ref/composition.py
@@ -1,0 +1,108 @@
+"""Explicit policy gate for composing individually admitted memories.
+
+Candidate-level recall admission and set-level context composition are distinct
+capabilities. This module exercises the latter without inventing a universal
+rule that different domains may never compose. A caller supplies explicit
+policy constraints describing domain combinations that are prohibited in the
+current context.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CompositionCandidate:
+    memory_ref: str
+    domain_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CompositionConstraint:
+    """One explicit set-level policy constraint.
+
+    Every domain in ``prohibited_domain_set`` must be present in the proposed
+    composition before the constraint is violated. The tuple is a set in
+    semantic meaning; tuple order carries no hierarchy.
+    """
+
+    constraint_ref: str
+    prohibited_domain_set: tuple[str, ...]
+    reason: str
+
+
+@dataclass(frozen=True)
+class CompositionResult:
+    allowed: bool
+    memory_refs: tuple[str, ...]
+    domain_refs: tuple[str, ...]
+    violated_constraint_refs: tuple[str, ...] = ()
+    reason: str = ""
+
+
+def evaluate_composition(
+    candidates: tuple[CompositionCandidate, ...],
+    *,
+    admitted_memory_refs: tuple[str, ...],
+    constraints: tuple[CompositionConstraint, ...],
+) -> CompositionResult:
+    """Evaluate a proposed context composition after candidate-level admission.
+
+    The caller must provide the memory references actually admitted by the
+    governed recall step. A composition cannot use a candidate that was not
+    admitted, and explicit set-level constraints are evaluated over the union
+    of domain provenance carried by the proposed context.
+    """
+    admitted = set(admitted_memory_refs)
+    requested_refs = tuple(candidate.memory_ref for candidate in candidates)
+
+    if len(set(requested_refs)) != len(requested_refs):
+        return CompositionResult(
+            allowed=False,
+            memory_refs=requested_refs,
+            domain_refs=(),
+            reason="duplicate_memory_reference",
+        )
+
+    for candidate in candidates:
+        if not candidate.memory_ref or not candidate.domain_refs:
+            return CompositionResult(
+                allowed=False,
+                memory_refs=requested_refs,
+                domain_refs=(),
+                reason="composition_candidate_scope_unresolved",
+            )
+        if candidate.memory_ref not in admitted:
+            return CompositionResult(
+                allowed=False,
+                memory_refs=requested_refs,
+                domain_refs=(),
+                reason="composition_candidate_not_admitted",
+            )
+
+    domain_union = tuple(sorted({domain for candidate in candidates for domain in candidate.domain_refs}))
+    present = set(domain_union)
+    violated: list[str] = []
+
+    for constraint in constraints:
+        prohibited = set(constraint.prohibited_domain_set)
+        if not constraint.constraint_ref or not prohibited:
+            raise ValueError("composition constraints require a reference and prohibited domain set")
+        if prohibited.issubset(present):
+            violated.append(constraint.constraint_ref)
+
+    if violated:
+        return CompositionResult(
+            allowed=False,
+            memory_refs=requested_refs,
+            domain_refs=domain_union,
+            violated_constraint_refs=tuple(violated),
+            reason="cross_domain_composition_prohibited",
+        )
+
+    return CompositionResult(
+        allowed=True,
+        memory_refs=requested_refs,
+        domain_refs=domain_union,
+    )

--- a/reference/tests/test_composition_gate.py
+++ b/reference/tests/test_composition_gate.py
@@ -1,0 +1,140 @@
+"""Executable cross-domain composition evidence for issue #68."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext  # noqa: E402
+from agentmem_ref.composition import (  # noqa: E402
+    CompositionCandidate,
+    CompositionConstraint,
+    evaluate_composition,
+)
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+TENANT = "tenant-a"
+DOMAIN_RED = "domain:project-red"
+DOMAIN_BLUE = "domain:project-blue"
+
+
+def proposal(reference: str, domain: str) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=f"proposal:{reference}",
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference=reference,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("evidence:source",),
+        tenant_ref=TENANT,
+        purpose="assistance",
+        isolation_domain_refs=(domain,),
+    )
+
+
+class CompositionGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), tenant=TENANT, clock=Clock())
+        red = self.adapter.commit_proposal(
+            proposal("mem:red", DOMAIN_RED),
+            "rotation evidence shared composition token",
+        )
+        blue = self.adapter.commit_proposal(
+            proposal("mem:blue", DOMAIN_BLUE),
+            "rotation evidence shared composition token",
+        )
+        self.assertTrue(red.committed)
+        self.assertTrue(blue.committed)
+        self.red_uuid = red.fact_uuid
+        self.blue_uuid = blue.fact_uuid
+
+    def _recall_both(self):
+        recall = self.adapter.governed_recall(
+            "rotation evidence shared composition token",
+            RecallContext(target_domain_refs=(DOMAIN_RED, DOMAIN_BLUE), purpose="assistance"),
+        )
+        self.assertIn(self.red_uuid, recall.admitted)
+        self.assertIn(self.blue_uuid, recall.admitted)
+        return recall
+
+    def _candidates(self):
+        return (
+            CompositionCandidate(self.red_uuid, (DOMAIN_RED,)),
+            CompositionCandidate(self.blue_uuid, (DOMAIN_BLUE,)),
+        )
+
+    def test_individually_admitted_memories_can_be_blocked_as_a_combination(self):
+        recall = self._recall_both()
+
+        result = evaluate_composition(
+            self._candidates(),
+            admitted_memory_refs=tuple(recall.admitted),
+            constraints=(
+                CompositionConstraint(
+                    constraint_ref="policy:separate-red-blue",
+                    prohibited_domain_set=(DOMAIN_RED, DOMAIN_BLUE),
+                    reason="project separation forbids combined context",
+                ),
+            ),
+        )
+
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.reason, "cross_domain_composition_prohibited")
+        self.assertEqual(result.violated_constraint_refs, ("policy:separate-red-blue",))
+        self.assertEqual(set(result.domain_refs), {DOMAIN_RED, DOMAIN_BLUE})
+
+    def test_no_explicit_composition_constraint_does_not_invent_a_block(self):
+        recall = self._recall_both()
+
+        result = evaluate_composition(
+            self._candidates(),
+            admitted_memory_refs=tuple(recall.admitted),
+            constraints=(),
+        )
+
+        self.assertTrue(result.allowed)
+        self.assertEqual(result.violated_constraint_refs, ())
+
+    def test_composition_cannot_reintroduce_a_candidate_recall_did_not_admit(self):
+        recall = self._recall_both()
+        admitted_without_blue = tuple(ref for ref in recall.admitted if ref != self.blue_uuid)
+
+        result = evaluate_composition(
+            self._candidates(),
+            admitted_memory_refs=admitted_without_blue,
+            constraints=(),
+        )
+
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.reason, "composition_candidate_not_admitted")
+
+    def test_unresolved_domain_provenance_fails_closed(self):
+        recall = self._recall_both()
+        unresolved = (
+            CompositionCandidate(self.red_uuid, (DOMAIN_RED,)),
+            CompositionCandidate(self.blue_uuid, ()),
+        )
+
+        result = evaluate_composition(
+            unresolved,
+            admitted_memory_refs=tuple(recall.admitted),
+            constraints=(),
+        )
+
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.reason, "composition_candidate_scope_unresolved")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First implementation slice from the merged #68 gap reconciliation.

This PR adds a set-level composition gate for contexts containing memories that have already passed governed recall. It deliberately does not invent a blanket rule that different isolation domains may never compose.

The slice:
- requires every proposed composition member to have been admitted by recall
- preserves domain provenance across the proposed set
- enforces explicit policy constraints over prohibited domain combinations
- fails closed on unresolved candidate scope
- proves that two individually admitted memories can still be blocked as a combination
- proves that absence of an explicit constraint does not manufacture a cross-domain prohibition
- adds the permanent `cross-domain-composition-risk` fixture from #68
- records the research/claim boundary in `docs/audits/isolation/02-cross-domain-composition-evidence.md`

Research inputs include NIST SP 800-162, NIST SP 800-207, and open USENIX information-flow-control work. They inform the design but do not become Agent Memory doctrine by citation.

No visual/branding files are touched. Merge only after exact-head Validate Doctrine Evidence and CodeQL succeed.