### PR TITLE
Make reference validation dependencies reproducible

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -20,13 +20,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install validation dependencies
-        run: >-
-          python -m pip install --disable-pip-version-check
-          jsonschema==4.26.0
-          cryptography==50.0.0
-          agent-manifest==0.11.0
-          agentrust-trace==0.8.0
-          rfc8785==0.1.4
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
 
       - name: Validate fixture invariants
         run: python scripts/validate_fixtures.py fixtures
@@ -180,7 +174,7 @@ jobs:
             echo "Commands run by this workflow (reproducible locally):"
             echo ""
             echo '```'
-            echo "python -m pip install jsonschema==4.26.0 cryptography==50.0.0 agent-manifest==0.11.0 agentrust-trace==0.8.0 rfc8785==0.1.4"
+            echo "python -m pip install -r reference/requirements.txt"
             echo "python scripts/validate_fixtures.py fixtures"
             echo "python scripts/validate_schemas.py"
             echo "python scripts/validate_doctrine_boundaries.py"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,17 +199,17 @@ Every conformance fixture should:
 
 Fixture versioning rules: the version tracks the scenario contract, not the memory-unit schema. Prose-only changes may stay patch-compatible; changes to expected behavior, invariants, trap semantics, or material inputs require a version bump (major when scenario semantics break). Runtime evidence records `fixture_id` plus `fixture_version` so results stay comparable as fixtures evolve. Full rules live in `docs/27-schema-registry-and-type-evolution.md`.
 
-Run:
+For the main reference validation environment, install the repository-visible pinned dependency set:
 
 ```bash
-python -m pip install jsonschema
+python -m pip install -r reference/requirements.txt
 python scripts/validate_fixtures.py fixtures
 python scripts/validate_schemas.py
 ```
 
-The repository workflow runs the same checks on pushes and pull requests.
+The repository workflow consumes the same manifest. Comparator-only environments remain separately pinned where dependency isolation is part of the evidence boundary.
 
-## Validator dependency policy
+## Validator and reference dependency policy
 
 Validation tooling keeps a deliberate dependency split:
 
@@ -219,10 +219,11 @@ scripts/validate_schemas.py              jsonschema permitted/required
 scripts/validate_markdown_links.py       Python standard library only
 scripts/validate_doctrine_boundaries.py  Python standard library only
 scripts/generate_calibration_report.py   Python standard library only
+reference/ governed/interoperability     pinned dependencies in reference/requirements.txt
 other validation dependencies            require explicit justification in the PR
 ```
 
-The stdlib-only validators must stay runnable with no installation step, so the cheapest check is always available. `jsonschema` is the one sanctioned exception because hand-rolled JSON Schema validation is how schema and validator drift apart. CI remains reproducible from the commands documented above and in the workflow summary.
+The stdlib-only claim applies to the listed low-cost validator surfaces, not to the entire `reference/` implementation. The stdlib-only validators must stay runnable with no installation step; `jsonschema` is the sanctioned schema-validation exception. Reference/runtime evidence dependencies are declared explicitly in [`reference/requirements.txt`](reference/requirements.txt) so a fresh contributor does not have to reverse-engineer CI to reproduce the supported validation environment.
 
 ## Documentation changes
 
@@ -238,6 +239,18 @@ Optimize for:
 - original synthesis when reuse rights are unclear or unnecessary
 
 For the root README, prefer stable static overview graphics or compact tables when GitHub's interactive Mermaid renderer harms legibility. Mermaid remains useful in detailed documentation where the source graph itself is part of the working artifact.
+
+Documentation alignment is part of the change, not a post-merge cleanup task. When a contribution changes architecture, maturity, setup, governance, contribution behavior, security posture, roadmap state, interoperability, or public project relationships, review the affected public surfaces in the same PR. Depending on impact, that includes:
+
+- `README.md`
+- `docs/README.md` and the relevant canonical doctrine/profile/program document
+- `docs/adr/README.md` and affected ADR status text
+- `wiki-src/`
+- `CONTRIBUTING.md`, `GOVERNANCE.md`, and `SECURITY.md`
+- `reference/README.md` and dependency/setup instructions
+- roadmap and aligned-project/source-rights records
+
+Do not edit every surface ceremonially. Do update every surface whose current statement would become stale, misleading, or contradictory because of the change.
 
 Avoid:
 
@@ -260,6 +273,7 @@ A pull request should state:
 - what validation was run
 - what the change proves
 - what remains unproven
+- which public documentation surfaces were reviewed and which required updates
 
 For a human-directed agent workflow, the PR should also make the material delegation or authorization boundary clear when it is relevant to understanding who exercised repository authority.
 
@@ -271,7 +285,7 @@ A contribution is complete when:
 
 1. the intended architectural or evidence change is explicit
 2. affected doctrine is internally consistent
-3. relevant links and indexes are updated
+3. affected public documentation, links, indexes, setup instructions, and status surfaces are aligned
 4. schemas/fixtures are updated when the contract changed
 5. source rights and attribution obligations are resolved for any material reuse
 6. validation passes

--- a/reference/README.md
+++ b/reference/README.md
@@ -38,6 +38,7 @@ The Governance Context Projection adds a complementary boundary: remembered cont
 
 ```text
 reference/
+  requirements.txt                   pinned main reference-validation dependencies
   agentmem_ref/
     substrate.py                     port + permissive in-memory temporal graph
     policy.py                        PAMA evaluation: base table, class floors, modifiers
@@ -58,18 +59,15 @@ reference/
   run_conformance.py
 ```
 
-Schema validation uses `jsonschema`. P4.5a Ed25519 signing and public-key verification use `cryptography`, added under the explicit dependency-justification rule in `../CONTRIBUTING.md`. P4.5b uses `agent-manifest==0.11.0` as a test-only comparator and does not import it from production reference modules. P4.5c uses `agentrust-trace==0.8.0` plus `rfc8785==0.1.4` for the TRACE/JCS contract and runs `cmcp-runtime==0.4.0` in an isolated comparator environment. CI pins the main validation profile to `jsonschema==4.26.0`, `cryptography==50.0.0`, `agent-manifest==0.11.0`, `agentrust-trace==0.8.0`, and `rfc8785==0.1.4`. The Governance Context Projection builder adds no runtime dependency. The low-cost fixture, doctrine-boundary, and link validators remain standard-library only except the JSON Schema validator.
+The reference implementation is **not** standard-library only. Its main validation dependency set is declared and pinned in [`requirements.txt`](requirements.txt): `jsonschema`, `cryptography`, `agent-manifest`, `agentrust-trace`, and `rfc8785`. P4.5b uses Agent Manifest as a test-only comparator and does not import it from production reference modules. P4.5c uses TRACE/JCS dependencies in the main reference environment, while `cmcp-runtime==0.4.0` is kept in an isolated comparator environment because its dependency line differs. The Governance Context Projection builder adds no runtime dependency.
+
+The low-cost repository validators intentionally keep a different dependency posture: fixture, doctrine-boundary, link, visual, and calibration tooling stays standard-library only where documented, with `jsonschema` as the explicit schema-validation exception. See [`../CONTRIBUTING.md`](../CONTRIBUTING.md). CI installs the main reference validation environment from the same checked-in manifest used by contributors rather than maintaining a second hidden pin list.
 
 ## Running it
 
 ```bash
 # reference model and interoperability paths
-python -m pip install \
-  jsonschema==4.26.0 \
-  cryptography==50.0.0 \
-  agent-manifest==0.11.0 \
-  agentrust-trace==0.8.0 \
-  rfc8785==0.1.4
+python -m pip install -r reference/requirements.txt
 python -m unittest discover -s reference/tests -t reference
 
 # TRACE/cMCP comparator in a dependency-isolated environment

--- a/reference/requirements.txt
+++ b/reference/requirements.txt
@@ -1,0 +1,7 @@
+# Reproducible dependency set for the main reference-implementation validation profile.
+# Keep comparator-only environments (for example cmcp-runtime and Mem0) isolated in CI.
+jsonschema==4.26.0
+cryptography==50.0.0
+agent-manifest==0.11.0
+agentrust-trace==0.8.0
+rfc8785==0.1.4


### PR DESCRIPTION
## Summary

Closes #156 by making the main reference-validation dependency set repository-visible and making CI consume that same manifest.

### Changes

- add `reference/requirements.txt` with the exact pins exercised by the main validation workflow;
- install those dependencies from the manifest in `Validate Doctrine Evidence` instead of duplicating pins inline;
- update the workflow summary to give contributors the same manifest-based command;
- clarify in `reference/README.md` that the reference implementation is not standard-library only and document the isolated comparator dependency boundary;
- update `CONTRIBUTING.md` so the stdlib-only claim applies only to the intended low-cost validator surfaces;
- make public-documentation impact review an explicit contribution/Definition-of-Done expectation.

## Why

A fresh contributor should not have to reverse-engineer workflow YAML to reproduce the supported reference environment. The previous stdlib-only language also blurred the distinction between deliberately low-dependency validators and the broader reference/runtime-evidence implementation.

## Evidence / validation boundary

This PR deliberately preserves the existing dependency versions rather than upgrading packages. The behavioral change is dependency declaration and documentation alignment, not runtime doctrine.

CI must validate the exact PR head before merge. The root README status/maturity drift identified during triage is a separate public-documentation cleanup because it predates #156 and spans broader repository maturity claims; it remains next in the documentation-alignment queue rather than being silently bundled into this dependency fix.

## Documentation impact reviewed

Updated here:
- `CONTRIBUTING.md`
- `reference/README.md`
- workflow reproducibility summary

No doctrine/ADR/Wiki semantic change is introduced by this slice.
