### PR TITLE
Define vendor-neutral policy and enforcement composition boundary

### DIFF
--- a/docs/profiles/external-enforcement-decision-profile.md
+++ b/docs/profiles/external-enforcement-decision-profile.md
@@ -1,0 +1,333 @@
+# External Enforcement Decision Projection Profile
+
+## Purpose
+
+This profile defines the smallest vendor-neutral boundary needed to carry an Agent Memory governed mutation decision to an optional external policy or enforcement host without surrendering memory-specific semantics.
+
+It implements the Phase 1 contract work of issue #152. It does not make any external governance system a dependency and does not define a general agent-wide policy engine.
+
+The responsibility split is:
+
+```text
+Agent Memory
+  owns memory semantics, lifecycle, scope, correction,
+  PAMA authority, recall admission, and mutation meaning
+        |
+        v
+External Enforcement Decision Projection
+  content-minimized action + authority context
+        |
+        v
+optional external policy decision
+        |
+        v
+explicit monotonic composition
+        |
+        v
+enforcement / approval host
+```
+
+The same product may implement more than one box. The evidence contracts remain distinct.
+
+## Core invariants
+
+### Stricter authority is monotonic
+
+A decision from one authority may tighten another authority's result. It may not silently loosen it.
+
+```text
+Agent Memory deny + external allow          -> deny
+Agent Memory require_approval + external allow -> require_approval
+Agent Memory allow + external deny          -> deny
+Agent Memory allow + external escalate      -> require_approval
+```
+
+### Decision is not enforcement
+
+```text
+decision issued
+!=
+decision delivered
+!=
+enforcement point reached
+!=
+action executed or prevented
+```
+
+A projection or composition receipt proves only the decision information it records. It does not prove that a downstream host enforced that result.
+
+### Proposal identity stays bound
+
+An external decision is usable only when it binds to the exact `input_identity` calculated for the projected proposal. A stale, mismatched, or detached decision fails closed under the configured provider posture.
+
+### Memory semantics remain local
+
+An external provider may contribute broader runtime policy. It does not redefine:
+
+- correction versus supersession;
+- rejection and governed re-admission;
+- lifecycle state;
+- memory isolation domains;
+- PAMA target class;
+- recall admission;
+- deletion completeness;
+- whether a memory-specific mutation actually occurred.
+
+## Projection shape
+
+The first profile carries only information needed to identify and constrain the requested consequence.
+
+```text
+projection_id
+projection_version
+input_identity
+proposal_id
+memory_id / target_reference
+operation
+actor_id
+scope
+isolation_domain_refs
+state_snapshot
+risk_class
+reversibility
+pama_decision_ref
+pama_outcome
+permitted_actions
+prohibited_actions
+policy_version
+evidence_refs
+receipt_ref, when available
+```
+
+The projection does not require raw memory content, prompts, rationale prose, or retrieved context.
+
+`input_identity` is a deterministic SHA-256 identity over the canonical projection inputs that define the requested action and its authority state. The reference profile will define the exact canonicalization before claiming cross-runtime interoperability.
+
+## Normalized composition lattice
+
+External systems use different vocabularies. V0.1 normalizes only the smallest common consequence lattice:
+
+```text
+allow < warn < require_approval < deny
+```
+
+Agent Memory PAMA maps conservatively:
+
+```text
+allow                       -> allow
+allow_with_ledger           -> allow
+require_review              -> require_approval
+require_external_verification -> require_approval
+abstain                     -> require_approval
+collect_more_evidence       -> require_approval
+quarantine                  -> deny
+block                       -> deny
+```
+
+An optional external provider V0.1 may return:
+
+```text
+allow
+warn
+escalate
+ deny
+```
+
+with the adapter mapping:
+
+```text
+allow    -> allow
+warn     -> warn
+escalate -> require_approval
+deny     -> deny
+```
+
+V0.1 deliberately excludes provider-directed mutation transforms. A provider may not silently rewrite the memory proposal and then claim it evaluated the original action. Transform-like systems require a later explicit identity-preserving contract.
+
+The effective decision is the stricter normalized consequence.
+
+## External decision record
+
+A provider response should preserve at least:
+
+```text
+provider_id
+provider_version
+input_identity
+decision
+reason
+evidence
+issued_at
+```
+
+`reason` and provider evidence are provenance for the external decision. They do not become Agent Memory truth merely because the provider is trusted to make policy decisions.
+
+## Provider posture
+
+Provider availability must be explicit.
+
+### Advisory provider
+
+The provider may tighten a local decision when it responds. If unavailable, the local Agent Memory decision remains authoritative and the result records that external policy was unavailable.
+
+```text
+provider_mode = advisory
+provider unavailable
+-> effective decision = local PAMA mapping
+-> external governance status = unavailable
+```
+
+This is not a claim that external policy approved the action.
+
+### Authoritative provider
+
+The configured external provider is required for the action class.
+
+```text
+provider_mode = authoritative
+provider unavailable / invalid / stale
+-> deny
+```
+
+This is the reference fail-closed posture. Implementations may define a different stricter posture, but may not treat provider failure as implicit allow.
+
+## Approval continuity
+
+When `require_approval` is the effective result:
+
+- approval must bind to the same `input_identity`;
+- state drift requires a new projection and decision;
+- approval cannot broaden scope or change the memory operation silently;
+- the approval principal and authority evidence remain separate from the memory proposal itself;
+- approval satisfaction still does not prove execution.
+
+The existing durable-decision overwrite and shared-write coordination evidence demonstrate the same general rule inside Agent Memory: a valid coordination or approval artifact is not a bypass token for PAMA.
+
+## Decision composition receipt
+
+The composition layer should be able to record:
+
+```text
+composition_id
+input_identity
+local_decision_ref
+local_normalized_decision
+external_decision_ref, when present
+external_provider_status
+external_normalized_decision, when present
+effective_decision
+composition_rule_version
+execution_evidence_ref, when available
+execution_status
+```
+
+For Phase 1, `execution_status` is limited to explicit non-claims such as:
+
+```text
+unknown
+not_observed
+```
+
+A future enforcement-evidence slice may define stronger states only when an actual enforcement witness can substantiate them.
+
+## Required Phase 1 adversarial cases
+
+### External allow cannot loosen local block
+
+```text
+local = deny
+external = allow
+expected = deny
+```
+
+### External allow cannot discharge local review
+
+```text
+local = require_approval
+external = allow
+expected = require_approval
+```
+
+### External deny tightens local allow
+
+```text
+local = allow
+external = deny
+expected = deny
+```
+
+### External escalation tightens local allow
+
+```text
+local = allow
+external = require_approval
+expected = require_approval
+```
+
+### Stale action identity
+
+```text
+external.input_identity != current projection.input_identity
+expected = invalid external decision
+```
+
+Under authoritative provider mode the effective result is deny. Under advisory mode the invalid result is ignored as policy authority and the local decision remains, with mismatch evidence preserved.
+
+### Provider unavailable
+
+```text
+advisory provider unavailable     -> local decision + unavailable evidence
+authoritative provider unavailable -> deny
+```
+
+### Decision issued, execution unknown
+
+```text
+valid composed decision exists
+execution witness absent
+expected execution_status = unknown
+```
+
+No conformance report may upgrade that state to enforced, prevented, or executed by inference.
+
+## Relationship to existing Agent Memory contracts
+
+This profile composes with existing artifacts rather than replacing them:
+
+- PAMA decision remains authoritative for Agent Memory mutation semantics;
+- decision receipt records the selected Agent Memory consequence;
+- portable governance evidence may correlate a completed Agent Memory decision with external trust systems;
+- Governance Context Projection carries remembered context/precedent outward and does not become this action-decision projection;
+- execution evidence remains a separate future surface.
+
+The outbound directions are therefore distinct:
+
+```text
+Governance Context Projection
+  remembered context / precedent
+  -> external decision input
+
+External Enforcement Decision Projection
+  current requested memory consequence + PAMA boundary
+  -> policy / enforcement host
+
+Portable governance evidence
+  recorded decision / action evidence
+  -> verifier / attestation consumer
+```
+
+## Non-goals
+
+- making Agent Memory a universal PDP;
+- adopting Microsoft AGT, DashClaw, OPA, Cedar, or another provider as a dependency;
+- importing a vendor policy language into memory doctrine;
+- allowing external `allow` to weaken PAMA;
+- treating a decision receipt as execution proof;
+- exporting raw memory content when stable references and characteristics suffice;
+- supporting transform-style provider verdicts in V0.1.
+
+## Doctrine boundary
+
+The reusable rule is:
+
+> **External governance may narrow Agent Memory's permitted consequence, but it cannot silently widen it, and neither decision layer may claim enforcement without execution evidence.**

--- a/fixtures/external-policy-composition-matrix.json
+++ b/fixtures/external-policy-composition-matrix.json
@@ -1,0 +1,138 @@
+{
+  "fixture_id": "external-policy-composition-matrix",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "Vendor-neutral decision-composition cases prove that external policy may tighten Agent Memory authority but cannot silently loosen it, and that decision evidence remains distinct from enforcement evidence.",
+  "expected_behavior": {
+    "all_cases_pass": true,
+    "composition_rule_version": "0.1.0",
+    "execution_status_without_witness": "unknown"
+  },
+  "memory_unit": {
+    "id": "mem:external-policy-composition",
+    "content_ref": "fixture://external-policy-composition/action",
+    "type": "decision",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "external-policy-composition-matrix",
+      "timestamp": "2026-08-12T18:00:00Z",
+      "source_refs": ["issue://152"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:external-policy-composition",
+        "kind": "policy_composition_fixture",
+        "ref": "issue://152",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["interoperability_contract"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "policy_refs": ["ADR-020", "ADR-021", "issue:152"],
+      "permitted_actions": ["enter_pending_verification", "collect_more_evidence", "defer"],
+      "prohibited_actions": ["promotion"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T18:00:00Z"
+  },
+  "composition_cases": [
+    {
+      "case_id": "local-deny-external-allow",
+      "local_pama_outcome": "block",
+      "provider_mode": "advisory",
+      "external_decision": "allow",
+      "identity_mode": "current",
+      "expected_provider_status": "available",
+      "expected_effective_decision": "deny",
+      "expected_execution_status": "unknown"
+    },
+    {
+      "case_id": "local-review-external-allow",
+      "local_pama_outcome": "require_review",
+      "provider_mode": "advisory",
+      "external_decision": "allow",
+      "identity_mode": "current",
+      "expected_provider_status": "available",
+      "expected_effective_decision": "require_approval",
+      "expected_execution_status": "unknown"
+    },
+    {
+      "case_id": "local-allow-external-deny",
+      "local_pama_outcome": "allow_with_ledger",
+      "provider_mode": "advisory",
+      "external_decision": "deny",
+      "identity_mode": "current",
+      "expected_provider_status": "available",
+      "expected_effective_decision": "deny",
+      "expected_execution_status": "unknown"
+    },
+    {
+      "case_id": "local-allow-external-escalate",
+      "local_pama_outcome": "allow_with_ledger",
+      "provider_mode": "advisory",
+      "external_decision": "escalate",
+      "identity_mode": "current",
+      "expected_provider_status": "available",
+      "expected_effective_decision": "require_approval",
+      "expected_execution_status": "unknown"
+    },
+    {
+      "case_id": "advisory-unavailable-preserves-local",
+      "local_pama_outcome": "allow_with_ledger",
+      "provider_mode": "advisory",
+      "external_decision": null,
+      "identity_mode": "none",
+      "expected_provider_status": "unavailable",
+      "expected_effective_decision": "allow",
+      "expected_execution_status": "unknown"
+    },
+    {
+      "case_id": "authoritative-unavailable-denies",
+      "local_pama_outcome": "allow_with_ledger",
+      "provider_mode": "authoritative",
+      "external_decision": null,
+      "identity_mode": "none",
+      "expected_provider_status": "unavailable",
+      "expected_effective_decision": "deny",
+      "expected_execution_status": "unknown"
+    },
+    {
+      "case_id": "advisory-stale-identity-ignored",
+      "local_pama_outcome": "allow_with_ledger",
+      "provider_mode": "advisory",
+      "external_decision": "deny",
+      "identity_mode": "stale",
+      "expected_provider_status": "stale_identity",
+      "expected_effective_decision": "allow",
+      "expected_execution_status": "unknown"
+    },
+    {
+      "case_id": "authoritative-stale-identity-denies",
+      "local_pama_outcome": "allow_with_ledger",
+      "provider_mode": "authoritative",
+      "external_decision": "allow",
+      "identity_mode": "stale",
+      "expected_provider_status": "stale_identity",
+      "expected_effective_decision": "deny",
+      "expected_execution_status": "unknown"
+    },
+    {
+      "case_id": "decision-issued-execution-unknown",
+      "local_pama_outcome": "allow_with_ledger",
+      "provider_mode": "none",
+      "external_decision": null,
+      "identity_mode": "none",
+      "expected_provider_status": "not_configured",
+      "expected_effective_decision": "allow",
+      "expected_execution_status": "unknown"
+    }
+  ]
+}

--- a/reference/agentmem_ref/enforcement_composition.py
+++ b/reference/agentmem_ref/enforcement_composition.py
@@ -1,0 +1,294 @@
+"""Vendor-neutral policy decision projection and monotonic composition.
+
+Issue #152 keeps three facts separate:
+
+1. Agent Memory/PAMA decides memory-specific mutation authority.
+2. An optional external provider may tighten the requested consequence.
+3. A composed decision is still not evidence that any enforcement point was
+   reached or that the action executed / was prevented.
+
+The projection input identity uses RFC 8785/JCS, an existing reference
+validation dependency, so action/state binding is deterministic across runtimes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Protocol
+
+import rfc8785
+
+from . import policy, receipts
+
+PROJECTION_VERSION = "0.1.0"
+COMPOSITION_RULE_VERSION = "0.1.0"
+
+ALLOW = "allow"
+WARN = "warn"
+REQUIRE_APPROVAL = "require_approval"
+DENY = "deny"
+
+PROVIDER_NONE = "none"
+PROVIDER_ADVISORY = "advisory"
+PROVIDER_AUTHORITATIVE = "authoritative"
+
+STATUS_NOT_CONFIGURED = "not_configured"
+STATUS_AVAILABLE = "available"
+STATUS_UNAVAILABLE = "unavailable"
+STATUS_INVALID = "invalid"
+STATUS_STALE_IDENTITY = "stale_identity"
+
+EXECUTION_UNKNOWN = "unknown"
+
+_STRICTNESS = {
+    ALLOW: 0,
+    WARN: 1,
+    REQUIRE_APPROVAL: 2,
+    DENY: 3,
+}
+
+_PAMA_TO_NORMALIZED = {
+    policy.ALLOW: ALLOW,
+    policy.ALLOW_WITH_LEDGER: ALLOW,
+    policy.REQUIRE_REVIEW: REQUIRE_APPROVAL,
+    policy.REQUIRE_EXTERNAL_VERIFICATION: REQUIRE_APPROVAL,
+    policy.BLOCK: DENY,
+    "abstain": REQUIRE_APPROVAL,
+    "collect_more_evidence": REQUIRE_APPROVAL,
+    "quarantine": DENY,
+}
+
+_EXTERNAL_TO_NORMALIZED = {
+    "allow": ALLOW,
+    "warn": WARN,
+    "escalate": REQUIRE_APPROVAL,
+    "deny": DENY,
+}
+
+
+class ExternalPolicyProvider(Protocol):
+    provider_id: str
+    provider_version: str
+
+    def evaluate(self, projection: dict) -> dict | None: ...
+
+
+@dataclass(frozen=True)
+class DeterministicFakeProvider:
+    """No-network provider used only to characterize the generic seam."""
+
+    provider_id: str = "fake-policy-provider"
+    provider_version: str = "1.0.0"
+    decision: str = "allow"
+    reason: str = "deterministic conformance fixture"
+    available: bool = True
+    issued_at: str = "2026-08-12T18:00:00Z"
+
+    def evaluate(self, projection: dict) -> dict | None:
+        if not self.available:
+            return None
+        return build_external_decision(
+            provider_id=self.provider_id,
+            provider_version=self.provider_version,
+            input_identity=projection["input_identity"],
+            decision=self.decision,
+            reason=self.reason,
+            issued_at=self.issued_at,
+            evidence={"fixture": True},
+        )
+
+
+def _jcs_sha256(document: dict) -> str:
+    canonical = rfc8785.dumps(document)
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def _bound_projection_input(proposal: policy.Proposal, decision: policy.Decision) -> dict:
+    if not proposal.state_snapshot:
+        raise ValueError("external enforcement projection requires a bound state_snapshot")
+    return {
+        "proposal_id": proposal.proposal_id,
+        "memory_id": proposal.target_reference,
+        "operation": proposal.operation,
+        "actor_id": proposal.actor_id,
+        "scope": proposal.scope,
+        "tenant_ref": proposal.tenant_ref,
+        "purpose": proposal.purpose,
+        "isolation_domain_refs": sorted(set(proposal.isolation_domain_refs)),
+        "required_isolation_domain_refs": sorted(set(proposal.required_isolation_domain_refs)),
+        "state_snapshot": proposal.state_snapshot,
+        "risk_class": proposal.risk_class,
+        "reversibility": proposal.reversibility,
+        "pama_decision_ref": receipts.decision_ref_for(proposal.proposal_id),
+        "pama_outcome": decision.outcome,
+        "permitted_actions": sorted(set(decision.permitted_actions)),
+        "prohibited_actions": sorted(set(decision.prohibited_actions)),
+        "policy_version": decision.policy_version,
+        "evidence_refs": sorted(set(proposal.evidence_refs)),
+    }
+
+
+def build_projection(
+    proposal: policy.Proposal,
+    decision: policy.Decision,
+    *,
+    receipt_ref: str | None = None,
+) -> dict:
+    """Build the content-minimized action/authority projection.
+
+    ``receipt_ref`` is intentionally not part of ``input_identity``. The same
+    action/state authority identity can be projected before or after a local
+    receipt object is materialized without changing what the provider evaluated.
+    """
+
+    bound = _bound_projection_input(proposal, decision)
+    input_identity = _jcs_sha256(bound)
+    document = {
+        "schema_version": "1.0.0",
+        "projection_version": PROJECTION_VERSION,
+        "projection_id": f"enforcement-projection:{input_identity}",
+        "input_identity": input_identity,
+        **bound,
+    }
+    if receipt_ref:
+        document["receipt_ref"] = receipt_ref
+    receipts.validate("external-enforcement-decision-projection.schema.json", document)
+    return document
+
+
+def build_external_decision(
+    *,
+    provider_id: str,
+    provider_version: str,
+    input_identity: str,
+    decision: str,
+    reason: str,
+    issued_at: str,
+    evidence: dict | None = None,
+) -> dict:
+    document = {
+        "schema_version": "1.0.0",
+        "provider_id": provider_id,
+        "provider_version": provider_version,
+        "input_identity": input_identity,
+        "decision": decision,
+        "reason": reason,
+        "issued_at": issued_at,
+    }
+    if evidence is not None:
+        document["evidence"] = evidence
+    receipts.validate("external-policy-decision.schema.json", document)
+    return document
+
+
+def external_decision_ref(decision: dict) -> str:
+    receipts.validate("external-policy-decision.schema.json", decision)
+    return f"external-policy-decision:{_jcs_sha256(decision)}"
+
+
+def normalize_pama(outcome: str) -> str:
+    try:
+        return _PAMA_TO_NORMALIZED[outcome]
+    except KeyError as exc:
+        raise ValueError(f"unsupported PAMA outcome for external composition: {outcome!r}") from exc
+
+
+def normalize_external(decision: str) -> str:
+    try:
+        return _EXTERNAL_TO_NORMALIZED[decision]
+    except KeyError as exc:
+        raise ValueError(f"unsupported external policy decision: {decision!r}") from exc
+
+
+def strictest(*decisions: str) -> str:
+    for decision in decisions:
+        if decision not in _STRICTNESS:
+            raise ValueError(f"unknown normalized decision {decision!r}")
+    return max(decisions, key=lambda value: _STRICTNESS[value])
+
+
+def compose(
+    projection: dict,
+    *,
+    provider_mode: str,
+    external_decision: dict | None = None,
+) -> dict:
+    """Compose local and external decisions without weakening authority.
+
+    Advisory provider failures preserve the local result while explicitly
+    recording that external policy was unavailable/invalid/stale. Authoritative
+    provider failures deny. No branch of this function can turn a stricter local
+    result into a weaker effective result.
+    """
+
+    receipts.validate("external-enforcement-decision-projection.schema.json", projection)
+    if provider_mode not in {PROVIDER_NONE, PROVIDER_ADVISORY, PROVIDER_AUTHORITATIVE}:
+        raise ValueError(f"invalid provider_mode {provider_mode!r}")
+    if provider_mode == PROVIDER_NONE and external_decision is not None:
+        raise ValueError("provider_mode 'none' cannot carry an external decision")
+
+    local = normalize_pama(projection["pama_outcome"])
+    provider_status = STATUS_NOT_CONFIGURED if provider_mode == PROVIDER_NONE else STATUS_UNAVAILABLE
+    external_ref: str | None = None
+    external_normalized: str | None = None
+    reason = "no external policy provider configured"
+
+    if provider_mode != PROVIDER_NONE and external_decision is not None:
+        try:
+            receipts.validate("external-policy-decision.schema.json", external_decision)
+        except ValueError:
+            provider_status = STATUS_INVALID
+            reason = "external policy decision failed schema validation"
+        else:
+            external_ref = external_decision_ref(external_decision)
+            if external_decision["input_identity"] != projection["input_identity"]:
+                provider_status = STATUS_STALE_IDENTITY
+                reason = "external policy decision input identity does not match current projection"
+            else:
+                provider_status = STATUS_AVAILABLE
+                external_normalized = normalize_external(external_decision["decision"])
+                reason = external_decision["reason"]
+
+    if provider_status == STATUS_AVAILABLE:
+        assert external_normalized is not None
+        effective = strictest(local, external_normalized)
+    elif provider_mode == PROVIDER_AUTHORITATIVE:
+        effective = DENY
+    else:
+        effective = local
+
+    body = {
+        "input_identity": projection["input_identity"],
+        "local_decision_ref": projection["pama_decision_ref"],
+        "local_normalized_decision": local,
+        "provider_mode": provider_mode,
+        "external_provider_status": provider_status,
+        "effective_decision": effective,
+        "composition_rule_version": COMPOSITION_RULE_VERSION,
+        "execution_status": EXECUTION_UNKNOWN,
+        "reason": reason,
+    }
+    if external_ref:
+        body["external_decision_ref"] = external_ref
+    if external_normalized is not None and provider_status == STATUS_AVAILABLE:
+        body["external_normalized_decision"] = external_normalized
+
+    composition_identity = _jcs_sha256(body)
+    document = {
+        "schema_version": "1.0.0",
+        "composition_id": f"decision-composition:{composition_identity}",
+        **body,
+    }
+    receipts.validate("decision-composition-receipt.schema.json", document)
+    _enforce_monotonicity(document)
+    return document
+
+
+def _enforce_monotonicity(receipt: dict) -> None:
+    local = receipt["local_normalized_decision"]
+    effective = receipt["effective_decision"]
+    if _STRICTNESS[effective] < _STRICTNESS[local]:
+        raise ValueError(
+            f"composed decision weakened local authority: local={local!r}, effective={effective!r}"
+        )

--- a/reference/tests/test_enforcement_composition.py
+++ b/reference/tests/test_enforcement_composition.py
@@ -1,0 +1,222 @@
+"""Vendor-neutral external policy composition tests for issue #152."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from agentmem_ref import policy
+from agentmem_ref.enforcement_composition import (
+    ALLOW,
+    DENY,
+    EXECUTION_UNKNOWN,
+    PROVIDER_ADVISORY,
+    PROVIDER_AUTHORITATIVE,
+    PROVIDER_NONE,
+    REQUIRE_APPROVAL,
+    STATUS_AVAILABLE,
+    STATUS_INVALID,
+    STATUS_STALE_IDENTITY,
+    DeterministicFakeProvider,
+    build_external_decision,
+    build_projection,
+    compose,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "external-policy-composition-matrix.json"
+OPERATION = "promotion"
+
+
+def _proposal(*, state_snapshot: str = "v1") -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id="proposal:external-policy",
+        actor_id="agent:planner",
+        charter_version="charter:external-policy",
+        target_reference="mem:external-policy",
+        target_class=policy.M4,
+        scope="tenant-a",
+        operation=OPERATION,
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A3,
+        reversibility="reversible",
+        risk_class="medium",
+        evidence_refs=("evidence:proposal",),
+        state_snapshot=state_snapshot,
+        tenant_ref="tenant-a",
+        purpose="external-policy-composition",
+        isolation_domain_refs=("domain:project-a",),
+        required_isolation_domain_refs=("domain:project-a",),
+    )
+
+
+def _decision(outcome: str) -> policy.Decision:
+    if outcome in (policy.ALLOW, policy.ALLOW_WITH_LEDGER):
+        permitted = (OPERATION, "collect_more_evidence", "defer")
+        prohibited = ()
+    elif outcome == policy.REQUIRE_REVIEW:
+        permitted = ("enter_pending_verification", "collect_more_evidence", "defer")
+        prohibited = (OPERATION,)
+    elif outcome == policy.REQUIRE_EXTERNAL_VERIFICATION:
+        permitted = ("request_external_verification", "collect_more_evidence", "defer")
+        prohibited = (OPERATION,)
+    elif outcome == policy.BLOCK:
+        permitted = ()
+        prohibited = (OPERATION, "enter_pending_verification", "request_external_verification")
+    else:
+        permitted = ("collect_more_evidence", "defer")
+        prohibited = (OPERATION,)
+    return policy.Decision(
+        outcome=outcome,
+        permitted_actions=permitted,
+        prohibited_actions=prohibited,
+        policy_version="ref-external-policy-test",
+    )
+
+
+def _external(projection: dict, decision: str, *, stale: bool = False) -> dict:
+    identity = projection["input_identity"]
+    if stale:
+        identity = "sha256:" + ("0" * 64 if identity != "sha256:" + "0" * 64 else "1" * 64)
+    return build_external_decision(
+        provider_id="fixture-provider",
+        provider_version="1.0.0",
+        input_identity=identity,
+        decision=decision,
+        reason=f"fixture decision {decision}",
+        issued_at="2026-08-12T18:00:00Z",
+        evidence={"fixture": True},
+    )
+
+
+class EnforcementCompositionTests(unittest.TestCase):
+    def test_projection_identity_binds_state_and_pama_outcome(self):
+        proposal = _proposal(state_snapshot="v1")
+        allow = build_projection(proposal, _decision(policy.ALLOW_WITH_LEDGER))
+        state_changed = build_projection(replace(proposal, state_snapshot="v2"), _decision(policy.ALLOW_WITH_LEDGER))
+        decision_changed = build_projection(proposal, _decision(policy.REQUIRE_REVIEW))
+
+        self.assertNotEqual(allow["input_identity"], state_changed["input_identity"])
+        self.assertNotEqual(allow["input_identity"], decision_changed["input_identity"])
+        self.assertEqual(allow["pama_decision_ref"], "pama-decision:proposal:external-policy")
+        self.assertNotIn("content", allow)
+        self.assertNotIn("fact_text", allow)
+
+    def test_receipt_ref_does_not_change_action_identity(self):
+        proposal = _proposal()
+        decision = _decision(policy.ALLOW_WITH_LEDGER)
+        before_receipt = build_projection(proposal, decision)
+        after_receipt = build_projection(proposal, decision, receipt_ref="receipt:1")
+
+        self.assertEqual(before_receipt["input_identity"], after_receipt["input_identity"])
+        self.assertEqual(after_receipt["receipt_ref"], "receipt:1")
+
+    def test_external_allow_cannot_loosen_local_block(self):
+        projection = build_projection(_proposal(), _decision(policy.BLOCK))
+        result = compose(
+            projection,
+            provider_mode=PROVIDER_ADVISORY,
+            external_decision=_external(projection, "allow"),
+        )
+        self.assertEqual(result["local_normalized_decision"], DENY)
+        self.assertEqual(result["effective_decision"], DENY)
+
+    def test_external_allow_cannot_discharge_local_review(self):
+        projection = build_projection(_proposal(), _decision(policy.REQUIRE_REVIEW))
+        result = compose(
+            projection,
+            provider_mode=PROVIDER_ADVISORY,
+            external_decision=_external(projection, "allow"),
+        )
+        self.assertEqual(result["local_normalized_decision"], REQUIRE_APPROVAL)
+        self.assertEqual(result["effective_decision"], REQUIRE_APPROVAL)
+
+    def test_external_deny_tightens_local_allow(self):
+        projection = build_projection(_proposal(), _decision(policy.ALLOW_WITH_LEDGER))
+        result = compose(
+            projection,
+            provider_mode=PROVIDER_ADVISORY,
+            external_decision=_external(projection, "deny"),
+        )
+        self.assertEqual(result["local_normalized_decision"], ALLOW)
+        self.assertEqual(result["effective_decision"], DENY)
+
+    def test_stale_external_identity_is_not_applied(self):
+        projection = build_projection(_proposal(), _decision(policy.ALLOW_WITH_LEDGER))
+        stale = _external(projection, "deny", stale=True)
+
+        advisory = compose(projection, provider_mode=PROVIDER_ADVISORY, external_decision=stale)
+        authoritative = compose(projection, provider_mode=PROVIDER_AUTHORITATIVE, external_decision=stale)
+
+        self.assertEqual(advisory["external_provider_status"], STATUS_STALE_IDENTITY)
+        self.assertEqual(advisory["effective_decision"], ALLOW)
+        self.assertEqual(authoritative["external_provider_status"], STATUS_STALE_IDENTITY)
+        self.assertEqual(authoritative["effective_decision"], DENY)
+
+    def test_invalid_provider_result_is_explicit_and_fail_closed_when_authoritative(self):
+        projection = build_projection(_proposal(), _decision(policy.ALLOW_WITH_LEDGER))
+        invalid = {
+            "schema_version": "1.0.0",
+            "provider_id": "broken-provider",
+            "provider_version": "1.0.0",
+            "input_identity": projection["input_identity"],
+            "decision": "permit-ish",
+            "reason": "invalid vocabulary",
+            "issued_at": "2026-08-12T18:00:00Z",
+        }
+        advisory = compose(projection, provider_mode=PROVIDER_ADVISORY, external_decision=invalid)
+        authoritative = compose(projection, provider_mode=PROVIDER_AUTHORITATIVE, external_decision=invalid)
+
+        self.assertEqual(advisory["external_provider_status"], STATUS_INVALID)
+        self.assertEqual(advisory["effective_decision"], ALLOW)
+        self.assertEqual(authoritative["external_provider_status"], STATUS_INVALID)
+        self.assertEqual(authoritative["effective_decision"], DENY)
+
+    def test_fake_provider_is_deterministic_and_bound(self):
+        projection = build_projection(_proposal(), _decision(policy.ALLOW_WITH_LEDGER))
+        provider = DeterministicFakeProvider(decision="escalate")
+
+        first = provider.evaluate(projection)
+        second = provider.evaluate(projection)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["input_identity"], projection["input_identity"])
+        result = compose(projection, provider_mode=PROVIDER_ADVISORY, external_decision=first)
+        self.assertEqual(result["external_provider_status"], STATUS_AVAILABLE)
+        self.assertEqual(result["effective_decision"], REQUIRE_APPROVAL)
+
+    def test_composition_receipt_never_claims_execution_without_witness(self):
+        projection = build_projection(_proposal(), _decision(policy.ALLOW_WITH_LEDGER))
+        result = compose(projection, provider_mode=PROVIDER_NONE)
+
+        self.assertEqual(result["execution_status"], EXECUTION_UNKNOWN)
+        self.assertNotIn("execution_evidence_ref", result)
+        self.assertNotIn(result["execution_status"], {"executed", "prevented", "enforced"})
+
+    def test_fixture_matrix(self):
+        data = json.loads(MATRIX.read_text(encoding="utf-8"))
+        for case in data["composition_cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                projection = build_projection(_proposal(), _decision(case["local_pama_outcome"]))
+                external = None
+                if case["external_decision"] is not None:
+                    external = _external(
+                        projection,
+                        case["external_decision"],
+                        stale=case["identity_mode"] == "stale",
+                    )
+                result = compose(
+                    projection,
+                    provider_mode=case["provider_mode"],
+                    external_decision=external,
+                )
+                self.assertEqual(result["external_provider_status"], case["expected_provider_status"])
+                self.assertEqual(result["effective_decision"], case["expected_effective_decision"])
+                self.assertEqual(result["execution_status"], case["expected_execution_status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/decision-composition-receipt.schema.json
+++ b/schemas/decision-composition-receipt.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/decision-composition-receipt.schema.json",
+  "title": "Agent Memory Decision Composition Receipt",
+  "description": "Evidence that a local Agent Memory authority decision and optional external policy decision were composed. This schema does not claim downstream enforcement.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "composition_id",
+    "input_identity",
+    "local_decision_ref",
+    "local_normalized_decision",
+    "provider_mode",
+    "external_provider_status",
+    "effective_decision",
+    "composition_rule_version",
+    "execution_status"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "composition_id": { "type": "string", "minLength": 1 },
+    "input_identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "local_decision_ref": { "type": "string", "minLength": 1 },
+    "local_normalized_decision": { "$ref": "#/$defs/normalizedDecision" },
+    "provider_mode": { "type": "string", "enum": ["none", "advisory", "authoritative"] },
+    "external_provider_status": {
+      "type": "string",
+      "enum": ["not_configured", "available", "unavailable", "invalid", "stale_identity"]
+    },
+    "external_decision_ref": { "type": "string", "minLength": 1 },
+    "external_normalized_decision": { "$ref": "#/$defs/normalizedDecision" },
+    "effective_decision": { "$ref": "#/$defs/normalizedDecision" },
+    "composition_rule_version": { "const": "0.1.0" },
+    "execution_status": { "type": "string", "enum": ["unknown", "not_observed"] },
+    "execution_evidence_ref": { "type": "string", "minLength": 1 },
+    "reason": { "type": "string", "minLength": 1 }
+  },
+  "$defs": {
+    "normalizedDecision": {
+      "type": "string",
+      "enum": ["allow", "warn", "require_approval", "deny"]
+    }
+  }
+}

--- a/schemas/external-enforcement-decision-projection.schema.json
+++ b/schemas/external-enforcement-decision-projection.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/external-enforcement-decision-projection.schema.json",
+  "title": "Agent Memory External Enforcement Decision Projection",
+  "description": "Content-minimized projection of a current Agent Memory mutation and PAMA boundary for optional external policy/enforcement consumers.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "projection_version",
+    "projection_id",
+    "input_identity",
+    "proposal_id",
+    "memory_id",
+    "operation",
+    "actor_id",
+    "scope",
+    "state_snapshot",
+    "risk_class",
+    "reversibility",
+    "pama_decision_ref",
+    "pama_outcome",
+    "permitted_actions",
+    "prohibited_actions",
+    "policy_version",
+    "evidence_refs"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "projection_version": { "const": "0.1.0" },
+    "projection_id": { "type": "string", "minLength": 1 },
+    "input_identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "proposal_id": { "type": "string", "minLength": 1 },
+    "memory_id": { "type": "string", "minLength": 1 },
+    "operation": { "type": "string", "minLength": 1 },
+    "actor_id": { "type": "string", "minLength": 1 },
+    "scope": { "type": "string", "minLength": 1 },
+    "tenant_ref": { "type": "string" },
+    "purpose": { "type": "string" },
+    "isolation_domain_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "required_isolation_domain_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "state_snapshot": { "type": "string", "minLength": 1 },
+    "risk_class": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+    "reversibility": {
+      "type": "string",
+      "enum": ["ephemeral", "reversible", "versioned_revocable", "compensatable", "irreversible", "unknown"]
+    },
+    "pama_decision_ref": { "type": "string", "minLength": 1 },
+    "pama_outcome": {
+      "type": "string",
+      "enum": [
+        "allow",
+        "allow_with_ledger",
+        "require_review",
+        "require_external_verification",
+        "block",
+        "abstain",
+        "quarantine",
+        "collect_more_evidence"
+      ]
+    },
+    "permitted_actions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "prohibited_actions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "policy_version": { "type": "string", "minLength": 1 },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "receipt_ref": { "type": "string", "minLength": 1 }
+  }
+}

--- a/schemas/external-policy-decision.schema.json
+++ b/schemas/external-policy-decision.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/external-policy-decision.schema.json",
+  "title": "External Policy Decision",
+  "description": "Vendor-neutral policy-provider response bound to an Agent Memory enforcement projection input identity. This records a decision, not execution evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "provider_id",
+    "provider_version",
+    "input_identity",
+    "decision",
+    "reason",
+    "issued_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "provider_id": { "type": "string", "minLength": 1 },
+    "provider_version": { "type": "string", "minLength": 1 },
+    "input_identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "decision": { "type": "string", "enum": ["allow", "warn", "escalate", "deny"] },
+    "reason": { "type": "string", "minLength": 1 },
+    "evidence": { "type": "object", "additionalProperties": true },
+    "issued_at": { "type": "string", "format": "date-time" }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the **generic Phase 1 / V0.1 vendor-neutral policy-decision and enforcement-composition boundary** for #152 before any real peer-specific adapter.

Current head: `dc4d2c5def7c0c8dcef68077dcba0238f44add21`

## Implemented V0.1 surface

The branch now contains:

- content-minimized current-action enforcement-decision projection;
- deterministic `input_identity` binding for proposal/action/state/authority inputs;
- normalized monotonic consequence lattice;
- advisory vs authoritative external-provider failure posture;
- explicit stale/mismatched action-identity behavior;
- generic external policy decision and composition receipt contracts;
- deterministic fake-provider/reference composition path;
- adversarial composition fixtures/tests;
- explicit decision-vs-execution non-claim (`execution_status` remains unknown/not observed without witness).

## Core boundary

```text
Agent Memory PAMA
  -> vendor-neutral action-decision projection
  -> optional external policy decision
  -> monotonic composition
  -> approval / enforcement host
```

External governance may tighten an Agent Memory decision but may not silently loosen it. A composed decision is not execution evidence.

## V0.1 consequence lattice

```text
allow < warn < require_approval < deny
```

External provider vocabulary is intentionally limited to the minimum normalized decision set needed for the contract. Transform-style provider verdicts that rewrite the underlying action remain out of scope until identity-preserving transformed-action semantics are explicitly designed.

## Required adversarial behavior

V0.1 must preserve at least:

```text
local deny + external allow -> deny
local require-approval + external allow -> require-approval
local allow + external deny -> deny
local allow + external escalation -> require-approval
advisory provider unavailable -> preserve local result + record unavailable
authoritative provider unavailable -> deny
stale/mismatched external identity -> external result not applied
valid decision without witness -> execution remains unknown
```

## Explicit stop line

Do **not** expand this PR into:

- AGT, OPA, Cedar, PIC, or other real peer adapters/dependencies;
- trust/attestation evidence normalization (#180);
- precedent applicability / approval-fatigue logic (#181 / #153);
- framework or MCP/A2A integrations;
- execution-witness semantics that claim more than this branch can prove;
- transform-style external verdicts;
- peer-specific vocabulary added to canonical memory semantics.

If review exposes a genuine missing primitive, record it separately rather than broadening V0.1 opportunistically.

## Current validation state

At head `dc4d2c5def7c0c8dcef68077dcba0238f44add21`:

- `Validate Doctrine Evidence` — **success**
- `P9 Systems Characterization` — **success**

The PR remains draft until the V0.1 completion review confirms the issue-level acceptance criteria at the exact head.

## Completion review before marking ready

- [ ] verify every changed schema/profile/reference artifact agrees on the V0.1 vocabulary and identity binding
- [ ] verify the fake-provider path exercises the generic contract without third-party coupling
- [ ] verify all required disagreement/failure/stale-identity cases are executable
- [ ] verify no receipt/field claims enforcement or execution without a witness
- [ ] verify no peer-specific ontology leaked into canonical Agent Memory semantics
- [ ] re-run/confirm exact-head CI if the head changes
- [ ] confirm no unresolved review thread or documented acceptance gap remains

Merge only after that bounded completion review. Follow-on interoperability work belongs in separately scoped issues.