### PR TITLE
Normalize external trust and attestation evidence

### DIFF
--- a/docs/profiles/external-evidence-normalization-profile.md
+++ b/docs/profiles/external-evidence-normalization-profile.md
@@ -1,0 +1,369 @@
+# External Trust and Attestation Evidence Normalization Profile
+
+## Status
+
+Reference V0.1 implementation profile for issue #180.
+
+## Purpose
+
+This profile defines the smallest vendor-neutral boundary for accepting external identity, trust, attestation, decision, enforcement, execution, runtime, or delegation evidence as an Agent Memory evidence candidate without importing peer authority.
+
+The core invariants are:
+
+```text
+payload parsed
+!= signature / claim verified
+!= claim current
+!= claim applicable to this subject/action/scope
+!= Agent Memory authority
+```
+
+and:
+
+```text
+verified identity
+!= memory authority
+
+valid attestation
+!= semantic correctness
+
+policy / decision evidence
+!= enforcement evidence
+
+execution evidence
+!= lifecycle obligation satisfaction
+```
+
+The normalizer exists to preserve those distinctions in executable form.
+
+## Layering
+
+```text
+peer-specific record
+  -> peer adapter / verifier result
+  -> vendor-neutral external evidence normalizer
+  -> Agent Memory evidence candidate
+  -> normal provenance / scope / lifecycle / PAMA handling
+```
+
+The reference implementation begins at the adapter/verifier-result boundary. It does not parse arbitrary peer wire formats and does not perform peer cryptography itself.
+
+That split is intentional. A peer adapter may understand peer vocabulary and wire details. Canonical Agent Memory evidence semantics must not.
+
+## Pinned V0.1 reference peer
+
+TRACE is the first reference comparator because the repository already has executable TRACE/cMCP evidence work and an exact release pin.
+
+V0.1 recognizes only this pinned source tuple as supported evidence input:
+
+```text
+peer:                TRACE
+TRACE SDK:           agentrust-trace==0.8.0
+TRACE release ref:   671f2a8b22f1c995798a0c6d711b4b0b77dad4c7
+reference contract:  TRACE action-receipt verification / external action-evidence surface
+```
+
+This reuses the existing P4.5c pin documented in `docs/programs/runtime-evidence/trace-action-evidence.md`.
+
+TRACE remains a comparator. It is not a required Agent Memory runtime dependency and does not define Agent Memory vocabulary.
+
+A different TRACE version, release ref, or unsupported peer is preserved as source metadata but receives `applicability.status = unsupported` until a later implementation explicitly validates that version.
+
+## Adapter/verifier input boundary
+
+The normalizer consumes a bounded result containing the facts needed for evidence interpretation, including:
+
+```text
+parse_status
+source_peer
+source_version
+source_release_ref
+record_ref
+evidence_digest
+adapter_id / adapter_version
+issuer_id / signer_id
+verifier_id
+verification_status
+verification_method
+claim_type
+claim_scope
+subject_ref
+tenant_ref
+resource_ref
+action_ref
+runtime_ref
+configuration_ref
+policy_ref
+decision_ref / decision_disposition
+enforcement_posture
+execution_posture
+attestation_mode
+delegation_ref
+issued_at / expires_at
+revocation_status / revocation_evidence_ref
+evidence_refs
+explicit limitations / non-claims
+```
+
+The input is not automatically durable state. It is material supplied to the normalizer by a peer-specific adapter or verifier.
+
+Unknown peer-only fields are ignored. In particular, a peer cannot widen Agent Memory authority by adding fields that resemble:
+
+```text
+pama_outcome
+permitted_actions
+lifecycle_state
+trust_score
+```
+
+Those fields do not enter the normalized output.
+
+## Normalized evidence candidate
+
+Schema:
+
+`schemas/external-evidence-normalized.schema.json`
+
+Reference implementation:
+
+`reference/agentmem_ref/external_evidence.py`
+
+The normalized candidate contains distinct surfaces for:
+
+```text
+source provenance
+issuer / signer identity
+verification state
+claim identity and scope
+freshness
+revocation
+current-context applicability
+stable evidence digest / references
+explicit interpretation non-claims
+```
+
+The V0.1 interpretation block is deliberately fixed:
+
+```json
+{
+  "authority_effect": "none",
+  "memory_authority": "not_established",
+  "semantic_correctness": "not_established",
+  "lifecycle_satisfaction": "not_established"
+}
+```
+
+A consumer that needs to make an Agent Memory mutation decision must still use normal Agent Memory provenance, trust, scope, lifecycle, and PAMA logic. The normalized evidence candidate is evidence input, never a bypass token.
+
+## Verification state
+
+Verification remains explicit:
+
+```text
+verified
+failed
+unknown
+not_performed
+unavailable
+```
+
+Schema-valid or successfully parsed evidence is never promoted to `verified` by the normalizer.
+
+A failed verification produces an invalid applicability result.
+
+Unknown, not-performed, or unavailable verification produces insufficient evidence rather than optimistic acceptance.
+
+## Freshness and revocation
+
+Freshness and revocation are independent dimensions.
+
+Freshness:
+
+```text
+current
+expired
+not_yet_valid
+```
+
+Revocation:
+
+```text
+not_revoked
+revoked
+unknown
+```
+
+Expired or revoked evidence is stale even when its historical signature remains valid.
+
+Unknown revocation state remains unknown and prevents V0.1 from reporting the evidence as fully applicable.
+
+Historical evidence may remain reconstructable after expiry or revocation. That historical reconstructability is not current authority.
+
+## Applicability
+
+The normalizer compares evidence binding against the current Agent Memory context supplied by the consumer.
+
+V0.1 supports:
+
+```text
+applicable
+mismatch
+stale
+unsupported
+insufficient_evidence
+invalid
+```
+
+At minimum, the current context can bind:
+
+```text
+subject_ref
+scope
+tenant_ref
+resource_ref
+action_ref
+```
+
+When the current context requires a binding and the evidence omits it, V0.1 reports a mismatch rather than assuming equivalence.
+
+Examples:
+
+```text
+verified signature + wrong scope       -> mismatch
+verified signature + wrong tenant      -> mismatch
+verified signature + wrong action      -> mismatch
+verified + expired                      -> stale
+verified + revoked                      -> stale
+unknown verification                    -> insufficient_evidence
+failed verification                     -> invalid
+unsupported TRACE version               -> unsupported
+exact/current/verified/not-revoked      -> applicable
+```
+
+`applicable` means the evidence is applicable as evidence to the supplied context. It does not mean the underlying memory action is authorized.
+
+## Claim-layer separation
+
+The normalized claim may preserve independently supplied references or postures for:
+
+```text
+decision
+enforcement
+execution
+runtime / configuration
+identity / attestation
+delegation
+```
+
+The normalizer does not manufacture missing layers.
+
+For example, a valid decision record with no enforcement or execution claim remains decision evidence only. A runtime/configuration attestation remains evidence about runtime/configuration identity and does not become semantic correctness.
+
+## Privacy and minimization
+
+V0.1 defaults to stable references and digests.
+
+The normalized output does not require:
+
+- raw prompts;
+- raw memory content;
+- full tool payloads;
+- complete peer attestation bundles;
+- peer signatures when a stable evidence digest/reference is sufficient for custody or later verification;
+- peer-only authority vocabulary.
+
+The source record remains independently referencable through `record_ref` and `evidence_digest` when policy permits retention or retrieval.
+
+## Deployment profiles
+
+### L: local / single-user / offline
+
+The normalizer has no network requirement. A local caller may supply static or pre-verified adapter results. Unknown verification remains unknown rather than being silently upgraded because the deployment is local.
+
+### T: team / multi-tenant
+
+`subject_ref`, `scope`, and `tenant_ref` remain explicit. Cross-tenant evidence mismatches fail deterministically.
+
+### E: enterprise
+
+The verifier identity and verification method are explicit, allowing external attestation or identity services to supply verifier results without becoming mandatory core dependencies.
+
+### H: high assurance
+
+Peer/release version, verifier identity, freshness, revocation, exact context binding, evidence digest, and explicit non-claims remain reconstructable.
+
+### X: cross-organization
+
+Cross-organization delegation semantics are not a V0.1 completion target. A `delegation_ref` may be preserved as evidence, but it does not create delegated Agent Memory authority.
+
+## Required negative paths
+
+The executable fixture matrix covers:
+
+- verified evidence with wrong scope;
+- cross-tenant mismatch;
+- wrong action binding;
+- expired evidence;
+- revoked evidence;
+- unknown verification;
+- verifier unavailable;
+- failed verification;
+- unknown revocation state;
+- unsupported TRACE version;
+- unsupported peer claim type;
+- decision evidence without enforcement/execution claims;
+- peer-only fields attempting to inject PAMA, lifecycle, or trust-score semantics;
+- malformed/unparsed peer evidence;
+- missing required current-context binding.
+
+Fixture:
+
+`fixtures/external-evidence-normalization-matrix.json`
+
+Tests:
+
+`reference/tests/test_external_evidence.py`
+
+## What V0.1 proves
+
+Within the bounded reference implementation and fixtures, V0.1 demonstrates that:
+
+- external trust/attestation evidence enters through an explicit vendor-neutral normalization boundary;
+- TRACE version and release provenance remain reconstructable;
+- parsing, verification, freshness, revocation, and applicability remain distinct;
+- verified evidence cannot itself create Agent Memory authority;
+- wrong-scope and cross-tenant evidence cannot become applicable silently;
+- decision evidence is not upgraded into enforcement/execution evidence;
+- runtime/configuration attestation does not establish semantic correctness;
+- raw peer payloads are unnecessary for the normalized candidate;
+- unknown peer fields cannot widen PAMA or mutate canonical lifecycle state;
+- removing the peer adapter leaves the normalized evidence contract understandable as generic evidence metadata.
+
+## What V0.1 does not prove
+
+V0.1 does not prove:
+
+- that TRACE or another peer is universally trustworthy;
+- production key discovery, rotation, revocation, or trust-anchor policy;
+- semantic correctness of an attested claim;
+- Agent Memory mutation authorization;
+- downstream enforcement merely because a decision exists;
+- physical execution merely because an attestation exists;
+- correction, deletion, forgetting, or other lifecycle obligation satisfaction;
+- cross-organization delegation authority;
+- compatibility with future TRACE versions or other peers;
+- a need for a TRACE core-schema change.
+
+## Rollback / disable behavior
+
+The normalizer and all peer adapters are optional evidence surfaces.
+
+Disabling or removing the TRACE adapter does not invalidate canonical Agent Memory records. Existing normalized records remain understandable through the vendor-neutral schema and retain their source/version/reference metadata.
+
+No canonical memory object requires TRACE-only vocabulary to remain interpretable.
+
+## Follow-on gate
+
+Only after this V0.1 boundary is stable should a second materially different peer be added. cMCP or Agent Manifest are reasonable next comparators because their evidence semantics differ enough to test whether the generic contract actually generalizes.
+
+A second peer should expose real incompatibilities before this profile gains additional canonical fields. Speculative breadth is not evidence.

--- a/fixtures/external-evidence-normalization-matrix.json
+++ b/fixtures/external-evidence-normalization-matrix.json
@@ -1,0 +1,166 @@
+{
+  "fixture_id": "external-evidence-normalization-matrix",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "Pinned TRACE reference evidence exercises vendor-neutral normalization while proving that verification, freshness, revocation, and applicability remain distinct from Agent Memory authority.",
+  "pinned_reference": {
+    "source_peer": "TRACE",
+    "source_version": "agentrust-trace==0.8.0",
+    "source_release_ref": "671f2a8b22f1c995798a0c6d711b4b0b77dad4c7",
+    "source_contract": "TRACE action-receipt verification / external action-evidence surface"
+  },
+  "context": {
+    "subject_ref": "agent:planner",
+    "scope": "project-a",
+    "tenant_ref": "tenant-a",
+    "resource_ref": "memory:123",
+    "action_ref": "action:456",
+    "observed_at": "2026-08-12T20:00:00Z"
+  },
+  "base_adapter_result": {
+    "parse_status": "parsed",
+    "source_peer": "TRACE",
+    "source_version": "agentrust-trace==0.8.0",
+    "source_release_ref": "671f2a8b22f1c995798a0c6d711b4b0b77dad4c7",
+    "record_ref": "trace://receipt/fixture-1",
+    "evidence_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "adapter_id": "agent-memory.trace-reference-adapter",
+    "adapter_version": "0.1.0",
+    "issuer_id": "spiffe://runtime.example/agent-memory-controller",
+    "signer_id": "key:fixture-ed25519",
+    "verifier_id": "trace-reference-verifier",
+    "verification_status": "verified",
+    "verification_method": "detached-signature-and-binding",
+    "claim_type": "execution",
+    "claim_scope": "project-a",
+    "subject_ref": "agent:planner",
+    "tenant_ref": "tenant-a",
+    "resource_ref": "memory:123",
+    "action_ref": "action:456",
+    "runtime_ref": "runtime:fixture",
+    "configuration_ref": "config:fixture",
+    "policy_ref": "policy:fixture",
+    "decision_ref": "decision:fixture",
+    "decision_disposition": "permitted",
+    "enforcement_posture": "external-receipt-present",
+    "execution_posture": "accepted",
+    "attestation_mode": "external-action-receipt",
+    "issued_at": "2026-08-12T19:00:00Z",
+    "expires_at": "2026-08-13T19:00:00Z",
+    "revocation_status": "not_revoked",
+    "evidence_refs": ["trace://verification/fixture-1"],
+    "limitations": [
+      "does not establish Agent Memory authority",
+      "does not establish semantic correctness",
+      "does not establish lifecycle satisfaction"
+    ]
+  },
+  "cases": [
+    {
+      "case_id": "verified-current-exact-binding",
+      "input_overrides": {},
+      "remove_fields": [],
+      "expected_status": "applicable",
+      "expected_reasons": []
+    },
+    {
+      "case_id": "verified-wrong-scope",
+      "input_overrides": {"claim_scope": "project-b"},
+      "remove_fields": [],
+      "expected_status": "mismatch",
+      "expected_reasons": ["scope_mismatch"]
+    },
+    {
+      "case_id": "verified-cross-tenant-mismatch",
+      "input_overrides": {"tenant_ref": "tenant-b"},
+      "remove_fields": [],
+      "expected_status": "mismatch",
+      "expected_reasons": ["tenant_ref_mismatch"]
+    },
+    {
+      "case_id": "verified-wrong-action",
+      "input_overrides": {"action_ref": "action:other"},
+      "remove_fields": [],
+      "expected_status": "mismatch",
+      "expected_reasons": ["action_ref_mismatch"]
+    },
+    {
+      "case_id": "expired-evidence",
+      "input_overrides": {"expires_at": "2026-08-12T19:30:00Z"},
+      "remove_fields": [],
+      "expected_status": "stale",
+      "expected_reasons": ["evidence_expired"]
+    },
+    {
+      "case_id": "revoked-evidence",
+      "input_overrides": {
+        "revocation_status": "revoked",
+        "revocation_evidence_ref": "revocation://fixture-1"
+      },
+      "remove_fields": [],
+      "expected_status": "stale",
+      "expected_reasons": ["evidence_revoked"]
+    },
+    {
+      "case_id": "unknown-verification",
+      "input_overrides": {"verification_status": "unknown"},
+      "remove_fields": [],
+      "expected_status": "insufficient_evidence",
+      "expected_reasons": ["verification_unknown"]
+    },
+    {
+      "case_id": "verifier-unavailable",
+      "input_overrides": {"verification_status": "unavailable"},
+      "remove_fields": [],
+      "expected_status": "insufficient_evidence",
+      "expected_reasons": ["verification_unavailable"]
+    },
+    {
+      "case_id": "failed-verification",
+      "input_overrides": {"verification_status": "failed"},
+      "remove_fields": [],
+      "expected_status": "invalid",
+      "expected_reasons": ["verification_failed"]
+    },
+    {
+      "case_id": "unknown-revocation",
+      "input_overrides": {"revocation_status": "unknown"},
+      "remove_fields": [],
+      "expected_status": "insufficient_evidence",
+      "expected_reasons": ["revocation_unknown"]
+    },
+    {
+      "case_id": "unsupported-trace-version",
+      "input_overrides": {"source_version": "agentrust-trace==999.0.0"},
+      "remove_fields": [],
+      "expected_status": "unsupported",
+      "expected_reasons": ["unsupported_source_version"]
+    },
+    {
+      "case_id": "unsupported-claim-type",
+      "input_overrides": {"claim_type": "peer_magic_permission"},
+      "remove_fields": [],
+      "expected_status": "unsupported",
+      "expected_reasons": ["unsupported_claim_type"]
+    },
+    {
+      "case_id": "decision-evidence-does-not-become-execution",
+      "input_overrides": {"claim_type": "decision"},
+      "remove_fields": ["execution_posture", "enforcement_posture"],
+      "expected_status": "applicable",
+      "expected_reasons": []
+    },
+    {
+      "case_id": "peer-only-authority-fields-ignored",
+      "input_overrides": {
+        "pama_outcome": "allow",
+        "permitted_actions": ["promotion", "delete"],
+        "lifecycle_state": "satisfied",
+        "trust_score": 1.0
+      },
+      "remove_fields": [],
+      "expected_status": "applicable",
+      "expected_reasons": []
+    }
+  ]
+}

--- a/fixtures/external-evidence-normalization-matrix.json
+++ b/fixtures/external-evidence-normalization-matrix.json
@@ -3,6 +3,11 @@
   "fixture_version": "1.0.0",
   "class": "trap",
   "description": "Pinned TRACE reference evidence exercises vendor-neutral normalization while proving that verification, freshness, revocation, and applicability remain distinct from Agent Memory authority.",
+  "expected_behavior": {
+    "all_cases_preserve_authority_non_escalation": true,
+    "applicable_requires_verified_current_unrevoked_exact_binding": true,
+    "authority_effect": "none"
+  },
   "memory_unit": {
     "id": "mem:external-evidence-normalization",
     "content_ref": "fixture://external-evidence-normalization/reference-claim",

--- a/fixtures/external-evidence-normalization-matrix.json
+++ b/fixtures/external-evidence-normalization-matrix.json
@@ -3,6 +3,41 @@
   "fixture_version": "1.0.0",
   "class": "trap",
   "description": "Pinned TRACE reference evidence exercises vendor-neutral normalization while proving that verification, freshness, revocation, and applicability remain distinct from Agent Memory authority.",
+  "memory_unit": {
+    "id": "mem:external-evidence-normalization",
+    "content_ref": "fixture://external-evidence-normalization/reference-claim",
+    "type": "decision",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "external-evidence-normalization-matrix",
+      "timestamp": "2026-08-12T20:00:00Z",
+      "source_refs": ["issue://180", "peer://TRACE/agentrust-trace==0.8.0"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:external-evidence-normalization",
+        "kind": "external_attestation_normalization_fixture",
+        "ref": "issue://180",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["interoperability_contract"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "policy_refs": ["ADR-021", "issue:180"],
+      "permitted_actions": ["collect_more_evidence", "defer"],
+      "prohibited_actions": ["promotion"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T20:00:00Z"
+  },
   "pinned_reference": {
     "source_peer": "TRACE",
     "source_version": "agentrust-trace==0.8.0",

--- a/reference/agentmem_ref/external_evidence.py
+++ b/reference/agentmem_ref/external_evidence.py
@@ -1,0 +1,318 @@
+"""Vendor-neutral normalization of external trust and attestation evidence.
+
+Issue #180 keeps four facts separate:
+
+1. A peer payload parsed.
+2. A verifier did or did not verify the peer claim.
+3. The claim is or is not current and applicable to the requested context.
+4. None of those facts creates Agent Memory authority by itself.
+
+Peer-specific parsing and cryptographic verification stay outside this module. The
+normalizer consumes a bounded adapter/verifier result, removes peer-only fields,
+and emits a content-minimized Agent Memory evidence candidate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping
+
+import rfc8785
+
+from . import receipts
+
+PROFILE_VERSION = "0.1.0"
+SCHEMA_VERSION = "1.0.0"
+
+TRACE_PEER = "TRACE"
+TRACE_VERSION = "agentrust-trace==0.8.0"
+TRACE_RELEASE = "671f2a8b22f1c995798a0c6d711b4b0b77dad4c7"
+
+VERIFIED = "verified"
+VERIFICATION_FAILED = "failed"
+VERIFICATION_UNKNOWN = "unknown"
+VERIFICATION_NOT_PERFORMED = "not_performed"
+VERIFIER_UNAVAILABLE = "unavailable"
+
+REVOCATION_NOT_REVOKED = "not_revoked"
+REVOCATION_REVOKED = "revoked"
+REVOCATION_UNKNOWN = "unknown"
+
+FRESH_CURRENT = "current"
+FRESH_EXPIRED = "expired"
+FRESH_NOT_YET_VALID = "not_yet_valid"
+
+APPLICABLE = "applicable"
+MISMATCH = "mismatch"
+STALE = "stale"
+UNSUPPORTED = "unsupported"
+INSUFFICIENT = "insufficient_evidence"
+INVALID = "invalid"
+
+SUPPORTED_CLAIM_TYPES = {
+    "identity",
+    "attestation",
+    "runtime_configuration",
+    "decision",
+    "enforcement",
+    "execution",
+    "delegation",
+}
+
+SUPPORTED_SOURCE_TUPLES = {
+    (TRACE_PEER, TRACE_VERSION, TRACE_RELEASE),
+}
+
+_ALLOWED_VERIFICATION = {
+    VERIFIED,
+    VERIFICATION_FAILED,
+    VERIFICATION_UNKNOWN,
+    VERIFICATION_NOT_PERFORMED,
+    VERIFIER_UNAVAILABLE,
+}
+_ALLOWED_REVOCATION = {
+    REVOCATION_NOT_REVOKED,
+    REVOCATION_REVOKED,
+    REVOCATION_UNKNOWN,
+}
+
+
+@dataclass(frozen=True)
+class EvidenceContext:
+    """Current Agent Memory context against which evidence applicability is tested."""
+
+    subject_ref: str
+    scope: str
+    tenant_ref: str | None = None
+    resource_ref: str | None = None
+    action_ref: str | None = None
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamps must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _sha256_jcs(document: Mapping[str, object]) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(dict(document))).hexdigest()
+
+
+def _require_string(record: Mapping[str, object], field: str) -> str:
+    value = record.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"external evidence adapter result requires non-empty {field!r}")
+    return value
+
+
+def _optional_string(record: Mapping[str, object], field: str) -> str | None:
+    value = record.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"external evidence adapter result field {field!r} must be a non-empty string")
+    return value
+
+
+def _string_list(record: Mapping[str, object], field: str) -> list[str]:
+    value = record.get(field, [])
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+        raise ValueError(f"external evidence adapter result field {field!r} must be a list of non-empty strings")
+    return sorted(set(value))
+
+
+def _freshness(issued_at: str, expires_at: str | None, observed_at: str) -> tuple[str, list[str]]:
+    issued = _parse_time(issued_at)
+    observed = _parse_time(observed_at)
+    if issued > observed:
+        return FRESH_NOT_YET_VALID, ["evidence_issued_in_future"]
+    if expires_at is not None:
+        expires = _parse_time(expires_at)
+        if expires < issued:
+            raise ValueError("external evidence expires_at precedes issued_at")
+        if observed > expires:
+            return FRESH_EXPIRED, ["evidence_expired"]
+    return FRESH_CURRENT, []
+
+
+def _binding_failures(record: Mapping[str, object], context: EvidenceContext) -> list[str]:
+    failures: list[str] = []
+    comparisons = (
+        ("subject_ref", context.subject_ref, record.get("subject_ref")),
+        ("scope", context.scope, record.get("claim_scope")),
+        ("tenant_ref", context.tenant_ref, record.get("tenant_ref")),
+        ("resource_ref", context.resource_ref, record.get("resource_ref")),
+        ("action_ref", context.action_ref, record.get("action_ref")),
+    )
+    for field, expected, actual in comparisons:
+        if expected is None:
+            continue
+        if actual is None:
+            failures.append(f"missing_{field}_binding")
+        elif actual != expected:
+            failures.append(f"{field}_mismatch")
+    return failures
+
+
+def normalize_external_evidence(
+    adapter_result: Mapping[str, object],
+    *,
+    context: EvidenceContext,
+    observed_at: str,
+) -> dict:
+    """Normalize a peer adapter/verifier result without importing peer authority.
+
+    The input is intentionally *not* a raw peer payload. A peer-specific adapter
+    is responsible for parsing the peer record and for reporting verification
+    state. This function never treats parsing as verification and never maps a
+    verified peer claim into PAMA permission or canonical lifecycle state.
+    """
+
+    parse_status = _require_string(adapter_result, "parse_status")
+    if parse_status != "parsed":
+        raise ValueError("malformed/unparsed peer evidence cannot enter normalization")
+
+    source_peer = _require_string(adapter_result, "source_peer")
+    source_version = _require_string(adapter_result, "source_version")
+    source_release_ref = _require_string(adapter_result, "source_release_ref")
+    record_ref = _require_string(adapter_result, "record_ref")
+    evidence_digest = _require_string(adapter_result, "evidence_digest")
+    adapter_id = _require_string(adapter_result, "adapter_id")
+    adapter_version = _require_string(adapter_result, "adapter_version")
+
+    issuer_id = _require_string(adapter_result, "issuer_id")
+    signer_id = _optional_string(adapter_result, "signer_id")
+    verifier_id = _require_string(adapter_result, "verifier_id")
+    verification_status = _require_string(adapter_result, "verification_status")
+    if verification_status not in _ALLOWED_VERIFICATION:
+        raise ValueError(f"unsupported verification_status {verification_status!r}")
+    verification_method = _require_string(adapter_result, "verification_method")
+
+    source_claim_type = _require_string(adapter_result, "claim_type")
+    claim_type = source_claim_type if source_claim_type in SUPPORTED_CLAIM_TYPES else "other"
+    claim_scope = _require_string(adapter_result, "claim_scope")
+    subject_ref = _require_string(adapter_result, "subject_ref")
+
+    issued_at = _require_string(adapter_result, "issued_at")
+    expires_at = _optional_string(adapter_result, "expires_at")
+    freshness_status, reasons = _freshness(issued_at, expires_at, observed_at)
+
+    revocation_status = _require_string(adapter_result, "revocation_status")
+    if revocation_status not in _ALLOWED_REVOCATION:
+        raise ValueError(f"unsupported revocation_status {revocation_status!r}")
+    revocation_evidence_ref = _optional_string(adapter_result, "revocation_evidence_ref")
+
+    binding_failures = _binding_failures(adapter_result, context)
+    reasons.extend(binding_failures)
+
+    source_supported = (source_peer, source_version, source_release_ref) in SUPPORTED_SOURCE_TUPLES
+    if not source_supported:
+        reasons.append("unsupported_source_version")
+    if source_claim_type not in SUPPORTED_CLAIM_TYPES:
+        reasons.append("unsupported_claim_type")
+
+    if verification_status == VERIFICATION_FAILED:
+        reasons.append("verification_failed")
+    elif verification_status in {VERIFICATION_UNKNOWN, VERIFICATION_NOT_PERFORMED, VERIFIER_UNAVAILABLE}:
+        reasons.append(f"verification_{verification_status}")
+
+    if revocation_status == REVOCATION_REVOKED:
+        reasons.append("evidence_revoked")
+    elif revocation_status == REVOCATION_UNKNOWN:
+        reasons.append("revocation_unknown")
+
+    if not source_supported or source_claim_type not in SUPPORTED_CLAIM_TYPES:
+        applicability_status = UNSUPPORTED
+    elif binding_failures:
+        applicability_status = MISMATCH
+    elif verification_status == VERIFICATION_FAILED:
+        applicability_status = INVALID
+    elif freshness_status != FRESH_CURRENT or revocation_status == REVOCATION_REVOKED:
+        applicability_status = STALE
+    elif verification_status != VERIFIED or revocation_status != REVOCATION_NOT_REVOKED:
+        applicability_status = INSUFFICIENT
+    else:
+        applicability_status = APPLICABLE
+
+    claim: dict[str, object] = {
+        "type": claim_type,
+        "source_claim_type": source_claim_type,
+        "scope": claim_scope,
+        "subject_ref": subject_ref,
+        "limitations": _string_list(adapter_result, "limitations"),
+    }
+    for output_name, input_name in (
+        ("tenant_ref", "tenant_ref"),
+        ("resource_ref", "resource_ref"),
+        ("action_ref", "action_ref"),
+        ("runtime_ref", "runtime_ref"),
+        ("configuration_ref", "configuration_ref"),
+        ("policy_ref", "policy_ref"),
+        ("decision_ref", "decision_ref"),
+        ("decision_disposition", "decision_disposition"),
+        ("enforcement_posture", "enforcement_posture"),
+        ("execution_posture", "execution_posture"),
+        ("attestation_mode", "attestation_mode"),
+        ("delegation_ref", "delegation_ref"),
+    ):
+        value = _optional_string(adapter_result, input_name)
+        if value is not None:
+            claim[output_name] = value
+
+    source = {
+        "peer": source_peer,
+        "version": source_version,
+        "release_ref": source_release_ref,
+        "record_ref": record_ref,
+        "adapter_id": adapter_id,
+        "adapter_version": adapter_version,
+        "parse_status": parse_status,
+    }
+    verification = {
+        "status": verification_status,
+        "verifier_id": verifier_id,
+        "method": verification_method,
+    }
+    issuer = {"id": issuer_id}
+    if signer_id is not None:
+        issuer["signer_id"] = signer_id
+
+    normalized_body = {
+        "schema_version": SCHEMA_VERSION,
+        "profile_version": PROFILE_VERSION,
+        "source": source,
+        "issuer": issuer,
+        "verification": verification,
+        "claim": claim,
+        "freshness": {
+            "issued_at": issued_at,
+            "observed_at": observed_at,
+            "status": freshness_status,
+        },
+        "revocation": {
+            "status": revocation_status,
+        },
+        "applicability": {
+            "status": applicability_status,
+            "reasons": sorted(set(reasons)),
+        },
+        "evidence_digest": evidence_digest,
+        "evidence_refs": _string_list(adapter_result, "evidence_refs"),
+        "interpretation": {
+            "authority_effect": "none",
+            "memory_authority": "not_established",
+            "semantic_correctness": "not_established",
+            "lifecycle_satisfaction": "not_established",
+        },
+    }
+    if expires_at is not None:
+        normalized_body["freshness"]["expires_at"] = expires_at
+    if revocation_evidence_ref is not None:
+        normalized_body["revocation"]["evidence_ref"] = revocation_evidence_ref
+
+    normalized_body["evidence_id"] = "external-evidence:" + _sha256_jcs(normalized_body)
+    receipts.validate("external-evidence-normalized.schema.json", normalized_body)
+    return normalized_body

--- a/reference/tests/test_external_evidence.py
+++ b/reference/tests/test_external_evidence.py
@@ -1,0 +1,164 @@
+"""Vendor-neutral external trust/attestation evidence tests for issue #180."""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from agentmem_ref.external_evidence import (
+    EvidenceContext,
+    TRACE_PEER,
+    TRACE_RELEASE,
+    TRACE_VERSION,
+    normalize_external_evidence,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "external-evidence-normalization-matrix.json"
+
+
+class ExternalEvidenceNormalizationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MATRIX.read_text(encoding="utf-8"))
+        context = cls.data["context"]
+        cls.context = EvidenceContext(
+            subject_ref=context["subject_ref"],
+            scope=context["scope"],
+            tenant_ref=context["tenant_ref"],
+            resource_ref=context["resource_ref"],
+            action_ref=context["action_ref"],
+        )
+        cls.observed_at = context["observed_at"]
+
+    def _normalize_case(self, case: dict) -> dict:
+        record = copy.deepcopy(self.data["base_adapter_result"])
+        record.update(copy.deepcopy(case["input_overrides"]))
+        for field in case["remove_fields"]:
+            record.pop(field, None)
+        return normalize_external_evidence(
+            record,
+            context=self.context,
+            observed_at=self.observed_at,
+        )
+
+    def test_trace_reference_is_exactly_pinned(self):
+        pinned = self.data["pinned_reference"]
+        self.assertEqual(pinned["source_peer"], TRACE_PEER)
+        self.assertEqual(pinned["source_version"], TRACE_VERSION)
+        self.assertEqual(pinned["source_release_ref"], TRACE_RELEASE)
+
+    def test_adversarial_matrix(self):
+        for case in self.data["cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                result = self._normalize_case(case)
+                self.assertEqual(result["applicability"]["status"], case["expected_status"])
+                for reason in case["expected_reasons"]:
+                    self.assertIn(reason, result["applicability"]["reasons"])
+
+                self.assertEqual(result["interpretation"]["authority_effect"], "none")
+                self.assertEqual(result["interpretation"]["memory_authority"], "not_established")
+                self.assertEqual(result["interpretation"]["semantic_correctness"], "not_established")
+                self.assertEqual(result["interpretation"]["lifecycle_satisfaction"], "not_established")
+
+    def test_verified_identity_and_execution_claim_do_not_create_memory_authority(self):
+        result = self._normalize_case(self.data["cases"][0])
+        self.assertEqual(result["verification"]["status"], "verified")
+        self.assertEqual(result["claim"]["type"], "execution")
+        self.assertEqual(result["applicability"]["status"], "applicable")
+        self.assertEqual(result["interpretation"]["authority_effect"], "none")
+        self.assertNotIn("pama_outcome", result)
+        self.assertNotIn("permitted_actions", result)
+
+    def test_wrong_scope_remains_mismatch_even_when_verified(self):
+        case = next(case for case in self.data["cases"] if case["case_id"] == "verified-wrong-scope")
+        result = self._normalize_case(case)
+        self.assertEqual(result["verification"]["status"], "verified")
+        self.assertEqual(result["applicability"]["status"], "mismatch")
+        self.assertIn("scope_mismatch", result["applicability"]["reasons"])
+
+    def test_unknown_verification_is_not_coerced_to_valid(self):
+        case = next(case for case in self.data["cases"] if case["case_id"] == "unknown-verification")
+        result = self._normalize_case(case)
+        self.assertEqual(result["verification"]["status"], "unknown")
+        self.assertEqual(result["applicability"]["status"], "insufficient_evidence")
+
+    def test_expired_and_revoked_evidence_are_not_current_authority(self):
+        for case_id in ("expired-evidence", "revoked-evidence"):
+            case = next(case for case in self.data["cases"] if case["case_id"] == case_id)
+            result = self._normalize_case(case)
+            self.assertEqual(result["applicability"]["status"], "stale")
+            self.assertEqual(result["interpretation"]["authority_effect"], "none")
+
+    def test_decision_evidence_does_not_claim_enforcement_or_execution(self):
+        case = next(
+            case
+            for case in self.data["cases"]
+            if case["case_id"] == "decision-evidence-does-not-become-execution"
+        )
+        result = self._normalize_case(case)
+        self.assertEqual(result["claim"]["type"], "decision")
+        self.assertIn("decision_ref", result["claim"])
+        self.assertIn("decision_disposition", result["claim"])
+        self.assertNotIn("enforcement_posture", result["claim"])
+        self.assertNotIn("execution_posture", result["claim"])
+
+    def test_runtime_attestation_does_not_claim_semantic_correctness(self):
+        record = copy.deepcopy(self.data["base_adapter_result"])
+        record["claim_type"] = "runtime_configuration"
+        record.pop("execution_posture", None)
+        record.pop("enforcement_posture", None)
+        result = normalize_external_evidence(
+            record,
+            context=self.context,
+            observed_at=self.observed_at,
+        )
+        self.assertEqual(result["applicability"]["status"], "applicable")
+        self.assertEqual(result["interpretation"]["semantic_correctness"], "not_established")
+
+    def test_peer_only_authority_fields_are_dropped(self):
+        case = next(case for case in self.data["cases"] if case["case_id"] == "peer-only-authority-fields-ignored")
+        result = self._normalize_case(case)
+        serialized = json.dumps(result, sort_keys=True)
+        self.assertNotIn("pama_outcome", serialized)
+        self.assertNotIn("permitted_actions", serialized)
+        self.assertNotIn("trust_score", serialized)
+        self.assertNotIn("lifecycle_state", serialized)
+        self.assertEqual(result["interpretation"]["authority_effect"], "none")
+
+    def test_adapter_removal_leaves_only_generic_evidence_contract(self):
+        result = self._normalize_case(self.data["cases"][0])
+        self.assertEqual(result["source"]["peer"], "TRACE")
+        self.assertEqual(result["source"]["adapter_id"], "agent-memory.trace-reference-adapter")
+        self.assertNotIn("raw_payload", result)
+        self.assertNotIn("trace_record", result)
+        self.assertNotIn("signature", result)
+        self.assertIn("evidence_digest", result)
+        self.assertIn("record_ref", result["source"])
+
+    def test_malformed_peer_evidence_is_rejected_before_normalization(self):
+        record = copy.deepcopy(self.data["base_adapter_result"])
+        record["parse_status"] = "malformed"
+        with self.assertRaisesRegex(ValueError, "malformed/unparsed"):
+            normalize_external_evidence(
+                record,
+                context=self.context,
+                observed_at=self.observed_at,
+            )
+
+    def test_missing_required_context_binding_is_mismatch_not_optimistic_match(self):
+        record = copy.deepcopy(self.data["base_adapter_result"])
+        record.pop("resource_ref")
+        result = normalize_external_evidence(
+            record,
+            context=self.context,
+            observed_at=self.observed_at,
+        )
+        self.assertEqual(result["applicability"]["status"], "mismatch")
+        self.assertIn("missing_resource_ref_binding", result["applicability"]["reasons"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/external-evidence-normalized.schema.json
+++ b/schemas/external-evidence-normalized.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/external-evidence-normalized.schema.json",
+  "title": "Agent Memory Normalized External Evidence",
+  "description": "Vendor-neutral, content-minimized evidence candidate produced from a peer adapter/verifier result. Verification and applicability are evidence facts only and never create Agent Memory authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_version",
+    "evidence_id",
+    "source",
+    "issuer",
+    "verification",
+    "claim",
+    "freshness",
+    "revocation",
+    "applicability",
+    "evidence_digest",
+    "evidence_refs",
+    "interpretation"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "profile_version": { "const": "0.1.0" },
+    "evidence_id": { "type": "string", "pattern": "^external-evidence:sha256:[0-9a-f]{64}$" },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["peer", "version", "release_ref", "record_ref", "adapter_id", "adapter_version", "parse_status"],
+      "properties": {
+        "peer": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "release_ref": { "type": "string", "minLength": 1 },
+        "record_ref": { "type": "string", "minLength": 1 },
+        "adapter_id": { "type": "string", "minLength": 1 },
+        "adapter_version": { "type": "string", "minLength": 1 },
+        "parse_status": { "const": "parsed" }
+      }
+    },
+    "issuer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "signer_id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "verifier_id", "method"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["verified", "failed", "unknown", "not_performed", "unavailable"]
+        },
+        "verifier_id": { "type": "string", "minLength": 1 },
+        "method": { "type": "string", "minLength": 1 }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "source_claim_type", "scope", "subject_ref", "limitations"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["identity", "attestation", "runtime_configuration", "decision", "enforcement", "execution", "delegation", "other"]
+        },
+        "source_claim_type": { "type": "string", "minLength": 1 },
+        "scope": { "type": "string", "minLength": 1 },
+        "subject_ref": { "type": "string", "minLength": 1 },
+        "tenant_ref": { "type": "string", "minLength": 1 },
+        "resource_ref": { "type": "string", "minLength": 1 },
+        "action_ref": { "type": "string", "minLength": 1 },
+        "runtime_ref": { "type": "string", "minLength": 1 },
+        "configuration_ref": { "type": "string", "minLength": 1 },
+        "policy_ref": { "type": "string", "minLength": 1 },
+        "decision_ref": { "type": "string", "minLength": 1 },
+        "decision_disposition": { "type": "string", "minLength": 1 },
+        "enforcement_posture": { "type": "string", "minLength": 1 },
+        "execution_posture": { "type": "string", "minLength": 1 },
+        "attestation_mode": { "type": "string", "minLength": 1 },
+        "delegation_ref": { "type": "string", "minLength": 1 },
+        "limitations": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issued_at", "observed_at", "status"],
+      "properties": {
+        "issued_at": { "type": "string", "format": "date-time" },
+        "observed_at": { "type": "string", "format": "date-time" },
+        "expires_at": { "type": "string", "format": "date-time" },
+        "status": { "type": "string", "enum": ["current", "expired", "not_yet_valid"] }
+      }
+    },
+    "revocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "type": "string", "enum": ["not_revoked", "revoked", "unknown"] },
+        "evidence_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "applicability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reasons"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["applicable", "mismatch", "stale", "unsupported", "insufficient_evidence", "invalid"]
+        },
+        "reasons": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "evidence_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "interpretation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authority_effect", "memory_authority", "semantic_correctness", "lifecycle_satisfaction"],
+      "properties": {
+        "authority_effect": { "const": "none" },
+        "memory_authority": { "const": "not_established" },
+        "semantic_correctness": { "const": "not_established" },
+        "lifecycle_satisfaction": { "const": "not_established" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the **P0-B / V0.1 external trust and attestation evidence normalization boundary** for #180, now that #152 / PR #179 has merged.

## V0.1 surface

This branch adds:

- a vendor-neutral external evidence normalizer that consumes peer adapter/verifier results rather than raw peer payloads;
- explicit separation of parsing, verification, freshness, revocation, and current-context applicability;
- deterministic subject/scope/tenant/resource/action binding checks;
- a strict normalized evidence schema with no peer-derived PAMA permission or canonical lifecycle fields;
- fixed interpretation non-claims: external evidence does not establish Agent Memory authority, semantic correctness, or lifecycle satisfaction;
- a pinned TRACE reference comparator using the repository's existing P4.5c pin (`agentrust-trace==0.8.0`, release `671f2a8b22f1c995798a0c6d711b4b0b77dad4c7`);
- adversarial fixtures and tests for wrong scope/action/tenant, expiry, revocation, unknown/failed verification, verifier unavailability, unsupported versions/types, missing bindings, and peer-only authority-field injection;
- a profile documenting supported deployment assumptions, privacy/minimization, rollback, what V0.1 proves, and explicit non-claims.

## Core invariant

```text
payload parsed
!= signature / claim verified
!= claim current
!= claim applicable to this subject/action/scope
!= Agent Memory authority
```

and:

```text
verified identity != memory authority
valid attestation != semantic correctness
policy / decision evidence != enforcement evidence
execution evidence != lifecycle obligation satisfaction
```

## Reference peer boundary

TRACE is used only as a pinned fixture/comparator. V0.1 does not add a mandatory TRACE runtime dependency, adopt TRACE ontology as canonical Agent Memory semantics, or require a TRACE core-schema change.

Unknown or future peer fields cannot widen PAMA or mutate canonical lifecycle state because the normalized output is constructed only from the vendor-neutral evidence contract.

## Negative-path behavior

The fixture set requires, among others:

```text
verified + wrong scope/tenant/action -> mismatch
verified + expired/revoked -> stale
unknown/unperformed/unavailable verification -> insufficient_evidence
failed verification -> invalid
unsupported peer version/claim type -> unsupported
missing required context binding -> mismatch
decision evidence with no execution claim -> remains decision evidence
peer-supplied pama/lifecycle/trust-score fields -> discarded
```

## Validation state

The branch was written through the GitHub connector. A separate local clone/test attempt could not run because the current execution runtime could not resolve `github.com`; that failure is **not** treated as validation evidence.

This PR remains draft until GitHub Actions validate the exact head and a bounded completion review confirms #180's acceptance criteria.

## Stop line

Do not expand this PR into:

- a second peer adapter;
- production trust-anchor/key discovery or revocation infrastructure;
- cross-organization delegation authority;
- PAMA changes;
- canonical lifecycle changes;
- raw attestation-bundle persistence;
- TRACE/cMCP core-spec changes;
- precedent applicability work from #181.

Closes #180 only when the V0.1 acceptance criteria and exact-head CI are satisfied.