### PR TITLE
Add #137/#138 architecture ADRs for durable memory mutation

### DIFF
--- a/docs/adr/ADR-023-corrections-are-supersession-not-deletion.md
+++ b/docs/adr/ADR-023-corrections-are-supersession-not-deletion.md
@@ -1,0 +1,82 @@
+# ADR-023: Corrections Are Supersession, Not Deletion
+
+Status: Proposed
+
+Date: 2026-08-12
+
+## Context
+
+Issues #137 and #138 examine durable memory governance boundaries around what becomes memory, who may change durable state, and how memory changes remain auditable.
+
+Correction handling sits directly on that boundary. If a corrected memory is deleted, the current state may look clean, but the system loses the causal trail that explains why the decision, preference, instruction, or fact changed. That weakens auditability, replay, rollback, and governance review.
+
+The repository already separates memory lifecycle, scoring and decay, temporal causality, retention/deletion, audit events, PAMA mutation authority, and conflict resolution. This ADR does not replace those components. It makes the correction-specific decision explicit so implementation issues can compose with the existing doctrine rather than inventing a parallel mutation model.
+
+## Decision
+
+Ordinary correction of durable memory must be modeled as append-only supersession, not destructive deletion.
+
+A correction creates a new durable memory record that identifies the earlier record it supersedes. The earlier record remains available for audit, provenance, and causal reconstruction unless a separate deletion, erasure, or safety policy requires removal.
+
+The superseded record must no longer compete as current truth. It must be marked as corrected, superseded, or equivalent; linked to the replacement where available; and excluded from ordinary recall or demoted strongly enough that it cannot silently win over the correcting record.
+
+Deletion and erasure remain distinct lifecycle paths. User-requested deletion, legal erasure, safety-driven removal, and retention expiry are not reclassified as correction.
+
+## Rationale
+
+Auditability requires explaining why durable state changed, not merely presenting the latest value.
+
+Append-only supersession preserves the old record, the correcting record, the relationship between them, and the authority evidence that allowed the change. This supports temporal causality, replay, rollback, governance review, and negative-path testing.
+
+Destructive correction is attractive because it reduces surface area. It is also a convenient way to make uncomfortable history vanish, which is precisely why it is not acceptable as the default correction path.
+
+## Consequences
+
+### Positive
+
+- Correction history remains auditable.
+- Durable memory can explain how and why a prior belief, preference, instruction, or decision changed.
+- Recall can avoid stale truth while preserving provenance.
+- Conformance tests can verify both current recall behavior and historical reconstruction.
+- Deletion and erasure policy remain separate and explicit.
+
+### Negative
+
+- Storage systems must retain more records.
+- Retrieval systems must understand lifecycle state and supersession links.
+- User interfaces and APIs must avoid presenting superseded records as current truth.
+- Implementations need clear boundaries between correction, retention expiry, tombstoning, and erasure.
+
+## Implementation notes
+
+A conforming implementation should represent at least:
+
+- the correcting memory record;
+- the superseded memory record;
+- a `supersedes`, `superseded_by`, or equivalent relationship;
+- lifecycle state indicating corrected or superseded status;
+- authority evidence for the correction;
+- recall policy that excludes or heavily demotes superseded records in ordinary retrieval;
+- audit policy that can still surface superseded records as historical evidence.
+
+The exact field names are implementation-specific, but the semantics are not optional.
+
+## Validation and acceptance
+
+This ADR should not advance beyond Proposed until the repository includes evidence for:
+
+- a fixture where a corrected record remains auditable after supersession;
+- a recall test where the superseded record does not win ordinary retrieval;
+- a negative-path test where superseded content cannot silently overwrite the replacement;
+- documentation updates distinguishing correction/supersession from deletion/erasure;
+- scoring or recall documentation defining demotion or exclusion behavior for superseded records.
+
+## Related
+
+- #137
+- #138
+- #142
+- ADR-011: Temporal Causality Is Required for Memory Evolution
+- ADR-015: Retention, Deletion, and Tombstones Are Required
+- ADR-017: Memory Observability and Audit Events Are Required
+- ADR-020: Probabilistic Discovery, Deterministic Governance

--- a/docs/adr/ADR-024-shared-memory-writes-require-prewrite-claims.md
+++ b/docs/adr/ADR-024-shared-memory-writes-require-prewrite-claims.md
@@ -1,0 +1,83 @@
+# ADR-024: Shared Memory Writes Require Pre-Write Claims
+
+Status: Proposed
+
+Date: 2026-08-12
+
+## Context
+
+Issues #137 and #138 identify durable memory mutation as more than a retrieval problem. Shared agent memory must answer both what becomes memory and who may change durable state.
+
+In multi-agent systems, uncoordinated writes can create silent overwrites, stale updates, authority laundering, and conflict resolution after the damage has already been committed. The existing repository doctrine already includes PAMA mutation authority, conflict resolution, temporal causality, audit events, and concurrency evidence. This ADR makes the pre-write coordination requirement explicit.
+
+## Decision
+
+Shared durable memory writes require a pre-write claim, lock, lease, compare-and-swap guard, single-writer queue, transactional reservation, or equivalent coordination mechanism before durable state changes.
+
+The coordination mechanism must bind the actor, task, scope, proposed mutation class, authority basis, timestamp, and expiration or validity behavior before commit.
+
+Conflicting writes must fail closed or route into conflict resolution before commit. The system must not rely on post-hoc cleanup as the primary protection against unauthorized or conflicting shared-state mutation.
+
+Failed, rejected, expired, superseded, or unauthorized claims remain governance evidence.
+
+## Rationale
+
+Shared memory is trust infrastructure. Trustworthy mutation requires deciding authority and conflict boundaries before durable state changes, not after competing agents have already overwritten each other.
+
+This ADR does not require a specific distributed locking primitive. Different runtimes may use leases, transactions, compare-and-swap, optimistic concurrency, queue ownership, or database-native locks. The architectural requirement is that durable mutation is coordinated and auditable before commit.
+
+## Consequences
+
+### Positive
+
+- Concurrent writers have an explicit coordination boundary.
+- Conflict resolution happens before durable mutation.
+- Stale and unauthorized claims become testable negative paths.
+- Audit trails include both successful and failed write attempts.
+- PAMA can evaluate mutation authority against a bounded claim rather than an already-mutated state.
+
+### Negative
+
+- Implementations must manage claim expiry and abandoned work.
+- Systems must avoid deadlock, stale locks, and over-broad claims.
+- Claim granularity becomes an architectural decision.
+- Runtime adapters need evidence formats for both successful and failed claims.
+
+## Implementation notes
+
+A conforming implementation should record at least:
+
+- claim identifier;
+- actor identity;
+- task or operation identifier;
+- memory scope or affected record set;
+- requested mutation class;
+- authority basis;
+- timestamp and expiry or lease terms;
+- current claim status;
+- conflict disposition;
+- commit receipt or rejection reason.
+
+The claim must be narrow enough to prevent accidental broad authority and durable enough to support audit review.
+
+## Validation and acceptance
+
+This ADR should not advance beyond Proposed until the repository includes evidence for:
+
+- a successful shared-memory write using a valid pre-write claim;
+- a rejected concurrent write against the same scope;
+- a stale or expired claim that cannot commit;
+- an unauthorized claim that fails closed;
+- audit evidence preserving successful and failed claim outcomes;
+- documentation showing how the mechanism composes with PAMA, conflict resolution, temporal causality, and observability.
+
+## Related
+
+- #137
+- #138
+- #143
+- ADR-004: PAMA Controls Mutation Authority
+- ADR-010: Conflict Resolution Is a Separate Component
+- ADR-011: Temporal Causality Is Required for Memory Evolution
+- ADR-017: Memory Observability and Audit Events Are Required
+- ADR-020: Probabilistic Discovery, Deterministic Governance

--- a/docs/adr/ADR-025-durable-decision-overwrites-require-explicit-authority.md
+++ b/docs/adr/ADR-025-durable-decision-overwrites-require-explicit-authority.md
@@ -1,0 +1,86 @@
+# ADR-025: Durable Decision Overwrites Require Explicit Authority
+
+Status: Proposed
+
+Date: 2026-08-12
+
+## Context
+
+Issues #137 and #138 expose a critical boundary in agent memory systems: agents may be able to detect contradiction, propose correction, and identify supersession candidates, but that does not automatically grant authority to overwrite durable decisions.
+
+Durable decisions are different from ordinary observations. They may encode human approval, policy, governance posture, scope boundaries, or operational commitments. Allowing agents to quietly overwrite earlier durable decisions converts memory into an argument engine with a commit bit. That is not governance.
+
+The repository already treats PAMA as the mutation authority boundary and conflict resolution as a separate component. This ADR clarifies that durable decision overwrite is a distinct authority event and must be resolved before commit.
+
+## Decision
+
+The system must distinguish agent-proposed supersession from committed durable decision overwrite.
+
+Agents may propose corrections, supersession links, conflict candidates, replacement records, and supporting evidence. They must not independently overwrite, reverse, retire, or supersede prior durable decisions unless the applicable authority policy explicitly grants that mutation class for the affected scope.
+
+For high-impact decisions or prior human-confirmed decisions, the default posture is human confirmation before overwrite unless a bounded policy explicitly delegates that authority.
+
+Rejected, expired, or unapproved overwrite proposals remain auditable evidence and must not mutate durable decision state.
+
+## Rationale
+
+The useful work agents can do is proposing, gathering evidence, detecting contradiction, and presenting candidate resolutions. The risky work is granting those proposals durable authority without a valid policy basis.
+
+This ADR preserves automation where it is valuable while preventing silent decision reversal. It also keeps the repository aligned with deterministic governance: probabilistic discovery may identify a possible correction, but deterministic authority controls whether durable state changes.
+
+## Consequences
+
+### Positive
+
+- Durable decision overwrite becomes explicit and auditable.
+- Human-confirmed decisions cannot be silently displaced by agent consensus.
+- Agent proposals remain useful without becoming unauthorized mutation.
+- PAMA retains control over mutation authority.
+- Conflict resolution has a clear handoff into authority evaluation.
+
+### Negative
+
+- Some overwrites require human review, adding latency.
+- Implementations must classify ordinary memory correction separately from durable decision overwrite.
+- Delegated authority policies must be precise enough to avoid rubber-stamping.
+- User interfaces and APIs must represent pending, approved, rejected, and expired overwrite proposals.
+
+## Implementation notes
+
+A conforming implementation should represent at least:
+
+- proposal identifier;
+- proposing actor;
+- affected durable decision record;
+- proposed replacement or supersession record;
+- rationale and evidence basis;
+- requested mutation class;
+- authority policy used for evaluation;
+- approval, rejection, or expiry status;
+- approver identity where human confirmation is required;
+- final commit receipt only when approved.
+
+The proposal record may be durable evidence. It is not itself an overwrite unless approved under the applicable authority policy.
+
+## Validation and acceptance
+
+This ADR should not advance beyond Proposed until the repository includes evidence for:
+
+- an agent-proposed overwrite that remains pending or rejected without mutating durable decision state;
+- a human-confirmed durable decision overwrite that creates append-only supersession evidence;
+- an explicitly delegated low-risk overwrite case, if supported, with bounded policy evidence;
+- negative-path coverage for unauthorized overwrite, stale evidence, silent decision reversal, and agent-collusion scenarios;
+- documentation showing composition with PAMA, conflict resolution, temporal causality, lifecycle state, and audit events.
+
+## Related
+
+- #137
+- #138
+- #144
+- ADR-004: PAMA Controls Mutation Authority
+- ADR-010: Conflict Resolution Is a Separate Component
+- ADR-011: Temporal Causality Is Required for Memory Evolution
+- ADR-017: Memory Observability and Audit Events Are Required
+- ADR-020: Probabilistic Discovery, Deterministic Governance
+- ADR-023: Corrections Are Supersession, Not Deletion
+- ADR-024: Shared Memory Writes Require Pre-Write Claims


### PR DESCRIPTION
## Summary

Adds three Proposed ADRs formalizing the durable memory mutation findings from #137 and #138:

- ADR-023: Corrections are supersession, not deletion
- ADR-024: Shared memory writes require pre-write claims
- ADR-025: Durable decision overwrites require explicit authority

## Architectural stance

This PR keeps the findings issue-first and ADR-scoped. It does not advance ADR maturity, does not claim runtime conformance, and does not replace existing PAMA, lifecycle, temporal causality, retention/deletion, audit, or conflict-resolution doctrine.

## Related issues

- #137
- #138
- #142
- #143
- #144

## Validation boundary

These ADRs are Proposed. Acceptance still requires follow-up documentation, fixtures, negative-path tests, and conformance evidence before stronger claims are appropriate.