### PR TITLE
Prove repetition and derived copies do not manufacture corroboration

### DIFF
--- a/fixtures/derived-self-corroboration.json
+++ b/fixtures/derived-self-corroboration.json
@@ -19,82 +19,35 @@
       "observer": "conformance-suite",
       "method": "synthetic-derived-lineage-trap",
       "timestamp": "2026-08-12T00:00:00Z",
-      "source_refs": [
-        "fixture://source/origin-a"
-      ]
+      "source_refs": ["fixture://source/origin-a"]
     },
     "evidence": [
-      {
-        "id": "evidence:origin-a",
-        "kind": "single_source_assertion",
-        "ref": "fixture://source/origin-a",
-        "confidence": 0.78
-      },
-      {
-        "id": "evidence:summary-b",
-        "kind": "derived_summary",
-        "ref": "fixture://derived/summary-b",
-        "confidence": 0.9
-      },
-      {
-        "id": "evidence:summary-c",
-        "kind": "derived_summary",
-        "ref": "fixture://derived/summary-c",
-        "confidence": 0.94
-      }
+      {"id": "evidence:origin-a", "kind": "single_source_assertion", "ref": "fixture://source/origin-a", "confidence": 0.78},
+      {"id": "evidence:summary-b", "kind": "derived_summary", "ref": "fixture://derived/summary-b", "confidence": 0.9},
+      {"id": "evidence:summary-c", "kind": "derived_summary", "ref": "fixture://derived/summary-c", "confidence": 0.94}
     ],
     "saturation": {
       "sigma": 0.88,
       "calibrated": true,
       "threshold": 0.8,
-      "durability_dimensions": [
-        "reuse",
-        "apparent_corroboration"
-      ]
+      "durability_dimensions": ["reuse", "apparent_corroboration"]
     },
     "authority": {
       "pama_outcome": "require_external_verification",
       "risk_class": "medium",
-      "policy_refs": [
-        "ADR-003",
-        "ADR-009"
-      ],
-      "permitted_actions": [
-        "retain_candidate",
-        "request_independent_evidence"
-      ],
-      "prohibited_actions": [
-        "crystallize"
-      ],
+      "policy_refs": ["ADR-003", "ADR-009"],
+      "permitted_actions": ["retain_candidate", "request_independent_evidence"],
+      "prohibited_actions": ["crystallize"],
       "selection_mode": "deterministic"
     },
-    "certification": {
-      "status": "none",
-      "scope": "fixture"
-    },
+    "certification": {"status": "none", "scope": "fixture"},
     "created_at": "2026-08-12T00:00:00Z"
   },
   "epistemic_promotion": {
     "lineage": [
-      {
-        "evidence_id": "evidence:origin-a",
-        "origin_id": "origin:a",
-        "derived_from": []
-      },
-      {
-        "evidence_id": "evidence:summary-b",
-        "origin_id": "origin:a",
-        "derived_from": [
-          "evidence:origin-a"
-        ]
-      },
-      {
-        "evidence_id": "evidence:summary-c",
-        "origin_id": "origin:a",
-        "derived_from": [
-          "evidence:summary-b"
-        ]
-      }
+      {"evidence_id": "evidence:origin-a", "origin_refs": ["origin:a"], "derived_from": []},
+      {"evidence_id": "evidence:summary-b", "origin_refs": ["origin:a"], "derived_from": ["evidence:origin-a"]},
+      {"evidence_id": "evidence:summary-c", "origin_refs": ["origin:a"], "derived_from": ["evidence:summary-b"]}
     ],
     "retrieval_count": 60,
     "downstream_use_count": 25,

--- a/fixtures/derived-self-corroboration.json
+++ b/fixtures/derived-self-corroboration.json
@@ -1,0 +1,109 @@
+{
+  "fixture_id": "derived-self-corroboration",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "Multiple derived restatements of one source must remain one independent origin rather than manufacturing corroboration.",
+  "expected_behavior": {
+    "candidate": true,
+    "crystallized": false,
+    "trap_class_check": "pass",
+    "reason": "Derivation depth and repeated restatement do not create independent evidence."
+  },
+  "memory_unit": {
+    "id": "fixture:epistemic:derived-self-corroboration",
+    "content_ref": "fixture://derived-self-corroboration/claim",
+    "type": "semantic",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "synthetic-derived-lineage-trap",
+      "timestamp": "2026-08-12T00:00:00Z",
+      "source_refs": [
+        "fixture://source/origin-a"
+      ]
+    },
+    "evidence": [
+      {
+        "id": "evidence:origin-a",
+        "kind": "single_source_assertion",
+        "ref": "fixture://source/origin-a",
+        "confidence": 0.78
+      },
+      {
+        "id": "evidence:summary-b",
+        "kind": "derived_summary",
+        "ref": "fixture://derived/summary-b",
+        "confidence": 0.9
+      },
+      {
+        "id": "evidence:summary-c",
+        "kind": "derived_summary",
+        "ref": "fixture://derived/summary-c",
+        "confidence": 0.94
+      }
+    ],
+    "saturation": {
+      "sigma": 0.88,
+      "calibrated": true,
+      "threshold": 0.8,
+      "durability_dimensions": [
+        "reuse",
+        "apparent_corroboration"
+      ]
+    },
+    "authority": {
+      "pama_outcome": "require_external_verification",
+      "risk_class": "medium",
+      "policy_refs": [
+        "ADR-003",
+        "ADR-009"
+      ],
+      "permitted_actions": [
+        "retain_candidate",
+        "request_independent_evidence"
+      ],
+      "prohibited_actions": [
+        "crystallize"
+      ],
+      "selection_mode": "deterministic"
+    },
+    "certification": {
+      "status": "none",
+      "scope": "fixture"
+    },
+    "created_at": "2026-08-12T00:00:00Z"
+  },
+  "epistemic_promotion": {
+    "lineage": [
+      {
+        "evidence_id": "evidence:origin-a",
+        "origin_id": "origin:a",
+        "derived_from": []
+      },
+      {
+        "evidence_id": "evidence:summary-b",
+        "origin_id": "origin:a",
+        "derived_from": [
+          "evidence:origin-a"
+        ]
+      },
+      {
+        "evidence_id": "evidence:summary-c",
+        "origin_id": "origin:a",
+        "derived_from": [
+          "evidence:summary-b"
+        ]
+      }
+    ],
+    "retrieval_count": 60,
+    "downstream_use_count": 25,
+    "corroboration_threshold": 2,
+    "certification_gate_passed": false,
+    "expected": {
+      "independent_origin_count": 1,
+      "corroboration_threshold_met": false,
+      "certification_status": "none"
+    }
+  }
+}

--- a/fixtures/high-confidence-reuse-no-corroboration.json
+++ b/fixtures/high-confidence-reuse-no-corroboration.json
@@ -20,9 +20,7 @@
       "observer": "conformance-suite",
       "method": "synthetic-high-confidence-reuse-trap",
       "timestamp": "2026-08-12T00:00:00Z",
-      "source_refs": [
-        "fixture://source/inference-a"
-      ]
+      "source_refs": ["fixture://source/inference-a"]
     },
     "evidence": [
       {
@@ -31,51 +29,29 @@
         "ref": "fixture://source/inference-a",
         "confidence": 0.99,
         "confidence_kind": "estimator_confidence",
-        "estimator": {
-          "id": "fixture-estimator",
-          "version": "1.0.0"
-        }
+        "estimator": {"id": "fixture-estimator", "version": "1.0.0"}
       }
     ],
     "saturation": {
       "sigma": 0.97,
       "calibrated": true,
       "threshold": 0.8,
-      "durability_dimensions": [
-        "retrieval",
-        "reuse"
-      ]
+      "durability_dimensions": ["retrieval", "reuse"]
     },
     "authority": {
       "pama_outcome": "require_external_verification",
       "risk_class": "medium",
-      "policy_refs": [
-        "ADR-002",
-        "ADR-003",
-        "ADR-009"
-      ],
-      "permitted_actions": [
-        "retain_candidate",
-        "request_independent_evidence"
-      ],
-      "prohibited_actions": [
-        "crystallize"
-      ],
+      "policy_refs": ["ADR-002", "ADR-003", "ADR-009"],
+      "permitted_actions": ["retain_candidate", "request_independent_evidence"],
+      "prohibited_actions": ["crystallize"],
       "selection_mode": "deterministic"
     },
-    "certification": {
-      "status": "none",
-      "scope": "fixture"
-    },
+    "certification": {"status": "none", "scope": "fixture"},
     "created_at": "2026-08-12T00:00:00Z"
   },
   "epistemic_promotion": {
     "lineage": [
-      {
-        "evidence_id": "evidence:inference-a",
-        "origin_id": "origin:inference-a",
-        "derived_from": []
-      }
+      {"evidence_id": "evidence:inference-a", "origin_refs": ["origin:inference-a"], "derived_from": []}
     ],
     "retrieval_count": 250,
     "downstream_use_count": 100,

--- a/fixtures/high-confidence-reuse-no-corroboration.json
+++ b/fixtures/high-confidence-reuse-no-corroboration.json
@@ -1,0 +1,90 @@
+{
+  "fixture_id": "high-confidence-reuse-no-corroboration",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "A high-confidence inference that is retrieved and reused repeatedly must not gain independent corroboration or certification without new evidence.",
+  "expected_behavior": {
+    "candidate": true,
+    "crystallized": false,
+    "trap_class_check": "pass",
+    "reason": "Estimator confidence and operational reuse remain separate from corroboration and certification."
+  },
+  "memory_unit": {
+    "id": "fixture:epistemic:high-confidence-reuse",
+    "content_ref": "fixture://high-confidence-reuse/claim",
+    "type": "semantic",
+    "acquisition_mode": "inferred",
+    "state": "operationally_reused",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "synthetic-high-confidence-reuse-trap",
+      "timestamp": "2026-08-12T00:00:00Z",
+      "source_refs": [
+        "fixture://source/inference-a"
+      ]
+    },
+    "evidence": [
+      {
+        "id": "evidence:inference-a",
+        "kind": "agent_generated_inference",
+        "ref": "fixture://source/inference-a",
+        "confidence": 0.99,
+        "confidence_kind": "estimator_confidence",
+        "estimator": {
+          "id": "fixture-estimator",
+          "version": "1.0.0"
+        }
+      }
+    ],
+    "saturation": {
+      "sigma": 0.97,
+      "calibrated": true,
+      "threshold": 0.8,
+      "durability_dimensions": [
+        "retrieval",
+        "reuse"
+      ]
+    },
+    "authority": {
+      "pama_outcome": "require_external_verification",
+      "risk_class": "medium",
+      "policy_refs": [
+        "ADR-002",
+        "ADR-003",
+        "ADR-009"
+      ],
+      "permitted_actions": [
+        "retain_candidate",
+        "request_independent_evidence"
+      ],
+      "prohibited_actions": [
+        "crystallize"
+      ],
+      "selection_mode": "deterministic"
+    },
+    "certification": {
+      "status": "none",
+      "scope": "fixture"
+    },
+    "created_at": "2026-08-12T00:00:00Z"
+  },
+  "epistemic_promotion": {
+    "lineage": [
+      {
+        "evidence_id": "evidence:inference-a",
+        "origin_id": "origin:inference-a",
+        "derived_from": []
+      }
+    ],
+    "retrieval_count": 250,
+    "downstream_use_count": 100,
+    "corroboration_threshold": 2,
+    "certification_gate_passed": false,
+    "expected": {
+      "independent_origin_count": 1,
+      "corroboration_threshold_met": false,
+      "certification_status": "none"
+    }
+  }
+}

--- a/fixtures/independent-corroboration-arrives.json
+++ b/fixtures/independent-corroboration-arrives.json
@@ -19,67 +19,33 @@
       "observer": "conformance-suite",
       "method": "synthetic-independent-corroboration-control",
       "timestamp": "2026-08-12T00:00:00Z",
-      "source_refs": [
-        "fixture://source/origin-a",
-        "fixture://source/origin-b"
-      ]
+      "source_refs": ["fixture://source/origin-a", "fixture://source/origin-b"]
     },
     "evidence": [
-      {
-        "id": "evidence:origin-a",
-        "kind": "single_source_assertion",
-        "ref": "fixture://source/origin-a",
-        "confidence": 0.72
-      },
-      {
-        "id": "evidence:origin-b",
-        "kind": "independent_observation",
-        "ref": "fixture://source/origin-b",
-        "confidence": 0.81
-      }
+      {"id": "evidence:origin-a", "kind": "single_source_assertion", "ref": "fixture://source/origin-a", "confidence": 0.72},
+      {"id": "evidence:origin-b", "kind": "independent_observation", "ref": "fixture://source/origin-b", "confidence": 0.81}
     ],
     "saturation": {
       "sigma": 0.76,
       "calibrated": true,
       "threshold": 0.8,
-      "durability_dimensions": [
-        "corroboration"
-      ]
+      "durability_dimensions": ["corroboration"]
     },
     "authority": {
       "pama_outcome": "require_review",
       "risk_class": "medium",
-      "policy_refs": [
-        "ADR-003",
-        "ADR-009"
-      ],
-      "permitted_actions": [
-        "retain_candidate",
-        "request_certification"
-      ],
-      "prohibited_actions": [
-        "auto_crystallize"
-      ],
+      "policy_refs": ["ADR-003", "ADR-009"],
+      "permitted_actions": ["retain_candidate", "request_certification"],
+      "prohibited_actions": ["auto_crystallize"],
       "selection_mode": "deterministic"
     },
-    "certification": {
-      "status": "pending",
-      "scope": "fixture"
-    },
+    "certification": {"status": "pending", "scope": "fixture"},
     "created_at": "2026-08-12T00:00:00Z"
   },
   "epistemic_promotion": {
     "lineage": [
-      {
-        "evidence_id": "evidence:origin-a",
-        "origin_id": "origin:a",
-        "derived_from": []
-      },
-      {
-        "evidence_id": "evidence:origin-b",
-        "origin_id": "origin:b",
-        "derived_from": []
-      }
+      {"evidence_id": "evidence:origin-a", "origin_refs": ["origin:a"], "derived_from": []},
+      {"evidence_id": "evidence:origin-b", "origin_refs": ["origin:b"], "derived_from": []}
     ],
     "retrieval_count": 3,
     "downstream_use_count": 1,

--- a/fixtures/independent-corroboration-arrives.json
+++ b/fixtures/independent-corroboration-arrives.json
@@ -1,0 +1,94 @@
+{
+  "fixture_id": "independent-corroboration-arrives",
+  "fixture_version": "1.0.0",
+  "class": "positive_control",
+  "description": "A claim receives genuinely independent evidence later. The corroboration threshold may become satisfied, but certification remains a separate governed transition.",
+  "expected_behavior": {
+    "candidate": true,
+    "crystallized": false,
+    "trap_class_check": "pass",
+    "reason": "Independent evidence can improve corroboration without automatically granting certification or durable promotion."
+  },
+  "memory_unit": {
+    "id": "fixture:epistemic:independent-corroboration",
+    "content_ref": "fixture://independent-corroboration/claim",
+    "type": "semantic",
+    "state": "pending_verification",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "synthetic-independent-corroboration-control",
+      "timestamp": "2026-08-12T00:00:00Z",
+      "source_refs": [
+        "fixture://source/origin-a",
+        "fixture://source/origin-b"
+      ]
+    },
+    "evidence": [
+      {
+        "id": "evidence:origin-a",
+        "kind": "single_source_assertion",
+        "ref": "fixture://source/origin-a",
+        "confidence": 0.72
+      },
+      {
+        "id": "evidence:origin-b",
+        "kind": "independent_observation",
+        "ref": "fixture://source/origin-b",
+        "confidence": 0.81
+      }
+    ],
+    "saturation": {
+      "sigma": 0.76,
+      "calibrated": true,
+      "threshold": 0.8,
+      "durability_dimensions": [
+        "corroboration"
+      ]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "policy_refs": [
+        "ADR-003",
+        "ADR-009"
+      ],
+      "permitted_actions": [
+        "retain_candidate",
+        "request_certification"
+      ],
+      "prohibited_actions": [
+        "auto_crystallize"
+      ],
+      "selection_mode": "deterministic"
+    },
+    "certification": {
+      "status": "pending",
+      "scope": "fixture"
+    },
+    "created_at": "2026-08-12T00:00:00Z"
+  },
+  "epistemic_promotion": {
+    "lineage": [
+      {
+        "evidence_id": "evidence:origin-a",
+        "origin_id": "origin:a",
+        "derived_from": []
+      },
+      {
+        "evidence_id": "evidence:origin-b",
+        "origin_id": "origin:b",
+        "derived_from": []
+      }
+    ],
+    "retrieval_count": 3,
+    "downstream_use_count": 1,
+    "corroboration_threshold": 2,
+    "certification_gate_passed": false,
+    "expected": {
+      "independent_origin_count": 2,
+      "corroboration_threshold_met": true,
+      "certification_status": "pending"
+    }
+  }
+}

--- a/reference/agentmem_ref/fixture_conformance.py
+++ b/reference/agentmem_ref/fixture_conformance.py
@@ -1,30 +1,29 @@
-"""Drive the doctrine fixture corpus through the adapter's enforcement code.
+"""Drive the doctrine fixture corpus through executable conformance checks.
 
 The governance-path tests assert that the adapter behaves correctly on
 scenarios written alongside the adapter. This module does something harder:
 it takes the repository's independently authored conformance fixtures and
-runs their declared authority envelopes through the *same* enforcement
-function the adapter uses in production, `receipts.enforce_selection`.
-
-That distinction matters. A test suite written by the same hand as the code
-can agree with itself. The fixture corpus was written to describe doctrine,
-not to satisfy this implementation, so agreement between them is evidence
-rather than tautology.
+runs declared authority envelopes through the same enforcement function the
+adapter uses, while also checking selected cross-cutting fixture contracts.
 
 What is checked, per fixture carrying an authority envelope:
 
 1. permitted and prohibited action sets are disjoint;
-2. the declared selection is a member of the permitted set, enforced by the
-   adapter's own membership rule rather than a reimplementation of it;
+2. the declared selection is a member of the permitted set;
 3. the declared selection is not a prohibited action;
-4. every prohibited action is *rejected* by that same enforcement rule; and
+4. every prohibited action is rejected by that same enforcement rule; and
 5. a fixture expecting no crystallization does not permit one.
 
-What is not checked is listed in `exemptions()`. Decay, calibration, retrieval
-ranking, and lifecycle transition mechanics are outside this adapter, and a
-runner that silently skipped them would misrepresent its own coverage.
+Fixtures carrying ``epistemic_promotion`` additionally prove that evidence
+lineage, not retrieval/use volume, determines independent-origin count; that
+derived evidence cannot silently invent a new origin; and that corroboration
+does not itself satisfy a separate certification gate.
 
-Stdlib only apart from schema validation reached through `receipts`.
+What is not checked is listed in ``exemptions()``. Decay, calibration,
+retrieval ranking, and most lifecycle transition mechanics are outside this
+adapter, and a runner that silently skipped them would misrepresent coverage.
+
+Stdlib only apart from schema validation reached through ``receipts``.
 """
 
 from __future__ import annotations
@@ -75,13 +74,161 @@ def check_envelope(source: str, envelope: dict) -> list[str]:
         except ValueError as exc:
             failures.append(f"{source}: {exc}")
 
-    # The enforcement rule must actively refuse every prohibited action.
     for action in prohibited:
         try:
             receipts.enforce_selection(permitted, action)
         except ValueError:
             continue
         failures.append(f"{source}: enforcement accepted prohibited action {action!r}")
+
+    return failures
+
+
+def check_epistemic_promotion(fixture: dict) -> list[str]:
+    """Validate the optional source-lineage / corroboration assertion contract.
+
+    ``retrieval_count`` and ``downstream_use_count`` are deliberately recorded
+    but never used in independent-origin or certification calculations.
+    """
+    block = fixture.get("epistemic_promotion")
+    if block is None:
+        return []
+    if not isinstance(block, dict):
+        return ["epistemic_promotion must be an object"]
+
+    failures: list[str] = []
+    lineage = block.get("lineage")
+    expected = block.get("expected")
+    threshold = block.get("corroboration_threshold")
+    gate_passed = block.get("certification_gate_passed")
+
+    for counter_name in ("retrieval_count", "downstream_use_count"):
+        value = block.get(counter_name)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            failures.append(f"epistemic_promotion.{counter_name} must be a non-negative integer")
+
+    if not isinstance(threshold, int) or isinstance(threshold, bool) or threshold < 1:
+        failures.append("epistemic_promotion.corroboration_threshold must be a positive integer")
+        threshold = None
+    if not isinstance(gate_passed, bool):
+        failures.append("epistemic_promotion.certification_gate_passed must be boolean")
+    if not isinstance(lineage, list) or not lineage:
+        failures.append("epistemic_promotion.lineage must be a non-empty list")
+        return failures
+    if not isinstance(expected, dict):
+        failures.append("epistemic_promotion.expected must be an object")
+        return failures
+
+    evidence = fixture.get("memory_unit", {}).get("evidence") or []
+    evidence_ids = {
+        item.get("id") for item in evidence if isinstance(item, dict) and isinstance(item.get("id"), str)
+    }
+
+    entries: dict[str, dict] = {}
+    for index, entry in enumerate(lineage):
+        path = f"epistemic_promotion.lineage[{index}]"
+        if not isinstance(entry, dict):
+            failures.append(f"{path} must be an object")
+            continue
+        evidence_id = entry.get("evidence_id")
+        origins = entry.get("origin_refs")
+        parents = entry.get("derived_from")
+        if not isinstance(evidence_id, str) or not evidence_id:
+            failures.append(f"{path}.evidence_id must be a non-empty string")
+            continue
+        if evidence_id in entries:
+            failures.append(f"{path}: duplicate evidence_id {evidence_id!r}")
+            continue
+        if evidence_id not in evidence_ids:
+            failures.append(f"{path}: evidence_id {evidence_id!r} not present in memory_unit.evidence")
+        if not isinstance(origins, list) or not origins or not all(isinstance(x, str) and x for x in origins):
+            failures.append(f"{path}.origin_refs must be a non-empty list of strings")
+        elif len(set(origins)) != len(origins):
+            failures.append(f"{path}.origin_refs must be unique")
+        if not isinstance(parents, list) or not all(isinstance(x, str) and x for x in parents):
+            failures.append(f"{path}.derived_from must be a list of evidence ids")
+        entries[evidence_id] = entry
+
+    if set(entries) != evidence_ids:
+        missing = sorted(evidence_ids - set(entries))
+        extra = sorted(set(entries) - evidence_ids)
+        if missing:
+            failures.append(f"epistemic_promotion.lineage missing evidence ids: {missing}")
+        if extra:
+            failures.append(f"epistemic_promotion.lineage has unknown evidence ids: {extra}")
+
+    # Derived evidence must preserve exactly the union of its parents' origins.
+    # A summary/restatement therefore cannot acquire a fresh origin merely by
+    # being transformed or copied.
+    unresolved = dict(entries)
+    resolved_origins: dict[str, set[str]] = {}
+    while unresolved:
+        progressed = False
+        for evidence_id, entry in list(unresolved.items()):
+            parents = entry.get("derived_from") or []
+            declared = set(entry.get("origin_refs") or [])
+            if not parents:
+                resolved_origins[evidence_id] = declared
+                unresolved.pop(evidence_id)
+                progressed = True
+                continue
+            unknown = [parent for parent in parents if parent not in entries]
+            if unknown:
+                failures.append(
+                    f"epistemic_promotion.lineage {evidence_id!r} references unknown parent(s): {sorted(unknown)}"
+                )
+                resolved_origins[evidence_id] = declared
+                unresolved.pop(evidence_id)
+                progressed = True
+                continue
+            if not all(parent in resolved_origins for parent in parents):
+                continue
+            inherited: set[str] = set()
+            for parent in parents:
+                inherited.update(resolved_origins[parent])
+            if declared != inherited:
+                failures.append(
+                    f"epistemic_promotion.lineage {evidence_id!r} changes inherited origins: "
+                    f"declared={sorted(declared)} inherited={sorted(inherited)}"
+                )
+            resolved_origins[evidence_id] = inherited
+            unresolved.pop(evidence_id)
+            progressed = True
+        if not progressed:
+            failures.append(
+                "epistemic_promotion.lineage contains a derivation cycle that prevents origin reconstruction"
+            )
+            break
+
+    independent_origins: set[str] = set()
+    for origins in resolved_origins.values():
+        independent_origins.update(origins)
+    independent_count = len(independent_origins)
+
+    expected_count = expected.get("independent_origin_count")
+    if independent_count != expected_count:
+        failures.append(
+            "epistemic_promotion independent origin count mismatch: "
+            f"derived={independent_count} expected={expected_count!r}"
+        )
+
+    if threshold is not None:
+        threshold_met = independent_count >= threshold
+        if threshold_met is not expected.get("corroboration_threshold_met"):
+            failures.append(
+                "epistemic_promotion corroboration threshold mismatch: "
+                f"derived={threshold_met} expected={expected.get('corroboration_threshold_met')!r}"
+            )
+
+    certification = fixture.get("memory_unit", {}).get("certification") or {}
+    certification_status = certification.get("status", "none")
+    if certification_status != expected.get("certification_status"):
+        failures.append(
+            "epistemic_promotion certification status mismatch: "
+            f"memory={certification_status!r} expected={expected.get('certification_status')!r}"
+        )
+    if gate_passed is False and certification_status == "pass":
+        failures.append("epistemic_promotion certification passed without its separate certification gate")
 
     return failures
 
@@ -101,6 +248,8 @@ def check_fixture(fixture: dict) -> list[str]:
                 failures.append(
                     f"{source}: fixture expects no crystallization but permits {crystallizing}"
                 )
+
+    failures.extend(check_epistemic_promotion(fixture))
     return failures
 
 
@@ -112,7 +261,9 @@ def exemptions() -> list[str]:
         "not the substrate's hybrid search.",
         "Lifecycle transition mechanics beyond commit, supersession, pruning, and deletion "
         "are not driven through the adapter.",
-        "Fixtures without a declared authority envelope contribute structural coverage only.",
+        "Epistemic-promotion fixtures reconstruct declared evidence lineage and certification separation; "
+        "they do not define a universal corroboration threshold or certification algorithm.",
+        "Fixtures without a declared authority envelope or specialized assertion block contribute structural coverage only.",
     ]
 
 
@@ -120,9 +271,12 @@ def run(fixture_dir: Path | None = None) -> dict:
     """Execute the corpus and summarize per-fixture results."""
     results: dict[str, list[str]] = {}
     with_envelope = 0
+    with_epistemic_promotion = 0
     for name, fixture in load_fixtures(fixture_dir):
         if _envelopes(fixture):
             with_envelope += 1
+        if isinstance(fixture.get("epistemic_promotion"), dict):
+            with_epistemic_promotion += 1
         results[name] = check_fixture(fixture)
 
     passed = sorted(name for name, failures in results.items() if not failures)
@@ -133,4 +287,5 @@ def run(fixture_dir: Path | None = None) -> dict:
         "fixtures_failed": failed,
         "failures": {name: results[name] for name in failed},
         "fixtures_with_authority_envelope": with_envelope,
+        "fixtures_with_epistemic_promotion": with_epistemic_promotion,
     }

--- a/reference/tests/test_fixture_corpus.py
+++ b/reference/tests/test_fixture_corpus.py
@@ -1,12 +1,12 @@
-"""The doctrine fixture corpus, driven through the adapter's enforcement code.
+"""The doctrine fixture corpus, driven through executable conformance checks.
 
 Two kinds of test live here, and the second is what makes the first mean
 anything:
 
-1. every fixture's declared authority envelope is enforced by the adapter's
-   own membership rule; and
-2. the checker itself is mutation-tested, so a corpus that passes is evidence
-   rather than a check that cannot fail.
+1. every fixture's declared authority and specialized assertion contracts are
+   checked; and
+2. the checkers are mutation-tested, so a passing corpus is evidence rather
+   than a collection of checks that cannot fail.
 
 Run: python -m unittest discover -s reference/tests -t reference
 """
@@ -33,15 +33,16 @@ class FixtureCorpusTests(unittest.TestCase):
         for name, fixture in fixtures:
             self.assertIn("fixture_version", fixture, f"{name} lacks fixture_version")
 
-    def test_every_declared_envelope_is_enforced(self):
+    def test_every_declared_contract_is_enforced(self):
         result = fc.run()
         self.assertEqual(
             result["fixtures_failed"],
             [],
-            msg=f"envelope enforcement failures: {json.dumps(result['failures'], indent=2)}",
+            msg=f"fixture conformance failures: {json.dumps(result['failures'], indent=2)}",
         )
         self.assertEqual(len(result["fixtures_run"]), len(list(REPO_FIXTURES.glob("*.json"))))
         self.assertGreater(result["fixtures_with_authority_envelope"], 0)
+        self.assertGreaterEqual(result["fixtures_with_epistemic_promotion"], 3)
 
 
 class CheckerHasTeethTests(unittest.TestCase):
@@ -51,37 +52,94 @@ class CheckerHasTeethTests(unittest.TestCase):
         source = REPO_FIXTURES / "high-confidence-false-promotion.json"
         self.base = json.loads(source.read_text(encoding="utf-8"))
 
-    def _run_mutant(self, mutate) -> dict:
-        fixture = json.loads(json.dumps(self.base))
-        mutate(fixture)
+    def _run_mutant(self, fixture: dict, mutate) -> dict:
+        mutant = json.loads(json.dumps(fixture))
+        mutate(mutant)
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "mutant.json"
-            path.write_text(json.dumps(fixture), encoding="utf-8")
+            path.write_text(json.dumps(mutant), encoding="utf-8")
             return fc.run(Path(tmp))
 
     def test_detects_permitted_and_prohibited_overlap(self):
         result = self._run_mutant(
+            self.base,
             lambda f: f["governed_uncertainty"].update(
                 {"permitted_actions": ["crystallize", "mark_disputed"]}
-            )
+            ),
         )
         self.assertEqual(result["fixtures_failed"], ["mutant"])
 
     def test_detects_selection_of_prohibited_action(self):
         result = self._run_mutant(
-            lambda f: f["governed_uncertainty"].update({"selected_action": "crystallize"})
+            self.base,
+            lambda f: f["governed_uncertainty"].update({"selected_action": "crystallize"}),
         )
         self.assertEqual(result["fixtures_failed"], ["mutant"])
 
     def test_detects_selection_outside_permitted_set(self):
         result = self._run_mutant(
-            lambda f: f["governed_uncertainty"].update({"selected_action": "invented_action"})
+            self.base,
+            lambda f: f["governed_uncertainty"].update({"selected_action": "invented_action"}),
         )
         self.assertEqual(result["fixtures_failed"], ["mutant"])
 
     def test_detects_crystallization_against_stated_expectation(self):
         result = self._run_mutant(
-            lambda f: f["governed_uncertainty"]["permitted_actions"].append("crystallize_anyway")
+            self.base,
+            lambda f: f["governed_uncertainty"]["permitted_actions"].append("crystallize_anyway"),
+        )
+        self.assertEqual(result["fixtures_failed"], ["mutant"])
+
+
+class EpistemicPromotionCheckerHasTeethTests(unittest.TestCase):
+    def setUp(self) -> None:
+        derived = REPO_FIXTURES / "derived-self-corroboration.json"
+        corroborated = REPO_FIXTURES / "independent-corroboration-arrives.json"
+        self.derived = json.loads(derived.read_text(encoding="utf-8"))
+        self.corroborated = json.loads(corroborated.read_text(encoding="utf-8"))
+
+    def _run_mutant(self, fixture: dict, mutate) -> dict:
+        mutant = json.loads(json.dumps(fixture))
+        mutate(mutant)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mutant.json"
+            path.write_text(json.dumps(mutant), encoding="utf-8")
+            return fc.run(Path(tmp))
+
+    def test_detects_derived_copy_inventing_new_origin(self):
+        result = self._run_mutant(
+            self.derived,
+            lambda f: f["epistemic_promotion"]["lineage"][1].update(
+                {"origin_refs": ["origin:invented"]}
+            ),
+        )
+        self.assertEqual(result["fixtures_failed"], ["mutant"])
+
+    def test_detects_fake_independent_source_count(self):
+        result = self._run_mutant(
+            self.derived,
+            lambda f: f["epistemic_promotion"]["expected"].update(
+                {"independent_origin_count": 3}
+            ),
+        )
+        self.assertEqual(result["fixtures_failed"], ["mutant"])
+
+    def test_detects_repetition_claimed_as_corroboration(self):
+        result = self._run_mutant(
+            self.derived,
+            lambda f: f["epistemic_promotion"]["expected"].update(
+                {"corroboration_threshold_met": True}
+            ),
+        )
+        self.assertEqual(result["fixtures_failed"], ["mutant"])
+
+    def test_detects_certification_without_gate(self):
+        result = self._run_mutant(
+            self.corroborated,
+            lambda f: (
+                f["memory_unit"]["certification"].update({"status": "pass"}),
+                f["epistemic_promotion"]["expected"].update({"certification_status": "pass"}),
+            ),
         )
         self.assertEqual(result["fixtures_failed"], ["mutant"])
 


### PR DESCRIPTION
## Summary

Implements the remaining conformance-depth work for #149 without introducing a new ADR or new canonical memory primitive.

### New executable scenarios

- `derived-self-corroboration`: one source is repeatedly summarized/restated; all derived copies must reconstruct to the same origin lineage and count as one independent origin.
- `high-confidence-reuse-no-corroboration`: a 0.99-confidence inference is retrieved 250 times and used 100 times; those counters have no path into independent-origin count or certification.
- `independent-corroboration-arrives`: genuinely independent evidence can satisfy a scenario-specific corroboration threshold, while certification remains a separate governed transition.

### Checker behavior

`reference/agentmem_ref/fixture_conformance.py` now reconstructs declared evidence lineage for fixtures carrying `epistemic_promotion` and checks:

- derived evidence preserves exactly the union of its parent origins;
- independent-origin count is derived from lineage, not usage frequency;
- retrieval/use counters are recorded but never enter the corroboration calculation;
- scenario-specific corroboration threshold results match the declared expected result;
- certification status remains independent, and cannot be `pass` when the fixture says the certification gate did not pass.

The checker is mutation-tested for invented origins, fake independent-source counts, repetition masquerading as corroboration, and certification without its separate gate.

## Architectural conclusion under test

This PR provides executable evidence that existing ADR-003 / ADR-009 doctrine is sufficient:

```text
repetition != corroboration
usage != evidence
retrieval success != truth
derived copies of one source != independent witnesses
corroboration != certification
```

If the exact-head evidence remains green, #149 can close with **no new ADR**.

## Scope / non-goals

- no universal corroboration threshold;
- no new evidence field in the canonical memory-unit schema;
- no semantic-similarity estimator;
- no automatic certification or promotion rule;
- no claim that two sources are universally sufficient evidence.

The `epistemic_promotion` block is fixture assertion metadata, not a proposed canonical memory object.

## Documentation impact review

Reviewed:

- ADR-003 already explicitly states crystallization cannot be granted by repetition, retrieval frequency, saturation, relevance, or model confidence alone.
- `docs/16-source-trust-and-reputation.md` already requires derivation graphs, self-citation-loop detection, independent-witness distinction, and shows `A -> B -> C` sharing one origin as `independent_source_count = 1`.
- `docs/06-conformance-test-plan.md` already requires that access volume and model confidence not cause crystallization and that certification remain separate.

Those canonical statements remain accurate after this PR, so changing their prose would be ceremonial rather than alignment. The change is executable conformance depth under existing doctrine. The root README's separate pre-existing maturity/count drift is tracked in #159.

## Validation

Draft until both exact-head `Validate Doctrine Evidence` and `P9 Systems Characterization` succeed. Post-merge `main` validation remains a separate evidence boundary.
