### PR TITLE
Runtime: prove authorized redacted export

### DIFF
--- a/fixtures/authorized-redacted-export.json
+++ b/fixtures/authorized-redacted-export.json
@@ -1,0 +1,77 @@
+{
+  "fixture_id": "authorized-redacted-export",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "A privacy-minimized redacted representation is exported to an external destination only after the scope-expansion decision receives external approval. Redaction participates in representation safety but does not authorize the crossing.",
+  "expected_behavior": {
+    "privacy_minimized": true,
+    "external_review_required": true,
+    "external_review_satisfied": true,
+    "export_committed": true,
+    "redaction_is_authority": false
+  },
+  "governed_uncertainty": {
+    "requested_action": "export",
+    "permitted_actions": [
+      "export",
+      "collect_more_evidence",
+      "defer"
+    ],
+    "prohibited_actions": [],
+    "selected_action": "export",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "redaction_not_equal_authority",
+      "destination_scope_expansion_governed",
+      "external_approval_bound_to_export",
+      "representation_metadata_preserved"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:authorized-redacted-export",
+    "type": "summary",
+    "state": "crystallized",
+    "scope": {
+      "owner_principal": "user:alice",
+      "origin_actor": "agent:planner",
+      "tenant": "tenant-a",
+      "purpose": "security-review",
+      "isolation_domain_refs": ["domain:project-a"],
+      "allowed_destinations": ["domain:external-partner"]
+    },
+    "provenance": {
+      "origin": "synthetic redacted export",
+      "observer": "boundary-crossing-evaluator",
+      "method": "approved redaction plus governed scope expansion",
+      "timestamp": "2026-08-12T00:00:00Z"
+    },
+    "evidence": [
+      {
+        "id": "evidence:redaction-shape",
+        "kind": "redaction",
+        "ref": "redaction:approved-shape",
+        "confidence": 1.0
+      },
+      {
+        "id": "evidence:data-owner-approval",
+        "kind": "approval",
+        "ref": "approval:data-owner",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.8,
+      "calibrated": true,
+      "durability_dimensions": ["authorized_export"]
+    },
+    "authority": {
+      "pama_outcome": "allow_with_ledger",
+      "risk_class": "medium",
+      "authority_refs": ["approval:data-owner"],
+      "permitted_actions": ["export", "collect_more_evidence", "defer"],
+      "prohibited_actions": [],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-12T00:00:00Z"
+  }
+}

--- a/reference/tests/test_boundary_crossing.py
+++ b/reference/tests/test_boundary_crossing.py
@@ -137,13 +137,44 @@ class BoundaryCrossingTests(unittest.TestCase):
         self.assertTrue(result.receipt["representation"]["privacy_minimized"])
         self.assertEqual(result.receipt["outcome"], "review_required")
 
+    def test_reviewed_privacy_minimized_export_can_commit_without_redaction_becoming_authority(self):
+        result = evaluate_crossing(
+            request(
+                operation="export",
+                destination_domain_refs=("domain:external-partner",),
+                representation_kind="redacted_summary",
+                privacy_minimized=True,
+                redaction_ref="redaction:approved-shape",
+                after_scope_refs=("domain:external-partner",),
+                authority_refs=("authority:external-export",),
+            ),
+            proposal(
+                review_satisfied=True,
+                approval_refs=("approval:data-owner",),
+            ),
+            receipt_id="crossing:authorized-redacted-export",
+            timestamp="2026-08-11T20:00:05Z",
+            decision_receipt_ref="decision:authorized-redacted-export",
+            ledger_ref="ledger:authorized-redacted-export",
+        )
+
+        self.assertTrue(result.committed)
+        self.assertEqual(result.decision.outcome, policy.ALLOW_WITH_LEDGER)
+        self.assertEqual(result.receipt["operation"], "export")
+        self.assertEqual(result.receipt["destination_domain_refs"], ["domain:external-partner"])
+        self.assertEqual(result.receipt["representation"]["kind"], "redacted_summary")
+        self.assertTrue(result.receipt["representation"]["privacy_minimized"])
+        self.assertEqual(result.receipt["representation"]["redaction_ref"], "redaction:approved-shape")
+        self.assertEqual(result.receipt["pama_disposition"], "allow_with_ledger")
+        self.assertEqual(result.receipt["decision_receipt_ref"], "decision:authorized-redacted-export")
+
     def test_crossing_requires_explicit_source_and_destination_domains(self):
         with self.assertRaises(ValueError):
             evaluate_crossing(
                 request(destination_domain_refs=()),
                 proposal(),
                 receipt_id="crossing:missing-domain",
-                timestamp="2026-08-11T20:00:05Z",
+                timestamp="2026-08-11T20:00:06Z",
             )
 
 


### PR DESCRIPTION
Replacement for #135 after rebasing the implementation branch onto the refreshed visual baseline caused GitHub to auto-close the zero-diff PR during the branch reset.

This is the same final concrete implementation slice from the #68 research-led gap reconciliation, now based on current `main`.

The existing negative path already proves that privacy minimization and redaction do not self-authorize an export. This PR adds the complementary positive path: a redacted representation may participate in an external export only when the crossing is still evaluated as `scope_expansion` and the required external review is satisfied.

The slice:
- keeps `redaction != authority`
- binds destination domain, redaction reference, representation kind, approval, decision receipt, and ledger evidence into the existing boundary-crossing receipt
- proves the reviewed export commits as `allow_with_ledger`
- preserves the existing unreviewed privacy-minimized export refusal
- adds the permanent `authorized-redacted-export` fixture from #68

No new export mechanism or authority primitive is introduced. No visual/branding files are touched.

Supersedes #135 only because of the rebase/auto-close mechanics. Merge only after exact-head Validate Doctrine Evidence, P9 Systems Characterization, and CodeQL succeed.