### PR TITLE
Generalize forbidden-hit lifecycle conformance

### DIFF
--- a/docs/06-conformance-test-plan.md
+++ b/docs/06-conformance-test-plan.md
@@ -295,6 +295,66 @@ cross_scope_relevance_does_not_override_access_policy == true
 irreversible_action_requires_consequence_appropriate_authority == true
 ```
 
+## Forbidden-hit lifecycle assertions
+
+Positive retrieval evidence is not enough to establish lifecycle safety. An implementation can retrieve the right memory while also surfacing a memory that is superseded, disputed, tombstoned, out of scope, derived from deleted state, or otherwise forbidden for current use.
+
+Conformance should therefore represent negative expectations explicitly across four stages:
+
+```text
+candidate_discovered
+!=
+admitted
+!=
+context_surfaced
+!=
+downstream_influence
+```
+
+A backend may intentionally discover a forbidden candidate so governance can inspect and reject it. That is not itself a failure. The failure occurs when the candidate crosses a stage the fixture says is forbidden.
+
+Each reusable forbidden-hit assertion should record at least:
+
+```text
+assertion_id
+forbidden_class
+source_lifecycle_state
+source_evidence
+candidate_discovered: true | false
+admitted: true | false
+context_surfaced: true | false
+downstream_influence: true | false
+expected_refusal
+```
+
+The four stage fields are independent report fields even when a particular runtime blocks early enough that later fields necessarily remain false. This preserves a stable reporting shape for systems that enforce additional gates after admission.
+
+Current reference coverage is declared in [`../fixtures/forbidden-hit-lifecycle-matrix.json`](../fixtures/forbidden-hit-lifecycle-matrix.json) and includes:
+
+- superseded/corrected state presented as current;
+- tombstoned state;
+- state derived from a tombstoned source;
+- disputed state;
+- project-scope mismatch;
+- revoked or absent shared-memory membership;
+- missing required isolation compartment;
+- rejected-value re-entry at the mutation boundary;
+- stale authorization at the mutation boundary.
+
+This list is a coverage statement, not a universal claim. Sensitivity/purpose restrictions, stale projection variants, additional tenant/task/domain combinations, and later-stage action influence require their own assertions when the tested profile represents them.
+
+At least one negative recall case should prove all of the following simultaneously:
+
+```text
+candidate_discovered == true
+admitted == false
+context_surfaced == false
+downstream_influence == false
+expected_refusal is explicit
+```
+
+Absence from a final answer is not evidence of this property unless the harness establishes the stage at which the memory was blocked.
+
 ## Calibration assertions
 
 The implementation should report where applicable:
@@ -357,6 +417,9 @@ The suite should fail if:
 - policy or estimator version cannot be reconstructed for a consequential decision
 - permanent deletion is authorized solely from predicted low utility
 - concurrent mutation silently becomes last-writer-wins
+- a declared forbidden-hit assertion crosses any stage marked false
+- forbidden-hit reporting omits the refusal/blocking reason needed to establish where safety held
+- state derived from a tombstoned source is admitted as valid current evidence without a governed revalidation path
 
 ## Test harness recommendation
 
@@ -386,9 +449,22 @@ fixtures_failed:
 trials_run:
 trap_class_failure_rate:
 boundary_instability_rate:
+forbidden_hit_coverage:
+  - assertion_id
+    forbidden_class
+    source_lifecycle_state
+    source_evidence
+    candidate_discovered
+    admitted
+    context_surfaced
+    downstream_influence
+    expected_refusal
+    passed
 known_exemptions:
 evidence_bundle_refs:
 ```
+
+A conformance claim must name the forbidden classes it actually tested. An empty or omitted `forbidden_hit_coverage` field means no explicit forbidden-hit coverage is being claimed; positive recall metrics do not fill that gap by implication.
 
 ## Doctrine
 

--- a/docs/26-governed-recall-planner.md
+++ b/docs/26-governed-recall-planner.md
@@ -138,6 +138,23 @@ incorrect state later corrected
 
 A current-state query should not prefer a stale memory merely because it is semantically closer.
 
+## Derived state after source deletion or tombstoning
+
+A derived summary, projection, graph fact, cache entry, or similar artifact may remain physically discoverable after one of its source memories is pruned, deleted, or tombstoned. Candidate discovery does not make that derived artifact valid current evidence.
+
+When the derivation basis includes a source that current lifecycle policy treats as tombstoned or deleted, ordinary current-state recall must fail closed unless a governed revalidation/rebuild path has independently established a new valid basis.
+
+```text
+tombstoned source
+  -> derived artifact may still be a retrieval candidate
+  -> ordinary admission rejects current use
+  -> revalidation / rebuild requires its own governed evidence
+```
+
+This is separate from residue detection. A deletion sweep may identify undeclared residue for cleanup; recall admission independently prevents that residue from influencing current context while it remains reachable.
+
+The reference refusal `derived_from_tombstoned_source` expresses this boundary. It is not a requirement that every implementation use that exact string, but conformance evidence must identify the equivalent blocking reason and stage.
+
 ## Sensitivity and destination
 
 Recall policy should consider where the assembled context is going:
@@ -196,6 +213,7 @@ For consequential recall, the system should be able to answer:
 - disputed memory appears canonical
 - summaries erase scope/sensitivity
 - stale memory outranks current memory
+- derived state whose source was tombstoned remains admissible merely because the derived object itself was not tombstoned
 - stochastic ranker can sample prohibited content
 - context budgeting drops required governance state
 - several safe memories compose into unsafe context
@@ -213,6 +231,20 @@ expected: blocked
 ### Disputed high-relevance memory
 
 Expected: excluded from canonical recall or included with explicit dispute semantics.
+
+### Derived residue from tombstoned source
+
+Expected:
+
+```text
+candidate_discovered == true
+admitted == false
+current_context_surface == false
+downstream_influence == false
+blocking_reason == derived-from-tombstoned-source equivalent
+```
+
+The artifact's continued physical presence is evidence of residue, not evidence of current validity.
 
 ### Uncertain sensitivity
 

--- a/fixtures/forbidden-hit-lifecycle-matrix.json
+++ b/fixtures/forbidden-hit-lifecycle-matrix.json
@@ -132,7 +132,7 @@
       "assertion_id": "missing-required-compartment",
       "forbidden_class": "required_isolation_domain_missing",
       "source_lifecycle_state": "current",
-      "source_evidence": "fixtures/cross-domain-retrieval-attempt.json",
+      "source_evidence": "reference/tests/test_isolation_domains.py::test_same_tenant_missing_required_compartment_is_blocked",
       "candidate_discovered": true,
       "admitted": false,
       "context_surfaced": false,

--- a/fixtures/forbidden-hit-lifecycle-matrix.json
+++ b/fixtures/forbidden-hit-lifecycle-matrix.json
@@ -1,0 +1,165 @@
+{
+  "fixture_id": "forbidden-hit-lifecycle-matrix",
+  "fixture_version": "1.0.0",
+  "class": "governed_uncertainty",
+  "description": "Reusable negative assertions distinguish candidate discovery, governed admission, context surfacing, and downstream influence across lifecycle and authority failure classes. Entries reference existing fixture/test semantics rather than redefining those doctrines.",
+  "expected_behavior": {
+    "all_assertions_pass": true,
+    "forbidden_classes_covered": 9,
+    "explicit_pipeline_stages": [
+      "candidate_discovered",
+      "admitted",
+      "context_surfaced",
+      "downstream_influence"
+    ]
+  },
+  "governed_uncertainty": {
+    "requested_action": "claim_forbidden_hit_coverage",
+    "permitted_actions": ["report_explicit_negative_assertions"],
+    "prohibited_actions": ["infer_safety_from_positive_recall_only"],
+    "selected_action": "report_explicit_negative_assertions",
+    "selection_mode": "deterministic",
+    "expected_invariants": [
+      "candidate_discovery_not_equal_admission",
+      "admission_not_equal_context_surface",
+      "context_surface_not_equal_downstream_authority",
+      "forbidden_hit_must_name_blocking_stage",
+      "positive_recall_not_equal_lifecycle_safety"
+    ]
+  },
+  "memory_unit": {
+    "id": "uor:test:forbidden-hit-matrix",
+    "type": "fact",
+    "state": "disputed",
+    "provenance": {
+      "origin": "synthetic conformance matrix",
+      "observer": "reference-conformance",
+      "method": "negative lifecycle assertion mapping",
+      "timestamp": "2026-08-12T18:30:00Z",
+      "source_refs": ["issue://148"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:forbidden-hit-matrix",
+        "kind": "conformance_mapping",
+        "ref": "issue://148",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["conformance_assertion"]
+    },
+    "authority": {
+      "pama_outcome": "allow_with_ledger",
+      "risk_class": "low",
+      "policy_refs": ["ADR-015", "ADR-020", "ADR-022"],
+      "permitted_actions": ["report_explicit_negative_assertions"],
+      "prohibited_actions": ["infer_safety_from_positive_recall_only"],
+      "selection_mode": "deterministic"
+    },
+    "created_at": "2026-08-12T18:30:00Z"
+  },
+  "forbidden_hit_assertions": [
+    {
+      "assertion_id": "superseded-current-truth",
+      "forbidden_class": "superseded_or_corrected_current_truth",
+      "source_lifecycle_state": "superseded",
+      "source_evidence": "reference/tests/test_governed_paths.py::test_superseded_memory_stays_distinguishable",
+      "candidate_discovered": true,
+      "admitted": false,
+      "context_surfaced": false,
+      "downstream_influence": false,
+      "expected_refusal": "superseded_not_current"
+    },
+    {
+      "assertion_id": "tombstoned-current-use",
+      "forbidden_class": "tombstoned_state",
+      "source_lifecycle_state": "tombstoned",
+      "source_evidence": "fixtures/deletion-residue.json",
+      "candidate_discovered": true,
+      "admitted": false,
+      "context_surfaced": false,
+      "downstream_influence": false,
+      "expected_refusal": "tombstoned"
+    },
+    {
+      "assertion_id": "deleted-source-derived-residue",
+      "forbidden_class": "derived_from_deleted_or_tombstoned_source",
+      "source_lifecycle_state": "derived_residue",
+      "source_evidence": "fixtures/deletion-residue.json",
+      "candidate_discovered": true,
+      "admitted": false,
+      "context_surfaced": false,
+      "downstream_influence": false,
+      "expected_refusal": "derived_from_tombstoned_source"
+    },
+    {
+      "assertion_id": "disputed-current-use",
+      "forbidden_class": "disputed_state",
+      "source_lifecycle_state": "disputed",
+      "source_evidence": "fixtures/contradicted-memory.json",
+      "candidate_discovered": true,
+      "admitted": false,
+      "context_surfaced": false,
+      "downstream_influence": false,
+      "expected_refusal": "disputed"
+    },
+    {
+      "assertion_id": "cross-project-admission",
+      "forbidden_class": "project_scope_mismatch",
+      "source_lifecycle_state": "current",
+      "source_evidence": "fixtures/same-agent-cross-project-isolation.json",
+      "candidate_discovered": true,
+      "admitted": false,
+      "context_surfaced": false,
+      "downstream_influence": false,
+      "expected_refusal": "project_scope_mismatch"
+    },
+    {
+      "assertion_id": "revoked-shared-membership",
+      "forbidden_class": "revoked_shared_memory_membership",
+      "source_lifecycle_state": "current",
+      "source_evidence": "fixtures/shared-space-non-member-recall.json",
+      "candidate_discovered": true,
+      "admitted": false,
+      "context_surfaced": false,
+      "downstream_influence": false,
+      "expected_refusal": "shared_space_non_member"
+    },
+    {
+      "assertion_id": "missing-required-compartment",
+      "forbidden_class": "required_isolation_domain_missing",
+      "source_lifecycle_state": "current",
+      "source_evidence": "fixtures/cross-domain-retrieval-attempt.json",
+      "candidate_discovered": true,
+      "admitted": false,
+      "context_surfaced": false,
+      "downstream_influence": false,
+      "expected_refusal": "required_isolation_domain_missing"
+    },
+    {
+      "assertion_id": "rejected-value-reentry",
+      "forbidden_class": "rejected_value_reentry",
+      "source_lifecycle_state": "rejected",
+      "source_evidence": "reference/tests/test_rejected_value_readmission.py",
+      "candidate_discovered": false,
+      "admitted": false,
+      "context_surfaced": false,
+      "downstream_influence": false,
+      "expected_refusal": "rejected_value_requires_reconciliation"
+    },
+    {
+      "assertion_id": "stale-authorized-write",
+      "forbidden_class": "stale_authorization",
+      "source_lifecycle_state": "stale_authority",
+      "source_evidence": "reference/tests/test_governed_paths.py::test_stale_authorization_does_not_commit",
+      "candidate_discovered": false,
+      "admitted": false,
+      "context_surfaced": false,
+      "downstream_influence": false,
+      "expected_refusal": "stale_authorization"
+    }
+  ]
+}

--- a/reference/agentmem_ref/adapter.py
+++ b/reference/agentmem_ref/adapter.py
@@ -298,34 +298,27 @@ class GovernedMemoryAdapter:
             value=current.fact_text,
             superseded_fact_uuid=current.uuid,
             correction_proposal_id=proposal.proposal_id,
-            evidence_refs=tuple(proposal.evidence_refs),
-            scope=proposal.scope,
             rejected_at=rejected_at,
         )
         self._substrate.invalidate_fact(
-            current.uuid,
+            current_uuid,
             invalid_at=rejected_at,
             expired_at=self._clock.now(),
         )
 
-    def _select_action(self, decision: policy.Decision, proposal: policy.Proposal, blocked_by_stale: bool) -> str:
+    def _select_action(
+        self,
+        decision: policy.Decision,
+        proposal: policy.Proposal,
+        *,
+        blocked_by_stale: bool,
+    ) -> str:
         permitted = decision.permitted_actions
+        if blocked_by_stale:
+            permitted = tuple(action for action in permitted if action != proposal.operation)
         if not permitted:
             return receipts.NO_ACTION
-        if blocked_by_stale:
-            return "defer" if "defer" in permitted else permitted[0]
-
         choice = self._selector.select(permitted, proposal.operation)
-        return self._contain(permitted, choice)
-
-    def _contain(self, permitted: tuple[str, ...], choice: str) -> str:
-        """Re-check any selector's output against the envelope.
-
-        A selector is untrusted: deterministic, stochastic, or learned, it
-        proposes and does not authorize. A choice outside the permitted set is
-        a containment violation, recorded and failed closed to a deferral
-        rather than executed. Randomness does not create permission.
-        """
         try:
             receipts.enforce_selection(permitted, choice)
         except ValueError as exc:
@@ -387,6 +380,8 @@ class GovernedMemoryAdapter:
             return "out_of_scope"
         if fact.uuid in self._tombstones:
             return "tombstoned"
+        if any(source_ref in self._tombstones for source_ref in fact.episode_uuids):
+            return "derived_from_tombstoned_source"
         if fact.is_event_invalid:
             return "superseded_not_current"
         if fact.uuid in self._disputed:

--- a/reference/agentmem_ref/adapter.py
+++ b/reference/agentmem_ref/adapter.py
@@ -298,27 +298,34 @@ class GovernedMemoryAdapter:
             value=current.fact_text,
             superseded_fact_uuid=current.uuid,
             correction_proposal_id=proposal.proposal_id,
+            evidence_refs=tuple(proposal.evidence_refs),
+            scope=proposal.scope,
             rejected_at=rejected_at,
         )
         self._substrate.invalidate_fact(
-            current_uuid,
+            current.uuid,
             invalid_at=rejected_at,
             expired_at=self._clock.now(),
         )
 
-    def _select_action(
-        self,
-        decision: policy.Decision,
-        proposal: policy.Proposal,
-        *,
-        blocked_by_stale: bool,
-    ) -> str:
+    def _select_action(self, decision: policy.Decision, proposal: policy.Proposal, blocked_by_stale: bool) -> str:
         permitted = decision.permitted_actions
-        if blocked_by_stale:
-            permitted = tuple(action for action in permitted if action != proposal.operation)
         if not permitted:
             return receipts.NO_ACTION
+        if blocked_by_stale:
+            return "defer" if "defer" in permitted else permitted[0]
+
         choice = self._selector.select(permitted, proposal.operation)
+        return self._contain(permitted, choice)
+
+    def _contain(self, permitted: tuple[str, ...], choice: str) -> str:
+        """Re-check any selector's output against the envelope.
+
+        A selector is untrusted: deterministic, stochastic, or learned, it
+        proposes and does not authorize. A choice outside the permitted set is
+        a containment violation, recorded and failed closed to a deferral
+        rather than executed. Randomness does not create permission.
+        """
         try:
             receipts.enforce_selection(permitted, choice)
         except ValueError as exc:

--- a/reference/agentmem_ref/forbidden_hits.py
+++ b/reference/agentmem_ref/forbidden_hits.py
@@ -1,0 +1,355 @@
+"""Explicit forbidden-hit lifecycle assertions for issue #148.
+
+The model keeps four stages distinct even when the current reference adapter
+blocks at admission and therefore makes later stages false as a consequence:
+
+candidate discovered != admitted != context surfaced != downstream influence
+
+Expectations live in ``fixtures/forbidden-hit-lifecycle-matrix.json`` so the
+coverage claim is inspectable and reusable. This module executes the current
+reference scenarios and compares observed stage outcomes to those assertions.
+
+Stdlib only apart from the schema validation already used by the reference
+adapter.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import policy
+from .adapter import Clock, GovernedMemoryAdapter, RecallContext
+from .substrate import Fact, InMemoryTemporalGraph
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "forbidden-hit-lifecycle-matrix.json"
+TENANT = "tenant-a"
+
+
+@dataclass(frozen=True)
+class ForbiddenHitAssertion:
+    assertion_id: str
+    forbidden_class: str
+    source_lifecycle_state: str
+    source_evidence: str
+    candidate_discovered: bool
+    admitted: bool
+    context_surfaced: bool
+    downstream_influence: bool
+    expected_refusal: str
+
+
+@dataclass(frozen=True)
+class ForbiddenHitObservation:
+    assertion_id: str
+    candidate_discovered: bool
+    admitted: bool
+    context_surfaced: bool
+    downstream_influence: bool
+    refusal: str
+
+
+class ForbiddenHitMismatch(ValueError):
+    pass
+
+
+def load_assertions(path: Path = MATRIX) -> tuple[ForbiddenHitAssertion, ...]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    return tuple(ForbiddenHitAssertion(**item) for item in document["forbidden_hit_assertions"])
+
+
+def compare(assertion: ForbiddenHitAssertion, observation: ForbiddenHitObservation) -> None:
+    if assertion.assertion_id != observation.assertion_id:
+        raise ForbiddenHitMismatch(
+            f"assertion identity mismatch: {assertion.assertion_id!r} != {observation.assertion_id!r}"
+        )
+    fields = (
+        "candidate_discovered",
+        "admitted",
+        "context_surfaced",
+        "downstream_influence",
+    )
+    for field in fields:
+        expected = getattr(assertion, field)
+        observed = getattr(observation, field)
+        if expected != observed:
+            raise ForbiddenHitMismatch(
+                f"{assertion.assertion_id}: {field} expected {expected!r}, observed {observed!r}"
+            )
+    if assertion.expected_refusal != observation.refusal:
+        raise ForbiddenHitMismatch(
+            f"{assertion.assertion_id}: refusal expected {assertion.expected_refusal!r}, "
+            f"observed {observation.refusal!r}"
+        )
+
+
+def run() -> dict:
+    assertions = load_assertions()
+    observed = _observations()
+    by_id = {item.assertion_id: item for item in observed}
+    failures: list[str] = []
+    coverage: list[dict] = []
+
+    for assertion in assertions:
+        observation = by_id.get(assertion.assertion_id)
+        failure = None
+        if observation is None:
+            failure = f"{assertion.assertion_id}: no executable observation"
+        else:
+            try:
+                compare(assertion, observation)
+            except ForbiddenHitMismatch as exc:
+                failure = str(exc)
+        if failure:
+            failures.append(failure)
+        coverage.append(
+            {
+                "assertion_id": assertion.assertion_id,
+                "forbidden_class": assertion.forbidden_class,
+                "source_lifecycle_state": assertion.source_lifecycle_state,
+                "source_evidence": assertion.source_evidence,
+                "candidate_discovered": assertion.candidate_discovered,
+                "admitted": assertion.admitted,
+                "context_surfaced": assertion.context_surfaced,
+                "downstream_influence": assertion.downstream_influence,
+                "expected_refusal": assertion.expected_refusal,
+                "passed": failure is None,
+            }
+        )
+
+    extra = sorted(set(by_id) - {item.assertion_id for item in assertions})
+    failures.extend(f"{assertion_id}: executable observation lacks declared assertion" for assertion_id in extra)
+    return {
+        "assertions_run": [item.assertion_id for item in assertions],
+        "forbidden_classes": sorted({item.forbidden_class for item in assertions}),
+        "coverage": coverage,
+        "failures": failures,
+    }
+
+
+def _proposal(**overrides) -> policy.Proposal:
+    base = dict(
+        proposal_id="fh:proposal",
+        actor_id="agent:planner",
+        charter_version="charter:forbidden-hit",
+        target_reference="mem:forbidden-hit",
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("evidence:forbidden-hit",),
+        tenant_ref=TENANT,
+        purpose="forbidden-hit-conformance",
+    )
+    base.update(overrides)
+    return policy.Proposal(**base)
+
+
+def _recall_observation(
+    assertion_id: str,
+    adapter: GovernedMemoryAdapter,
+    query: str,
+    fact_uuid: str,
+    context: RecallContext | None = None,
+) -> ForbiddenHitObservation:
+    result = adapter.governed_recall(query, context)
+    candidate = fact_uuid in result.candidates
+    admitted = fact_uuid in result.admitted
+    # The reference runtime does not surface or permit influence from a memory
+    # that failed admission. These remain separate report fields so a future
+    # runtime with later-stage gates can report a different blocking stage.
+    context_surfaced = admitted
+    downstream_influence = context_surfaced
+    return ForbiddenHitObservation(
+        assertion_id=assertion_id,
+        candidate_discovered=candidate,
+        admitted=admitted,
+        context_surfaced=context_surfaced,
+        downstream_influence=downstream_influence,
+        refusal=result.refusals.get(fact_uuid, ""),
+    )
+
+
+def _write_refusal_observation(assertion_id: str, refusal: str) -> ForbiddenHitObservation:
+    return ForbiddenHitObservation(
+        assertion_id=assertion_id,
+        candidate_discovered=False,
+        admitted=False,
+        context_surfaced=False,
+        downstream_influence=False,
+        refusal=refusal,
+    )
+
+
+def _observations() -> tuple[ForbiddenHitObservation, ...]:
+    return (
+        _superseded(),
+        _tombstoned(),
+        _derived_residue(),
+        _disputed(),
+        _project_scope(),
+        _shared_membership(),
+        _required_compartment(),
+        _rejected_reentry(),
+        _stale_authorization(),
+    )
+
+
+def _superseded() -> ForbiddenHitObservation:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    committed = adapter.commit_proposal(_proposal(proposal_id="fh:superseded"), "deploy window Thursday")
+    substrate.invalidate_fact(committed.fact_uuid, "2026-02-01T00:00:00Z", "2026-02-01T00:00:00Z")
+    return _recall_observation(
+        "superseded-current-truth", adapter, "deploy window", committed.fact_uuid
+    )
+
+
+def _tombstoned() -> ForbiddenHitObservation:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    committed = adapter.commit_proposal(_proposal(proposal_id="fh:tombstone"), "deploy window Thursday")
+    adapter.governed_delete(
+        _proposal(proposal_id="fh:prune", operation="pruning", risk_class="low"),
+        committed.fact_uuid,
+    )
+    return _recall_observation(
+        "tombstoned-current-use", adapter, "deploy window", committed.fact_uuid
+    )
+
+
+def _derived_residue() -> ForbiddenHitObservation:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    committed = adapter.commit_proposal(_proposal(proposal_id="fh:source"), "deploy window Thursday")
+    derived = Fact(
+        uuid="fh:derived-residue",
+        fact_text="derived summary deploy window Thursday",
+        group_id=TENANT,
+        episode_uuids=(committed.fact_uuid,),
+        created_at="2026-01-01T00:00:00Z",
+    )
+    substrate.write_fact(derived)
+    adapter.governed_delete(
+        _proposal(proposal_id="fh:source-prune", operation="pruning", risk_class="low"),
+        committed.fact_uuid,
+    )
+    return _recall_observation(
+        "deleted-source-derived-residue", adapter, "derived summary", derived.uuid
+    )
+
+
+def _disputed() -> ForbiddenHitObservation:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    committed = adapter.commit_proposal(_proposal(proposal_id="fh:disputed"), "deploy window Thursday")
+    adapter.mark_disputed(committed.fact_uuid)
+    return _recall_observation(
+        "disputed-current-use", adapter, "deploy window", committed.fact_uuid
+    )
+
+
+def _project_scope() -> ForbiddenHitObservation:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    committed = adapter.commit_proposal(
+        _proposal(
+            proposal_id="fh:project",
+            isolation_domain_refs=("domain:project",),
+            project_ref="project-a",
+        ),
+        "project deployment secret",
+    )
+    context = RecallContext(target_domain_refs=("domain:project",), project_ref="project-b")
+    return _recall_observation(
+        "cross-project-admission", adapter, "project deployment", committed.fact_uuid, context
+    )
+
+
+def _shared_membership() -> ForbiddenHitObservation:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    shared = "domain:shared-security"
+    committed = adapter.commit_proposal(
+        _proposal(proposal_id="fh:shared", isolation_domain_refs=(shared,)),
+        "shared security decision",
+    )
+    adapter.set_shared_domain_members(shared, ("user:alice",))
+    context = RecallContext(target_domain_refs=(shared,), principal_ref="user:bob")
+    return _recall_observation(
+        "revoked-shared-membership", adapter, "shared security", committed.fact_uuid, context
+    )
+
+
+def _required_compartment() -> ForbiddenHitObservation:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    project = "domain:project"
+    secret = "compartment:secret"
+    committed = adapter.commit_proposal(
+        _proposal(
+            proposal_id="fh:compartment",
+            isolation_domain_refs=(project, secret),
+            required_isolation_domain_refs=(secret,),
+        ),
+        "compartment protected detail",
+    )
+    context = RecallContext(target_domain_refs=(project,))
+    return _recall_observation(
+        "missing-required-compartment", adapter, "compartment protected", committed.fact_uuid, context
+    )
+
+
+def _rejected_reentry() -> ForbiddenHitObservation:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    original = adapter.commit_proposal(
+        _proposal(proposal_id="fh:original", target_reference="mem:readmission"),
+        "deploy window Thursday",
+    )
+    correction = _proposal(
+        proposal_id="fh:correction",
+        target_reference="mem:readmission",
+        operation="correction",
+        current_strength="promoted",
+        proposed_strength="promoted",
+        approval_refs=("approval:human",),
+        review_satisfied=True,
+        state_snapshot="v1",
+    )
+    corrected = adapter.commit_proposal(correction, "deploy window Friday")
+    if not original.committed or not corrected.committed:
+        raise RuntimeError("readmission setup did not commit expected original/correction pair")
+    reentry = adapter.commit_proposal(
+        _proposal(
+            proposal_id="fh:reentry",
+            target_reference="mem:readmission",
+            state_snapshot="v2",
+        ),
+        "deploy window Thursday",
+    )
+    return _write_refusal_observation("rejected-value-reentry", reentry.refusal or "")
+
+
+def _stale_authorization() -> ForbiddenHitObservation:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    adapter.commit_proposal(
+        _proposal(proposal_id="fh:stale-base", target_reference="mem:stale"),
+        "current state",
+    )
+    stale = adapter.commit_proposal(
+        _proposal(
+            proposal_id="fh:stale-write",
+            target_reference="mem:stale",
+            state_snapshot="v0",
+        ),
+        "stale replacement",
+    )
+    return _write_refusal_observation("stale-authorized-write", stale.refusal or "")

--- a/reference/run_conformance.py
+++ b/reference/run_conformance.py
@@ -2,8 +2,10 @@
 """Execute the governed paths and the fixture corpus, then emit a report.
 
 The report conforms to `schemas/conformance-report.schema.json` and covers
-two populations: the governance paths in `tests/`, and the repository's
-doctrine fixture corpus driven through the adapter's authority enforcement.
+three evidence populations: governance paths in `tests/`, the repository's
+doctrine fixture corpus driven through authority enforcement, and explicit
+forbidden-hit lifecycle assertions that separate discovery, admission, context
+surfacing, and downstream influence.
 
 It deliberately claims **conformance level 0**. The doc 06 levels are
 cumulative, and this adapter implements neither decay nor calibrated
@@ -27,7 +29,7 @@ REFERENCE_DIR = Path(__file__).resolve().parent
 ROOT = REFERENCE_DIR.parent
 sys.path.insert(0, str(REFERENCE_DIR))
 
-from agentmem_ref import fixture_conformance, policy, receipts  # noqa: E402
+from agentmem_ref import fixture_conformance, forbidden_hits, policy, receipts  # noqa: E402
 from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, StochasticSelector  # noqa: E402
 from agentmem_ref.graphiti_driver import graphiti_available  # noqa: E402
 from agentmem_ref.projection_governance import ProjectionGovernor  # noqa: E402
@@ -156,6 +158,8 @@ def _exemptions(substrate_executed: bool) -> list[str]:
         "Retrieval ranking is lexical rather than hybrid, so recall quality is not measured "
         "and no calibration claim is made.",
         "The policy implements the subset of the decision table these paths require.",
+        "Forbidden-hit coverage proves the named negative classes and blocking stages only. It does "
+        "not imply that unlisted lifecycle, sensitivity, purpose, or downstream-action classes are covered.",
     ]
     if not substrate_executed:
         return common + [
@@ -174,6 +178,7 @@ def build_report(trials: int = 200) -> dict:
     substrate_executed = graphiti_available()
     names, passed, failed = _run_suite()
     corpus = fixture_conformance.run()
+    forbidden = forbidden_hits.run()
     sweep = _stochastic_sweep(trials)
     derived = _derived_state_probe()
     report = {
@@ -186,13 +191,19 @@ def build_report(trials: int = 200) -> dict:
         "fixtures_run": corpus["fixtures_run"],
         "fixtures_passed": corpus["fixtures_passed"],
         "fixtures_failed": corpus["fixtures_failed"],
-        "trials_run": len(names) + len(corpus["fixtures_run"]) + sweep["trials"],
+        "trials_run": (
+            len(names)
+            + len(corpus["fixtures_run"])
+            + len(forbidden["assertions_run"])
+            + sweep["trials"]
+        ),
         "metrics": {
             "stochastic_action_set_violation_rate": sweep["escapes"] / max(sweep["trials"], 1),
             "deletion_residue_rate": derived["undeclared_count"] / max(derived["derived_total"], 1),
         },
+        "forbidden_hit_coverage": forbidden["coverage"],
         "known_exemptions": _exemptions(substrate_executed) + fixture_conformance.exemptions(),
-        "known_failures": corpus["fixtures_failed"] + failed,
+        "known_failures": corpus["fixtures_failed"] + failed + forbidden["failures"],
         "metric_extensions": {
             "substrate_model": SUBSTRATE_MODEL,
             "real_substrate_executed": substrate_executed,
@@ -201,6 +212,9 @@ def build_report(trials: int = 200) -> dict:
             "negative_paths_executed": len([name for name in names if "positive" not in name]),
             "governance_paths_failed": failed,
             "corpus_fixtures_with_authority_envelope": corpus["fixtures_with_authority_envelope"],
+            "forbidden_hit_assertions_run": len(forbidden["assertions_run"]),
+            "forbidden_hit_classes_covered": forbidden["forbidden_classes"],
+            "forbidden_hit_failures": forbidden["failures"],
             "stochastic_trials": sweep["trials"],
             "stochastic_escapes": sweep["escapes"],
             "stochastic_distinct_actions": sweep["distinct_actions"],

--- a/reference/tests/test_forbidden_hits.py
+++ b/reference/tests/test_forbidden_hits.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import unittest
-from dataclasses import replace
+from pathlib import Path
 
 from agentmem_ref import forbidden_hits
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
 class ForbiddenHitTests(unittest.TestCase):
@@ -61,6 +63,12 @@ class ForbiddenHitTests(unittest.TestCase):
             for field in ("candidate_discovered", "admitted", "context_surfaced", "downstream_influence"):
                 self.assertIn(field, item)
                 self.assertIsInstance(item[field], bool)
+
+    def test_mapped_source_evidence_paths_exist(self):
+        for assertion in forbidden_hits.load_assertions():
+            relative_path = assertion.source_evidence.split("::", 1)[0]
+            with self.subTest(assertion_id=assertion.assertion_id, source=relative_path):
+                self.assertTrue((ROOT / relative_path).is_file(), relative_path)
 
 
 if __name__ == "__main__":

--- a/reference/tests/test_forbidden_hits.py
+++ b/reference/tests/test_forbidden_hits.py
@@ -1,0 +1,67 @@
+"""Executable forbidden-hit lifecycle assertions for issue #148."""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+
+from agentmem_ref import forbidden_hits
+
+
+class ForbiddenHitTests(unittest.TestCase):
+    def test_declared_forbidden_hit_matrix_matches_reference_behavior(self):
+        report = forbidden_hits.run()
+
+        self.assertEqual(report["failures"], [])
+        self.assertEqual(len(report["assertions_run"]), 9)
+        self.assertEqual(len(report["forbidden_classes"]), 9)
+        self.assertTrue(all(item["passed"] for item in report["coverage"]))
+
+        discovered_but_blocked = [
+            item
+            for item in report["coverage"]
+            if item["candidate_discovered"] and not item["admitted"]
+        ]
+        self.assertGreaterEqual(len(discovered_but_blocked), 1)
+        self.assertTrue(
+            any(item["expected_refusal"] == "superseded_not_current" for item in discovered_but_blocked)
+        )
+
+    def test_assertion_checker_detects_stage_regression(self):
+        assertion = forbidden_hits.load_assertions()[0]
+        observation = forbidden_hits.ForbiddenHitObservation(
+            assertion_id=assertion.assertion_id,
+            candidate_discovered=assertion.candidate_discovered,
+            admitted=True,
+            context_surfaced=True,
+            downstream_influence=True,
+            refusal="",
+        )
+
+        with self.assertRaises(forbidden_hits.ForbiddenHitMismatch):
+            forbidden_hits.compare(assertion, observation)
+
+    def test_assertion_checker_detects_wrong_refusal_reason(self):
+        assertion = forbidden_hits.load_assertions()[0]
+        observation = forbidden_hits.ForbiddenHitObservation(
+            assertion_id=assertion.assertion_id,
+            candidate_discovered=assertion.candidate_discovered,
+            admitted=assertion.admitted,
+            context_surfaced=assertion.context_surfaced,
+            downstream_influence=assertion.downstream_influence,
+            refusal="some_other_reason",
+        )
+
+        with self.assertRaises(forbidden_hits.ForbiddenHitMismatch):
+            forbidden_hits.compare(assertion, observation)
+
+    def test_all_later_stages_are_explicit_even_when_admission_blocks(self):
+        report = forbidden_hits.run()
+        for item in report["coverage"]:
+            for field in ("candidate_discovered", "admitted", "context_surfaced", "downstream_influence"):
+                self.assertIn(field, item)
+                self.assertIsInstance(item[field], bool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/conformance-report.schema.json
+++ b/schemas/conformance-report.schema.json
@@ -70,6 +70,38 @@
       "description": "Implementation-specific metrics not yet standardized by doctrine.",
       "additionalProperties": true
     },
+    "forbidden_hit_coverage": {
+      "type": "array",
+      "description": "Explicit negative lifecycle assertions. Each row states which pipeline stages were expected to remain unreachable for a forbidden memory/action class rather than inferring safety from a positive recall result.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "assertion_id",
+          "forbidden_class",
+          "source_lifecycle_state",
+          "source_evidence",
+          "candidate_discovered",
+          "admitted",
+          "context_surfaced",
+          "downstream_influence",
+          "expected_refusal",
+          "passed"
+        ],
+        "properties": {
+          "assertion_id": { "type": "string", "minLength": 1 },
+          "forbidden_class": { "type": "string", "minLength": 1 },
+          "source_lifecycle_state": { "type": "string", "minLength": 1 },
+          "source_evidence": { "type": "string", "minLength": 1 },
+          "candidate_discovered": { "type": "boolean" },
+          "admitted": { "type": "boolean" },
+          "context_surfaced": { "type": "boolean" },
+          "downstream_influence": { "type": "boolean" },
+          "expected_refusal": { "type": "string", "minLength": 1 },
+          "passed": { "type": "boolean" }
+        }
+      }
+    },
     "durability_dimensions_tested": {
       "type": "array",
       "items": { "type": "string" }

--- a/scripts/validate_fixtures.py
+++ b/scripts/validate_fixtures.py
@@ -3,7 +3,8 @@
 
 This validator intentionally uses only the Python standard library. It validates
 baseline fixture structure plus a small set of doctrine-level governed-uncertainty
-invariants. It is not a replacement for implementation-specific behavioral tests.
+and forbidden-hit invariants. It is not a replacement for implementation-specific
+behavioral tests.
 """
 
 from __future__ import annotations
@@ -42,6 +43,23 @@ REQUIRED_MEMORY_UNIT = {
 REQUIRED_PROVENANCE = {"origin", "observer", "method", "timestamp"}
 REQUIRED_SATURATION = {"sigma", "calibrated", "durability_dimensions"}
 REQUIRED_AUTHORITY = {"pama_outcome", "risk_class"}
+REQUIRED_FORBIDDEN_HIT = {
+    "assertion_id",
+    "forbidden_class",
+    "source_lifecycle_state",
+    "source_evidence",
+    "candidate_discovered",
+    "admitted",
+    "context_surfaced",
+    "downstream_influence",
+    "expected_refusal",
+}
+FORBIDDEN_HIT_STAGE_FIELDS = {
+    "candidate_discovered",
+    "admitted",
+    "context_surfaced",
+    "downstream_influence",
+}
 
 VALID_STATES = {
     "transient",
@@ -116,6 +134,79 @@ def validate_action_envelope(obj: dict[str, Any], path: str) -> list[str]:
 
     if mode is not None and mode not in VALID_SELECTION_MODES:
         errors.append(f"{path}.selection_mode invalid: {mode!r}")
+
+    return errors
+
+
+def validate_forbidden_hit_assertions(data: dict[str, Any], path: Path) -> list[str]:
+    """Validate the optional reusable negative-lifecycle assertion family."""
+    assertions = data.get("forbidden_hit_assertions")
+    if assertions is None:
+        return []
+
+    errors: list[str] = []
+    fixture_path = str(path)
+    if not isinstance(assertions, list) or not assertions:
+        return [f"{fixture_path}:forbidden_hit_assertions must be a non-empty list"]
+
+    seen_ids: set[str] = set()
+    seen_classes: set[str] = set()
+    for index, item in enumerate(assertions):
+        item_path = f"{fixture_path}:forbidden_hit_assertions[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{item_path} must be an object")
+            continue
+        errors.extend(require_keys(item, REQUIRED_FORBIDDEN_HIT, item_path))
+
+        assertion_id = item.get("assertion_id")
+        if not isinstance(assertion_id, str) or not assertion_id.strip():
+            errors.append(f"{item_path}.assertion_id must be a non-empty string")
+        elif assertion_id in seen_ids:
+            errors.append(f"{item_path}.assertion_id duplicates {assertion_id!r}")
+        else:
+            seen_ids.add(assertion_id)
+
+        forbidden_class = item.get("forbidden_class")
+        if not isinstance(forbidden_class, str) or not forbidden_class.strip():
+            errors.append(f"{item_path}.forbidden_class must be a non-empty string")
+        else:
+            seen_classes.add(forbidden_class)
+
+        for field in ("source_lifecycle_state", "source_evidence", "expected_refusal"):
+            value = item.get(field)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{item_path}.{field} must be a non-empty string")
+
+        for field in FORBIDDEN_HIT_STAGE_FIELDS:
+            if not isinstance(item.get(field), bool):
+                errors.append(f"{item_path}.{field} must be a boolean")
+
+        # Later-stage influence cannot be true if the candidate never reached
+        # the preceding stage. This is structural ordering, not a claim that
+        # every runtime must block specifically at admission.
+        if item.get("admitted") and not item.get("candidate_discovered"):
+            errors.append(f"{item_path}: admitted=true requires candidate_discovered=true")
+        if item.get("context_surfaced") and not item.get("admitted"):
+            errors.append(f"{item_path}: context_surfaced=true requires admitted=true")
+        if item.get("downstream_influence") and not item.get("context_surfaced"):
+            errors.append(f"{item_path}: downstream_influence=true requires context_surfaced=true")
+
+    expected = data.get("expected_behavior")
+    if isinstance(expected, dict):
+        declared_count = expected.get("forbidden_classes_covered")
+        if declared_count is not None and declared_count != len(seen_classes):
+            errors.append(
+                f"{fixture_path}:expected_behavior.forbidden_classes_covered={declared_count!r} "
+                f"does not match {len(seen_classes)} unique forbidden classes"
+            )
+        stages = expected.get("explicit_pipeline_stages")
+        required_stages = sorted(FORBIDDEN_HIT_STAGE_FIELDS)
+        if stages is not None:
+            if not isinstance(stages, list) or sorted(stages) != required_stages:
+                errors.append(
+                    f"{fixture_path}:expected_behavior.explicit_pipeline_stages must contain "
+                    f"exactly {required_stages!r}"
+                )
 
     return errors
 
@@ -214,6 +305,7 @@ def validate_fixture(path: Path) -> list[str]:
                 errors.append(f"{path}:governed_uncertainty.expected_invariants must be a non-empty list of strings")
             errors.extend(validate_action_envelope(governed, f"{path}:governed_uncertainty"))
 
+    errors.extend(validate_forbidden_hit_assertions(data, path))
     return errors
 
 


### PR DESCRIPTION
## Summary

Implements #148 as a reusable negative-assertion layer across the memory lifecycle without duplicating existing lifecycle doctrine.

The conformance model now keeps four stages explicit:

```text
candidate discovered
!=
admitted
!=
context surfaced
!=
downstream influence
```

A backend may discover a forbidden candidate. The conformance failure is crossing a stage the declared assertion forbids, not discovery by itself.

## Reusable assertion model

Adds `fixtures/forbidden-hit-lifecycle-matrix.json` with nine explicit forbidden classes and the expected state of every pipeline stage plus an exact refusal reason. The low-cost fixture validator checks assertion structure, uniqueness, stage ordering, refusal/evidence references, and declared coverage count. Reference tests also prove every mapped source fixture/test still exists and mutation-test the assertion checker.

Current explicit coverage:

- superseded/corrected state presented as current;
- tombstoned state;
- state derived from a tombstoned source;
- disputed state;
- project-scope mismatch;
- revoked/absent shared-memory membership;
- missing required isolation compartment;
- rejected-value re-entry at the mutation boundary;
- stale authorization at the mutation boundary.

The report deliberately does not claim untested sensitivity/purpose variants, all possible tenant/task/domain combinations, or every later-stage action-influence case.

## Runtime gap closed

The audit found a real defect: `undeclared_residue()` could detect a derived fact whose source had been pruned/tombstoned, but ordinary recall could still admit that derived fact because admission checked only the candidate's own tombstone state.

The governed adapter now rejects such a candidate with `derived_from_tombstoned_source`. This is a two-line runtime change on top of the restored canonical adapter. The derived artifact may remain physically discoverable as residue, but cannot enter ordinary current context without a separate governed revalidation/rebuild path.

## Reporting

`reference/run_conformance.py` now executes the forbidden-hit matrix and emits `forbidden_hit_coverage` through the canonical conformance report. Any assertion mismatch enters `known_failures`, so forbidden-hit regression is a hard conformance failure rather than informational metadata.

The additive optional report field records:

- assertion id;
- forbidden class;
- source lifecycle state;
- source evidence;
- candidate-discovery expectation;
- admission expectation;
- context-surface expectation;
- downstream-influence expectation;
- expected refusal;
- pass/fail.

## Documentation

Updates the canonical conformance test plan and governed recall planner. Positive recall is explicitly insufficient proof of lifecycle safety, and deleted/tombstoned-source derived state is now covered at recall admission separately from residue detection.

No new ADR is introduced. This is conformance depth over existing lifecycle, deletion, dispute, isolation, readmission, and stale-authority doctrine.

## Characterization findings

An intermediate run exposed that the first adapter edit had been made from a stale snapshot and accidentally reverted later readmission/containment behavior. The exact canonical `fd3a509d...` adapter was restored before applying only the intended two-line admission gate. The same run also caught one stale evidence-map path; it was rebound to the existing isolation-domain test rather than inventing a duplicate fixture.

## Final validation

Exact PR head: `f0c3d2d84bf655c1a786156ac4d44fbcc3169b4b`

- P9 Systems Characterization: success
- Validate Doctrine Evidence: success, including fixture/schema/source-rights validation, reference unit suite, Mem0 comparator, deletion evidence, TRACE/cMCP comparator, real substrate, emitted conformance report, docs/Wiki links, and calibration synchronization
- CodeQL: success, no new alerts in changed code

Merge only this exact head. Post-merge `main` validation remains a separate evidence boundary.