### PR TITLE
Runtime: propagate source scope reduction to derived state

### DIFF
--- a/fixtures/scope-reduction-propagates-to-derived-state.json
+++ b/fixtures/scope-reduction-propagates-to-derived-state.json
@@ -1,0 +1,72 @@
+{
+  "fixture_id": "scope-reduction-propagates-to-derived-state",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "A source memory loses part of its audience/purpose authority after a derived memory was created. The previously valid derived scope must not remain current merely because it was authorized at creation time.",
+  "expected_behavior": {
+    "source_scope_reduced": true,
+    "derived_scope_recomputed": true,
+    "old_derived_scope_current": false,
+    "narrowing_required": true
+  },
+  "governed_uncertainty": {
+    "requested_action": "admit_to_context",
+    "permitted_actions": [
+      "narrow_derived_scope",
+      "rebuild_under_current_scope",
+      "defer"
+    ],
+    "prohibited_actions": [
+      "admit_to_context"
+    ],
+    "selected_action": "defer",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "prior_authorization_not_equal_current_authorization",
+      "derived_scope_recomputed_after_source_scope_change",
+      "scope_reduction_not_silently_ignored",
+      "prohibited_action_not_selected"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:stale-derived-scope",
+    "type": "summary",
+    "state": "candidate",
+    "scope": {
+      "owner_principal": "team:security",
+      "origin_actor": "agent:planner",
+      "tenant": "tenant-a",
+      "purpose": "security-review",
+      "isolation_domain_refs": ["domain:shared"],
+      "source_isolation_domain_refs": ["domain:project-a", "domain:project-b"]
+    },
+    "provenance": {
+      "origin": "synthetic derived summary before source scope reduction",
+      "observer": "scope-reconciler",
+      "method": "derived scope recomputation",
+      "timestamp": "2026-08-12T00:00:00Z",
+      "derived_from": ["uor:test:source-a", "uor:test:source-b"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:scope-reduction",
+        "kind": "scope_change",
+        "ref": "fixture://scope-reduction/source-a",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.8,
+      "calibrated": true,
+      "durability_dimensions": ["derived_scope"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "high",
+      "permitted_actions": ["narrow_derived_scope", "rebuild_under_current_scope", "defer"],
+      "prohibited_actions": ["admit_to_context"],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-12T00:00:00Z"
+  }
+}

--- a/reference/agentmem_ref/scope_governance.py
+++ b/reference/agentmem_ref/scope_governance.py
@@ -1,7 +1,7 @@
 """Isolation-domain scope propagation for derived memory.
 
-Executable evidence toward proposed ADR-022. A transform may change
-representation but does not erase source authority constraints.
+Executable evidence for ADR-022. A transform may change representation but does
+not erase source authority constraints.
 
 The safe default is:
 
@@ -40,6 +40,18 @@ class DerivedScope:
     allowed_audiences: frozenset[str]
     allowed_purposes: frozenset[str]
     restrictions: frozenset[str]
+
+
+@dataclass(frozen=True)
+class ScopeReconciliation:
+    """Result of re-evaluating derived authority after source scope changes."""
+
+    inherited_scope: DerivedScope | None
+    current_scope: DerivedScope
+    current_for_use: bool
+    requires_narrowing: bool
+    incompatible: bool = False
+    reason: str = ""
 
 
 def derive_scope(sources: tuple[SourceScope, ...]) -> DerivedScope:
@@ -81,6 +93,50 @@ def scope_broadens(inherited: DerivedScope, requested: DerivedScope) -> bool:
         or not requested.allowed_audiences.issubset(inherited.allowed_audiences)
         or not requested.allowed_purposes.issubset(inherited.allowed_purposes)
         or not requested.restrictions.issuperset(inherited.restrictions)
+    )
+
+
+def reconcile_derived_scope(
+    current: DerivedScope,
+    current_sources: tuple[SourceScope, ...],
+) -> ScopeReconciliation:
+    """Recompute inherited authority after a source scope change.
+
+    A derived object that remains broader than the newly inherited scope is not
+    current for use until it is narrowed or rebuilt through a governed path.
+    If the sources no longer have any compatible scope at all, the derivation
+    fails closed rather than retaining its historical authority envelope.
+    """
+    expected_refs = tuple(source.source_ref for source in current_sources)
+    if current.source_refs != expected_refs:
+        return ScopeReconciliation(
+            inherited_scope=None,
+            current_scope=current,
+            current_for_use=False,
+            requires_narrowing=False,
+            incompatible=True,
+            reason="source_basis_changed",
+        )
+
+    try:
+        inherited = derive_scope(current_sources)
+    except ScopeConflict as exc:
+        return ScopeReconciliation(
+            inherited_scope=None,
+            current_scope=current,
+            current_for_use=False,
+            requires_narrowing=False,
+            incompatible=True,
+            reason=str(exc),
+        )
+
+    broader = scope_broadens(inherited, current)
+    return ScopeReconciliation(
+        inherited_scope=inherited,
+        current_scope=current,
+        current_for_use=not broader,
+        requires_narrowing=broader,
+        reason="derived_scope_exceeds_current_source_authority" if broader else "",
     )
 
 

--- a/reference/tests/test_scope_reduction.py
+++ b/reference/tests/test_scope_reduction.py
@@ -1,0 +1,124 @@
+"""Executable scope-reduction propagation evidence for issue #68."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.scope_governance import (  # noqa: E402
+    DerivedScope,
+    SourceScope,
+    derive_scope,
+    reconcile_derived_scope,
+)
+
+
+class ScopeReductionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.source_a = SourceScope(
+            source_ref="mem:a",
+            domain_refs=frozenset({"domain:shared", "domain:project-a"}),
+            allowed_audiences=frozenset({"team:security", "agent:planner"}),
+            allowed_purposes=frozenset({"security-review", "incident-response"}),
+            restrictions=frozenset({"retain-provenance"}),
+        )
+        self.source_b = SourceScope(
+            source_ref="mem:b",
+            domain_refs=frozenset({"domain:shared", "domain:project-b"}),
+            allowed_audiences=frozenset({"team:security", "agent:planner"}),
+            allowed_purposes=frozenset({"security-review"}),
+            restrictions=frozenset({"no-external-export"}),
+        )
+        self.original = derive_scope((self.source_a, self.source_b))
+
+    def test_derived_state_becomes_non_current_when_source_scope_narrows(self):
+        narrowed_a = SourceScope(
+            source_ref="mem:a",
+            domain_refs=self.source_a.domain_refs,
+            allowed_audiences=frozenset({"team:security"}),
+            allowed_purposes=frozenset({"security-review"}),
+            restrictions=self.source_a.restrictions | {"no-agent-direct-use"},
+        )
+
+        result = reconcile_derived_scope(self.original, (narrowed_a, self.source_b))
+
+        self.assertFalse(result.current_for_use)
+        self.assertTrue(result.requires_narrowing)
+        self.assertFalse(result.incompatible)
+        self.assertEqual(result.reason, "derived_scope_exceeds_current_source_authority")
+        self.assertEqual(result.inherited_scope.allowed_audiences, frozenset({"team:security"}))
+        self.assertIn("no-agent-direct-use", result.inherited_scope.restrictions)
+
+    def test_derived_state_stays_current_when_source_change_does_not_narrow_authority(self):
+        equivalent_a = SourceScope(
+            source_ref="mem:a",
+            domain_refs=self.source_a.domain_refs,
+            allowed_audiences=self.source_a.allowed_audiences,
+            allowed_purposes=self.source_a.allowed_purposes,
+            restrictions=self.source_a.restrictions,
+        )
+
+        result = reconcile_derived_scope(self.original, (equivalent_a, self.source_b))
+
+        self.assertTrue(result.current_for_use)
+        self.assertFalse(result.requires_narrowing)
+        self.assertFalse(result.incompatible)
+
+    def test_incompatible_source_scopes_fail_closed(self):
+        isolated_b = SourceScope(
+            source_ref="mem:b",
+            domain_refs=frozenset({"domain:project-b-only"}),
+            allowed_audiences=self.source_b.allowed_audiences,
+            allowed_purposes=self.source_b.allowed_purposes,
+            restrictions=self.source_b.restrictions,
+        )
+
+        result = reconcile_derived_scope(self.original, (self.source_a, isolated_b))
+
+        self.assertFalse(result.current_for_use)
+        self.assertTrue(result.incompatible)
+        self.assertFalse(result.requires_narrowing)
+        self.assertIn("no compatible intersection", result.reason)
+
+    def test_changed_source_basis_does_not_reuse_old_derived_authority(self):
+        replacement = SourceScope(
+            source_ref="mem:c",
+            domain_refs=frozenset({"domain:shared"}),
+            allowed_audiences=frozenset({"team:security"}),
+            allowed_purposes=frozenset({"security-review"}),
+        )
+
+        result = reconcile_derived_scope(self.original, (self.source_a, replacement))
+
+        self.assertFalse(result.current_for_use)
+        self.assertTrue(result.incompatible)
+        self.assertEqual(result.reason, "source_basis_changed")
+
+    def test_narrowed_copy_is_current_after_reconciliation(self):
+        narrowed_a = SourceScope(
+            source_ref="mem:a",
+            domain_refs=self.source_a.domain_refs,
+            allowed_audiences=frozenset({"team:security"}),
+            allowed_purposes=frozenset({"security-review"}),
+            restrictions=self.source_a.restrictions | {"no-agent-direct-use"},
+        )
+        inherited = derive_scope((narrowed_a, self.source_b))
+        narrowed_copy = DerivedScope(
+            source_refs=inherited.source_refs,
+            domain_refs=inherited.domain_refs,
+            allowed_audiences=inherited.allowed_audiences,
+            allowed_purposes=inherited.allowed_purposes,
+            restrictions=inherited.restrictions,
+        )
+
+        result = reconcile_derived_scope(narrowed_copy, (narrowed_a, self.source_b))
+
+        self.assertTrue(result.current_for_use)
+        self.assertFalse(result.requires_narrowing)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Second implementation slice from the #68 research-led gap reconciliation.

This PR makes later source-scope changes load-bearing for already-derived state. It recomputes inherited derived scope from the current source authority rather than grandfathering the authority that existed when the derived object was created.

The slice:
- adds `reconcile_derived_scope()` over the existing SourceScope/DerivedScope contract
- marks a derived object non-current when its stored scope exceeds current inherited authority
- fails closed when source scopes become incompatible
- fails closed when the source basis itself changes
- proves a correctly narrowed/rebuilt derived scope can become current again
- adds the permanent `scope-reduction-propagates-to-derived-state` fixture

Research pressure comes from NIST ABAC and current zero-trust implementation guidance: authorization is evaluated from current request/object/context attributes and policy, and access conditions are continuously re-evaluated. These are supporting research inputs, not imported Agent Memory doctrine.

No new schema or authority primitive is introduced. No visual/branding files are touched. Merge only after exact-head Validate Doctrine Evidence and CodeQL succeed.