### PR TITLE
Runtime: enforce required isolation-domain compartments

### DIFF
--- a/docs/audits/isolation/02-required-compartment-semantics.md
+++ b/docs/audits/isolation/02-required-compartment-semantics.md
@@ -1,0 +1,164 @@
+# Required Compartment Semantics Research and Evidence
+
+## Purpose
+
+Resolve the final semantic question left open by the issue #68 gap reconciliation: when a memory is associated with multiple logical domains, does one matching domain authorize recall, or must every domain be present?
+
+The answer is that **both semantics are legitimate, but they represent different policy meanings and must not be overloaded onto one field**.
+
+This document records research support and the executable reference decision. It clarifies the implementation surface; it does not establish a universal hierarchy of compartments.
+
+## Existing behavior
+
+Before this slice, the reference adapter treated `isolation_domain_refs` as alternative governed routes:
+
+```text
+memory_domains ∩ target_domains != empty
+=> domain route satisfied
+```
+
+Other gates still applied, including shared-space membership, project, task, lifecycle state, and dispute state.
+
+That behavior is appropriate for a memory eligible through multiple governed domains. It is not sufficient to express a memory that requires **all** of several compartment constraints.
+
+## Research pressure
+
+### NIST SP 800-162: Attribute Based Access Control
+
+NIST defines ABAC authorization as evaluation of subject, object, requested-operation, and relevant environment attributes against explicit policy rules or relationships.
+
+Relevant implication for Agent Memory:
+
+- a multi-valued attribute is not inherently OR or AND;
+- the policy relationship defines which combinations are required;
+- authorization should therefore preserve the distinction between alternative routing attributes and mandatory constraint attributes.
+
+Reference:
+
+- NIST SP 800-162, *Guide to Attribute Based Access Control (ABAC) Definition and Considerations*: https://doi.org/10.6028/NIST.SP.800-162
+
+### NIST mandatory / non-discretionary access control terminology
+
+NIST describes mandatory access control as restricting access based on information sensitivity labels and formal user authorization, with subjects prevented from freely passing protected information or changing security attributes.
+
+Relevant implication for Agent Memory:
+
+- a compartment/sensitivity requirement is an enforced authorization condition, not merely another discoverable namespace;
+- satisfying one routing domain cannot erase another explicitly required compartment.
+
+Reference:
+
+- NIST CSRC glossary, non-discretionary / mandatory access control: https://csrc.nist.gov/glossary/term/non_discretionary_access_control
+
+These sources support the distinction. They do not define Agent Memory field names or import a mandatory-access-control hierarchy into the repository.
+
+## Chosen semantics
+
+### `isolation_domain_refs`
+
+These remain ordinary governed domain bindings / routes.
+
+For the reference adapter, at least one bound route must match the active recall context:
+
+```text
+intersection(memory.isolation_domain_refs, context.target_domain_refs) != empty
+```
+
+This preserves existing behavior and backwards compatibility.
+
+### `required_isolation_domain_refs`
+
+These are explicit conjunctive domain constraints.
+
+Every required ref must be present in the active recall context:
+
+```text
+memory.required_isolation_domain_refs <= context.target_domain_refs
+```
+
+A missing required ref produces a hard admission refusal:
+
+```text
+required_isolation_domain_missing
+```
+
+### Coherence rule
+
+A required ref must also be a bound isolation-domain ref for the memory.
+
+```text
+required_isolation_domain_refs <= isolation_domain_refs
+```
+
+An incoherent proposal fails closed at PAMA evaluation before a substrate mutation can be selected.
+
+## Why this is additive rather than a reinterpretation
+
+Changing all existing `isolation_domain_refs` tuples to conjunctive semantics would silently narrow previously valid memory and would encode a policy meaning that the existing field never promised.
+
+Keeping ordinary routes separate from mandatory constraints preserves:
+
+```text
+multiple_routes != all_routes_required
+shared_store != shared_authority
+same_tenant != same_memory_scope
+relevance != permission
+```
+
+The distinction also avoids imposing a universal hierarchy such as:
+
+```text
+tenant -> project -> task -> compartment
+```
+
+Deployments may use required constraints for compartments, legal boundaries, contractual partitions, purpose-specific enclaves, or other policy-defined domains without requiring those concepts to become fixed schema enums.
+
+## Machine-readable representation
+
+The reference `policy.Proposal` now carries `required_isolation_domain_refs` for runtime evidence.
+
+A companion schema, `schemas/isolation-domain-constraints.schema.json`, provides a portable sidecar shape for binding:
+
+- `memory_ref`
+- `isolation_domain_refs`
+- `required_isolation_domain_refs`
+- optional policy / authority references
+
+This deliberately avoids rewriting the existing memory-unit scope schema solely to close a test gap. Implementations may later integrate the companion contract into a canonical scope representation if comparative evidence shows that is superior to a sidecar.
+
+## Executable evidence
+
+`reference/tests/test_isolation_domains.py` proves:
+
+1. an ordinary multi-domain memory is still admissible through one valid route when no conjunctive constraint is declared;
+2. a same-tenant, same-project, same-task candidate is blocked when one mandatory compartment is absent;
+3. the same memory is admitted when all mandatory compartments and all other gates match.
+
+`reference/tests/test_required_compartment_semantics.py` proves:
+
+1. a required domain not bound to the memory fails closed at PAMA evaluation;
+2. a coherent required-domain declaration does not by itself strengthen or weaken the ordinary PAMA operation/risk outcome.
+
+`fixtures/same-tenant-prohibited-compartment.json` preserves the negative path as a permanent hard-gate fixture.
+
+## Claim boundary
+
+This evidence supports:
+
+- explicit separation of alternative domain routes from conjunctive required-domain constraints;
+- fail-closed same-tenant compartment admission when an explicitly required domain is absent;
+- preservation of existing non-hierarchical domain semantics.
+
+It does **not** claim:
+
+- every multiple-domain memory requires every domain simultaneously;
+- universal mandatory-access-control conformance;
+- a fixed compartment hierarchy;
+- that a domain label alone proves user clearance or membership;
+- that compartment satisfaction bypasses project, task, purpose, lifecycle, shared-space membership, crossing, or PAMA gates.
+
+## Closure relevance for #68
+
+The #68 gap reconciliation identified conjunctive compartment semantics as the final research question after the four concrete implementation gaps.
+
+This slice resolves that question without changing the governing doctrine that memory scope is an authority boundary. Once this exact implementation passes repository validation, #68 may proceed to a final closure audit mapping all named negative paths and fixtures to current executable evidence.

--- a/fixtures/same-tenant-prohibited-compartment.json
+++ b/fixtures/same-tenant-prohibited-compartment.json
@@ -1,0 +1,74 @@
+{
+  "fixture_id": "same-tenant-prohibited-compartment",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "A same-tenant, same-project candidate matches one valid routing domain but is missing one mandatory compartment in the active recall context. Candidate discovery remains possible; context admission must fail closed.",
+  "expected_behavior": {
+    "same_tenant": true,
+    "routing_domain_matches": true,
+    "all_required_compartments_present": false,
+    "candidate_visible": true,
+    "context_admitted": false,
+    "failure_is_hard_gate": true
+  },
+  "governed_uncertainty": {
+    "requested_action": "admit_to_context",
+    "permitted_actions": ["defer"],
+    "prohibited_actions": ["admit_to_context"],
+    "selected_action": "defer",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "same_tenant_not_equal_same_memory_scope",
+      "ordinary_domain_route_not_equal_required_compartment_satisfaction",
+      "all_required_isolation_domains_must_be_present",
+      "relevance_not_equal_permission",
+      "prohibited_action_not_selected"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:same-tenant-prohibited-compartment",
+    "type": "policy",
+    "state": "crystallized",
+    "scope": {
+      "owner_principal": "team:security",
+      "origin_actor": "agent:planner",
+      "tenant": "tenant-a",
+      "project": "project-a",
+      "task": "task-1",
+      "purpose": "assistance",
+      "isolation_domain_refs": [
+        "domain:project-a",
+        "compartment:export-controlled",
+        "compartment:legal"
+      ]
+    },
+    "provenance": {
+      "origin": "synthetic compartment-isolation scenario",
+      "observer": "governed-adapter",
+      "method": "same-tenant recall with one required compartment absent",
+      "timestamp": "2026-08-12T00:00:00Z"
+    },
+    "evidence": [
+      {
+        "id": "evidence:required-compartments",
+        "kind": "policy",
+        "ref": "schema://isolation-domain-constraints/same-tenant-prohibited-compartment",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.9,
+      "calibrated": true,
+      "durability_dimensions": ["isolation_scope"]
+    },
+    "authority": {
+      "pama_outcome": "block",
+      "risk_class": "high",
+      "policy_refs": ["policy:required-compartments"],
+      "permitted_actions": ["defer"],
+      "prohibited_actions": ["admit_to_context"],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-12T00:00:00Z"
+  }
+}

--- a/reference/agentmem_ref/adapter.py
+++ b/reference/agentmem_ref/adapter.py
@@ -91,7 +91,9 @@ class RecallContext:
     """Authority context for one governed recall request.
 
     Domain refs are logical authority boundaries. They are not storage
-    partitions and their tuple order does not imply hierarchy.
+    partitions and their tuple order does not imply hierarchy. A target context
+    may carry several active domains so mandatory compartment constraints can
+    be checked conjunctively without redefining ordinary domain routes.
     """
 
     target_domain_refs: tuple[str, ...]
@@ -263,8 +265,12 @@ class GovernedMemoryAdapter:
             )
         )
         domain_refs = tuple(proposal.isolation_domain_refs) or ((proposal.scope,) if proposal.scope else (self._tenant,))
+        required_domains = tuple(dict.fromkeys(proposal.required_isolation_domain_refs))
+        if required_domains and not set(required_domains).issubset(set(domain_refs)):
+            raise ValueError("required isolation domains must also be bound isolation domains")
         self._fact_scope[uuid] = {
             "domain_refs": domain_refs,
+            "required_domain_refs": required_domains,
             "project_ref": proposal.project_ref,
             "task_ref": proposal.task_ref,
             "purpose": proposal.purpose,
@@ -278,10 +284,10 @@ class GovernedMemoryAdapter:
         """Retrieve candidates, then admit only what current authority allows.
 
         Tenant partitioning is enforced before retrieval. Logical isolation
-        domains, shared-space membership, project, and task are evaluated at
-        admission because the in-memory substrate is trusted to return
-        same-tenant candidates for policy evaluation. Candidate presence and
-        shared-space membership remain distinct from admission authority.
+        domains, mandatory compartment constraints, shared-space membership,
+        project, and task are evaluated at admission because the in-memory
+        substrate is trusted to return same-tenant candidates for policy
+        evaluation. Candidate presence remains distinct from admission authority.
         """
         context = context or RecallContext(target_domain_refs=(self._tenant,))
         result = AdmissionResult()
@@ -309,10 +315,13 @@ class GovernedMemoryAdapter:
             return None
 
         memory_domains = set(scope["domain_refs"])
+        required_domains = set(scope.get("required_domain_refs", ()))
         target_domains = set(context.target_domain_refs)
         matching_domains = memory_domains.intersection(target_domains)
         if not target_domains or not matching_domains:
             return "isolation_domain_mismatch"
+        if required_domains and not required_domains.issubset(target_domains):
+            return "required_isolation_domain_missing"
 
         # A shared domain is still an isolation boundary. If all matching
         # routes are governed shared spaces, at least one must currently admit

--- a/reference/agentmem_ref/adapter.py
+++ b/reference/agentmem_ref/adapter.py
@@ -253,6 +253,11 @@ class GovernedMemoryAdapter:
         return choice
 
     def _write(self, proposal: policy.Proposal, fact_text: str) -> str:
+        domain_refs = tuple(proposal.isolation_domain_refs) or ((proposal.scope,) if proposal.scope else (self._tenant,))
+        required_domains = tuple(dict.fromkeys(proposal.required_isolation_domain_refs))
+        if required_domains and not set(required_domains).issubset(set(domain_refs)):
+            raise ValueError("required isolation domains must also be bound isolation domains")
+
         uuid = self._ids.next()
         self._substrate.write_fact(
             Fact(
@@ -264,10 +269,6 @@ class GovernedMemoryAdapter:
                 created_at=self._clock.now(),
             )
         )
-        domain_refs = tuple(proposal.isolation_domain_refs) or ((proposal.scope,) if proposal.scope else (self._tenant,))
-        required_domains = tuple(dict.fromkeys(proposal.required_isolation_domain_refs))
-        if required_domains and not set(required_domains).issubset(set(domain_refs)):
-            raise ValueError("required isolation domains must also be bound isolation domains")
         self._fact_scope[uuid] = {
             "domain_refs": domain_refs,
             "required_domain_refs": required_domains,

--- a/reference/agentmem_ref/policy.py
+++ b/reference/agentmem_ref/policy.py
@@ -120,6 +120,7 @@ class Proposal:
     tenant_ref: str = ""
     purpose: str = ""
     isolation_domain_refs: tuple[str, ...] = ()
+    required_isolation_domain_refs: tuple[str, ...] = ()
     project_ref: str = ""
     task_ref: str = ""
 

--- a/reference/agentmem_ref/policy.py
+++ b/reference/agentmem_ref/policy.py
@@ -161,6 +161,10 @@ def _apply_modifiers(outcome: str, proposal: Proposal) -> tuple[str, list[str]]:
         return BLOCK, ["M-AUTH: actor authority could not be reconstructed"]
     if proposal.approves_own_authority:
         return BLOCK, ["invariant 4: an actor may not approve its own authority expansion"]
+    required_domains = set(proposal.required_isolation_domain_refs)
+    bound_domains = set(proposal.isolation_domain_refs)
+    if required_domains and not required_domains.issubset(bound_domains):
+        return BLOCK, ["required isolation domains must be bound to the memory scope"]
     if proposal.reversibility == "irreversible":
         escalated = _strictest(outcome, REQUIRE_REVIEW)
         if proposal.risk_class in ("high", "critical"):

--- a/reference/tests/test_isolation_domains.py
+++ b/reference/tests/test_isolation_domains.py
@@ -1,4 +1,4 @@
-"""Executable isolation-domain recall evidence for proposed ADR-022.
+"""Executable isolation-domain recall evidence for accepted ADR-022.
 
 These tests deliberately use one adapter, one agent identity, one tenant, and
 one physical substrate. The only changing boundary is logical memory scope.
@@ -21,9 +21,19 @@ TENANT = "tenant-a"
 AGENT = "agent:planner"
 DOMAIN_A = "domain:project-a"
 DOMAIN_B = "domain:project-b"
+COMPARTMENT_EXPORT = "compartment:export-controlled"
+COMPARTMENT_LEGAL = "compartment:legal"
 
 
-def proposal(reference: str, domain: str, project: str, task: str) -> policy.Proposal:
+def proposal(
+    reference: str,
+    domain: str,
+    project: str,
+    task: str,
+    *,
+    additional_domains: tuple[str, ...] = (),
+    required_domains: tuple[str, ...] = (),
+) -> policy.Proposal:
     return policy.Proposal(
         proposal_id=f"proposal:{reference}",
         actor_id=AGENT,
@@ -40,7 +50,8 @@ def proposal(reference: str, domain: str, project: str, task: str) -> policy.Pro
         evidence_refs=("evidence:source",),
         tenant_ref=TENANT,
         purpose="assistance",
-        isolation_domain_refs=(domain,),
+        isolation_domain_refs=(domain, *additional_domains),
+        required_isolation_domain_refs=required_domains,
         project_ref=project,
         task_ref=task,
     )
@@ -51,9 +62,25 @@ class IsolationDomainRecallTests(unittest.TestCase):
         self.substrate = InMemoryTemporalGraph()
         self.adapter = GovernedMemoryAdapter(self.substrate, tenant=TENANT, clock=Clock())
 
-    def _commit(self, reference: str, domain: str, project: str, task: str):
+    def _commit(
+        self,
+        reference: str,
+        domain: str,
+        project: str,
+        task: str,
+        *,
+        additional_domains: tuple[str, ...] = (),
+        required_domains: tuple[str, ...] = (),
+    ):
         result = self.adapter.commit_proposal(
-            proposal(reference, domain, project, task),
+            proposal(
+                reference,
+                domain,
+                project,
+                task,
+                additional_domains=additional_domains,
+                required_domains=required_domains,
+            ),
             "deployment credential rotation procedure",
         )
         self.assertTrue(result.committed)
@@ -140,6 +167,72 @@ class IsolationDomainRecallTests(unittest.TestCase):
         self.assertIn(fact_uuid, recall.candidates)
         self.assertNotIn(fact_uuid, recall.admitted)
         self.assertEqual(recall.refusals[fact_uuid], "isolation_domain_mismatch")
+
+    def test_same_tenant_missing_required_compartment_is_blocked(self):
+        fact_uuid = self._commit(
+            "mem:a6",
+            DOMAIN_A,
+            "project-a",
+            "task-1",
+            additional_domains=(COMPARTMENT_EXPORT, COMPARTMENT_LEGAL),
+            required_domains=(COMPARTMENT_EXPORT, COMPARTMENT_LEGAL),
+        )
+
+        recall = self.adapter.governed_recall(
+            "deployment credential rotation procedure",
+            RecallContext(
+                target_domain_refs=(DOMAIN_A, COMPARTMENT_EXPORT),
+                project_ref="project-a",
+                task_ref="task-1",
+                purpose="assistance",
+            ),
+        )
+
+        self.assertIn(fact_uuid, recall.candidates)
+        self.assertNotIn(fact_uuid, recall.admitted)
+        self.assertEqual(recall.refusals[fact_uuid], "required_isolation_domain_missing")
+
+    def test_all_required_compartments_allow_admission_when_other_gates_match(self):
+        fact_uuid = self._commit(
+            "mem:a7",
+            DOMAIN_A,
+            "project-a",
+            "task-1",
+            additional_domains=(COMPARTMENT_EXPORT, COMPARTMENT_LEGAL),
+            required_domains=(COMPARTMENT_EXPORT, COMPARTMENT_LEGAL),
+        )
+
+        recall = self.adapter.governed_recall(
+            "deployment credential rotation procedure",
+            RecallContext(
+                target_domain_refs=(DOMAIN_A, COMPARTMENT_EXPORT, COMPARTMENT_LEGAL),
+                project_ref="project-a",
+                task_ref="task-1",
+                purpose="assistance",
+            ),
+        )
+
+        self.assertIn(fact_uuid, recall.admitted)
+
+    def test_ordinary_multiple_domain_refs_remain_alternative_routes(self):
+        fact_uuid = self._commit(
+            "mem:a8",
+            DOMAIN_A,
+            "project-a",
+            "task-1",
+            additional_domains=("domain:shared-route",),
+        )
+
+        recall = self.adapter.governed_recall(
+            "deployment credential rotation procedure",
+            RecallContext(
+                target_domain_refs=(DOMAIN_A,),
+                project_ref="project-a",
+                task_ref="task-1",
+            ),
+        )
+
+        self.assertIn(fact_uuid, recall.admitted)
 
 
 if __name__ == "__main__":

--- a/reference/tests/test_required_compartment_semantics.py
+++ b/reference/tests/test_required_compartment_semantics.py
@@ -1,0 +1,62 @@
+"""Focused negative-path evidence for explicit required isolation domains."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+
+
+class RequiredCompartmentSemanticsTests(unittest.TestCase):
+    def _proposal(self, *, bound: tuple[str, ...], required: tuple[str, ...]) -> policy.Proposal:
+        return policy.Proposal(
+            proposal_id="proposal:required-compartment",
+            actor_id="agent:planner",
+            charter_version="charter-1",
+            target_reference="mem:compartmented",
+            target_class=policy.M2,
+            scope="tenant-a",
+            operation="promotion",
+            current_strength="reinforced",
+            proposed_strength="promoted",
+            downstream_authority=policy.A1,
+            reversibility="reversible",
+            risk_class="low",
+            evidence_refs=("evidence:scope-policy",),
+            tenant_ref="tenant-a",
+            isolation_domain_refs=bound,
+            required_isolation_domain_refs=required,
+            project_ref="project-a",
+            task_ref="task-1",
+        )
+
+    def test_required_domain_must_also_be_bound_to_memory(self):
+        decision = policy.evaluate(
+            self._proposal(
+                bound=("domain:project-a", "compartment:export-controlled"),
+                required=("compartment:export-controlled", "compartment:legal"),
+            )
+        )
+
+        self.assertEqual(decision.outcome, policy.BLOCK)
+        self.assertIn("promotion", decision.prohibited_actions)
+        self.assertIn("required isolation domains must be bound", decision.reasons[0])
+
+    def test_coherent_required_domains_do_not_change_pama_strength_by_themselves(self):
+        decision = policy.evaluate(
+            self._proposal(
+                bound=("domain:project-a", "compartment:export-controlled", "compartment:legal"),
+                required=("compartment:export-controlled", "compartment:legal"),
+            )
+        )
+
+        self.assertEqual(decision.outcome, policy.ALLOW_WITH_LEDGER)
+        self.assertIn("promotion", decision.permitted_actions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/isolation-domain-constraints.schema.json
+++ b/schemas/isolation-domain-constraints.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/isolation-domain-constraints.schema.json",
+  "title": "Agent Memory Isolation Domain Constraints",
+  "description": "Companion sidecar for explicit memory-domain routing and mandatory conjunctive compartment constraints. Ordinary isolation_domain_refs are alternate governed routes; required_isolation_domain_refs must all be present in the active authorization context.",
+  "type": "object",
+  "required": ["memory_ref", "isolation_domain_refs"],
+  "properties": {
+    "memory_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "isolation_domain_refs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1},
+      "description": "Governed domain routes through which the memory may be eligible for admission. A matching route is necessary but not sufficient."
+    },
+    "required_isolation_domain_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1},
+      "description": "Mandatory domain/compartment constraints. Every listed ref must be present in the active recall context; these refs must also appear in isolation_domain_refs."
+    },
+    "policy_ref": {
+      "type": "string"
+    },
+    "authority_ref": {
+      "type": "string"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["required_isolation_domain_refs"]
+      },
+      "then": {
+        "properties": {
+          "required_isolation_domain_refs": {
+            "minItems": 1
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Final semantic implementation slice from the #68 research-led gap reconciliation.

The existing reference runtime treats multiple `isolation_domain_refs` as alternative governed routes: one matching authorized route can satisfy the domain gate, while project/task/shared-membership/lifecycle gates still apply. That is valid for route eligibility, but it cannot also express a mandatory compartment requirement.

Research pressure from NIST SP 800-162 ABAC and NIST mandatory/non-discretionary access-control terminology supports keeping policy combinations explicit rather than silently treating every multi-valued domain attribute as either OR or AND.

This PR therefore separates the two meanings:
- `isolation_domain_refs` remain non-hierarchical alternative governed routes
- `required_isolation_domain_refs` are explicit conjunctive constraints; every required ref must be present in the active recall context
- required refs must also be bound isolation-domain refs
- incoherent required-domain proposals fail closed at PAMA before any substrate mutation
- `_write()` independently checks coherence before touching the substrate
- missing required compartments produce `required_isolation_domain_missing`
- ordinary multi-domain memories without required refs preserve existing route semantics

Evidence added:
- same-tenant missing-compartment negative path
- all-required-compartments positive path
- ordinary multi-route compatibility path
- incoherent required-domain PAMA block path
- `same-tenant-prohibited-compartment` permanent fixture
- companion `isolation-domain-constraints.schema.json`
- research/claim-boundary audit in `docs/audits/isolation/02-required-compartment-semantics.md`

This does not impose a fixed tenant/project/task/compartment hierarchy and does not claim NIST MAC conformance. Required-domain satisfaction is only one admission condition; it does not replace membership, purpose, project/task, lifecycle, crossing, or PAMA authority.

No visual/branding files are touched.

Merge only after exact-head Validate Doctrine Evidence, P9 Systems Characterization, and CodeQL succeed.