### PR TITLE
Add execution witness and enforcement posture evidence

### DIFF
--- a/docs/profiles/enforcement-evidence-profile.md
+++ b/docs/profiles/enforcement-evidence-profile.md
@@ -1,0 +1,195 @@
+# Enforcement Evidence and Posture Profile
+
+Status: reference V0.1 implementation profile for issue #152 Phase 3.
+
+## Purpose
+
+This profile closes the evidence gap between a governance decision and an observed enforcement/execution event.
+
+```text
+decision issued
+!= decision delivered
+!= enforcement point reached
+!= action prevented / executed
+```
+
+The profile therefore adds two vendor-neutral surfaces:
+
+- `execution-witness.schema.json` for a specific observed event bound to the exact composed decision identity;
+- `enforcement-posture-report.schema.json` for machine-readable configured enforcement modes, witness coverage, liveness, and the evidence scope actually observed.
+
+Neither surface changes Agent Memory memory semantics or PAMA authority.
+
+## Execution witness
+
+Reference implementation:
+
+`reference/agentmem_ref/enforcement_evidence.py`
+
+A witness binds to:
+
+```text
+input_identity
+composition_id
+action_ref
+witness_ref
+effective_decision
+enforcement_mode
+delivery_status
+enforcement_point_status
+action_status
+liveness_status
+observed_at
+```
+
+The witness may report:
+
+```text
+enforcement_mode = mechanical | cooperative | unknown
+delivery_status = delivered | failed | not_observed
+enforcement_point_status = reached | unavailable | not_observed
+action_status = executed | prevented | refused | unknown | not_observed
+```
+
+An action outcome cannot be claimed unless the enforcement point itself was observed.
+
+A witness input identity that does not match the composed decision is rejected.
+
+## Negative evidence is first-class
+
+A runtime action that executes despite an effective `deny` is preserved as:
+
+```text
+effective_decision = deny
+action_status = executed
+decision_alignment = violation
+```
+
+It is not discarded as malformed evidence. The violation is the evidence.
+
+For permitted actions, downstream prevention/refusal is represented as `stricter_than_decision`, because a downstream enforcement layer may narrow permission without widening it.
+
+For `require_approval`, observed execution alone is `unverifiable`; this V0.1 witness does not infer that an approval reference is valid or correctly bound merely because execution occurred.
+
+## Non-claims
+
+Every execution witness explicitly preserves these limits:
+
+```text
+lifecycle_satisfaction_not_established
+execution_witness_does_not_create_memory_authority
+```
+
+Execution evidence can show that an action occurred or was prevented. It does not prove correction completeness, forgetting, deletion closure, semantic authorization, or other lifecycle obligations.
+
+## Enforcement posture
+
+The posture report covers these surfaces independently:
+
+```text
+memory_write
+recall_admission
+background_maintenance
+external_import
+```
+
+Each is:
+
+```text
+mechanical | cooperative | unknown
+```
+
+Execution-witness capability is recorded separately as:
+
+```text
+available | partial | absent
+```
+
+Liveness is:
+
+```text
+healthy | degraded | unavailable | unknown
+```
+
+Most importantly, configured governance is not reported as observed enforcement.
+
+The report derives exactly one evidence scope:
+
+```text
+configuration_only
+witness_capability_only
+observed_enforcement
+```
+
+Examples:
+
+```text
+governance configured + no witness capability + zero witnesses
+-> configuration_only
+
+witness capability available + zero observed witnesses
+-> witness_capability_only
+
+one or more observed witnesses
+-> observed_enforcement
+```
+
+This prevents a configured policy engine or SDK hook from being described as mechanically enforced merely because it exists.
+
+## Adversarial fixture
+
+Fixture:
+
+`fixtures/enforcement-evidence-matrix.json`
+
+Tests:
+
+`reference/tests/test_enforcement_evidence.py`
+
+The V0.1 set covers:
+
+- deny + mechanical prevention;
+- deny + observed execution violation;
+- allow + execution;
+- allow + stricter downstream prevention;
+- approval-required + execution without approval verification;
+- decision delivered while the enforcement point remains unobserved;
+- configured governance with enforcement/witness absent;
+- witness capability present without an observed event;
+- observed enforcement posture;
+- action-identity mismatch;
+- impossible action-outcome overclaim without an observed enforcement point.
+
+## Relationship to decision composition
+
+This profile consumes the existing decision-composition receipt created by the #152 Phase 1 V0.1 seam.
+
+The composed decision remains immutable decision evidence. Execution evidence is a separate artifact bound back to the composition identity and exact `input_identity`.
+
+That separation prevents later runtime observations from rewriting what the original policy decision claimed.
+
+## What V0.1 proves
+
+Within the bounded fixture set, the profile demonstrates that:
+
+- action identity remains bound through execution evidence;
+- decision delivery is separate from enforcement-point observation;
+- cooperative, mechanical, and unknown enforcement modes are representable;
+- configured governance without observed enforcement stays `configuration_only`;
+- downstream execution despite deny is visible as a violation;
+- a witness cannot overclaim action execution/prevention when the enforcement point was not observed;
+- execution evidence does not imply lifecycle satisfaction.
+
+## What V0.1 does not prove
+
+This slice does not prove:
+
+- that every host intercept path is mechanically complete;
+- production liveness monitoring;
+- approval validity or approval-authority continuity;
+- physical-world completion;
+- lifecycle obligation satisfaction;
+- correctness of a third-party enforcement product;
+- AGT, DashClaw, OPA, Cedar, or other peer-specific interoperability.
+
+Those remain separate evidence or comparator slices.

--- a/fixtures/enforcement-evidence-matrix.json
+++ b/fixtures/enforcement-evidence-matrix.json
@@ -1,0 +1,148 @@
+{
+  "fixture_id": "enforcement-evidence-matrix",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "Execution witness and posture cases distinguish configured governance, delivered decisions, observed enforcement points, and action outcomes without inferring lifecycle satisfaction.",
+  "expected_behavior": {
+    "witness_cases": 6,
+    "decision_violations_observed": 1,
+    "configuration_only_postures": 1,
+    "witness_capability_only_postures": 1,
+    "observed_enforcement_postures": 1
+  },
+  "memory_unit": {
+    "id": "mem:enforcement-evidence",
+    "content_ref": "fixture://enforcement-evidence/action",
+    "type": "decision",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "enforcement-evidence-matrix",
+      "timestamp": "2026-08-12T21:20:00Z",
+      "source_refs": ["issue://152"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:enforcement-evidence",
+        "kind": "execution_witness_fixture",
+        "ref": "issue://152",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["enforcement_evidence", "execution_observation"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "high",
+      "policy_refs": ["issue:152", "ADR-020", "ADR-021"],
+      "permitted_actions": ["collect_more_evidence", "defer"],
+      "prohibited_actions": ["promotion"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T21:20:00Z"
+  },
+  "witness_cases": [
+    {
+      "case_id": "deny-prevented-mechanically",
+      "local_pama_outcome": "block",
+      "enforcement_mode": "mechanical",
+      "delivery_status": "delivered",
+      "enforcement_point_status": "reached",
+      "action_status": "prevented",
+      "liveness_status": "healthy",
+      "expected_alignment": "consistent"
+    },
+    {
+      "case_id": "deny-but-action-executed",
+      "local_pama_outcome": "block",
+      "enforcement_mode": "cooperative",
+      "delivery_status": "delivered",
+      "enforcement_point_status": "reached",
+      "action_status": "executed",
+      "liveness_status": "degraded",
+      "expected_alignment": "violation"
+    },
+    {
+      "case_id": "allow-and-action-executed",
+      "local_pama_outcome": "allow_with_ledger",
+      "enforcement_mode": "mechanical",
+      "delivery_status": "delivered",
+      "enforcement_point_status": "reached",
+      "action_status": "executed",
+      "liveness_status": "healthy",
+      "expected_alignment": "consistent"
+    },
+    {
+      "case_id": "allow-but-host-prevents",
+      "local_pama_outcome": "allow_with_ledger",
+      "enforcement_mode": "mechanical",
+      "delivery_status": "delivered",
+      "enforcement_point_status": "reached",
+      "action_status": "prevented",
+      "liveness_status": "healthy",
+      "expected_alignment": "stricter_than_decision"
+    },
+    {
+      "case_id": "approval-required-but-execution-observed",
+      "local_pama_outcome": "require_review",
+      "enforcement_mode": "cooperative",
+      "delivery_status": "delivered",
+      "enforcement_point_status": "reached",
+      "action_status": "executed",
+      "liveness_status": "healthy",
+      "expected_alignment": "unverifiable"
+    },
+    {
+      "case_id": "decision-delivered-enforcement-not-observed",
+      "local_pama_outcome": "block",
+      "enforcement_mode": "unknown",
+      "delivery_status": "delivered",
+      "enforcement_point_status": "not_observed",
+      "action_status": "not_observed",
+      "liveness_status": "unknown",
+      "expected_alignment": "unverifiable"
+    }
+  ],
+  "posture_cases": [
+    {
+      "case_id": "governance-configured-enforcement-absent",
+      "configured_governance": true,
+      "memory_write": "cooperative",
+      "recall_admission": "unknown",
+      "background_maintenance": "unknown",
+      "external_import": "cooperative",
+      "execution_witness": "absent",
+      "observed_witness_count": 0,
+      "liveness_status": "degraded",
+      "expected_evidence_scope": "configuration_only"
+    },
+    {
+      "case_id": "witness-capability-without-event",
+      "configured_governance": true,
+      "memory_write": "mechanical",
+      "recall_admission": "mechanical",
+      "background_maintenance": "cooperative",
+      "external_import": "mechanical",
+      "execution_witness": "available",
+      "observed_witness_count": 0,
+      "liveness_status": "healthy",
+      "expected_evidence_scope": "witness_capability_only"
+    },
+    {
+      "case_id": "observed-enforcement-posture",
+      "configured_governance": true,
+      "memory_write": "mechanical",
+      "recall_admission": "mechanical",
+      "background_maintenance": "cooperative",
+      "external_import": "mechanical",
+      "execution_witness": "available",
+      "observed_witness_count": 3,
+      "liveness_status": "healthy",
+      "expected_evidence_scope": "observed_enforcement"
+    }
+  ]
+}

--- a/reference/agentmem_ref/enforcement_evidence.py
+++ b/reference/agentmem_ref/enforcement_evidence.py
@@ -1,0 +1,195 @@
+"""Vendor-neutral enforcement evidence for issue #152 Phase 3.
+
+This module keeps configured governance, decision delivery, enforcement-point
+observation, and action execution/prevention as distinct evidence states.
+A decision receipt is never upgraded to execution proof by inference.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import rfc8785
+
+from . import receipts
+
+WITNESS_VERSION = "0.1.0"
+POSTURE_VERSION = "0.1.0"
+
+ENFORCEMENT_MODES = {"mechanical", "cooperative", "unknown"}
+DELIVERY_STATUSES = {"delivered", "failed", "not_observed"}
+POINT_STATUSES = {"reached", "unavailable", "not_observed"}
+ACTION_STATUSES = {"executed", "prevented", "refused", "unknown", "not_observed"}
+LIVENESS_STATUSES = {"healthy", "degraded", "unavailable", "unknown"}
+WITNESS_COVERAGE = {"available", "partial", "absent"}
+
+
+def _sha256_ref(value: dict) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+
+
+def _alignment(effective_decision: str, action_status: str, enforcement_point_status: str) -> str:
+    if enforcement_point_status != "reached" or action_status in {"unknown", "not_observed"}:
+        return "unverifiable"
+
+    if effective_decision == "deny":
+        return "violation" if action_status == "executed" else "consistent"
+
+    if effective_decision in {"allow", "warn"}:
+        if action_status == "executed":
+            return "consistent"
+        if action_status in {"prevented", "refused"}:
+            return "stricter_than_decision"
+        return "unverifiable"
+
+    # ``require_approval`` cannot be upgraded to authorized execution merely
+    # because a witness sees execution. Approval validity is a separate check.
+    if effective_decision == "require_approval":
+        if action_status in {"prevented", "refused"}:
+            return "consistent"
+        return "unverifiable"
+
+    return "unverifiable"
+
+
+def build_execution_witness(
+    composition: dict,
+    *,
+    action_ref: str,
+    witness_ref: str,
+    enforcement_mode: str,
+    delivery_status: str,
+    enforcement_point_status: str,
+    action_status: str,
+    liveness_status: str,
+    observed_at: str,
+    observed_input_identity: str | None = None,
+    approval_evidence_ref: str | None = None,
+    evidence_refs: tuple[str, ...] = (),
+) -> dict:
+    """Bind an observed enforcement/execution event to a composed decision.
+
+    The witness may record a policy violation rather than rejecting the event.
+    That distinction matters: evidence that an action executed despite ``deny``
+    is valuable negative evidence, not malformed evidence.
+    """
+
+    receipts.validate("decision-composition-receipt.schema.json", composition)
+    if not action_ref or not witness_ref or not observed_at:
+        raise ValueError("execution witness requires action_ref, witness_ref, and observed_at")
+    if enforcement_mode not in ENFORCEMENT_MODES:
+        raise ValueError(f"invalid enforcement_mode {enforcement_mode!r}")
+    if delivery_status not in DELIVERY_STATUSES:
+        raise ValueError(f"invalid delivery_status {delivery_status!r}")
+    if enforcement_point_status not in POINT_STATUSES:
+        raise ValueError(f"invalid enforcement_point_status {enforcement_point_status!r}")
+    if action_status not in ACTION_STATUSES:
+        raise ValueError(f"invalid action_status {action_status!r}")
+    if liveness_status not in LIVENESS_STATUSES:
+        raise ValueError(f"invalid liveness_status {liveness_status!r}")
+
+    identity = composition["input_identity"]
+    if observed_input_identity is not None and observed_input_identity != identity:
+        raise ValueError("execution witness input identity does not match composed decision")
+
+    if enforcement_point_status == "reached" and delivery_status != "delivered":
+        raise ValueError("reached enforcement point requires delivered decision evidence")
+    if enforcement_point_status != "reached" and action_status in {"executed", "prevented", "refused"}:
+        raise ValueError("action outcome cannot be claimed without observing the enforcement point")
+
+    body = {
+        "input_identity": identity,
+        "composition_id": composition["composition_id"],
+        "action_ref": action_ref,
+        "witness_ref": witness_ref,
+        "effective_decision": composition["effective_decision"],
+        "enforcement_mode": enforcement_mode,
+        "delivery_status": delivery_status,
+        "enforcement_point_status": enforcement_point_status,
+        "action_status": action_status,
+        "decision_alignment": _alignment(
+            composition["effective_decision"], action_status, enforcement_point_status
+        ),
+        "liveness_status": liveness_status,
+        "observed_at": observed_at,
+        "evidence_refs": list(dict.fromkeys(evidence_refs)),
+        "non_claims": [
+            "lifecycle_satisfaction_not_established",
+            "execution_witness_does_not_create_memory_authority",
+        ],
+    }
+    if approval_evidence_ref:
+        body["approval_evidence_ref"] = approval_evidence_ref
+
+    witness = {
+        "schema_version": "1.0.0",
+        "witness_version": WITNESS_VERSION,
+        "witness_id": f"execution-witness:{_sha256_ref(body)}",
+        **body,
+    }
+    receipts.validate("execution-witness.schema.json", witness)
+    return witness
+
+
+def build_posture_report(
+    *,
+    policy_context_ref: str,
+    configured_governance: bool,
+    memory_write: str,
+    recall_admission: str,
+    background_maintenance: str,
+    external_import: str,
+    execution_witness: str,
+    observed_witness_count: int,
+    liveness_status: str,
+    generated_at: str,
+    evidence_refs: tuple[str, ...] = (),
+) -> dict:
+    """Describe configured enforcement separately from what was actually seen."""
+
+    if not policy_context_ref or not generated_at:
+        raise ValueError("posture report requires policy_context_ref and generated_at")
+    surfaces = {
+        "memory_write": memory_write,
+        "recall_admission": recall_admission,
+        "background_maintenance": background_maintenance,
+        "external_import": external_import,
+    }
+    invalid = {name: value for name, value in surfaces.items() if value not in ENFORCEMENT_MODES}
+    if invalid:
+        raise ValueError(f"invalid enforcement surface modes: {invalid}")
+    if execution_witness not in WITNESS_COVERAGE:
+        raise ValueError(f"invalid execution_witness coverage {execution_witness!r}")
+    if liveness_status not in LIVENESS_STATUSES:
+        raise ValueError(f"invalid liveness_status {liveness_status!r}")
+    if observed_witness_count < 0:
+        raise ValueError("observed_witness_count cannot be negative")
+    if execution_witness == "absent" and observed_witness_count:
+        raise ValueError("absent execution witness capability cannot have observed witnesses")
+
+    if observed_witness_count > 0:
+        evidence_scope = "observed_enforcement"
+    elif execution_witness in {"available", "partial"}:
+        evidence_scope = "witness_capability_only"
+    else:
+        evidence_scope = "configuration_only"
+
+    body = {
+        "policy_context_ref": policy_context_ref,
+        "configured_governance": configured_governance,
+        "surfaces": surfaces,
+        "execution_witness": execution_witness,
+        "observed_witness_count": observed_witness_count,
+        "liveness_status": liveness_status,
+        "evidence_scope": evidence_scope,
+        "generated_at": generated_at,
+        "evidence_refs": list(dict.fromkeys(evidence_refs)),
+    }
+    report = {
+        "schema_version": "1.0.0",
+        "posture_version": POSTURE_VERSION,
+        "report_id": f"enforcement-posture:{_sha256_ref(body)}",
+        **body,
+    }
+    receipts.validate("enforcement-posture-report.schema.json", report)
+    return report

--- a/reference/tests/test_enforcement_evidence.py
+++ b/reference/tests/test_enforcement_evidence.py
@@ -1,0 +1,193 @@
+"""Execution witness and enforcement posture tests for issue #152 Phase 3."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from agentmem_ref import policy
+from agentmem_ref.enforcement_composition import PROVIDER_NONE, build_projection, compose
+from agentmem_ref.enforcement_evidence import build_execution_witness, build_posture_report
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "enforcement-evidence-matrix.json"
+OPERATION = "promotion"
+
+
+def _proposal() -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id="proposal:enforcement-evidence",
+        actor_id="agent:planner",
+        charter_version="charter:enforcement-evidence",
+        target_reference="mem:enforcement-evidence",
+        target_class=policy.M4,
+        scope="tenant-a",
+        operation=OPERATION,
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A3,
+        reversibility="reversible",
+        risk_class="high",
+        evidence_refs=("evidence:proposal",),
+        state_snapshot="state:v1",
+        tenant_ref="tenant-a",
+        purpose="enforcement-evidence",
+        isolation_domain_refs=("domain:project-a",),
+        required_isolation_domain_refs=("domain:project-a",),
+    )
+
+
+def _decision(outcome: str) -> policy.Decision:
+    if outcome in (policy.ALLOW, policy.ALLOW_WITH_LEDGER):
+        permitted = (OPERATION, "collect_more_evidence", "defer")
+        prohibited = ()
+    elif outcome == policy.REQUIRE_REVIEW:
+        permitted = ("enter_pending_verification", "collect_more_evidence", "defer")
+        prohibited = (OPERATION,)
+    elif outcome == policy.REQUIRE_EXTERNAL_VERIFICATION:
+        permitted = ("request_external_verification", "collect_more_evidence", "defer")
+        prohibited = (OPERATION,)
+    else:
+        permitted = ()
+        prohibited = (OPERATION,)
+    return policy.Decision(
+        outcome=outcome,
+        permitted_actions=permitted,
+        prohibited_actions=prohibited,
+        policy_version="ref-enforcement-evidence-test",
+    )
+
+
+def _composition(outcome: str) -> dict:
+    projection = build_projection(_proposal(), _decision(outcome))
+    return compose(projection, provider_mode=PROVIDER_NONE)
+
+
+class EnforcementEvidenceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.matrix = json.loads(MATRIX.read_text(encoding="utf-8"))
+
+    def test_witness_matrix(self):
+        violation_count = 0
+        for case in self.matrix["witness_cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                composition = _composition(case["local_pama_outcome"])
+                witness = build_execution_witness(
+                    composition,
+                    action_ref=f"action:{case['case_id']}",
+                    witness_ref=f"witness-source:{case['case_id']}",
+                    enforcement_mode=case["enforcement_mode"],
+                    delivery_status=case["delivery_status"],
+                    enforcement_point_status=case["enforcement_point_status"],
+                    action_status=case["action_status"],
+                    liveness_status=case["liveness_status"],
+                    observed_at="2026-08-12T21:20:00Z",
+                    evidence_refs=(f"evidence:{case['case_id']}",),
+                )
+                self.assertEqual(witness["input_identity"], composition["input_identity"])
+                self.assertEqual(witness["composition_id"], composition["composition_id"])
+                self.assertEqual(witness["decision_alignment"], case["expected_alignment"])
+                self.assertIn("lifecycle_satisfaction_not_established", witness["non_claims"])
+                self.assertIn("execution_witness_does_not_create_memory_authority", witness["non_claims"])
+                if witness["decision_alignment"] == "violation":
+                    violation_count += 1
+
+        self.assertEqual(violation_count, self.matrix["expected_behavior"]["decision_violations_observed"])
+        self.assertEqual(len(self.matrix["witness_cases"]), self.matrix["expected_behavior"]["witness_cases"])
+
+    def test_denied_action_executing_is_negative_evidence_not_invalid_input(self):
+        composition = _composition(policy.BLOCK)
+        witness = build_execution_witness(
+            composition,
+            action_ref="action:executed-despite-deny",
+            witness_ref="runtime:audit:1",
+            enforcement_mode="cooperative",
+            delivery_status="delivered",
+            enforcement_point_status="reached",
+            action_status="executed",
+            liveness_status="degraded",
+            observed_at="2026-08-12T21:20:00Z",
+        )
+        self.assertEqual(witness["effective_decision"], "deny")
+        self.assertEqual(witness["action_status"], "executed")
+        self.assertEqual(witness["decision_alignment"], "violation")
+
+    def test_witness_identity_mismatch_is_rejected(self):
+        composition = _composition(policy.ALLOW_WITH_LEDGER)
+        with self.assertRaisesRegex(ValueError, "input identity"):
+            build_execution_witness(
+                composition,
+                action_ref="action:mismatch",
+                witness_ref="runtime:audit:mismatch",
+                enforcement_mode="mechanical",
+                delivery_status="delivered",
+                enforcement_point_status="reached",
+                action_status="executed",
+                liveness_status="healthy",
+                observed_at="2026-08-12T21:20:00Z",
+                observed_input_identity="sha256:" + "0" * 64,
+            )
+
+    def test_action_outcome_requires_observed_enforcement_point(self):
+        composition = _composition(policy.BLOCK)
+        with self.assertRaisesRegex(ValueError, "without observing the enforcement point"):
+            build_execution_witness(
+                composition,
+                action_ref="action:overclaim",
+                witness_ref="runtime:audit:overclaim",
+                enforcement_mode="unknown",
+                delivery_status="delivered",
+                enforcement_point_status="not_observed",
+                action_status="prevented",
+                liveness_status="unknown",
+                observed_at="2026-08-12T21:20:00Z",
+            )
+
+    def test_posture_matrix_separates_configuration_capability_and_observation(self):
+        counts = {
+            "configuration_only": 0,
+            "witness_capability_only": 0,
+            "observed_enforcement": 0,
+        }
+        for case in self.matrix["posture_cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                report = build_posture_report(
+                    policy_context_ref="policy-context:fixture",
+                    configured_governance=case["configured_governance"],
+                    memory_write=case["memory_write"],
+                    recall_admission=case["recall_admission"],
+                    background_maintenance=case["background_maintenance"],
+                    external_import=case["external_import"],
+                    execution_witness=case["execution_witness"],
+                    observed_witness_count=case["observed_witness_count"],
+                    liveness_status=case["liveness_status"],
+                    generated_at="2026-08-12T21:20:00Z",
+                    evidence_refs=(f"evidence:{case['case_id']}",),
+                )
+                self.assertEqual(report["evidence_scope"], case["expected_evidence_scope"])
+                counts[report["evidence_scope"]] += 1
+
+        self.assertEqual(counts["configuration_only"], self.matrix["expected_behavior"]["configuration_only_postures"])
+        self.assertEqual(counts["witness_capability_only"], self.matrix["expected_behavior"]["witness_capability_only_postures"])
+        self.assertEqual(counts["observed_enforcement"], self.matrix["expected_behavior"]["observed_enforcement_postures"])
+
+    def test_absent_witness_capability_cannot_claim_observed_witnesses(self):
+        with self.assertRaisesRegex(ValueError, "absent execution witness"):
+            build_posture_report(
+                policy_context_ref="policy-context:invalid",
+                configured_governance=True,
+                memory_write="cooperative",
+                recall_admission="unknown",
+                background_maintenance="unknown",
+                external_import="cooperative",
+                execution_witness="absent",
+                observed_witness_count=1,
+                liveness_status="degraded",
+                generated_at="2026-08-12T21:20:00Z",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/enforcement-posture-report.schema.json
+++ b/schemas/enforcement-posture-report.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/enforcement-posture-report.schema.json",
+  "title": "Agent Memory Enforcement Posture Report",
+  "description": "Machine-readable statement of configured enforcement modes, witness coverage, liveness, and the evidence scope actually observed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "posture_version",
+    "report_id",
+    "policy_context_ref",
+    "configured_governance",
+    "surfaces",
+    "execution_witness",
+    "observed_witness_count",
+    "liveness_status",
+    "evidence_scope",
+    "generated_at",
+    "evidence_refs"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "posture_version": { "const": "0.1.0" },
+    "report_id": { "type": "string", "minLength": 1 },
+    "policy_context_ref": { "type": "string", "minLength": 1 },
+    "configured_governance": { "type": "boolean" },
+    "surfaces": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["memory_write", "recall_admission", "background_maintenance", "external_import"],
+      "properties": {
+        "memory_write": { "$ref": "#/$defs/enforcementMode" },
+        "recall_admission": { "$ref": "#/$defs/enforcementMode" },
+        "background_maintenance": { "$ref": "#/$defs/enforcementMode" },
+        "external_import": { "$ref": "#/$defs/enforcementMode" }
+      }
+    },
+    "execution_witness": {
+      "type": "string",
+      "enum": ["available", "partial", "absent"]
+    },
+    "observed_witness_count": { "type": "integer", "minimum": 0 },
+    "liveness_status": {
+      "type": "string",
+      "enum": ["healthy", "degraded", "unavailable", "unknown"]
+    },
+    "evidence_scope": {
+      "type": "string",
+      "enum": ["configuration_only", "witness_capability_only", "observed_enforcement"]
+    },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "enforcementMode": {
+      "type": "string",
+      "enum": ["mechanical", "cooperative", "unknown"]
+    }
+  }
+}

--- a/schemas/execution-witness.schema.json
+++ b/schemas/execution-witness.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/execution-witness.schema.json",
+  "title": "Agent Memory Execution Witness",
+  "description": "Vendor-neutral evidence correlating a composed governance decision to an observed enforcement/execution event. The witness does not establish lifecycle satisfaction.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "witness_version",
+    "witness_id",
+    "input_identity",
+    "composition_id",
+    "action_ref",
+    "witness_ref",
+    "effective_decision",
+    "enforcement_mode",
+    "delivery_status",
+    "enforcement_point_status",
+    "action_status",
+    "decision_alignment",
+    "liveness_status",
+    "observed_at",
+    "evidence_refs",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "witness_version": { "const": "0.1.0" },
+    "witness_id": { "type": "string", "minLength": 1 },
+    "input_identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "composition_id": { "type": "string", "minLength": 1 },
+    "action_ref": { "type": "string", "minLength": 1 },
+    "witness_ref": { "type": "string", "minLength": 1 },
+    "effective_decision": {
+      "type": "string",
+      "enum": ["allow", "warn", "require_approval", "deny"]
+    },
+    "enforcement_mode": {
+      "type": "string",
+      "enum": ["mechanical", "cooperative", "unknown"]
+    },
+    "delivery_status": {
+      "type": "string",
+      "enum": ["delivered", "failed", "not_observed"]
+    },
+    "enforcement_point_status": {
+      "type": "string",
+      "enum": ["reached", "unavailable", "not_observed"]
+    },
+    "action_status": {
+      "type": "string",
+      "enum": ["executed", "prevented", "refused", "unknown", "not_observed"]
+    },
+    "decision_alignment": {
+      "type": "string",
+      "enum": ["consistent", "stricter_than_decision", "violation", "unverifiable"]
+    },
+    "liveness_status": {
+      "type": "string",
+      "enum": ["healthy", "degraded", "unavailable", "unknown"]
+    },
+    "approval_evidence_ref": { "type": "string", "minLength": 1 },
+    "observed_at": { "type": "string", "format": "date-time" },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "non_claims": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the remaining **Phase 3 enforcement-evidence V0.1** slice of #152 on top of the already-merged vendor-neutral decision composition boundary.

## Implemented

- vendor-neutral execution-witness contract bound to exact `input_identity` and `composition_id`;
- explicit decision delivery vs enforcement-point observation vs action outcome states;
- mechanical / cooperative / unknown enforcement modes;
- liveness state on witnesses and posture reports;
- negative evidence for `deny` followed by observed execution (`decision_alignment = violation`);
- stricter downstream prevention after local allow without authority widening;
- conservative `require_approval` execution handling that remains unverifiable without a separate approval-validity proof;
- machine-readable posture across memory write, recall admission, background maintenance, and external import;
- explicit distinction among `configuration_only`, `witness_capability_only`, and `observed_enforcement`;
- adversarial fixtures/tests for missing enforcement observation, identity mismatch, impossible outcome overclaims, and configured governance with absent witness capability.

## Core evidence boundary

```text
decision issued
!= decision delivered
!= enforcement point reached
!= action prevented / executed
```

Configured governance is not reported as observed enforcement.

## Non-claims

Execution witnesses explicitly do not establish lifecycle satisfaction or create Agent Memory authority.

## Stop line

This PR does not add AGT, DashClaw, OPA, Cedar, or other peer-specific adapters; production liveness infrastructure; approval-authority verification; or lifecycle-completeness claims.

This PR remains draft until exact-head CI and bounded completion review pass.

Refs #152