### PR TITLE
Make decision receipts reconstruct authority outcomes

### DIFF
--- a/docs/27-schema-registry-and-type-evolution.md
+++ b/docs/27-schema-registry-and-type-evolution.md
@@ -175,6 +175,8 @@ Authority must not be inferred from estimator fields.
 A common receipt should support:
 
 ```text
+decision_ref
+decision_outcome
 requested_action
 state_snapshot
 estimate_refs
@@ -190,6 +192,35 @@ evidence_refs
 rollback_or_recovery_ref
 timestamp
 ```
+
+The decision and receipt remain distinct artifacts. The receipt carries enough authority context to identify the decision and reconstruct its outcome class, while the referenced decision remains authoritative for the full PAMA evaluation record.
+
+Decision-receipt version compatibility currently follows this boundary:
+
+```text
+1.0.0
+  historical receipt shape
+  decision_ref / decision_outcome absent or optional
+  remains valid historical evidence
+
+1.1.0
+  decision_ref required
+  decision_outcome required
+  receipt <-> decision binding can be verified bidirectionally
+```
+
+This is intentionally versioned rather than retroactively making new fields required on all stored receipts. Optional-to-required evolution is breaking unless historical objects are migrated, and signed or content-addressed evidence must not be silently rewritten merely to satisfy a newer convenience contract.
+
+For 1.1.0 receipts, consumers that possess the referenced decision should verify at least:
+
+- `decision_ref` resolves to the intended PAMA/authority decision;
+- `decision_outcome` matches that decision;
+- policy version and permitted/prohibited action sets match;
+- selected action matches the decision and belongs to the permitted set;
+- the decision points back to the same receipt;
+- the outcome and action envelope are internally consistent.
+
+A receipt proves what was recorded about the authority decision and selected consequence. It does not, by itself, prove downstream execution occurred.
 
 ## Migration
 
@@ -233,12 +264,16 @@ Schema changes should be reviewed for:
 
 ## Current repository schemas
 
-The repository's schema registry currently contains seven schemas, reconciled with the governed-uncertainty model in evidence slice 7B and after:
+The repository schema registry includes machine-readable contracts for memory units, conformance results, audit events, decision receipts, PAMA decisions, calibration evidence, source records, portable/interchange evidence, isolation boundaries, governance projections, and other bounded profiles introduced by validated architecture slices.
+
+The canonical inventory is the [`../schemas/`](../schemas/) directory. Do not rely on a hand-maintained schema count in prose as a maturity signal.
+
+Core examples include:
 
 - [`../schemas/memory-unit.schema.json`](../schemas/memory-unit.schema.json) — the memory unit, including uncertainty, scope, tombstone, and action-envelope fields
 - [`../schemas/conformance-report.schema.json`](../schemas/conformance-report.schema.json) — conformance results with estimator/policy versioning and the standardized metric family
 - [`../schemas/memory-audit-event.schema.json`](../schemas/memory-audit-event.schema.json) — structured audit events with correlation/causation identifiers
-- [`../schemas/decision-receipt.schema.json`](../schemas/decision-receipt.schema.json) — reconstruction receipts for consequential decisions
+- [`../schemas/decision-receipt.schema.json`](../schemas/decision-receipt.schema.json) — reconstruction receipts for consequential decisions, including the versioned authority-decision backlink
 - [`../schemas/pama-decision.schema.json`](../schemas/pama-decision.schema.json) — PAMA authority decision records
 - [`../schemas/calibration-results.schema.json`](../schemas/calibration-results.schema.json) — labeled calibration case input for the calibration report generator
 - [`../schemas/source-record.schema.json`](../schemas/source-record.schema.json) — source-registry records with rights and reuse gating
@@ -251,7 +286,7 @@ Conformance fixtures are versioned artifacts with their own evolution rules, dis
 "fixture_version": "MAJOR.MINOR.PATCH"
 ```
 
-- The fixture version describes the **scenario contract** — expected behavior, required invariants, trap semantics, and material scenario inputs — not the memory-unit schema version.
+- The fixture version describes the **scenario contract**: expected behavior, required invariants, trap semantics, and material scenario inputs, not the memory-unit schema version.
 - Prose or metadata changes that leave expected behavior untouched may remain patch-compatible.
 - Changing expected behavior, required invariants, trap semantics, or material scenario inputs requires a version change; breaking scenario-semantic changes require a major version change.
 - Runtime evidence must record `fixture_id` plus `fixture_version`, so results remain comparable after fixtures evolve.
@@ -261,11 +296,17 @@ Conformance fixtures are versioned artifacts with their own evolution rules, dis
 
 - old consumer receives new optional field
 - old consumer receives unknown enum member
+- historical 1.0 decision receipt remains valid under the compatibility schema
+- 1.1 decision receipt omits required decision backlink/outcome
+- decision receipt references the wrong authority decision
+- decision receipt outcome does not match the referenced decision
+- decision and receipt point at different counterparts
+- outcome class contradicts the permitted/prohibited action envelope
+- decision receipt references mismatched policy version
 - estimator score changes semantics without type change
 - migrated object loses provenance
 - schema adapter strips tenant scope
 - unknown schema attempts durable mutation
-- decision receipt references mismatched policy version
 
 ## Doctrine
 

--- a/reference/agentmem_ref/receipts.py
+++ b/reference/agentmem_ref/receipts.py
@@ -30,6 +30,14 @@ SCHEMA_DIR = Path(__file__).resolve().parents[2] / "schemas"
 #: Sentinel recorded when governance permitted no action at all.
 NO_ACTION = "none"
 
+_DEFERRED_OUTCOMES = {
+    "require_review",
+    "require_external_verification",
+    "abstain",
+    "quarantine",
+    "collect_more_evidence",
+}
+
 
 @lru_cache(maxsize=None)
 def _validator(schema_name: str) -> jsonschema.Draft202012Validator:
@@ -45,6 +53,18 @@ def validate(schema_name: str, document: dict) -> None:
         raise ValueError(f"{schema_name} at {location}: {errors[0].message}")
 
 
+def decision_ref_for(proposal_id: str) -> str:
+    """Stable logical reference for the PAMA decision produced for a proposal.
+
+    The PAMA decision already carries ``proposal_id`` as its stable identity
+    anchor. This names that artifact without introducing a second, cyclic
+    content identity merely to link it back from the receipt.
+    """
+    if not proposal_id:
+        raise ValueError("decision reference requires a proposal id")
+    return f"pama-decision:{proposal_id}"
+
+
 def enforce_selection(permitted: tuple[str, ...], selected: str) -> None:
     """Selected action must come from the permitted set.
 
@@ -58,6 +78,45 @@ def enforce_selection(permitted: tuple[str, ...], selected: str) -> None:
         return
     if selected not in permitted:
         raise ValueError(f"selected action {selected!r} is not in the permitted set {list(permitted)}")
+
+
+def enforce_decision_consistency(
+    outcome: str,
+    requested_action: str,
+    permitted: tuple[str, ...],
+    prohibited: tuple[str, ...],
+) -> None:
+    """Reject authority outcomes that contradict their action envelope.
+
+    This intentionally enforces only invariants that are stable across the
+    current decision vocabulary. It does not invent one universal policy table.
+    """
+    overlap = set(permitted) & set(prohibited)
+    if overlap:
+        raise ValueError(f"actions cannot be both permitted and prohibited: {sorted(overlap)}")
+
+    if outcome in ("allow", "allow_with_ledger"):
+        if requested_action not in permitted:
+            raise ValueError(f"{outcome} must permit the requested action {requested_action!r}")
+        if requested_action in prohibited:
+            raise ValueError(f"{outcome} cannot prohibit the requested action {requested_action!r}")
+        return
+
+    if outcome == "block":
+        if permitted:
+            raise ValueError("block outcome cannot expose permitted actions")
+        if requested_action not in prohibited:
+            raise ValueError("block outcome must prohibit the requested action")
+        return
+
+    if outcome in _DEFERRED_OUTCOMES:
+        if requested_action in permitted:
+            raise ValueError(f"{outcome} cannot directly permit the requested action")
+        if requested_action not in prohibited:
+            raise ValueError(f"{outcome} must keep the requested action prohibited pending resolution")
+        return
+
+    raise ValueError(f"unknown decision outcome {outcome!r}")
 
 
 def build_pama_decision(
@@ -124,10 +183,18 @@ def build_receipt(
     after_state: str,
     rollback_ref: str | None = None,
 ) -> dict:
+    enforce_decision_consistency(
+        decision.outcome,
+        proposal.operation,
+        decision.permitted_actions,
+        decision.prohibited_actions,
+    )
     enforce_selection(decision.permitted_actions, selected_action)
     document = {
-        "schema_version": "1.0.0",
+        "schema_version": "1.1.0",
         "receipt_id": receipt_id,
+        "decision_ref": decision_ref_for(proposal.proposal_id),
+        "decision_outcome": decision.outcome,
         "memory_id": proposal.target_reference,
         "actor": proposal.actor_id,
         "requested_action": proposal.operation,
@@ -153,6 +220,52 @@ def build_receipt(
         document["rollback_or_recovery_ref"] = rollback_ref
     validate("decision-receipt.schema.json", document)
     return document
+
+
+def verify_receipt_decision_pair(receipt: dict, pama_decision: dict) -> None:
+    """Verify that a receipt and PAMA decision describe the same authority event."""
+    validate("decision-receipt.schema.json", receipt)
+    validate("pama-decision.schema.json", pama_decision)
+
+    expected_ref = decision_ref_for(pama_decision["proposal_id"])
+    if receipt.get("decision_ref") != expected_ref:
+        raise ValueError(
+            f"receipt decision_ref {receipt.get('decision_ref')!r} does not match {expected_ref!r}"
+        )
+
+    decision = pama_decision["decision"]
+    comparisons = {
+        "decision_outcome": decision["outcome"],
+        "permitted_actions": decision["permitted_actions"],
+        "prohibited_actions": decision["prohibited_actions"],
+        "policy_version": pama_decision["policy"]["policy_version"],
+    }
+    for receipt_field, decision_value in comparisons.items():
+        if receipt.get(receipt_field) != decision_value:
+            raise ValueError(
+                f"receipt {receipt_field} does not match referenced decision: "
+                f"receipt={receipt.get(receipt_field)!r} decision={decision_value!r}"
+            )
+
+    receipt_selected = receipt["selected_action"]
+    decision_selected = decision.get("selected_action")
+    normalized_decision_selected = NO_ACTION if decision_selected is None else decision_selected
+    if receipt_selected != normalized_decision_selected:
+        raise ValueError(
+            "receipt selected_action does not match referenced decision: "
+            f"receipt={receipt_selected!r} decision={normalized_decision_selected!r}"
+        )
+
+    if decision.get("decision_receipt_ref") != receipt["receipt_id"]:
+        raise ValueError("referenced decision does not point back to this receipt")
+
+    enforce_decision_consistency(
+        receipt["decision_outcome"],
+        receipt["requested_action"],
+        tuple(receipt["permitted_actions"]),
+        tuple(receipt.get("prohibited_actions") or ()),
+    )
+    enforce_selection(tuple(receipt["permitted_actions"]), receipt_selected)
 
 
 def build_audit_event(

--- a/reference/tests/test_receipt_decision_binding.py
+++ b/reference/tests/test_receipt_decision_binding.py
@@ -1,0 +1,130 @@
+"""Decision receipt completeness and backward-compatibility tests.
+
+Run: python -m unittest discover -s reference/tests -t reference
+"""
+
+from __future__ import annotations
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy, receipts  # noqa: E402
+
+
+class ReceiptDecisionBindingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proposal = policy.Proposal(
+            proposal_id="proposal:receipt-binding",
+            actor_id="actor:test",
+            charter_version="charter:1",
+            target_reference="memory:test",
+            target_class=policy.M2,
+            scope="project:test",
+            operation="promotion",
+            current_strength="tentative",
+            proposed_strength="promoted",
+            downstream_authority=policy.A1,
+            reversibility="reversible",
+            risk_class="low",
+            evidence_refs=("evidence:test",),
+            state_snapshot="v1",
+        )
+        self.decision = policy.evaluate(self.proposal)
+        self.assertEqual(self.decision.outcome, policy.ALLOW_WITH_LEDGER)
+        self.receipt = receipts.build_receipt(
+            receipt_id="receipt:test",
+            proposal=self.proposal,
+            decision=self.decision,
+            selected_action="promotion",
+            selection_mode="deterministic",
+            timestamp="2026-08-12T00:00:00Z",
+            before_state="v1",
+            after_state="v2",
+        )
+        self.pama = receipts.build_pama_decision(
+            self.proposal,
+            self.decision,
+            "promotion",
+            "deterministic",
+            "receipt:test",
+        )
+
+    def test_new_receipt_reconstructs_authority_and_backlinks_to_decision(self):
+        self.assertEqual(self.receipt["schema_version"], "1.1.0")
+        self.assertEqual(
+            self.receipt["decision_ref"],
+            receipts.decision_ref_for(self.proposal.proposal_id),
+        )
+        self.assertEqual(self.receipt["decision_outcome"], policy.ALLOW_WITH_LEDGER)
+        receipts.verify_receipt_decision_pair(self.receipt, self.pama)
+
+    def test_historical_1_0_receipt_remains_schema_valid(self):
+        historical = {
+            "schema_version": "1.0.0",
+            "receipt_id": "receipt:historical",
+            "requested_action": "promotion",
+            "policy_version": "ref-p1",
+            "permitted_actions": ["promotion"],
+            "prohibited_actions": [],
+            "selected_action": "promotion",
+            "selection_mode": "deterministic",
+            "timestamp": "2026-08-01T00:00:00Z",
+        }
+        receipts.validate("decision-receipt.schema.json", historical)
+
+    def test_1_1_receipt_requires_decision_ref(self):
+        mutant = copy.deepcopy(self.receipt)
+        mutant.pop("decision_ref")
+        with self.assertRaises(ValueError):
+            receipts.validate("decision-receipt.schema.json", mutant)
+
+    def test_1_1_receipt_requires_decision_outcome(self):
+        mutant = copy.deepcopy(self.receipt)
+        mutant.pop("decision_outcome")
+        with self.assertRaises(ValueError):
+            receipts.validate("decision-receipt.schema.json", mutant)
+
+    def test_wrong_decision_ref_is_rejected(self):
+        mutant = copy.deepcopy(self.receipt)
+        mutant["decision_ref"] = "pama-decision:other"
+        with self.assertRaisesRegex(ValueError, "decision_ref"):
+            receipts.verify_receipt_decision_pair(mutant, self.pama)
+
+    def test_wrong_decision_outcome_is_rejected(self):
+        mutant = copy.deepcopy(self.receipt)
+        mutant["decision_outcome"] = "require_review"
+        with self.assertRaisesRegex(ValueError, "decision_outcome"):
+            receipts.verify_receipt_decision_pair(mutant, self.pama)
+
+    def test_wrong_receipt_backlink_is_rejected(self):
+        mutant = copy.deepcopy(self.pama)
+        mutant["decision"]["decision_receipt_ref"] = "receipt:other"
+        with self.assertRaisesRegex(ValueError, "does not point back"):
+            receipts.verify_receipt_decision_pair(self.receipt, mutant)
+
+    def test_outcome_envelope_inconsistency_is_rejected_at_build_time(self):
+        inconsistent = policy.Decision(
+            outcome=policy.ALLOW_WITH_LEDGER,
+            permitted_actions=("collect_more_evidence",),
+            prohibited_actions=("promotion",),
+            policy_version=policy.POLICY_VERSION,
+        )
+        with self.assertRaisesRegex(ValueError, "must permit the requested action"):
+            receipts.build_receipt(
+                receipt_id="receipt:bad",
+                proposal=self.proposal,
+                decision=inconsistent,
+                selected_action="collect_more_evidence",
+                selection_mode="deterministic",
+                timestamp="2026-08-12T00:00:00Z",
+                before_state="v1",
+                after_state="v1",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/decision-receipt.schema.json
+++ b/schemas/decision-receipt.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/decision-receipt.schema.json",
   "title": "Agent Memory Decision Receipt",
+  "description": "Decision-receipt compatibility schema. Version 1.0.0 receipts remain valid historical evidence; version 1.1.0 adds a required backlink to the authority decision and its outcome class for standalone authority/consequence reconstruction.",
   "type": "object",
   "required": [
     "receipt_id",
@@ -15,6 +16,25 @@
   "properties": {
     "schema_version": { "type": "string" },
     "receipt_id": { "type": "string" },
+    "decision_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable reference to the PAMA/authority decision artifact that produced this receipt."
+    },
+    "decision_outcome": {
+      "type": "string",
+      "enum": [
+        "allow",
+        "allow_with_ledger",
+        "require_review",
+        "require_external_verification",
+        "block",
+        "abstain",
+        "quarantine",
+        "collect_more_evidence"
+      ],
+      "description": "Authority outcome class copied from the referenced decision for standalone reconstruction; consumers must verify consistency with the referenced decision when it is available."
+    },
     "memory_id": { "type": "string" },
     "actor": { "type": "string" },
     "principal": { "type": "string" },
@@ -68,6 +88,15 @@
     "timestamp": { "type": "string", "format": "date-time" }
   },
   "allOf": [
+    {
+      "if": {
+        "properties": { "schema_version": { "const": "1.1.0" } },
+        "required": ["schema_version"]
+      },
+      "then": {
+        "required": ["decision_ref", "decision_outcome"]
+      }
+    },
     {
       "if": {
         "properties": {


### PR DESCRIPTION
## Summary

Addresses #157 by making newly emitted decision receipts self-sufficient for locating and identifying the authority decision that produced them, while preserving historical receipt compatibility.

## Contract evolution

`schemas/decision-receipt.schema.json` now supports:

- historical `1.0.0` receipts unchanged;
- `1.1.0` receipts that require:
  - `decision_ref`
  - `decision_outcome`

This follows `docs/27-schema-registry-and-type-evolution.md`: making an existing optional field required would be breaking. The compatibility schema therefore does not retroactively invalidate stored 1.0 evidence.

The reference builder now emits `1.1.0` receipts. `decision_ref` is the stable logical reference `pama-decision:<proposal_id>`, derived from the PAMA decision's existing stable `proposal_id`; no second decision identity or content-hash cycle is introduced.

## Executable consistency

The receipt builder now enforces outcome/envelope consistency before emission:

- `allow` / `allow_with_ledger` must permit the requested action;
- deferred/review/verification outcomes must not directly permit it and must keep it prohibited pending resolution;
- `block` exposes no permitted actions and prohibits the request;
- permitted/prohibited sets cannot overlap.

`verify_receipt_decision_pair()` verifies:

- receipt `decision_ref` matches the referenced PAMA decision;
- outcome, policy version, permitted/prohibited sets, and selected action match;
- the PAMA decision points back to the same receipt;
- the action envelope remains internally consistent.

## Negative / compatibility tests

Dedicated tests cover:

- historical 1.0 receipt still validates;
- 1.1 receipt missing `decision_ref` fails;
- 1.1 receipt missing `decision_outcome` fails;
- wrong decision ref fails;
- wrong outcome fails;
- wrong decision -> receipt backlink fails;
- inconsistent outcome/envelope fails at build time.

## Documentation alignment

`docs/27-schema-registry-and-type-evolution.md` now documents the 1.0/1.1 compatibility boundary, bidirectional verification obligations, outcome/envelope consistency, and the distinction between recorded authority evidence and proof of downstream execution.

The PAMA replay doctrine in `docs/04-governance-and-pama.md` was reviewed and already states the correct invariant: exact reconstruction of authority and consequence is required. Its semantics did not need rewriting.

The schema-registry page also no longer relies on a stale hand-maintained total schema count; the `schemas/` directory is the canonical inventory.

## Non-goals

- invalidating historical signed evidence;
- collapsing the decision and receipt into one artifact;
- changing PAMA outcome semantics;
- introducing a content-derived decision ID with circular receipt/decision hashing;
- claiming the receipt proves execution occurred.

## Validation

The executable-only head `6d0f406dece9dbd86910f11a6e72eaece71aa5e9` passed both `Validate Doctrine Evidence` and `P9 Systems Characterization` before the documentation update.

Final merge candidate head: `691f6200cc25f93700f9d5e5880810a6d8962dfc`. Merge only after both required exact-head workflows pass on that revision. Post-merge `main` validation remains separate.
