### PR TITLE
Runtime: propagate shared-memory membership revocation

### DIFF
--- a/fixtures/shared-memory-revocation-propagation.json
+++ b/fixtures/shared-memory-revocation-propagation.json
@@ -1,0 +1,74 @@
+{
+  "fixture_id": "shared-memory-revocation-propagation",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "A principal is removed from a governed shared-memory domain after a derived downstream memory was created while membership was valid. Future shared recall is blocked and the downstream derived authority must be recomputed rather than grandfathered.",
+  "expected_behavior": {
+    "shared_membership_revoked": true,
+    "future_shared_recall_admitted": false,
+    "downstream_scope_recomputed": true,
+    "old_downstream_scope_current": false,
+    "remote_mutation_implied": false
+  },
+  "governed_uncertainty": {
+    "requested_action": "admit_to_context",
+    "permitted_actions": [
+      "narrow_derived_scope",
+      "rebuild_under_current_scope",
+      "defer"
+    ],
+    "prohibited_actions": [
+      "admit_to_context"
+    ],
+    "selected_action": "defer",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "shared_membership_is_current_authority_state",
+      "revocation_blocks_future_shared_recall",
+      "revocation_propagates_as_authority_obligation_not_remote_command",
+      "prior_shared_membership_not_equal_permanent_downstream_permission",
+      "prohibited_action_not_selected"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:revoked-shared-derived-memory",
+    "type": "summary",
+    "state": "candidate",
+    "scope": {
+      "owner_principal": "team:security",
+      "origin_actor": "agent:planner",
+      "tenant": "tenant-a",
+      "purpose": "security-review",
+      "isolation_domain_refs": ["domain:shared-security"],
+      "source_isolation_domain_refs": ["domain:shared-security"]
+    },
+    "provenance": {
+      "origin": "synthetic shared-memory derivation before membership revocation",
+      "observer": "shared-revocation-reconciler",
+      "method": "membership revocation plus derived-scope recomputation",
+      "timestamp": "2026-08-12T00:00:00Z",
+      "derived_from": ["uor:test:shared-source"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:membership-revocation",
+        "kind": "authority_change",
+        "ref": "fixture://shared-membership/revoked-user-alice",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.8,
+      "calibrated": true,
+      "durability_dimensions": ["shared_derived_scope"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "high",
+      "permitted_actions": ["narrow_derived_scope", "rebuild_under_current_scope", "defer"],
+      "prohibited_actions": ["admit_to_context"],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-12T00:00:00Z"
+  }
+}

--- a/reference/agentmem_ref/shared_revocation.py
+++ b/reference/agentmem_ref/shared_revocation.py
@@ -1,0 +1,71 @@
+"""Shared-memory membership revocation propagation.
+
+A shared-space membership change is current authority state, not a command to
+mutate every downstream store. This reference seam updates the shared-domain
+recall membership and recomputes the authority inherited by derived state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .scope_governance import DerivedScope, ScopeReconciliation, SourceScope, reconcile_derived_scope
+
+
+@dataclass(frozen=True)
+class SharedRevocationResult:
+    domain_ref: str
+    revoked_principal: str
+    affected_source_refs: tuple[str, ...]
+    reconciliation: ScopeReconciliation
+
+
+def propagate_shared_membership_revocation(
+    adapter,
+    *,
+    domain_ref: str,
+    revoked_principal: str,
+    remaining_members: tuple[str, ...],
+    current_derived_scope: DerivedScope,
+    source_scopes: tuple[SourceScope, ...],
+) -> SharedRevocationResult:
+    """Apply current membership and recompute downstream derived authority.
+
+    Only sources actually bound to ``domain_ref`` lose the revoked principal
+    from their allowed audience. Other source authority remains unchanged.
+    The result reports whether the existing derived scope is still current; it
+    does not silently rewrite, delete, or re-authorize the downstream object.
+    """
+    if not domain_ref or not revoked_principal:
+        raise ValueError("shared revocation requires a domain and principal")
+    if revoked_principal in remaining_members:
+        raise ValueError("revoked principal cannot remain a member")
+
+    adapter.set_shared_domain_members(domain_ref, remaining_members)
+
+    updated: list[SourceScope] = []
+    affected: list[str] = []
+    for source in source_scopes:
+        if domain_ref not in source.domain_refs:
+            updated.append(source)
+            continue
+        affected.append(source.source_ref)
+        updated.append(
+            SourceScope(
+                source_ref=source.source_ref,
+                domain_refs=source.domain_refs,
+                allowed_audiences=frozenset(
+                    audience for audience in source.allowed_audiences if audience != revoked_principal
+                ),
+                allowed_purposes=source.allowed_purposes,
+                restrictions=source.restrictions,
+            )
+        )
+
+    reconciliation = reconcile_derived_scope(current_derived_scope, tuple(updated))
+    return SharedRevocationResult(
+        domain_ref=domain_ref,
+        revoked_principal=revoked_principal,
+        affected_source_refs=tuple(affected),
+        reconciliation=reconciliation,
+    )

--- a/reference/tests/test_shared_revocation_propagation.py
+++ b/reference/tests/test_shared_revocation_propagation.py
@@ -1,0 +1,156 @@
+"""Executable shared-memory revocation propagation evidence for issue #68."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext  # noqa: E402
+from agentmem_ref.scope_governance import SourceScope, derive_scope  # noqa: E402
+from agentmem_ref.shared_revocation import propagate_shared_membership_revocation  # noqa: E402
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+TENANT = "tenant-a"
+SHARED = "domain:shared-security"
+AGGREGATE = "domain:security-aggregate"
+ALICE = "user:alice"
+BOB = "user:bob"
+
+
+def proposal(reference: str) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=f"proposal:{reference}",
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference=reference,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("evidence:shared",),
+        tenant_ref=TENANT,
+        purpose="security-review",
+        isolation_domain_refs=(SHARED,),
+    )
+
+
+class SharedRevocationPropagationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), tenant=TENANT, clock=Clock())
+        self.adapter.set_shared_domain_members(SHARED, (ALICE, BOB))
+        commit = self.adapter.commit_proposal(
+            proposal("mem:shared"),
+            "shared revocation evidence token",
+        )
+        self.assertTrue(commit.committed)
+        self.fact_uuid = commit.fact_uuid
+        self.sources = (
+            SourceScope(
+                source_ref="mem:shared",
+                domain_refs=frozenset({SHARED}),
+                allowed_audiences=frozenset({ALICE, BOB}),
+                allowed_purposes=frozenset({"security-review"}),
+            ),
+        )
+        self.derived = derive_scope(self.sources)
+
+    def test_revocation_blocks_future_shared_recall_and_invalidates_broader_derived_scope(self):
+        before = self.adapter.governed_recall(
+            "shared revocation evidence token",
+            RecallContext(
+                target_domain_refs=(SHARED,),
+                principal_ref=ALICE,
+                purpose="security-review",
+            ),
+        )
+        self.assertIn(self.fact_uuid, before.admitted)
+
+        result = propagate_shared_membership_revocation(
+            self.adapter,
+            domain_ref=SHARED,
+            revoked_principal=ALICE,
+            remaining_members=(BOB,),
+            current_derived_scope=self.derived,
+            source_scopes=self.sources,
+        )
+
+        after = self.adapter.governed_recall(
+            "shared revocation evidence token",
+            RecallContext(
+                target_domain_refs=(SHARED,),
+                principal_ref=ALICE,
+                purpose="security-review",
+            ),
+        )
+        self.assertNotIn(self.fact_uuid, after.admitted)
+        self.assertEqual(after.refusals[self.fact_uuid], "shared_space_non_member")
+        self.assertEqual(result.affected_source_refs, ("mem:shared",))
+        self.assertFalse(result.reconciliation.current_for_use)
+        self.assertTrue(result.reconciliation.requires_narrowing)
+        self.assertEqual(result.reconciliation.inherited_scope.allowed_audiences, frozenset({BOB}))
+
+    def test_revocation_does_not_remotely_rewrite_the_derived_object(self):
+        result = propagate_shared_membership_revocation(
+            self.adapter,
+            domain_ref=SHARED,
+            revoked_principal=ALICE,
+            remaining_members=(BOB,),
+            current_derived_scope=self.derived,
+            source_scopes=self.sources,
+        )
+
+        self.assertIn(ALICE, self.derived.allowed_audiences)
+        self.assertFalse(result.reconciliation.current_for_use)
+        self.assertNotIn(ALICE, result.reconciliation.inherited_scope.allowed_audiences)
+
+    def test_unrelated_source_scope_is_not_mutated_by_shared_domain_revocation(self):
+        shared = SourceScope(
+            source_ref="mem:shared",
+            domain_refs=frozenset({SHARED, AGGREGATE}),
+            allowed_audiences=frozenset({ALICE, BOB}),
+            allowed_purposes=frozenset({"security-review"}),
+        )
+        private = SourceScope(
+            source_ref="mem:private",
+            domain_refs=frozenset({"domain:private", AGGREGATE}),
+            allowed_audiences=frozenset({ALICE, BOB}),
+            allowed_purposes=frozenset({"security-review"}),
+        )
+        sources = (shared, private)
+        current = derive_scope(sources)
+
+        result = propagate_shared_membership_revocation(
+            self.adapter,
+            domain_ref=SHARED,
+            revoked_principal=ALICE,
+            remaining_members=(BOB,),
+            current_derived_scope=current,
+            source_scopes=sources,
+        )
+
+        self.assertEqual(result.affected_source_refs, ("mem:shared",))
+        self.assertFalse(result.reconciliation.current_for_use)
+        self.assertEqual(result.reconciliation.inherited_scope.allowed_audiences, frozenset({BOB}))
+
+    def test_revoked_principal_cannot_be_listed_as_remaining_member(self):
+        with self.assertRaises(ValueError):
+            propagate_shared_membership_revocation(
+                self.adapter,
+                domain_ref=SHARED,
+                revoked_principal=ALICE,
+                remaining_members=(ALICE, BOB),
+                current_derived_scope=self.derived,
+                source_scopes=self.sources,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Third implementation slice from the #68 research-led gap reconciliation.

This PR composes two existing governance boundaries instead of inventing a remote revocation command:
- shared-domain membership is current recall authority
- source scope changes must be propagated into derived-state eligibility

When a principal is revoked from a shared domain, future recall from that domain is blocked and source scopes bound to that shared domain lose the revoked principal from their allowed audience. Any downstream derived scope that still contains the prior broader audience becomes non-current until narrowed/rebuilt under governance.

The slice explicitly proves that revocation does not silently rewrite the downstream object and does not mutate unrelated source authority.

This preserves:
`prior membership != permanent downstream permission`
and
`revocation obligation != remote mutation authority`.

No visual/branding files are touched. Merge only after exact-head Validate Doctrine Evidence and CodeQL succeed.