### PR TITLE
Test and govern rejected-value re-admission

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -82,6 +82,12 @@ Doctrine changes require explicit rationale, affected-surface analysis, evidence
 
 ## Evidence rule
 
+Agent Memory adopts [`docs/policies/EVIDENCE_PROMOTION.md`](docs/policies/EVIDENCE_PROMOTION.md) as the source-neutral evidence and doctrine-promotion policy.
+
+> **Origin establishes provenance, not evidentiary privilege.**
+
+This applies to every material input, including native doctrine, maintainer or contributor statements, AI-generated analysis, practitioner feedback, external research, standards, implementations, benchmarks, production observations, and external corpora.
+
 A merged statement should make its epistemic status clear.
 
 Where material, distinguish:
@@ -95,6 +101,8 @@ runtime proof
 hypothesis
 analogy
 ```
+
+Native authorship establishes provenance and repository ownership of a decision. It does not prove the decision correct. External publication or popularity does not prove a claim correct either. Accepted ADRs remain challengeable and may be narrowed, superseded, or rejected when stronger evidence justifies a change.
 
 A validator passing is evidence about the validator's declared contract. It is not automatic proof of production behavior.
 

--- a/docs/adr/ADR-026-origin-is-provenance-not-evidentiary-authority.md
+++ b/docs/adr/ADR-026-origin-is-provenance-not-evidentiary-authority.md
@@ -1,0 +1,113 @@
+# ADR-026: Origin Is Provenance, Not Evidentiary Authority
+
+Status: Proposed
+
+Date: 2026-08-12
+
+## Context
+
+Agent Memory consumes heterogeneous inputs: native doctrine, maintainer decisions, contributor proposals, AI-generated analysis, practitioner feedback, research papers, standards, source code, benchmarks, conformance fixtures, runtime evidence, production observations, and external corpora.
+
+The repository already distinguishes evidence classes and requires explicit evidence for doctrine changes. However, parts of the repository frame the strongest skepticism rules around external sources. That leaves an avoidable ambiguity: a native or maintainer-authored claim could appear to receive more epistemic privilege merely because it originated inside the project, while an external paper or implementation could appear authoritative merely because it is published or widely used.
+
+Issue #146 makes the repository-wide rule explicit.
+
+## Decision
+
+The origin of a claim establishes its **provenance**. It does not establish its correctness, evidence strength, doctrine status, or authority.
+
+Material claims must be evaluated using source-neutral evidence and consequence-appropriate promotion gates.
+
+This applies equally to:
+
+- native Agent Memory doctrine;
+- maintainer and contributor claims;
+- existing and Accepted ADRs;
+- AI-generated analysis or implementation proposals;
+- practitioner/community reports;
+- research publications and standards;
+- external implementations and corpora;
+- benchmarks and evaluators;
+- runtime and production observations.
+
+The repository must preserve three distinct questions:
+
+```text
+origin / provenance
+        !=
+evidence / epistemic status
+        !=
+governance / permitted consequence
+```
+
+An Accepted ADR records the currently adopted decision for its stated scope. It is not immune to later contradictory evidence. Stronger evidence may clarify, narrow, supersede, or reject an earlier decision through the normal decision trail.
+
+## Rationale
+
+Source-specific privilege creates predictable failure modes:
+
+- maintainer intuition can become doctrine without sufficient challenge;
+- published work can be imported beyond the scope it actually proves;
+- benchmark scores can masquerade as production assurance;
+- AI output can be accepted or dismissed based on origin rather than verification;
+- prior decisions can become self-protecting because they are already canonical;
+- popular implementation patterns can acquire authority through repetition rather than evidence.
+
+A source-neutral rule does not imply that every source has equal reliability. Source quality, study design, reproducibility, implementation version, independence, and scope remain relevant evidence characteristics. The rule is that those properties must be evaluated rather than inferred from source identity alone.
+
+## Consequences
+
+### Positive
+
+- Internal and external claims face the same epistemic discipline.
+- Native authorship remains clear without becoming a truth claim.
+- External sources can challenge doctrine without automatically replacing it.
+- AI assistance remains usable without becoming an epistemic shortcut.
+- Accepted doctrine can evolve when evidence changes.
+- Negative results and failed reproductions remain useful outputs.
+
+### Negative
+
+- Doctrine changes may require more explicit evidence bookkeeping.
+- Maintainer certainty cannot substitute for a consequence-appropriate validation path.
+- Popular or prestigious sources may still require local boundary analysis.
+- Some research work will legitimately end with no doctrine change.
+
+## Implementation
+
+The repository should maintain the policy in `docs/policies/EVIDENCE_PROMOTION.md` and link it from `GOVERNANCE.md`.
+
+Material research records should be able to distinguish at least:
+
+```text
+claim
+provenance
+evidence class
+supporting evidence
+challenging evidence
+reproduction status
+scope / boundary conditions
+promotion state
+```
+
+The exact storage format is not architectural doctrine.
+
+## Validation and acceptance
+
+This ADR remains Proposed until:
+
+- repository governance text consistently expresses the source-neutral rule;
+- #67 and #138 research promotion paths can apply the rule without special-case source privilege;
+- at least one research cycle demonstrates preservation of an input as a hypothesis without premature doctrine promotion;
+- contradictory or negative evidence can be recorded without being treated as repository-policy failure;
+- review confirms that this ADR does not weaken authorship, licensing, source-rights, or repository authority rules.
+
+## Related
+
+- #146
+- #67
+- #138
+- ADR-020: Probabilistic Discovery, Deterministic Governance
+- `GOVERNANCE.md`
+- `docs/08-source-material-index.md`
+- `docs/policies/EVIDENCE_PROMOTION.md`

--- a/docs/adr/ADR-027-rejected-values-require-governed-readmission.md
+++ b/docs/adr/ADR-027-rejected-values-require-governed-readmission.md
@@ -1,0 +1,114 @@
+# ADR-027: Rejected Values Require Governed Re-Admission
+
+Status: Proposed
+
+Date: 2026-08-12
+
+## Context
+
+ADR-023 proposes that durable corrections preserve history through supersession rather than destructive deletion. That protects auditability and prevents the superseded row from remaining current.
+
+A separate failure remains possible in principle: a later extractor, import, background process, or agent may propose the same rejected value under a fresh record identity. If the write path considers only record identity and current retrieval state, the old proposition can become current again even though the original row remains correctly superseded.
+
+Agent Memory Atlas surfaced this as a candidate external failure pattern. Atlas is not authority for this ADR. Issue #147 requires the repository to reproduce or falsify the failure directly against the reference adapter before this ADR can advance.
+
+## Candidate decision
+
+If a durable value has been explicitly rejected through a governed correction, a later materially equivalent value must not silently regain current status solely because it arrives under a new proposal, record, source, or extraction identity.
+
+Re-admission must be a governed lifecycle transition.
+
+For an exact, deterministically identifiable rejected value, the default write-path consequence should fail closed into a non-committing state such as:
+
+```text
+defer
+require reconciliation
+require new evidence
+require review
+```
+
+The prior rejection is **not** an eternal ban. A later reversal may be legitimate when new evidence and appropriate authority justify it.
+
+Therefore the intended invariant is:
+
+> **Rejected value != permanently forbidden value. Rejected value == value that cannot silently become current again.**
+
+## Deterministic and probabilistic boundary
+
+Exact or structured identity may be enforced deterministically where the representation supports it.
+
+Semantic equivalence is different. A probabilistic matcher may identify that a new proposal resembles previously rejected content, but estimator similarity must not independently authorize either rejection or re-admission.
+
+A semantic matcher may route a proposal to reconciliation or review. The governed consequence remains deterministic under the applicable authority policy.
+
+## Required evidence state
+
+A conforming implementation may use different schemas, but it must preserve enough state to reconstruct:
+
+- which memory/proposition was corrected;
+- which value identity was rejected;
+- which correction established the rejection;
+- evidence and authority supporting that correction;
+- scope/isolation context;
+- whether the rejection is currently active;
+- any later authorized re-admission or reversal;
+- the decision receipt for blocked or permitted re-admission.
+
+The repository should avoid storing duplicate raw sensitive content solely to implement rejection history when a stable scoped fingerprint or structured identity is sufficient.
+
+## Relationship to ADR-023
+
+ADR-023 and this ADR solve different problems:
+
+```text
+ADR-023
+old record must not remain current after correction
+
+ADR-027
+old value must not silently become current again as a fresh record
+```
+
+A system may satisfy one and fail the other.
+
+Deletion, erasure, retention expiry, and safety removal remain separate lifecycle paths.
+
+## Consequences
+
+### Positive
+
+- Correction survives fresh-identity re-extraction.
+- Read-path suppression is no longer mistaken for write-path protection.
+- Legitimate reversals remain explicit and auditable.
+- Re-admission can compose with PAMA rather than creating a hidden blacklist authority.
+- Exact-value protection can remain deterministic while semantic similarity remains an estimator input.
+
+### Negative
+
+- Durable correction requires additional lifecycle metadata or an equivalent rejection registry.
+- Value identity is architecture/domain dependent and cannot be reduced safely to one universal string hash.
+- Semantic equivalence remains an open problem and may require review-oriented estimators.
+- Rejection history itself becomes governed state with privacy, retention, and deletion implications.
+
+## Validation and acceptance
+
+This ADR must remain Proposed until #147 demonstrates all of the following with executable evidence:
+
+- the pre-fix reference behavior can reproduce fresh-identity re-admission under the controlled scenario;
+- supersession of the original row is proven separately from the re-admission failure;
+- the write path blocks exact rejected-value re-entry after the implementation change;
+- the block emits reconstructable evidence rather than silently dropping the proposal;
+- an explicitly approved, evidence-backed reversal can re-admit the value;
+- the prior rejection remains historically reconstructable after reversal;
+- a probabilistic semantic matcher, if introduced, cannot independently authorize durable mutation;
+- tests clearly state that exact-value evidence does not prove architecture-independent semantic equivalence handling.
+
+## Related
+
+- #147
+- #142
+- #148
+- #146
+- ADR-010: Conflict Resolution Is a Separate Component
+- ADR-015: Retention, Deletion, and Tombstones Are Required
+- ADR-020: Probabilistic Discovery, Deterministic Governance
+- ADR-023: Corrections Are Supersession, Not Deletion

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,11 @@ Implementation maturity is tracked separately through documentation, fixtures, c
 ADR-001 through ADR-020: Accepted
 ADR-021: Proposed
 ADR-022: Accepted
+ADR-023: Proposed
+ADR-024: Proposed
+ADR-025: Proposed
+ADR-026: Proposed
+ADR-027: Proposed
 ```
 
 ADRs 001-020 and ADR-022 have satisfied their respective doctrine-maturity gates. ADR-020 is deliberately stronger than documentation-only acceptance: it required executable end-to-end runtime evidence and adversarial negative paths before acceptance.
@@ -35,6 +40,10 @@ ADRs 001-020 and ADR-022 have satisfied their respective doctrine-maturity gates
 ADR-021 proposes the interoperability boundary for **portable memory-governance evidence**. It keeps Agent Memory authoritative for memory semantics, PAMA, lifecycle obligations, and canonical decision receipts while allowing external trust systems such as AgenTrust to verify and correlate evidence without redefining those semantics.
 
 ADR-022 establishes **memory isolation domains and controlled boundary crossing** as first-class architecture. It extends ADR-016 by making same-agent cross-project/task separation, shared-memory domains, derived-scope inheritance, and scope crossing explicitly governable rather than leaving them as implied metadata filters.
+
+ADR-023 proposes that durable correction is **append-only supersession rather than destructive deletion**. ADR-024 proposes **pre-write coordination for shared-memory mutation**. ADR-025 proposes **explicit authority for overwriting durable decision memory**. All remain Proposed until their named evidence gates are satisfied.
+
+ADR-026 proposes a source-neutral epistemic boundary: **claim origin establishes provenance, not evidentiary authority**. ADR-027 proposes **governed re-admission for explicitly rejected values** so a corrected value cannot silently return merely by acquiring a fresh identity. Both remain Proposed while their linked evidence programs run.
 
 ## Current status policy
 
@@ -48,6 +57,8 @@ A decision may move from Proposed to Accepted when:
 6. acceptance does not depend on runtime evidence the ADR explicitly says is still missing
 
 If an ADR explicitly requires stronger evidence before acceptance, that requirement controls.
+
+The evidence policy is source-neutral. Native authorship, maintainer status, external publication, implementation popularity, AI generation, or prior acceptance do not make a claim immune to challenge. See [`../policies/EVIDENCE_PROMOTION.md`](../policies/EVIDENCE_PROMOTION.md).
 
 ## Governed uncertainty
 
@@ -106,6 +117,18 @@ It treats project, task, workspace, session, purpose, tenant, and shared-memory 
 Boundary crossing, including sharing, exporting, copying, deriving, inheriting, or broadening scope, is treated as a governed consequence. Derived state must not silently gain broader scope than its sources.
 
 Acceptance is backed by the canonical isolation-domain contract, additive schema/receipt representation, governed-recall enforcement, same-agent cross-project/task fixtures, derived-scope propagation, unauthorized scope-promotion tests, shared-space member/non-member recall tests, executable crossing receipts, and reconciliation with the future multi-agent shared-memory protocol. This is a doctrine-maturity statement, not universal production-runtime conformance.
+
+## Candidate durable-mutation decisions
+
+The current Proposed ADRs intentionally separate several related but non-identical questions:
+
+- [`ADR-023`](ADR-023-corrections-are-supersession-not-deletion.md): preserve correction history while removing superseded state from current truth;
+- [`ADR-024`](ADR-024-shared-memory-writes-require-prewrite-claims.md): coordinate shared durable writes before commit;
+- [`ADR-025`](ADR-025-durable-decision-overwrites-require-explicit-authority.md): require explicit authority before overwriting durable decision state;
+- [`ADR-026`](ADR-026-origin-is-provenance-not-evidentiary-authority.md): apply the same evidence discipline to claims regardless of origin;
+- [`ADR-027`](ADR-027-rejected-values-require-governed-readmission.md): require governed re-admission when a corrected/rejected value later reappears.
+
+These ADRs must not be collapsed into a single broad "memory safety" claim. Each has its own acceptance evidence and may be accepted, narrowed, or rejected independently.
 
 ## Canonical references
 

--- a/docs/policies/EVIDENCE_PROMOTION.md
+++ b/docs/policies/EVIDENCE_PROMOTION.md
@@ -1,0 +1,169 @@
+# Evidence and Doctrine Promotion Policy
+
+Status: Active repository policy when merged
+
+## Purpose
+
+Agent Memory evaluates claims by evidence and consequence, not by the identity or prestige of the source that supplied them.
+
+> **Origin establishes provenance, not evidentiary privilege.**
+
+This rule is source-neutral. It applies equally to native Agent Memory doctrine, maintainer statements, contributor proposals, AI-generated analysis, practitioner feedback, external implementations, research papers, standards, benchmark results, production observations, and external corpora such as Agent Memory Atlas.
+
+## Core distinction
+
+Every material claim should keep three questions separate:
+
+```text
+Who or what produced the claim?   -> provenance
+What evidence supports it?        -> epistemic status
+What may it change or authorize?  -> governance consequence
+```
+
+None answers either of the other two.
+
+Authorship does not prove correctness. Publication does not prove correctness. Popularity does not prove correctness. Deployment does not prove correctness outside the observed boundary. A passing validator does not prove more than the validator's declared contract. AI generation does not weaken or strengthen a claim by itself.
+
+## Claim record
+
+Where a claim may materially affect doctrine, contracts, conformance, security, privacy, lifecycle behavior, authority, or production guidance, record enough information to reconstruct its status:
+
+```text
+claim
+origin / provenance
+claim type
+evidence class
+supporting evidence
+challenging evidence
+reproduction status
+scope / boundary conditions
+known counterexamples
+promotion state
+```
+
+The representation may vary by research program. The distinctions may not be collapsed.
+
+## Evidence classes
+
+Useful evidence classes include:
+
+- `hypothesis`: a falsifiable candidate that has not yet been demonstrated;
+- `architectural_deduction`: a conclusion derived from stated premises and contracts;
+- `implementation_observation`: behavior inspected in a specific implementation/version;
+- `external_empirical_evidence`: an externally produced observation or experiment;
+- `conformance_evidence`: evidence against a declared conformance contract;
+- `runtime_evidence`: executed behavior from a pinned runtime/substrate and scenario;
+- `benchmark_evidence`: results from a pinned dataset, harness, evaluator, and configuration;
+- `production_evidence`: observations from an identified production boundary.
+
+These are not a universal scalar ranking. Evidence strength is claim-specific.
+
+Examples:
+
+```text
+A benchmark can strongly support a benchmark-scoped comparison
+while proving little about production isolation.
+
+A runtime fixture can prove one negative path
+without proving every storage architecture.
+
+A production incident can prove a failure occurred
+without proving a proposed root cause.
+```
+
+## Source-neutral challenge rule
+
+Material claims should be challengeable regardless of origin.
+
+That includes claims already present in Accepted ADRs. Accepted means the decision is currently adopted for its documented scope. It does not mean later contradictory evidence is inadmissible.
+
+For consequential claims:
+
+1. identify what would falsify or materially narrow the claim;
+2. seek credible contradictory evidence where practical;
+3. preserve negative results and counterexamples;
+4. distinguish inability to reproduce from proof of absence;
+5. change doctrine only when the evidence and consequence justify it.
+
+Do not manufacture false balance. A weak contradiction does not cancel strong evidence merely because both exist.
+
+## Reproduction and promotion
+
+An input may be valuable before it is proven. It can generate:
+
+- a hypothesis;
+- an adversarial fixture;
+- a comparator;
+- a threat scenario;
+- a research question;
+- a candidate implementation pattern.
+
+That is not the same as doctrine promotion.
+
+A typical path is:
+
+```text
+input
+ -> claim / hypothesis
+ -> primary-source inspection where applicable
+ -> local reproducer or independent evidence where applicable
+ -> supporting and challenging evidence
+ -> scoped conclusion
+ -> doctrine / contract / ADR proposal
+ -> validation at the consequence-appropriate boundary
+```
+
+Not every claim needs every step. Editorial facts do not require a research program. High-consequence security, authority, lifecycle, deletion, privacy, or conformance claims require stronger evidence than low-risk explanatory text.
+
+## External corpora and field guides
+
+External surveys, catalogs, field guides, and repositories may efficiently surface patterns that deserve testing. Their aggregation does not confer authority.
+
+For example, Agent Memory Atlas may be recorded as:
+
+```text
+source role: discovery / external evidence
+claim status: unverified until inspected or reproduced
+possible output: adversarial fixture or architecture comparison
+```
+
+The same treatment applies to any other source. There is no Atlas-specific skepticism rule and no native-Agent-Memory exemption.
+
+## AI-assisted analysis
+
+AI systems may search, synthesize, compare, propose, implement, and test under repository policy. Model output is a proposal/evidence-processing artifact, not an epistemic shortcut.
+
+A model stating that a paper, repository, benchmark, test, or prior ADR proves something does not make that statement true. The underlying evidence and its boundary remain the decision input.
+
+## Validator boundary
+
+A passing automated check establishes only what the check actually exercised at the tested revision.
+
+Preserve the distinction:
+
+```text
+CI green
+!= runtime behavior universally proven
+!= production outcome proven
+!= architecture-independent conformance
+!= doctrine correctness proven
+```
+
+Exact-head requirements remain exact-head requirements. A later revision does not inherit evidence automatically.
+
+## Promotion outcomes
+
+A researched claim may result in:
+
+- **no change**: current doctrine survives the challenge;
+- **clarification**: doctrine was correct but underspecified;
+- **boundary narrowing**: the claim holds only under identified conditions;
+- **new fixture or conformance requirement**: the failure is real but doctrine already covers it;
+- **candidate doctrine change**: current doctrine is insufficient;
+- **supersession/rejection**: stronger evidence invalidates an earlier decision for its stated scope.
+
+Recording a no-change result is useful evidence. Research is not required to produce novelty to justify its existence.
+
+## Governing principle
+
+> **Who said it is provenance. What proves it is evidence. What it may change is governance.**

--- a/reference/agentmem_ref/adapter.py
+++ b/reference/agentmem_ref/adapter.py
@@ -21,6 +21,7 @@ import random
 from dataclasses import dataclass, field
 
 from . import policy, receipts
+from .readmission import RejectedValueRegistry
 from .substrate import DeterministicIds, Episode, Fact, TemporalGraphPort
 
 
@@ -124,6 +125,8 @@ class GovernedMemoryAdapter:
         self._tombstones: dict[str, dict] = {}
         self._fact_scope: dict[str, dict] = {}
         self._shared_domain_members: dict[str, set[str]] = {}
+        self._current_fact_by_memory: dict[str, str] = {}
+        self._rejected_values = RejectedValueRegistry()
         self.events: list[dict] = []
 
     # -- isolation-domain administration -------------------------------
@@ -163,13 +166,38 @@ class GovernedMemoryAdapter:
         events = [propose_event, authorize_event]
 
         stale = self._is_stale(proposal)
-        selected = self._select_action(decision, proposal, blocked_by_stale=stale)
+        readmission_blocked = self._readmission_blocked(proposal, fact_text)
+        selected = self._select_action(
+            decision,
+            proposal,
+            blocked_by_stale=stale or readmission_blocked,
+        )
         commits = selected == proposal.operation
         before_state = f"v{self._state_version.get(proposal.target_reference, 0)}"
 
+        if readmission_blocked:
+            events.append(
+                self._event(
+                    "memory.readmission_blocked",
+                    proposal.target_reference,
+                    correlation,
+                    causation_id=authorize_event["event_id"],
+                    policy_version=decision.policy_version,
+                )
+            )
+
         fact_uuid = None
         if commits:
+            if proposal.operation == "correction":
+                self._supersede_current(proposal)
+                self._rejected_values.readmit(
+                    memory_id=proposal.target_reference,
+                    value=fact_text,
+                    proposal_id=proposal.proposal_id,
+                    readmitted_at=self._clock.now(),
+                )
             fact_uuid = self._write(proposal, fact_text)
+            self._current_fact_by_memory[proposal.target_reference] = fact_uuid
             events.append(
                 self._event(
                     "memory.commit",
@@ -210,6 +238,13 @@ class GovernedMemoryAdapter:
             )
         )
         self.events.extend(events)
+
+        refusal = None
+        if stale:
+            refusal = "stale_authorization"
+        elif readmission_blocked:
+            refusal = "rejected_value_requires_reconciliation"
+
         return CommitResult(
             decision=decision,
             pama_decision=pama_decision,
@@ -217,7 +252,7 @@ class GovernedMemoryAdapter:
             events=events,
             committed=commits,
             fact_uuid=fact_uuid,
-            refusal="stale_authorization" if stale else None,
+            refusal=refusal,
         )
 
     def _is_stale(self, proposal: policy.Proposal) -> bool:
@@ -226,6 +261,52 @@ class GovernedMemoryAdapter:
             return False
         current = f"v{self._state_version.get(proposal.target_reference, 0)}"
         return proposal.state_snapshot != current
+
+    def _readmission_blocked(self, proposal: policy.Proposal, fact_text: str) -> bool:
+        """Fail closed when an exact rejected value attempts silent re-entry.
+
+        An externally approved correction is an explicit reversal path. It may
+        re-admit a previously rejected value because policy has already required
+        review for correction. Ordinary promotion/import-style writes cannot.
+        """
+        if self._rejected_values.active(proposal.target_reference, fact_text) is None:
+            return False
+        approved_reversal = (
+            proposal.operation == "correction"
+            and proposal.review_satisfied
+            and bool(proposal.approval_refs)
+            and not proposal.approves_own_authority
+        )
+        return not approved_reversal
+
+    def _supersede_current(self, proposal: policy.Proposal) -> None:
+        """Invalidate the current fact and record its value as rejected.
+
+        This is the minimum correction seam needed to test ADR-023/ADR-027
+        composition. It does not claim full #142 closure.
+        """
+        current_uuid = self._current_fact_by_memory.get(proposal.target_reference)
+        if not current_uuid:
+            return
+        current = self._substrate.get_fact(current_uuid)
+        if current is None or current.is_event_invalid:
+            return
+
+        rejected_at = self._clock.now()
+        self._rejected_values.reject(
+            memory_id=proposal.target_reference,
+            value=current.fact_text,
+            superseded_fact_uuid=current.uuid,
+            correction_proposal_id=proposal.proposal_id,
+            evidence_refs=tuple(proposal.evidence_refs),
+            scope=proposal.scope,
+            rejected_at=rejected_at,
+        )
+        self._substrate.invalidate_fact(
+            current.uuid,
+            invalid_at=rejected_at,
+            expired_at=self._clock.now(),
+        )
 
     def _select_action(self, decision: policy.Decision, proposal: policy.Proposal, blocked_by_stale: bool) -> str:
         permitted = decision.permitted_actions
@@ -353,6 +434,12 @@ class GovernedMemoryAdapter:
     def state_version(self, memory_id: str) -> int:
         return self._state_version.get(memory_id, 0)
 
+    def current_fact_uuid(self, memory_id: str) -> str | None:
+        return self._current_fact_by_memory.get(memory_id)
+
+    def rejected_value_history(self, memory_id: str, fact_text: str) -> tuple[dict, ...]:
+        return self._rejected_values.history(memory_id, fact_text)
+
     def tombstoned_ids(self) -> set[str]:
         return {record["memory_id"] for record in self._tombstones.values()}
 
@@ -384,6 +471,8 @@ class GovernedMemoryAdapter:
             # only permanent deletion reaches the substrate's physical delete.
             if proposal.operation == "permanent_deletion":
                 self._substrate.delete_fact(fact_uuid)
+            if self._current_fact_by_memory.get(proposal.target_reference) == fact_uuid:
+                self._current_fact_by_memory.pop(proposal.target_reference, None)
             self._state_version[proposal.target_reference] = self._state_version.get(proposal.target_reference, 0) + 1
 
         receipt_id = self._ids.next()

--- a/reference/agentmem_ref/readmission.py
+++ b/reference/agentmem_ref/readmission.py
@@ -1,0 +1,118 @@
+"""Deterministic rejected-value history for governed re-admission.
+
+This module implements only the exact/normalized identity slice proven by #147.
+It deliberately does not attempt semantic-equivalence detection. A learned or
+probabilistic matcher may later propose a reconciliation path, but it must not
+independently authorize durable rejection or re-admission.
+
+Raw memory content is not retained here. Rejection history stores a scoped
+SHA-256 fingerprint plus provenance needed to reconstruct the lifecycle event.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+
+def normalize_value(value: str) -> str:
+    """Canonicalize only deterministic presentation differences.
+
+    Case and repeated whitespace are normalized. Punctuation, word order, and
+    semantic paraphrase are intentionally untouched so this helper cannot
+    quietly become a probabilistic equivalence oracle.
+    """
+
+    return " ".join(value.casefold().split())
+
+
+def value_fingerprint(value: str) -> str:
+    normalized = normalize_value(value)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class RejectionRecord:
+    memory_id: str
+    value_fingerprint: str
+    superseded_fact_uuid: str
+    correction_proposal_id: str
+    evidence_refs: tuple[str, ...]
+    scope: str
+    rejected_at: str
+    active: bool = True
+    readmitted_at: str | None = None
+    readmission_proposal_id: str | None = None
+
+    def as_dict(self) -> dict:
+        return {
+            "memory_id": self.memory_id,
+            "value_fingerprint": self.value_fingerprint,
+            "superseded_fact_uuid": self.superseded_fact_uuid,
+            "correction_proposal_id": self.correction_proposal_id,
+            "evidence_refs": list(self.evidence_refs),
+            "scope": self.scope,
+            "rejected_at": self.rejected_at,
+            "active": self.active,
+            "readmitted_at": self.readmitted_at,
+            "readmission_proposal_id": self.readmission_proposal_id,
+        }
+
+
+class RejectedValueRegistry:
+    """Append-oriented rejection history keyed by memory and exact value identity."""
+
+    def __init__(self) -> None:
+        self._records: dict[tuple[str, str], list[RejectionRecord]] = {}
+
+    def _key(self, memory_id: str, value: str) -> tuple[str, str]:
+        return memory_id, value_fingerprint(value)
+
+    def active(self, memory_id: str, value: str) -> RejectionRecord | None:
+        records = self._records.get(self._key(memory_id, value), ())
+        for record in reversed(records):
+            if record.active:
+                return record
+        return None
+
+    def reject(
+        self,
+        *,
+        memory_id: str,
+        value: str,
+        superseded_fact_uuid: str,
+        correction_proposal_id: str,
+        evidence_refs: tuple[str, ...],
+        scope: str,
+        rejected_at: str,
+    ) -> RejectionRecord:
+        record = RejectionRecord(
+            memory_id=memory_id,
+            value_fingerprint=value_fingerprint(value),
+            superseded_fact_uuid=superseded_fact_uuid,
+            correction_proposal_id=correction_proposal_id,
+            evidence_refs=tuple(evidence_refs),
+            scope=scope,
+            rejected_at=rejected_at,
+        )
+        self._records.setdefault(self._key(memory_id, value), []).append(record)
+        return record
+
+    def readmit(
+        self,
+        *,
+        memory_id: str,
+        value: str,
+        proposal_id: str,
+        readmitted_at: str,
+    ) -> RejectionRecord | None:
+        record = self.active(memory_id, value)
+        if record is None:
+            return None
+        record.active = False
+        record.readmitted_at = readmitted_at
+        record.readmission_proposal_id = proposal_id
+        return record
+
+    def history(self, memory_id: str, value: str) -> tuple[dict, ...]:
+        return tuple(record.as_dict() for record in self._records.get(self._key(memory_id, value), ()))

--- a/reference/tests/test_rejected_value_readmission.py
+++ b/reference/tests/test_rejected_value_readmission.py
@@ -1,13 +1,13 @@
-"""Characterization evidence for #147: fresh-identity rejected-value re-admission.
+"""Regression evidence for #147: governed exact-value re-admission.
 
-This first-stage test intentionally proves the *current* reference behavior before
-we change it. It is not a conformance assertion and must be inverted by the
-implementation commit that closes the reproduced gap.
+Commit 0e1eca3 first preserved the pre-fix characterization: after a value was
+superseded, the same value could return under a fresh fact identity and become
+admissible. The Validate Doctrine Evidence workflow executed that test through
+full unittest discovery before the implementation change.
 
-The test isolates re-admission from #142's correction implementation work by
-explicitly invalidating the original substrate fact, thereby granting the
-stronger assumption that supersession already happened correctly. It then asks
-whether the same rejected value can enter as a fresh fact and become admissible.
+These tests invert that characterization. They cover only deterministic exact
+identity after case/whitespace normalization. They do not claim semantic
+paraphrase equivalence or architecture-independent conformance.
 
 Run: python -m unittest reference.tests.test_rejected_value_readmission
 """
@@ -57,57 +57,88 @@ def proposal(
     )
 
 
-class RejectedValueReadmissionCharacterization(unittest.TestCase):
-    """Prove the pre-fix failure without relying on Agent Memory Atlas claims."""
+class RejectedValueReadmissionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.substrate = InMemoryTemporalGraph()
+        self.adapter = GovernedMemoryAdapter(self.substrate, TENANT, Clock())
 
-    def test_fresh_identity_can_reintroduce_a_superseded_value(self):
-        substrate = InMemoryTemporalGraph()
-        adapter = GovernedMemoryAdapter(substrate, TENANT, Clock())
+        self.original = self.adapter.commit_proposal(proposal("prop-original"), VALUE_A)
+        self.assertTrue(self.original.committed)
 
-        original = adapter.commit_proposal(proposal("prop-original"), VALUE_A)
-        self.assertTrue(original.committed)
-        self.assertIsNotNone(original.fact_uuid)
-
-        # Isolate the #147 question from #142. Assume correction-as-supersession
-        # has already worked and the old fact is no longer current.
-        substrate.invalidate_fact(
-            original.fact_uuid,
-            invalid_at="2026-01-01T00:10:00Z",
-            expired_at="2026-01-01T00:10:00Z",
-        )
-        adapter.record_correction(MEMORY)
-
-        replacement = adapter.commit_proposal(
+        self.replacement = self.adapter.commit_proposal(
             proposal("prop-correction", operation="correction", evidence_refs=("ev:correction",), approved=True),
             VALUE_B,
         )
-        self.assertTrue(replacement.committed)
+        self.assertTrue(self.replacement.committed)
 
-        # A later extraction uses a fresh proposal/fact identity and repeats the
-        # value that was just superseded. The current adapter has no write-path
-        # rejection history to consult.
-        reintroduced = adapter.commit_proposal(
+    def test_correction_supersedes_old_row_and_records_rejection_history(self):
+        recall = self.adapter.governed_recall("deploy window Thursday")
+
+        self.assertIn(self.original.fact_uuid, recall.candidates)
+        self.assertEqual(recall.refusals.get(self.original.fact_uuid), "superseded_not_current")
+
+        history = self.adapter.rejected_value_history(MEMORY, VALUE_A)
+        self.assertEqual(len(history), 1)
+        self.assertTrue(history[0]["active"])
+        self.assertEqual(history[0]["superseded_fact_uuid"], self.original.fact_uuid)
+        self.assertEqual(history[0]["correction_proposal_id"], "prop-correction")
+        self.assertNotIn("fact_text", history[0], "rejection history must not duplicate raw memory content")
+
+    def test_fresh_identity_cannot_silently_reintroduce_rejected_value(self):
+        reintroduced = self.adapter.commit_proposal(
             proposal("prop-reintroduced", evidence_refs=("ev:later-extraction",)),
             VALUE_A,
         )
-        self.assertTrue(
-            reintroduced.committed,
-            "characterization failed: the current adapter unexpectedly blocked re-admission",
+
+        self.assertFalse(reintroduced.committed)
+        self.assertIsNone(reintroduced.fact_uuid)
+        self.assertEqual(reintroduced.refusal, "rejected_value_requires_reconciliation")
+        self.assertEqual(reintroduced.receipt["selected_action"], "defer")
+        self.assertTrue(any(event["event_type"] == "memory.readmission_blocked" for event in reintroduced.events))
+
+        recall = self.adapter.governed_recall("deploy window Thursday")
+        self.assertEqual(recall.refusals.get(self.original.fact_uuid), "superseded_not_current")
+        self.assertNotIn(None, recall.admitted)
+
+    def test_deterministic_normalization_does_not_bypass_rejection(self):
+        variant = "  Deploy   Window is THURSDAY  "
+        result = self.adapter.commit_proposal(
+            proposal("prop-normalized-variant", evidence_refs=("ev:later-extraction",)),
+            variant,
         )
 
-        recall = adapter.governed_recall("deploy window Thursday")
+        self.assertFalse(result.committed)
+        self.assertEqual(result.refusal, "rejected_value_requires_reconciliation")
 
-        # Supersession protects the old row on the read path...
-        self.assertIn(original.fact_uuid, recall.candidates)
-        self.assertEqual(recall.refusals.get(original.fact_uuid), "superseded_not_current")
-
-        # ...but a fresh row carrying the same rejected value is admitted.
-        self.assertIn(reintroduced.fact_uuid, recall.candidates)
-        self.assertIn(
-            reintroduced.fact_uuid,
-            recall.admitted,
-            "characterization failed: fresh rejected value did not become current/admissible",
+    def test_explicit_approved_correction_can_reverse_prior_rejection(self):
+        reversal = self.adapter.commit_proposal(
+            proposal(
+                "prop-approved-reversal",
+                operation="correction",
+                evidence_refs=("ev:new-independent-evidence",),
+                approved=True,
+            ),
+            VALUE_A,
         )
+
+        self.assertTrue(reversal.committed)
+        self.assertEqual(self.adapter.current_fact_uuid(MEMORY), reversal.fact_uuid)
+
+        old_history = self.adapter.rejected_value_history(MEMORY, VALUE_A)
+        self.assertEqual(len(old_history), 1)
+        self.assertFalse(old_history[0]["active"])
+        self.assertEqual(old_history[0]["readmission_proposal_id"], "prop-approved-reversal")
+        self.assertIsNotNone(old_history[0]["readmitted_at"])
+
+        replaced_history = self.adapter.rejected_value_history(MEMORY, VALUE_B)
+        self.assertEqual(len(replaced_history), 1)
+        self.assertTrue(replaced_history[0]["active"])
+        self.assertEqual(replaced_history[0]["superseded_fact_uuid"], self.replacement.fact_uuid)
+
+        recall = self.adapter.governed_recall("deploy window Thursday")
+        self.assertIn(reversal.fact_uuid, recall.admitted)
+        self.assertEqual(recall.refusals.get(self.original.fact_uuid), "superseded_not_current")
+        self.assertEqual(recall.refusals.get(self.replacement.fact_uuid), "superseded_not_current")
 
 
 if __name__ == "__main__":

--- a/reference/tests/test_rejected_value_readmission.py
+++ b/reference/tests/test_rejected_value_readmission.py
@@ -1,0 +1,114 @@
+"""Characterization evidence for #147: fresh-identity rejected-value re-admission.
+
+This first-stage test intentionally proves the *current* reference behavior before
+we change it. It is not a conformance assertion and must be inverted by the
+implementation commit that closes the reproduced gap.
+
+The test isolates re-admission from #142's correction implementation work by
+explicitly invalidating the original substrate fact, thereby granting the
+stronger assumption that supersession already happened correctly. It then asks
+whether the same rejected value can enter as a fresh fact and become admissible.
+
+Run: python -m unittest reference.tests.test_rejected_value_readmission
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter  # noqa: E402
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+TENANT = "tenant-a"
+MEMORY = "mem:deploy-window"
+VALUE_A = "deploy window is Thursday"
+VALUE_B = "deploy window is Friday"
+
+
+def proposal(
+    proposal_id: str,
+    *,
+    operation: str = "promotion",
+    evidence_refs: tuple[str, ...] = ("ev:source-a",),
+    approved: bool = False,
+) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=proposal_id,
+        actor_id="agent:planner",
+        charter_version="charter-1",
+        target_reference=MEMORY,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation=operation,
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=evidence_refs,
+        tenant_ref=TENANT,
+        approval_refs=("approval:owner",) if approved else (),
+        review_satisfied=approved,
+    )
+
+
+class RejectedValueReadmissionCharacterization(unittest.TestCase):
+    """Prove the pre-fix failure without relying on Agent Memory Atlas claims."""
+
+    def test_fresh_identity_can_reintroduce_a_superseded_value(self):
+        substrate = InMemoryTemporalGraph()
+        adapter = GovernedMemoryAdapter(substrate, TENANT, Clock())
+
+        original = adapter.commit_proposal(proposal("prop-original"), VALUE_A)
+        self.assertTrue(original.committed)
+        self.assertIsNotNone(original.fact_uuid)
+
+        # Isolate the #147 question from #142. Assume correction-as-supersession
+        # has already worked and the old fact is no longer current.
+        substrate.invalidate_fact(
+            original.fact_uuid,
+            invalid_at="2026-01-01T00:10:00Z",
+            expired_at="2026-01-01T00:10:00Z",
+        )
+        adapter.record_correction(MEMORY)
+
+        replacement = adapter.commit_proposal(
+            proposal("prop-correction", operation="correction", evidence_refs=("ev:correction",), approved=True),
+            VALUE_B,
+        )
+        self.assertTrue(replacement.committed)
+
+        # A later extraction uses a fresh proposal/fact identity and repeats the
+        # value that was just superseded. The current adapter has no write-path
+        # rejection history to consult.
+        reintroduced = adapter.commit_proposal(
+            proposal("prop-reintroduced", evidence_refs=("ev:later-extraction",)),
+            VALUE_A,
+        )
+        self.assertTrue(
+            reintroduced.committed,
+            "characterization failed: the current adapter unexpectedly blocked re-admission",
+        )
+
+        recall = adapter.governed_recall("deploy window Thursday")
+
+        # Supersession protects the old row on the read path...
+        self.assertIn(original.fact_uuid, recall.candidates)
+        self.assertEqual(recall.refusals.get(original.fact_uuid), "superseded_not_current")
+
+        # ...but a fresh row carrying the same rejected value is admitted.
+        self.assertIn(reintroduced.fact_uuid, recall.candidates)
+        self.assertIn(
+            reintroduced.fact_uuid,
+            recall.admitted,
+            "characterization failed: fresh rejected value did not become current/admissible",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Execute an evidence-first implementation cycle for #147 while applying the source-neutral epistemic rule in #146.

No input is treated as true because of origin. Agent Memory Atlas surfaced the candidate failure; the repository's own executable reference adapter determines whether the failure exists here.

## Before/after evidence sequence

### 1. Characterization before implementation

Commit `0e1eca3` added a characterization test with the **pre-fix behavior as its assertion**:

```text
A is current
 -> A is superseded
 -> B becomes current
 -> fresh identity proposes A again
 -> A commits and is admitted
```

`Validate Doctrine Evidence` runs full `python -m unittest discover -s reference/tests -t reference`. That unit-test step completed successfully while the characterization assertion was still present.

This establishes the exact-value fresh-identity gap for the reference adapter under the controlled scenario. It does not establish Atlas's corpus claims, semantic-equivalence behavior, or universal architecture behavior.

### 2. Minimal governed implementation

The implementation adds:

- deterministic case/whitespace-normalized SHA-256 value identity;
- append-oriented rejection history without duplicating raw memory text;
- correction-time supersession of the current fact;
- a write-path re-admission guard that fails closed to `defer`;
- `rejected_value_requires_reconciliation` refusal evidence;
- `memory.readmission_blocked` audit events;
- an explicit externally approved correction path for legitimate reversal;
- preserved rejection/readmission history after reversal.

### 3. Inverted regression evidence

The characterization test was then inverted. The current tests require:

- the superseded row remains discoverable but is refused as `superseded_not_current`;
- a fresh identity carrying the exact rejected value does **not** commit;
- normalized case/whitespace variation does not bypass the guard;
- the blocked attempt produces a decision receipt and audit event;
- an approved evidence-backed correction can intentionally re-admit the prior value;
- the value being replaced by that reversal becomes the newly rejected value;
- historical rejection/readmission state remains reconstructable.

The current head has passed the workflow's first full unit-test discovery step. Full exact-head workflow completion is still required before merge.

## Governance and ADR work

This PR also adds:

- `docs/policies/EVIDENCE_PROMOTION.md` for source-neutral evidence and doctrine promotion;
- `GOVERNANCE.md` linkage and explicit source-neutral rule;
- ADR-026, **Origin Is Provenance, Not Evidentiary Authority**, Proposed;
- ADR-027, **Rejected Values Require Governed Re-Admission**, Proposed;
- ADR index reconciliation through ADR-027.

ADR-027 remains Proposed even though the exact-value reference slice is now evidenced. Its acceptance gate deliberately exceeds this one implementation slice.

## Explicit non-claims

- Agent Memory Atlas corpus counts/pattern prevalence are not accepted as fact by this PR.
- Exact deterministic value identity does not solve semantic paraphrase equivalence.
- A reference-adapter fix does not prove cross-architecture conformance.
- The minimal correction seam here does not by itself close #142.
- Passing CI proves the tested contracts at the exact head, not universal production behavior.

## Related

- #142
- #146
- #147
- #148
- #149
- ADR-020
- ADR-023
- ADR-026
- ADR-027