### PR TITLE
Complete governed rejected-value re-admission evidence

### DIFF
--- a/docs/profiles/semantic-readmission-profile.md
+++ b/docs/profiles/semantic-readmission-profile.md
@@ -1,0 +1,287 @@
+# Semantic Re-Admission Review Profile
+
+## Purpose
+
+This optional profile extends the exact rejected-value protection of ADR-027 into cases where a later proposal may be a paraphrase or semantically equivalent restatement of an actively rejected value.
+
+It does **not** redefine memory identity and does not claim that semantic equivalence is deterministic, architecture-independent, or universally decidable.
+
+The governing split is:
+
+```text
+exact / structured rejected identity
+  -> deterministic rejection lookup
+  -> exact write-path protection
+
+semantic similarity
+  -> estimator signal with provenance
+  -> deterministic reconciliation routing
+  -> ordinary governance / review / PAMA
+```
+
+A semantic estimator proposes that reconciliation may be needed. It does not decide whether the earlier rejection was correct, whether the new proposal is truly equivalent, or whether durable state may change.
+
+## Why this is a profile
+
+Raw string normalization can safely collapse presentation differences such as case and repeated whitespace. It cannot safely collapse arbitrary paraphrase, domain-specific equivalence, translation, inference, or changed factual context.
+
+Different implementations may use:
+
+- domain-specific structured keys;
+- proposition/value schemas;
+- embeddings;
+- classifiers;
+- LLM adjudication candidates;
+- hybrid retrieval over prior correction evidence.
+
+Those techniques have different calibration, privacy, portability, and failure properties. None belongs in canonical identity merely because it can find similar text.
+
+The profile therefore standardizes the **authority boundary**, not the estimator.
+
+## Rejection record
+
+The reference rejection record retains no raw rejected content. It records:
+
+```text
+rejection_id
+memory_id
+normalized-value fingerprint
+superseded fact reference
+correction proposal reference
+evidence refs
+authority refs
+scope
+rejected_at
+lifecycle state
+readmission metadata, when exact re-admission occurs
+```
+
+`rejection_id` is deterministic over the scoped exact fingerprint and correction proposal identity. It lets later evidence refer to the rejection without making the fingerprint itself a global identifier.
+
+The lifecycle states exercised by the reference are:
+
+```text
+rejected
+readmitted
+```
+
+Permanent deletion may purge the registry entry entirely. A deletion receipt/audit event may remain according to ordinary evidence/retention policy, but the rejection registry is not permitted to retain a fingerprint forever merely because it once served governance.
+
+## Semantic similarity signal
+
+A semantic signal contains estimator evidence only:
+
+```text
+memory_id
+rejection_ref
+estimator_id
+estimator_version
+candidate_match
+confidence, when supplied
+evidence_refs
+```
+
+It intentionally contains no:
+
+```text
+allow
+block
+approve
+reject
+readmit
+permission
+```
+
+The reference signal semantics are:
+
+```text
+candidate_match_for_reconciliation_not_authority
+```
+
+A matched signal maps deterministically to:
+
+```text
+require_reconciliation
+```
+
+A non-match maps to:
+
+```text
+no_semantic_reconciliation_signal
+```
+
+`no_semantic_reconciliation_signal` is not `allow`. It means only that this optional semantic gate added no extra review requirement. The ordinary write path and PAMA still decide whether anything may commit.
+
+## Signal binding
+
+Before a semantic signal may affect routing, the reference profile requires:
+
+- signal `memory_id` matches the proposal target;
+- `rejection_ref` names a currently active rejection for that memory;
+- estimator id/version are present;
+- confidence, when reported, is bounded to 0..1.
+
+An unbound/stale rejection reference fails closed as invalid governance evidence. This is not a semantic judgment about the proposed value. It is a failure to prove what rejection the estimator claims to have compared against.
+
+## Ordinary semantic re-entry
+
+For an ordinary promotion/import-like proposal:
+
+```text
+semantic candidate match
+  -> reconciliation required
+  -> proposal does not reach durable commit through this profile
+```
+
+The estimator is not performing the block. The configured profile applies a deterministic rule that a claimed semantic match to an active rejection must be reconciled before ordinary re-entry.
+
+Implementations that do not enable a semantic profile still retain the deterministic exact-value protection. They must not claim semantic-equivalence coverage merely because exact fingerprints are protected.
+
+## Approved reversal
+
+A prior rejection is not an eternal ban.
+
+If a proposal is already an externally approved correction with reconstructable approval evidence and no self-approval, the semantic gate may allow that proposal to continue to the ordinary PAMA path:
+
+```text
+semantic match
+  + explicit approved correction
+  -> semantic review requirement satisfied for routing
+  -> PAMA still evaluates
+  -> commit or refusal according to current authority
+```
+
+The semantic estimator still does not authorize the reversal. Human/external approval and PAMA do.
+
+A semantic reversal does not necessarily mark the old **exact fingerprint** as readmitted. A paraphrase can be accepted while the historically rejected exact value remains a distinct rejection record. Implementations should merge those identities only if a stronger structured identity model proves that equivalence under its domain contract.
+
+## Non-match behavior
+
+A semantic non-match must not create permission.
+
+Adversarial case:
+
+```text
+semantic estimator says no match
+PAMA says block
+```
+
+Expected:
+
+```text
+committed == false
+```
+
+The absence of a semantic warning is not an authority grant.
+
+## Privacy and retention
+
+Rejected-value metadata can still be sensitive. A deterministic fingerprint can support correlation and dictionary attacks when the underlying value space is small or guessable.
+
+Required posture:
+
+- do not store raw rejected content merely to implement the exact registry;
+- scope fingerprints by memory identity rather than treating them as universal content identity;
+- minimize estimator evidence to references/metadata where practical;
+- apply ordinary retention/deletion policy to rejection history;
+- permanent deletion should remove rejection fingerprints/history when no separate legal/policy obligation requires them;
+- audit evidence should record that purge occurred without copying the rejected content into telemetry.
+
+Hashing is minimization, not anonymization.
+
+## Reference implementation
+
+The reference profile lives in:
+
+```text
+reference/agentmem_ref/readmission.py
+reference/agentmem_ref/semantic_readmission_adapter.py
+reference/tests/test_semantic_readmission.py
+reference/tests/test_semantic_readmission_adapter.py
+fixtures/rejected-value-semantic-reentry.json
+```
+
+The profile subclasses the governed adapter so it shares the same rejection registry and PAMA path while remaining optional and replaceable.
+
+## Conformance cases
+
+### Exact rejected value
+
+Expected:
+
+```text
+exact normalized fingerprint match
+-> rejected_value_requires_reconciliation
+-> no durable commit
+```
+
+### Semantic paraphrase
+
+Expected:
+
+```text
+active rejection exists
+semantic estimator emits candidate_match=true
+-> require_reconciliation
+-> no ordinary durable commit
+```
+
+### Semantic non-match plus PAMA block
+
+Expected:
+
+```text
+semantic candidate_match=false
+PAMA block
+-> no durable commit
+```
+
+### Invalid rejection reference
+
+Expected:
+
+```text
+semantic signal does not bind to current active rejection
+-> semantic_reconciliation_signal_invalid
+-> no durable mutation
+```
+
+### Approved semantic reversal
+
+Expected:
+
+```text
+semantic candidate_match=true
+external correction approval current
+-> proceed to PAMA
+-> PAMA determines commit/refusal
+```
+
+### Permanent deletion
+
+Expected:
+
+```text
+permanent deletion commits
+-> rejection fingerprints/history for that memory purged
+-> purge event records count/reason without raw rejected content
+```
+
+## Explicit non-claims
+
+This profile does not prove:
+
+- universal semantic equivalence;
+- architecture-independent paraphrase detection;
+- calibration of any particular embedding or language model;
+- that a non-match means the proposal is safe;
+- that an old exact rejection and an approved paraphrase are the same identity;
+- that every backend must enable semantic re-admission matching.
+
+## Doctrine boundary
+
+The reusable invariant is not "semantic similarity blocks memory."
+
+It is:
+
+> **Uncertain similarity may identify a reconciliation candidate. Only governed authority may decide whether rejected state becomes durable again.**

--- a/fixtures/rejected-value-semantic-reentry.json
+++ b/fixtures/rejected-value-semantic-reentry.json
@@ -1,0 +1,63 @@
+{
+  "fixture_id": "rejected-value-semantic-reentry",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "A paraphrase of an actively rejected value may be identified by an estimator as a reconciliation candidate, but similarity cannot itself authorize rejection or re-admission.",
+  "expected_behavior": {
+    "exact_reentry_reason": "rejected_value_requires_reconciliation",
+    "semantic_candidate_match": true,
+    "semantic_consequence": "require_reconciliation",
+    "semantic_signal_is_authority": false,
+    "ordinary_semantic_reentry_commits": false,
+    "approved_correction_may_reenter_through_pama": true,
+    "permanent_deletion_purges_rejection_history": true
+  },
+  "memory_unit": {
+    "id": "mem:deploy-window",
+    "content_ref": "fixture://rejected-value-semantic-reentry/current",
+    "type": "fact",
+    "state": "corrected",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "semantic-reentry-adversarial-trap",
+      "timestamp": "2026-08-12T18:00:00Z",
+      "source_refs": ["fixture://rejected-value-semantic-reentry/source"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:semantic-reentry",
+        "kind": "correction_and_similarity_fixture",
+        "ref": "fixture://rejected-value-semantic-reentry/source",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.7,
+      "calibrated": false,
+      "durability_dimensions": ["correction_history", "reentry_governance"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "low",
+      "policy_refs": ["ADR-020", "ADR-023", "ADR-027"],
+      "permitted_actions": ["enter_pending_verification", "collect_more_evidence", "defer"],
+      "prohibited_actions": ["promotion"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T18:00:00Z"
+  },
+  "rejected_value": {
+    "original": "deploy window is Thursday",
+    "current_correction": "deploy window is Friday",
+    "semantic_paraphrase": "Thursday is the deployment window"
+  },
+  "semantic_signal": {
+    "signal_type": "semantic_rejected_value_similarity",
+    "signal_semantics": "candidate_match_for_reconciliation_not_authority",
+    "estimator_id": "semantic-paraphrase-test",
+    "estimator_version": "1.0.0",
+    "candidate_match": true,
+    "confidence": 0.93
+  }
+}

--- a/reference/agentmem_ref/readmission.py
+++ b/reference/agentmem_ref/readmission.py
@@ -1,18 +1,29 @@
-"""Deterministic rejected-value history for governed re-admission.
+"""Rejected-value history and governed semantic re-admission signals.
 
-This module implements only the exact/normalized identity slice proven by #147.
-It deliberately does not attempt semantic-equivalence detection. A learned or
-probabilistic matcher may later propose a reconciliation path, but it must not
-independently authorize durable rejection or re-admission.
+Exact/structured rejected identity and semantic similarity deliberately have
+different authority properties:
 
-Raw memory content is not retained here. Rejection history stores a scoped
-SHA-256 fingerprint plus provenance needed to reconstruct the lifecycle event.
+- deterministic normalized identity may enforce the already-proven exact-value
+  write guard;
+- semantic similarity is estimator evidence only. It may trigger a governed
+  reconciliation/review lane, but the estimator cannot emit allow/block or
+  authorize durable re-admission.
+
+Raw rejected memory content is not retained here. Rejection history stores a
+scoped SHA-256 fingerprint plus provenance, authority, and lifecycle metadata.
 """
 
 from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
+
+REJECTED = "rejected"
+READMITTED = "readmitted"
+PURGED = "purged"
+
+NO_SEMANTIC_SIGNAL = "no_semantic_reconciliation_signal"
+REQUIRE_RECONCILIATION = "require_reconciliation"
 
 
 def normalize_value(value: str) -> str:
@@ -31,6 +42,11 @@ def value_fingerprint(value: str) -> str:
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
+def rejection_id(memory_id: str, fingerprint: str, correction_proposal_id: str) -> str:
+    material = f"{memory_id}\n{fingerprint}\n{correction_proposal_id}".encode("utf-8")
+    return f"rejection:sha256:{hashlib.sha256(material).hexdigest()}"
+
+
 @dataclass
 class RejectionRecord:
     memory_id: str
@@ -38,25 +54,96 @@ class RejectionRecord:
     superseded_fact_uuid: str
     correction_proposal_id: str
     evidence_refs: tuple[str, ...]
+    authority_refs: tuple[str, ...]
     scope: str
     rejected_at: str
     active: bool = True
+    lifecycle_state: str = REJECTED
     readmitted_at: str | None = None
     readmission_proposal_id: str | None = None
 
+    @property
+    def rejection_id(self) -> str:
+        return rejection_id(self.memory_id, self.value_fingerprint, self.correction_proposal_id)
+
     def as_dict(self) -> dict:
         return {
+            "rejection_id": self.rejection_id,
             "memory_id": self.memory_id,
             "value_fingerprint": self.value_fingerprint,
             "superseded_fact_uuid": self.superseded_fact_uuid,
             "correction_proposal_id": self.correction_proposal_id,
             "evidence_refs": list(self.evidence_refs),
+            "authority_refs": list(self.authority_refs),
             "scope": self.scope,
             "rejected_at": self.rejected_at,
             "active": self.active,
+            "lifecycle_state": self.lifecycle_state,
             "readmitted_at": self.readmitted_at,
             "readmission_proposal_id": self.readmission_proposal_id,
         }
+
+
+@dataclass(frozen=True)
+class SemanticSimilaritySignal:
+    """Estimator evidence that a proposal may resemble an active rejection.
+
+    The signal has no authority/result field by design. Consumers may route it
+    through a deterministic policy, but cannot honestly interpret the object as
+    an allow, block, approval, or readmission decision.
+    """
+
+    memory_id: str
+    rejection_ref: str
+    estimator_id: str
+    estimator_version: str
+    candidate_match: bool
+    confidence: float | None = None
+    evidence_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for name in ("memory_id", "rejection_ref", "estimator_id", "estimator_version"):
+            if not getattr(self, name):
+                raise ValueError(f"semantic similarity signal requires {name}")
+        if self.confidence is not None and not 0 <= self.confidence <= 1:
+            raise ValueError("semantic similarity confidence must be between 0 and 1")
+
+    def as_evidence(self) -> dict:
+        evidence = {
+            "signal_type": "semantic_rejected_value_similarity",
+            "signal_semantics": "candidate_match_for_reconciliation_not_authority",
+            "signal_value": self.candidate_match,
+            "estimator_id": self.estimator_id,
+            "estimator_version": self.estimator_version,
+            "rejection_ref": self.rejection_ref,
+            "evidence_refs": list(self.evidence_refs),
+        }
+        if self.confidence is not None:
+            evidence["confidence"] = self.confidence
+        return evidence
+
+
+@dataclass(frozen=True)
+class SemanticReadmissionRouting:
+    """Deterministic consequence of an estimator signal.
+
+    The only restrictive outcome is reconciliation/review. There is no `allow`
+    or permanent `block` result in this type. Durable permission still belongs
+    to the ordinary PAMA/approval path.
+    """
+
+    consequence: str
+    review_required: bool
+    signal: SemanticSimilaritySignal
+
+
+def route_semantic_similarity(signal: SemanticSimilaritySignal) -> SemanticReadmissionRouting:
+    consequence = REQUIRE_RECONCILIATION if signal.candidate_match else NO_SEMANTIC_SIGNAL
+    return SemanticReadmissionRouting(
+        consequence=consequence,
+        review_required=signal.candidate_match,
+        signal=signal,
+    )
 
 
 class RejectedValueRegistry:
@@ -75,6 +162,25 @@ class RejectedValueRegistry:
                 return record
         return None
 
+    def active_records(self, memory_id: str) -> tuple[dict, ...]:
+        """Return active rejection metadata without raw rejected content."""
+        return tuple(
+            record.as_dict()
+            for (record_memory_id, _fingerprint), records in self._records.items()
+            if record_memory_id == memory_id
+            for record in records
+            if record.active
+        )
+
+    def find_active_by_ref(self, memory_id: str, rejection_ref: str) -> RejectionRecord | None:
+        for record in self.active_records(memory_id):
+            if record["rejection_id"] == rejection_ref:
+                fingerprint = record["value_fingerprint"]
+                for candidate in reversed(self._records.get((memory_id, fingerprint), ())):
+                    if candidate.active and candidate.rejection_id == rejection_ref:
+                        return candidate
+        return None
+
     def reject(
         self,
         *,
@@ -83,6 +189,7 @@ class RejectedValueRegistry:
         superseded_fact_uuid: str,
         correction_proposal_id: str,
         evidence_refs: tuple[str, ...],
+        authority_refs: tuple[str, ...] = (),
         scope: str,
         rejected_at: str,
     ) -> RejectionRecord:
@@ -92,6 +199,7 @@ class RejectedValueRegistry:
             superseded_fact_uuid=superseded_fact_uuid,
             correction_proposal_id=correction_proposal_id,
             evidence_refs=tuple(evidence_refs),
+            authority_refs=tuple(authority_refs),
             scope=scope,
             rejected_at=rejected_at,
         )
@@ -110,9 +218,23 @@ class RejectedValueRegistry:
         if record is None:
             return None
         record.active = False
+        record.lifecycle_state = READMITTED
         record.readmitted_at = readmitted_at
         record.readmission_proposal_id = proposal_id
         return record
 
     def history(self, memory_id: str, value: str) -> tuple[dict, ...]:
         return tuple(record.as_dict() for record in self._records.get(self._key(memory_id, value), ()))
+
+    def purge_memory(self, memory_id: str) -> int:
+        """Remove rejection fingerprints/history for a permanently deleted memory.
+
+        Rejection history is governed state, not an excuse to retain a sensitive
+        fingerprint forever. The caller is responsible for preserving whatever
+        deletion receipt/audit evidence policy requires outside this registry.
+        """
+        keys = [key for key in self._records if key[0] == memory_id]
+        count = sum(len(self._records[key]) for key in keys)
+        for key in keys:
+            del self._records[key]
+        return count

--- a/reference/agentmem_ref/semantic_readmission_adapter.py
+++ b/reference/agentmem_ref/semantic_readmission_adapter.py
@@ -1,0 +1,238 @@
+"""Optional semantic re-admission profile over the governed reference adapter.
+
+The core adapter keeps deterministic exact-value protection. This profile adds
+an estimator-mediated *review signal* for paraphrase/semantic-equivalence cases
+without making semantic matching a canonical identity primitive.
+
+A semantic match may stop the proposal before PAMA and route it to
+reconciliation. It cannot emit allow/block, cannot satisfy review, and cannot
+turn a rejected value into authority. An externally approved correction may
+proceed through the ordinary PAMA path; a semantic non-match likewise creates
+no permission and leaves PAMA fully authoritative.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from . import policy, receipts
+from .adapter import CommitResult, GovernedMemoryAdapter
+from .readmission import (
+    REQUIRE_RECONCILIATION,
+    SemanticReadmissionRouting,
+    SemanticSimilaritySignal,
+    route_semantic_similarity,
+)
+
+
+@dataclass
+class SemanticCommitResult:
+    committed: bool
+    refusal: str | None = None
+    routing: SemanticReadmissionRouting | None = None
+    downstream: CommitResult | None = None
+    events: list[dict] = field(default_factory=list)
+
+
+class SemanticReadmissionAdapter(GovernedMemoryAdapter):
+    """Governed adapter profile that treats semantic equivalence as review evidence."""
+
+    def active_rejection_records(self, memory_id: str) -> tuple[dict, ...]:
+        return self._rejected_values.active_records(memory_id)
+
+    def commit_with_semantic_signal(
+        self,
+        proposal: policy.Proposal,
+        fact_text: str,
+        semantic_signal: SemanticSimilaritySignal | None = None,
+        episode=None,
+    ) -> SemanticCommitResult:
+        if semantic_signal is None:
+            downstream = super().commit_proposal(proposal, fact_text, episode)
+            return SemanticCommitResult(
+                committed=downstream.committed,
+                refusal=downstream.refusal,
+                downstream=downstream,
+                events=list(downstream.events),
+            )
+
+        signal_valid = self._semantic_signal_is_bound(proposal, semantic_signal)
+        routing = route_semantic_similarity(semantic_signal)
+        signal_event = self._semantic_event(
+            proposal,
+            semantic_signal,
+            routing,
+            event_type="memory.semantic_readmission_signal",
+            valid_active_rejection=signal_valid,
+        )
+        self.events.append(signal_event)
+
+        if not signal_valid:
+            refusal_event = self._semantic_event(
+                proposal,
+                semantic_signal,
+                routing,
+                event_type="memory.semantic_readmission_signal_rejected",
+                valid_active_rejection=False,
+                refusal="semantic_reconciliation_signal_invalid",
+            )
+            self.events.append(refusal_event)
+            return SemanticCommitResult(
+                committed=False,
+                refusal="semantic_reconciliation_signal_invalid",
+                routing=routing,
+                events=[signal_event, refusal_event],
+            )
+
+        if routing.review_required and not self._approved_reversal(proposal):
+            review_event = self._semantic_event(
+                proposal,
+                semantic_signal,
+                routing,
+                event_type="memory.semantic_readmission_review_required",
+                valid_active_rejection=True,
+                refusal="semantic_reconciliation_required",
+            )
+            self.events.append(review_event)
+            return SemanticCommitResult(
+                committed=False,
+                refusal="semantic_reconciliation_required",
+                routing=routing,
+                events=[signal_event, review_event],
+            )
+
+        # A non-match creates no permission. A matched signal whose review has
+        # already been satisfied by an external approved correction likewise
+        # creates no authority of its own. In both cases PAMA still decides.
+        downstream = super().commit_proposal(proposal, fact_text, episode)
+        events = [signal_event] + list(downstream.events)
+        return SemanticCommitResult(
+            committed=downstream.committed,
+            refusal=downstream.refusal,
+            routing=routing,
+            downstream=downstream,
+            events=events,
+        )
+
+    def governed_delete(self, proposal: policy.Proposal, fact_uuid: str, derived_refs: tuple[str, ...] = ()) -> CommitResult:
+        result = super().governed_delete(proposal, fact_uuid, derived_refs)
+        if result.committed and proposal.operation == "permanent_deletion":
+            purged = self._rejected_values.purge_memory(proposal.target_reference)
+            event = self._purge_event(proposal, result.receipt["receipt_id"], purged)
+            result.events.append(event)
+            self.events.append(event)
+        return result
+
+    def _supersede_current(self, proposal: policy.Proposal) -> None:
+        """Preserve correction authority in rejection metadata for this profile."""
+        current_uuid = self._current_fact_by_memory.get(proposal.target_reference)
+        if not current_uuid:
+            return
+        current = self._substrate.get_fact(current_uuid)
+        if current is None or current.is_event_invalid:
+            return
+
+        rejected_at = self._clock.now()
+        self._rejected_values.reject(
+            memory_id=proposal.target_reference,
+            value=current.fact_text,
+            superseded_fact_uuid=current.uuid,
+            correction_proposal_id=proposal.proposal_id,
+            evidence_refs=tuple(proposal.evidence_refs),
+            authority_refs=tuple(proposal.approval_refs),
+            scope=proposal.scope,
+            rejected_at=rejected_at,
+        )
+        self._substrate.invalidate_fact(
+            current.uuid,
+            invalid_at=rejected_at,
+            expired_at=self._clock.now(),
+        )
+
+    def _semantic_signal_is_bound(
+        self,
+        proposal: policy.Proposal,
+        signal: SemanticSimilaritySignal,
+    ) -> bool:
+        if signal.memory_id != proposal.target_reference:
+            return False
+        return self._rejected_values.find_active_by_ref(
+            proposal.target_reference,
+            signal.rejection_ref,
+        ) is not None
+
+    @staticmethod
+    def _approved_reversal(proposal: policy.Proposal) -> bool:
+        return (
+            proposal.operation == "correction"
+            and proposal.review_satisfied
+            and bool(proposal.approval_refs)
+            and not proposal.approves_own_authority
+        )
+
+    def _semantic_event(
+        self,
+        proposal: policy.Proposal,
+        signal: SemanticSimilaritySignal,
+        routing: SemanticReadmissionRouting,
+        *,
+        event_type: str,
+        valid_active_rejection: bool,
+        refusal: str | None = None,
+    ) -> dict:
+        signal_payload = {
+            "signal_type": "semantic_rejected_value_similarity",
+            "signal_semantics": "candidate_match_for_reconciliation_not_authority",
+            "signal_value": signal.candidate_match,
+            "estimator_id": signal.estimator_id,
+            "estimator_version": signal.estimator_version,
+        }
+        if signal.confidence is not None:
+            signal_payload["uncertainty"] = {"reported_confidence": signal.confidence}
+        payload = {
+            "proposal_id": proposal.proposal_id,
+            "rejection_ref": signal.rejection_ref,
+            "evidence_refs": list(signal.evidence_refs),
+            "routing_consequence": routing.consequence,
+            "review_required": routing.review_required,
+            "valid_active_rejection": valid_active_rejection,
+            "proposal_review_satisfied": proposal.review_satisfied,
+            "proposal_approval_refs": list(proposal.approval_refs),
+        }
+        if refusal:
+            payload["refusal"] = refusal
+        document = {
+            "schema_version": "1.0.0",
+            "event_id": self._ids.next(),
+            "event_type": event_type,
+            "event_version": "1.0.0",
+            "timestamp": self._clock.now(),
+            "memory_id": proposal.target_reference,
+            "actor": proposal.actor_id,
+            "component": "semantic-readmission-adapter",
+            "correlation_id": proposal.proposal_id,
+            "signal": signal_payload,
+            "payload": payload,
+        }
+        receipts.validate("memory-audit-event.schema.json", document)
+        return document
+
+    def _purge_event(self, proposal: policy.Proposal, receipt_ref: str, purged_records: int) -> dict:
+        document = {
+            "schema_version": "1.0.0",
+            "event_id": self._ids.next(),
+            "event_type": "memory.rejection_history_purged",
+            "event_version": "1.0.0",
+            "timestamp": self._clock.now(),
+            "memory_id": proposal.target_reference,
+            "actor": proposal.actor_id,
+            "component": "semantic-readmission-adapter",
+            "correlation_id": proposal.proposal_id,
+            "receipt_ref": receipt_ref,
+            "payload": {
+                "purged_rejection_records": purged_records,
+                "reason": "permanent_deletion",
+            },
+        }
+        receipts.validate("memory-audit-event.schema.json", document)
+        return document

--- a/reference/tests/test_semantic_readmission.py
+++ b/reference/tests/test_semantic_readmission.py
@@ -1,0 +1,138 @@
+"""Semantic re-admission signals are estimator evidence, never mutation authority."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.readmission import (
+    NO_SEMANTIC_SIGNAL,
+    READMITTED,
+    REJECTED,
+    REQUIRE_RECONCILIATION,
+    RejectedValueRegistry,
+    SemanticSimilaritySignal,
+    route_semantic_similarity,
+)
+
+
+class SemanticReadmissionPrimitiveTests(unittest.TestCase):
+    def _registry(self) -> RejectedValueRegistry:
+        registry = RejectedValueRegistry()
+        registry.reject(
+            memory_id="mem:deploy-window",
+            value="deploy window is Thursday",
+            superseded_fact_uuid="fact:old",
+            correction_proposal_id="proposal:correction",
+            evidence_refs=("evidence:correction",),
+            authority_refs=("approval:owner",),
+            scope="tenant-a",
+            rejected_at="2026-08-12T18:00:00Z",
+        )
+        return registry
+
+    def test_rejection_metadata_preserves_authority_scope_and_lifecycle_without_raw_content(self):
+        registry = self._registry()
+        active = registry.active_records("mem:deploy-window")
+
+        self.assertEqual(len(active), 1)
+        record = active[0]
+        self.assertEqual(record["authority_refs"], ["approval:owner"])
+        self.assertEqual(record["scope"], "tenant-a")
+        self.assertEqual(record["lifecycle_state"], REJECTED)
+        self.assertTrue(record["active"])
+        self.assertTrue(record["rejection_id"].startswith("rejection:sha256:"))
+        self.assertNotIn("value", record)
+        self.assertNotIn("fact_text", record)
+
+    def test_semantic_match_routes_only_to_reconciliation(self):
+        registry = self._registry()
+        rejection_ref = registry.active_records("mem:deploy-window")[0]["rejection_id"]
+        signal = SemanticSimilaritySignal(
+            memory_id="mem:deploy-window",
+            rejection_ref=rejection_ref,
+            estimator_id="semantic-review-test",
+            estimator_version="1.0.0",
+            candidate_match=True,
+            confidence=0.94,
+            evidence_refs=("evidence:paraphrase",),
+        )
+
+        routing = route_semantic_similarity(signal)
+
+        self.assertTrue(routing.review_required)
+        self.assertEqual(routing.consequence, REQUIRE_RECONCILIATION)
+        self.assertNotIn(routing.consequence, {"allow", "block", "readmit", "reject"})
+        evidence = signal.as_evidence()
+        self.assertEqual(evidence["signal_semantics"], "candidate_match_for_reconciliation_not_authority")
+        self.assertEqual(evidence["estimator_id"], "semantic-review-test")
+        self.assertNotIn("authority", evidence)
+        self.assertNotIn("decision", evidence)
+
+    def test_semantic_nonmatch_does_not_create_permission(self):
+        registry = self._registry()
+        rejection_ref = registry.active_records("mem:deploy-window")[0]["rejection_id"]
+        signal = SemanticSimilaritySignal(
+            memory_id="mem:deploy-window",
+            rejection_ref=rejection_ref,
+            estimator_id="semantic-review-test",
+            estimator_version="1.0.0",
+            candidate_match=False,
+            confidence=0.12,
+        )
+
+        routing = route_semantic_similarity(signal)
+
+        self.assertFalse(routing.review_required)
+        self.assertEqual(routing.consequence, NO_SEMANTIC_SIGNAL)
+        self.assertNotIn(routing.consequence, {"allow", "block", "readmit", "reject"})
+
+    def test_readmission_updates_lifecycle_without_erasing_history(self):
+        registry = self._registry()
+        record = registry.readmit(
+            memory_id="mem:deploy-window",
+            value="deploy window is Thursday",
+            proposal_id="proposal:approved-reversal",
+            readmitted_at="2026-08-12T19:00:00Z",
+        )
+
+        self.assertIsNotNone(record)
+        history = registry.history("mem:deploy-window", "deploy window is Thursday")
+        self.assertEqual(len(history), 1)
+        self.assertFalse(history[0]["active"])
+        self.assertEqual(history[0]["lifecycle_state"], READMITTED)
+        self.assertEqual(history[0]["readmission_proposal_id"], "proposal:approved-reversal")
+
+    def test_permanent_deletion_can_purge_rejection_fingerprints(self):
+        registry = self._registry()
+        registry.reject(
+            memory_id="mem:other",
+            value="other rejected value",
+            superseded_fact_uuid="fact:other",
+            correction_proposal_id="proposal:other",
+            evidence_refs=("evidence:other",),
+            authority_refs=("approval:other",),
+            scope="tenant-a",
+            rejected_at="2026-08-12T18:10:00Z",
+        )
+
+        purged = registry.purge_memory("mem:deploy-window")
+
+        self.assertEqual(purged, 1)
+        self.assertEqual(registry.active_records("mem:deploy-window"), ())
+        self.assertEqual(registry.history("mem:deploy-window", "deploy window is Thursday"), ())
+        self.assertEqual(len(registry.active_records("mem:other")), 1)
+
+    def test_signal_rejects_invalid_confidence(self):
+        with self.assertRaises(ValueError):
+            SemanticSimilaritySignal(
+                memory_id="mem:deploy-window",
+                rejection_ref="rejection:sha256:test",
+                estimator_id="semantic-review-test",
+                estimator_version="1.0.0",
+                candidate_match=True,
+                confidence=1.1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_semantic_readmission_adapter.py
+++ b/reference/tests/test_semantic_readmission_adapter.py
@@ -1,0 +1,216 @@
+"""End-to-end governed semantic re-admission profile tests for #147."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock
+from agentmem_ref.readmission import SemanticSimilaritySignal
+from agentmem_ref.semantic_readmission_adapter import SemanticReadmissionAdapter
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+TENANT = "tenant-a"
+MEMORY_ID = "mem:deploy-window"
+VALUE_A = "deploy window is Thursday"
+VALUE_B = "deploy window is Friday"
+PARAPHRASE_A = "Thursday is the deployment window"
+
+
+def _proposal(
+    proposal_id: str,
+    *,
+    operation: str = "promotion",
+    state_snapshot: str = "",
+    actor_authority_resolved: bool = True,
+    approval_refs: tuple[str, ...] = (),
+    review_satisfied: bool = False,
+) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=proposal_id,
+        actor_id="agent:planner",
+        charter_version="charter:semantic-readmission",
+        target_reference=MEMORY_ID,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation=operation,
+        current_strength="reinforced" if operation != "correction" else "promoted",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=(f"evidence:{proposal_id}",),
+        actor_authority_resolved=actor_authority_resolved,
+        approval_refs=approval_refs,
+        review_satisfied=review_satisfied,
+        state_snapshot=state_snapshot,
+        tenant_ref=TENANT,
+        purpose="semantic-readmission-test",
+    )
+
+
+def _semantic_signal(adapter: SemanticReadmissionAdapter, *, candidate_match: bool = True) -> SemanticSimilaritySignal:
+    active = adapter.active_rejection_records(MEMORY_ID)
+    if not active:
+        raise AssertionError("semantic test requires an active rejection record")
+    return SemanticSimilaritySignal(
+        memory_id=MEMORY_ID,
+        rejection_ref=active[0]["rejection_id"],
+        estimator_id="semantic-paraphrase-test",
+        estimator_version="1.0.0",
+        candidate_match=candidate_match,
+        confidence=0.93 if candidate_match else 0.08,
+        evidence_refs=("evidence:semantic-comparison",),
+    )
+
+
+class SemanticReadmissionAdapterTests(unittest.TestCase):
+    def _corrected_adapter(self) -> tuple[SemanticReadmissionAdapter, str]:
+        adapter = SemanticReadmissionAdapter(InMemoryTemporalGraph(), tenant=TENANT, clock=Clock())
+        first = adapter.commit_proposal(_proposal("original"), VALUE_A)
+        self.assertTrue(first.committed)
+
+        correction = adapter.commit_proposal(
+            _proposal(
+                "correction",
+                operation="correction",
+                state_snapshot="v1",
+                approval_refs=("approval:owner",),
+                review_satisfied=True,
+            ),
+            VALUE_B,
+        )
+        self.assertTrue(correction.committed)
+        return adapter, correction.fact_uuid
+
+    def test_exact_reentry_remains_deterministically_blocked(self):
+        adapter, _ = self._corrected_adapter()
+
+        result = adapter.commit_with_semantic_signal(
+            _proposal("exact-reentry", state_snapshot="v2"),
+            VALUE_A,
+        )
+
+        self.assertFalse(result.committed)
+        self.assertEqual(result.refusal, "rejected_value_requires_reconciliation")
+        self.assertIsNotNone(result.downstream)
+
+    def test_semantic_paraphrase_match_routes_to_reconciliation_before_pama_commit(self):
+        adapter, _ = self._corrected_adapter()
+        signal = _semantic_signal(adapter, candidate_match=True)
+        before_state = adapter.state_version(MEMORY_ID)
+
+        result = adapter.commit_with_semantic_signal(
+            _proposal("semantic-reentry", state_snapshot="v2"),
+            PARAPHRASE_A,
+            semantic_signal=signal,
+        )
+
+        self.assertFalse(result.committed)
+        self.assertEqual(result.refusal, "semantic_reconciliation_required")
+        self.assertIsNone(result.downstream)
+        self.assertTrue(result.routing.review_required)
+        self.assertEqual(adapter.state_version(MEMORY_ID), before_state)
+        self.assertEqual(result.events[-1]["event_type"], "memory.semantic_readmission_review_required")
+        self.assertEqual(
+            result.events[0]["signal"]["signal_semantics"],
+            "candidate_match_for_reconciliation_not_authority",
+        )
+
+    def test_semantic_nonmatch_does_not_authorize_pama_blocked_mutation(self):
+        adapter, _ = self._corrected_adapter()
+        signal = _semantic_signal(adapter, candidate_match=False)
+
+        result = adapter.commit_with_semantic_signal(
+            _proposal(
+                "blocked-nonmatch",
+                state_snapshot="v2",
+                actor_authority_resolved=False,
+            ),
+            "unrelated candidate",
+            semantic_signal=signal,
+        )
+
+        self.assertFalse(result.committed)
+        self.assertIsNotNone(result.downstream)
+        self.assertEqual(result.downstream.decision.outcome, policy.BLOCK)
+        self.assertFalse(result.routing.review_required)
+
+    def test_invalid_semantic_rejection_reference_fails_closed_without_pama_mutation(self):
+        adapter, _ = self._corrected_adapter()
+        signal = SemanticSimilaritySignal(
+            memory_id=MEMORY_ID,
+            rejection_ref="rejection:sha256:not-active",
+            estimator_id="semantic-paraphrase-test",
+            estimator_version="1.0.0",
+            candidate_match=False,
+        )
+        before_state = adapter.state_version(MEMORY_ID)
+
+        result = adapter.commit_with_semantic_signal(
+            _proposal("invalid-signal", state_snapshot="v2"),
+            "unrelated candidate",
+            semantic_signal=signal,
+        )
+
+        self.assertFalse(result.committed)
+        self.assertEqual(result.refusal, "semantic_reconciliation_signal_invalid")
+        self.assertIsNone(result.downstream)
+        self.assertEqual(adapter.state_version(MEMORY_ID), before_state)
+
+    def test_externally_approved_semantic_reversal_still_passes_through_pama(self):
+        adapter, _ = self._corrected_adapter()
+        signal = _semantic_signal(adapter, candidate_match=True)
+
+        result = adapter.commit_with_semantic_signal(
+            _proposal(
+                "approved-semantic-reversal",
+                operation="correction",
+                state_snapshot="v2",
+                approval_refs=("approval:owner-reversal",),
+                review_satisfied=True,
+            ),
+            PARAPHRASE_A,
+            semantic_signal=signal,
+        )
+
+        self.assertTrue(result.committed)
+        self.assertIsNotNone(result.downstream)
+        self.assertTrue(result.downstream.committed)
+        self.assertEqual(result.downstream.decision.outcome, policy.ALLOW_WITH_LEDGER)
+        self.assertTrue(result.routing.review_required)
+        self.assertEqual(adapter.state_version(MEMORY_ID), 3)
+
+    def test_correction_rejection_record_carries_authority_and_lifecycle(self):
+        adapter, _ = self._corrected_adapter()
+        records = adapter.active_rejection_records(MEMORY_ID)
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["authority_refs"], ["approval:owner"])
+        self.assertEqual(records[0]["scope"], TENANT)
+        self.assertEqual(records[0]["lifecycle_state"], "rejected")
+        self.assertNotIn("value", records[0])
+
+    def test_permanent_deletion_purges_rejection_fingerprints_after_commit(self):
+        adapter, current_fact_uuid = self._corrected_adapter()
+        self.assertEqual(len(adapter.active_rejection_records(MEMORY_ID)), 1)
+
+        deletion = adapter.governed_delete(
+            _proposal(
+                "permanent-delete",
+                operation="permanent_deletion",
+                state_snapshot="v2",
+                approval_refs=("approval:deletion",),
+                review_satisfied=True,
+            ),
+            current_fact_uuid,
+        )
+
+        self.assertTrue(deletion.committed)
+        self.assertEqual(adapter.active_rejection_records(MEMORY_ID), ())
+        self.assertEqual(deletion.events[-1]["event_type"], "memory.rejection_history_purged")
+        self.assertEqual(deletion.events[-1]["payload"]["purged_rejection_records"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_semantic_readmission_fixture.py
+++ b/reference/tests/test_semantic_readmission_fixture.py
@@ -1,0 +1,111 @@
+"""Drive the semantic rejected-value fixture through the optional profile."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock
+from agentmem_ref.readmission import SemanticSimilaritySignal
+from agentmem_ref.semantic_readmission_adapter import SemanticReadmissionAdapter
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "fixtures" / "rejected-value-semantic-reentry.json"
+
+
+def _proposal(
+    proposal_id: str,
+    *,
+    operation: str = "promotion",
+    snapshot: str = "",
+    approvals: tuple[str, ...] = (),
+    reviewed: bool = False,
+) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=proposal_id,
+        actor_id="agent:fixture",
+        charter_version="charter:semantic-fixture",
+        target_reference="mem:deploy-window",
+        target_class=policy.M2,
+        scope="tenant-a",
+        operation=operation,
+        current_strength="promoted" if operation == "correction" else "reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=(f"evidence:{proposal_id}",),
+        approval_refs=approvals,
+        review_satisfied=reviewed,
+        state_snapshot=snapshot,
+        tenant_ref="tenant-a",
+    )
+
+
+class SemanticReadmissionFixtureTests(unittest.TestCase):
+    def test_fixture_expected_behavior_is_executable(self):
+        data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        values = data["rejected_value"]
+        expected = data["expected_behavior"]
+        signal_data = data["semantic_signal"]
+
+        adapter = SemanticReadmissionAdapter(InMemoryTemporalGraph(), tenant="tenant-a", clock=Clock())
+        original = adapter.commit_proposal(_proposal("fixture-original"), values["original"])
+        self.assertTrue(original.committed)
+        corrected = adapter.commit_proposal(
+            _proposal(
+                "fixture-correction",
+                operation="correction",
+                snapshot="v1",
+                approvals=("approval:fixture-owner",),
+                reviewed=True,
+            ),
+            values["current_correction"],
+        )
+        self.assertTrue(corrected.committed)
+
+        exact = adapter.commit_with_semantic_signal(
+            _proposal("fixture-exact", snapshot="v2"),
+            values["original"],
+        )
+        self.assertFalse(exact.committed)
+        self.assertEqual(exact.refusal, expected["exact_reentry_reason"])
+
+        rejection_ref = adapter.active_rejection_records("mem:deploy-window")[0]["rejection_id"]
+        signal = SemanticSimilaritySignal(
+            memory_id="mem:deploy-window",
+            rejection_ref=rejection_ref,
+            estimator_id=signal_data["estimator_id"],
+            estimator_version=signal_data["estimator_version"],
+            candidate_match=signal_data["candidate_match"],
+            confidence=signal_data["confidence"],
+        )
+        semantic = adapter.commit_with_semantic_signal(
+            _proposal("fixture-semantic", snapshot="v2"),
+            values["semantic_paraphrase"],
+            semantic_signal=signal,
+        )
+        self.assertEqual(signal.candidate_match, expected["semantic_candidate_match"])
+        self.assertEqual(semantic.routing.consequence, expected["semantic_consequence"])
+        self.assertEqual(semantic.committed, expected["ordinary_semantic_reentry_commits"])
+        self.assertFalse(expected["semantic_signal_is_authority"])
+
+        approved = adapter.commit_with_semantic_signal(
+            _proposal(
+                "fixture-approved-reversal",
+                operation="correction",
+                snapshot="v2",
+                approvals=("approval:fixture-reversal",),
+                reviewed=True,
+            ),
+            values["semantic_paraphrase"],
+            semantic_signal=signal,
+        )
+        self.assertEqual(approved.committed, expected["approved_correction_may_reenter_through_pama"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Completes the remaining executable investigation for #147 without pretending semantic similarity is deterministic identity.

The implemented boundary is:

```text
exact / structured rejected identity
  -> deterministic write-path protection

semantic similarity
  -> estimator evidence
  -> deterministic reconciliation routing
  -> ordinary approval / PAMA
```

The semantic estimator cannot emit allow/block/readmit authority. A semantic non-match likewise creates no permission.

## Exact rejected-value behavior

The existing normalized exact-value guard remains unchanged in authority semantics. Case and repeated whitespace normalize deterministically; semantic paraphrase does not.

Rejection records now support explicit:

- scoped deterministic rejection id;
- evidence refs;
- authority refs;
- scope;
- lifecycle state (`rejected` / `readmitted`);
- raw-content-free active rejection metadata;
- memory-scoped purge for permanent deletion.

Raw rejected content is not retained in the registry.

## Optional semantic profile

Adds `reference/agentmem_ref/semantic_readmission_adapter.py` as an optional profile over the existing governed adapter.

A `SemanticSimilaritySignal` binds:

- memory id;
- active rejection ref;
- estimator id/version;
- candidate-match signal;
- optional confidence and evidence refs.

The signal intentionally has no authority/result field.

A matched signal routes to `require_reconciliation`. It does not reach ordinary durable commit unless the proposal is already an externally approved correction, in which case it proceeds through the normal PAMA path. A non-match adds no permission and PAMA still controls the mutation.

Invalid/stale rejection refs fail closed as invalid governance evidence rather than being treated as a semantic judgment.

## Privacy / deletion

The semantic profile purges rejection fingerprints/history only after `permanent_deletion` actually commits. A schema-valid audit event records the purge count/reason without copying rejected content into telemetry.

This treats hashing as minimization, not anonymization or indefinite-retention permission.

## Evidence

Adds:

- `reference/tests/test_semantic_readmission.py`
- `reference/tests/test_semantic_readmission_adapter.py`
- `reference/tests/test_semantic_readmission_fixture.py`
- `fixtures/rejected-value-semantic-reentry.json`
- `docs/profiles/semantic-readmission-profile.md`

The tests separately prove:

- exact re-entry remains deterministically blocked;
- semantic paraphrase match routes to reconciliation before durable mutation;
- semantic non-match cannot authorize a PAMA-blocked mutation;
- invalid rejection reference fails closed without mutation;
- externally approved semantic reversal remains possible only through the ordinary PAMA path;
- correction rejection records carry authority/scope/lifecycle metadata without raw content;
- permanent deletion purges retained rejection fingerprints/history;
- semantic signal/routing objects contain no direct allow/block/readmit authority.

## Architecture boundary

This does **not** claim universal semantic equivalence or architecture-independent paraphrase detection. Exact deterministic protection remains core. Semantic matching is an optional profile because implementations may use structured domain identity, embeddings, classifiers, LLMs, or other estimators with different calibration/privacy properties.

The reusable invariant is:

> Uncertain similarity may identify a reconciliation candidate. Only governed authority may decide whether rejected state becomes durable again.

ADR-023 remains independently gated. ADR-027 remains Proposed in this PR; doctrine maturity is not silently inferred from implementation success.

## Validation / merge policy

Branch content is frozen for validation. Merge only through the protected PR workflow after P9, full doctrine/runtime validation, and CodeQL are green on the current PR head. Validate the actual merge commit separately before closing #147.