### PR TITLE
Add privacy-safe runtime trace correlation profile

### DIFF
--- a/docs/profiles/runtime-trace-correlation-profile.md
+++ b/docs/profiles/runtime-trace-correlation-profile.md
@@ -1,0 +1,216 @@
+# Privacy-Safe Runtime Trace Correlation Profile
+
+Status: reference V0.1 implementation profile for issue #185.
+
+## Purpose
+
+This profile correlates Agent Memory governance/evidence artifacts with distributed runtime traces while minimizing exported state and preserving evidence boundaries.
+
+```text
+trace correlation != memory authority
+span success != semantic correctness
+span completion != lifecycle satisfaction
+sampled telemetry != complete execution evidence
+```
+
+The correlation record is a linkage surface. It is not a replacement for PAMA decision receipts, decision-composition receipts, execution witnesses, or lifecycle evidence.
+
+## External reference pin
+
+V0.1 documentation/fixtures use OpenTelemetry Semantic Conventions **v1.42.0** as the pinned external reference point.
+
+The actual Agent Memory profile does not import OpenTelemetry semantic-convention vocabulary as canonical memory semantics and does not require an OpenTelemetry SDK dependency.
+
+The stable trace identity concepts used here are:
+
+```text
+TraceId: 16 bytes / 32 hexadecimal characters
+SpanId:   8 bytes / 16 hexadecimal characters
+```
+
+The V0.1 serialized profile requires lowercase hexadecimal and rejects all-zero identifiers.
+
+## Layering
+
+```text
+runtime / OpenTelemetry adapter
+  -> trace/span IDs + minimized runtime references
+  -> vendor-neutral Agent Memory trace correlation
+  -> optional exporter / collector / evidence consumer
+```
+
+Peer/runtime-specific attributes remain outside canonical Agent Memory semantics.
+
+## Normalized record
+
+Schema:
+
+`schemas/runtime-trace-correlation.schema.json`
+
+Reference implementation:
+
+`reference/agentmem_ref/runtime_trace_correlation.py`
+
+The bounded record can carry:
+
+- telemetry observation state;
+- sampling state;
+- trace/span/parent-span identity when observed;
+- runtime and optional service references;
+- Agent Memory action reference;
+- exact input identity when available;
+- PAMA decision reference;
+- decision composition reference;
+- execution-witness reference;
+- external evidence references;
+- policy references;
+- opaque scope, tenant, and project references;
+- correlation timestamp.
+
+It does not require raw memory content or complete trace payloads.
+
+## Telemetry state and sampling are separate
+
+Telemetry state:
+
+```text
+observed
+not_observed
+telemetry_unavailable
+```
+
+Sampling state:
+
+```text
+sampled
+not_sampled
+unknown
+```
+
+A record can therefore say that telemetry was observed while sampling configuration remains unknown. Likewise, `not_observed` does not become a claim that the underlying action did not execute.
+
+For `not_observed` or `telemetry_unavailable`, V0.1 prohibits trace/span IDs in the normalized record so absence semantics cannot be mixed with purported trace identity.
+
+## Binding
+
+Observed telemetry is compared against the expected Agent Memory context using available exact dimensions:
+
+```text
+action_ref
+input_identity
+scope_ref
+tenant_ref
+project_ref
+```
+
+The result is:
+
+```text
+exact
+mismatch
+not_evaluated
+```
+
+Missing or mismatched required context is preserved in `binding_reasons`, for example:
+
+```text
+action_ref_mismatch
+input_identity_mismatch
+scope_ref_mismatch
+tenant_ref_mismatch
+project_ref_mismatch
+```
+
+No timing heuristic, span name, semantic similarity, or model inference may turn a mismatch into an exact correlation in V0.1.
+
+## Privacy and minimization
+
+The normalizer accepts an adapter result but emits only a fixed whitelist of correlation metadata.
+
+Unknown adapter fields are discarded. The executable test suite explicitly injects and rejects persistence of fields such as:
+
+- `memory_content`;
+- `prompt`;
+- `system_instructions`;
+- `tool_request_payload`;
+- `hidden_reasoning`.
+
+Full decision receipts and raw tool/model payloads are not required by this profile.
+
+Opaque references should be preferred over tenant/project display names where they are sufficient for correlation.
+
+## Authority and evidence non-claims
+
+Every normalized record fixes:
+
+```text
+authority_effect = none
+execution_claim = not_established
+lifecycle_satisfaction = not_established
+```
+
+Even when an `execution_witness_ref` is present, the trace correlation itself does not duplicate or upgrade the witness claim. It simply links to the independent evidence surface introduced by #152 Phase 3.
+
+This prevents a successful span or completed trace from silently becoming proof that:
+
+- PAMA authorized a memory consequence;
+- a downstream action definitely executed;
+- deletion/correction/forgetting obligations were satisfied.
+
+## Adversarial evidence
+
+Fixture:
+
+`fixtures/runtime-trace-correlation-matrix.json`
+
+Tests:
+
+`reference/tests/test_runtime_trace_correlation.py`
+
+The bounded V0.1 set covers:
+
+- sampled exact trace correlation;
+- exact correlation with unknown sampling state;
+- wrong action identity;
+- wrong Agent Memory input identity;
+- cross-scope/tenant/project mismatch;
+- telemetry not observed;
+- telemetry unavailable;
+- all-zero TraceId rejection;
+- all-zero SpanId rejection;
+- raw sensitive adapter fields being discarded;
+- execution witness remaining an independent reference;
+- prohibition on attaching trace IDs to an unobserved telemetry state.
+
+## Removal / rollback
+
+The adapter and correlation surface are optional.
+
+Removing an OpenTelemetry/runtime adapter does not alter canonical memory records, PAMA decisions, lifecycle state, or execution-witness evidence. Existing normalized correlation records remain understandable from their vendor-neutral schema and references.
+
+## What V0.1 proves
+
+Within the bounded fixtures/tests, V0.1 demonstrates that:
+
+- runtime trace identity can be correlated without copying memory content;
+- TraceId and SpanId shape/non-zero rules are deterministic;
+- exact Agent Memory action/input/scope binding remains visible;
+- cross-scope evidence cannot silently become exact correlation;
+- telemetry absence remains absence, not non-execution proof;
+- unknown sampling remains unknown;
+- trace correlation does not create authority or lifecycle claims;
+- no OpenTelemetry SDK is required for the core/reference contract.
+
+## What V0.1 does not prove
+
+This slice does not prove:
+
+- production collector/exporter availability;
+- complete trace capture;
+- correctness of a framework's instrumentation;
+- execution merely because a span completed;
+- non-execution because no telemetry was observed;
+- semantic correctness of runtime behavior;
+- lifecycle obligation satisfaction;
+- compatibility with every OpenTelemetry semantic-convention version;
+- a need for new upstream OpenTelemetry semantic conventions.

--- a/fixtures/runtime-trace-correlation-matrix.json
+++ b/fixtures/runtime-trace-correlation-matrix.json
@@ -1,0 +1,162 @@
+{
+  "fixture_id": "runtime-trace-correlation-matrix",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "Privacy-safe runtime trace correlation cases prove that trace identity can bind to Agent Memory evidence without becoming authority, execution proof, or lifecycle satisfaction.",
+  "expected_behavior": {
+    "normalized_cases": 7,
+    "exact_bindings": 2,
+    "mismatched_bindings": 3,
+    "not_evaluated_bindings": 2,
+    "invalid_id_cases": 2,
+    "raw_sensitive_fields_preserved": 0
+  },
+  "memory_unit": {
+    "id": "mem:runtime-trace-correlation",
+    "content_ref": "fixture://runtime-trace-correlation/action",
+    "type": "decision",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "runtime-trace-correlation-matrix",
+      "timestamp": "2026-08-12T21:25:00Z",
+      "source_refs": ["issue://185", "issue://167"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:runtime-trace-correlation",
+        "kind": "trace_correlation_fixture",
+        "ref": "issue://185",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["runtime_correlation", "privacy_minimization"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "policy_refs": ["issue:185", "issue:167"],
+      "permitted_actions": ["collect_more_evidence", "defer"],
+      "prohibited_actions": ["promotion"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T21:25:00Z"
+  },
+  "pinned_reference": {
+    "peer": "OpenTelemetry",
+    "semantic_conventions_version": "1.42.0",
+    "reference_date": "2026-06-12",
+    "profile_dependency": "none"
+  },
+  "expected_context": {
+    "action_ref": "action:456",
+    "input_identity": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant:opaque-a",
+    "project_ref": "project:opaque-a"
+  },
+  "base_adapter_result": {
+    "telemetry_status": "observed",
+    "sampling_state": "sampled",
+    "trace_id": "0123456789abcdef0123456789abcdef",
+    "span_id": "0123456789abcdef",
+    "parent_span_id": "fedcba9876543210",
+    "runtime_ref": "runtime:service-a",
+    "service_ref": "service:agent-host",
+    "action_ref": "action:456",
+    "input_identity": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "pama_decision_ref": "pama-decision:proposal-456",
+    "composition_ref": "decision-composition:456",
+    "execution_witness_ref": "execution-witness:456",
+    "external_evidence_refs": ["external-evidence:456"],
+    "policy_refs": ["policy:v1"],
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant:opaque-a",
+    "project_ref": "project:opaque-a",
+    "correlated_at": "2026-08-12T21:25:00Z"
+  },
+  "cases": [
+    {
+      "case_id": "observed-sampled-exact",
+      "overrides": {},
+      "remove_fields": [],
+      "expected_binding_status": "exact",
+      "expected_binding_reasons": []
+    },
+    {
+      "case_id": "observed-sampling-unknown-exact",
+      "overrides": {"sampling_state": "unknown"},
+      "remove_fields": [],
+      "expected_binding_status": "exact",
+      "expected_binding_reasons": []
+    },
+    {
+      "case_id": "wrong-action-ref",
+      "overrides": {"action_ref": "action:other"},
+      "remove_fields": [],
+      "expected_binding_status": "mismatch",
+      "expected_binding_reasons": ["action_ref_mismatch"]
+    },
+    {
+      "case_id": "wrong-input-identity",
+      "overrides": {"input_identity": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},
+      "remove_fields": [],
+      "expected_binding_status": "mismatch",
+      "expected_binding_reasons": ["input_identity_mismatch"]
+    },
+    {
+      "case_id": "cross-scope-tenant-project-mismatch",
+      "overrides": {
+        "scope_ref": "scope:tenant-b/project-b",
+        "tenant_ref": "tenant:opaque-b",
+        "project_ref": "project:opaque-b"
+      },
+      "remove_fields": [],
+      "expected_binding_status": "mismatch",
+      "expected_binding_reasons": ["scope_ref_mismatch", "tenant_ref_mismatch", "project_ref_mismatch"]
+    },
+    {
+      "case_id": "telemetry-not-observed",
+      "overrides": {
+        "telemetry_status": "not_observed",
+        "sampling_state": "unknown"
+      },
+      "remove_fields": ["trace_id", "span_id", "parent_span_id"],
+      "expected_binding_status": "not_evaluated",
+      "expected_binding_reasons": []
+    },
+    {
+      "case_id": "telemetry-unavailable",
+      "overrides": {
+        "telemetry_status": "telemetry_unavailable",
+        "sampling_state": "unknown"
+      },
+      "remove_fields": ["trace_id", "span_id", "parent_span_id"],
+      "expected_binding_status": "not_evaluated",
+      "expected_binding_reasons": []
+    }
+  ],
+  "invalid_cases": [
+    {
+      "case_id": "all-zero-trace-id",
+      "overrides": {"trace_id": "00000000000000000000000000000000"},
+      "expected_error": "trace_id must not be all zero"
+    },
+    {
+      "case_id": "all-zero-span-id",
+      "overrides": {"span_id": "0000000000000000"},
+      "expected_error": "span_id must not be all zero"
+    }
+  ],
+  "raw_sensitive_field_probe": {
+    "memory_content": "must-not-survive",
+    "prompt": "must-not-survive",
+    "system_instructions": "must-not-survive",
+    "tool_request_payload": {"secret": "must-not-survive"},
+    "hidden_reasoning": "must-not-survive"
+  }
+}

--- a/reference/agentmem_ref/runtime_trace_correlation.py
+++ b/reference/agentmem_ref/runtime_trace_correlation.py
@@ -1,0 +1,174 @@
+"""Privacy-safe runtime trace correlation for issue #185.
+
+The V0.1 profile consumes a bounded runtime/telemetry adapter result and emits
+only stable trace identifiers plus Agent Memory references needed for
+correlation. Unknown adapter fields are intentionally discarded so raw memory,
+prompts, tool payloads, or peer-specific semantic attributes cannot become
+canonical correlation state by accident.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+import rfc8785
+
+from . import receipts
+
+PROFILE_VERSION = "0.1.0"
+
+OBSERVED = "observed"
+NOT_OBSERVED = "not_observed"
+TELEMETRY_UNAVAILABLE = "telemetry_unavailable"
+
+SAMPLED = "sampled"
+NOT_SAMPLED = "not_sampled"
+SAMPLING_UNKNOWN = "unknown"
+
+BINDING_EXACT = "exact"
+BINDING_MISMATCH = "mismatch"
+BINDING_NOT_EVALUATED = "not_evaluated"
+
+_TELEMETRY_STATUSES = {OBSERVED, NOT_OBSERVED, TELEMETRY_UNAVAILABLE}
+_SAMPLING_STATES = {SAMPLED, NOT_SAMPLED, SAMPLING_UNKNOWN}
+_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_SPAN_ID_RE = re.compile(r"^[0-9a-f]{16}$")
+
+
+def _sha256_ref(value: dict) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+
+
+def _require_ref(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _validate_trace_id(value: object) -> str:
+    if not isinstance(value, str) or not _TRACE_ID_RE.fullmatch(value):
+        raise ValueError("trace_id must be 32 lowercase hexadecimal characters")
+    if value == "0" * 32:
+        raise ValueError("trace_id must not be all zero")
+    return value
+
+
+def _validate_span_id(name: str, value: object) -> str:
+    if not isinstance(value, str) or not _SPAN_ID_RE.fullmatch(value):
+        raise ValueError(f"{name} must be 16 lowercase hexadecimal characters")
+    if value == "0" * 16:
+        raise ValueError(f"{name} must not be all zero")
+    return value
+
+
+def normalize_trace_correlation(adapter_result: dict, expected_context: dict) -> dict:
+    """Normalize runtime trace metadata into a vendor-neutral correlation record.
+
+    ``adapter_result`` may contain arbitrary peer/runtime fields. Only the
+    whitelisted V0.1 correlation surface is copied. ``expected_context`` binds
+    the supplied telemetry to the intended Agent Memory action/input/scope.
+    Mismatches are preserved as evidence rather than silently re-associated.
+    """
+
+    if not isinstance(adapter_result, dict) or not isinstance(expected_context, dict):
+        raise ValueError("adapter_result and expected_context must be objects")
+
+    telemetry_status = adapter_result.get("telemetry_status")
+    if telemetry_status not in _TELEMETRY_STATUSES:
+        raise ValueError(f"invalid telemetry_status {telemetry_status!r}")
+
+    sampling_state = adapter_result.get("sampling_state", SAMPLING_UNKNOWN)
+    if sampling_state not in _SAMPLING_STATES:
+        raise ValueError(f"invalid sampling_state {sampling_state!r}")
+
+    runtime_ref = _require_ref("runtime_ref", adapter_result.get("runtime_ref"))
+    action_ref = _require_ref("action_ref", adapter_result.get("action_ref"))
+    scope_ref = _require_ref("scope_ref", adapter_result.get("scope_ref"))
+    correlated_at = _require_ref("correlated_at", adapter_result.get("correlated_at"))
+
+    trace_id: str | None = None
+    span_id: str | None = None
+    parent_span_id: str | None = None
+
+    if telemetry_status == OBSERVED:
+        trace_id = _validate_trace_id(adapter_result.get("trace_id"))
+        span_id = _validate_span_id("span_id", adapter_result.get("span_id"))
+        if adapter_result.get("parent_span_id") is not None:
+            parent_span_id = _validate_span_id("parent_span_id", adapter_result["parent_span_id"])
+    else:
+        # Absence/unavailability is itself useful evidence state. Carrying trace
+        # IDs with an unobserved record would make the semantics ambiguous.
+        if any(adapter_result.get(name) is not None for name in ("trace_id", "span_id", "parent_span_id")):
+            raise ValueError("unobserved/unavailable telemetry must not claim trace or span identifiers")
+
+    binding_reasons: list[str] = []
+    if telemetry_status == OBSERVED:
+        for field in ("action_ref", "input_identity", "scope_ref", "tenant_ref", "project_ref"):
+            expected = expected_context.get(field)
+            if expected is None:
+                continue
+            observed = adapter_result.get(field)
+            if observed is None:
+                binding_reasons.append(f"{field}_missing")
+            elif observed != expected:
+                binding_reasons.append(f"{field}_mismatch")
+        binding_status = BINDING_MISMATCH if binding_reasons else BINDING_EXACT
+    else:
+        binding_status = BINDING_NOT_EVALUATED
+
+    body = {
+        "telemetry_status": telemetry_status,
+        "sampling_state": sampling_state,
+        "binding_status": binding_status,
+        "binding_reasons": binding_reasons,
+        "runtime_ref": runtime_ref,
+        "action_ref": action_ref,
+        "scope_ref": scope_ref,
+        "correlated_at": correlated_at,
+        "authority_effect": "none",
+        "execution_claim": "not_established",
+        "lifecycle_satisfaction": "not_established",
+    }
+
+    if trace_id is not None:
+        body["trace_id"] = trace_id
+    if span_id is not None:
+        body["span_id"] = span_id
+    if parent_span_id is not None:
+        body["parent_span_id"] = parent_span_id
+
+    optional_strings = (
+        "service_ref",
+        "input_identity",
+        "pama_decision_ref",
+        "composition_ref",
+        "execution_witness_ref",
+        "tenant_ref",
+        "project_ref",
+    )
+    for name in optional_strings:
+        value = adapter_result.get(name)
+        if value is not None:
+            body[name] = _require_ref(name, value)
+
+    for name in ("external_evidence_refs", "policy_refs"):
+        values = adapter_result.get(name)
+        if values is not None:
+            if not isinstance(values, (list, tuple)) or not all(isinstance(item, str) and item for item in values):
+                raise ValueError(f"{name} must be a list of non-empty strings")
+            body[name] = list(dict.fromkeys(values))
+
+    identity_body = {
+        key: value
+        for key, value in body.items()
+        if key not in {"correlated_at"}
+    }
+    document = {
+        "schema_version": "1.0.0",
+        "profile_version": PROFILE_VERSION,
+        "correlation_id": f"runtime-trace-correlation:{_sha256_ref(identity_body)}",
+        **body,
+    }
+    receipts.validate("runtime-trace-correlation.schema.json", document)
+    return document

--- a/reference/tests/test_runtime_trace_correlation.py
+++ b/reference/tests/test_runtime_trace_correlation.py
@@ -1,0 +1,116 @@
+"""Privacy-safe runtime trace correlation tests for issue #185."""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from agentmem_ref.runtime_trace_correlation import normalize_trace_correlation
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "runtime-trace-correlation-matrix.json"
+
+
+class RuntimeTraceCorrelationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.matrix = json.loads(MATRIX.read_text(encoding="utf-8"))
+
+    def _adapter_for(self, case: dict) -> dict:
+        adapter = copy.deepcopy(self.matrix["base_adapter_result"])
+        adapter.update(copy.deepcopy(case.get("overrides", {})))
+        for name in case.get("remove_fields", []):
+            adapter.pop(name, None)
+        return adapter
+
+    def test_normalized_matrix(self):
+        counts = {"exact": 0, "mismatch": 0, "not_evaluated": 0}
+        for case in self.matrix["cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                result = normalize_trace_correlation(
+                    self._adapter_for(case),
+                    self.matrix["expected_context"],
+                )
+                self.assertEqual(result["binding_status"], case["expected_binding_status"])
+                self.assertEqual(result["binding_reasons"], case["expected_binding_reasons"])
+                self.assertEqual(result["authority_effect"], "none")
+                self.assertEqual(result["execution_claim"], "not_established")
+                self.assertEqual(result["lifecycle_satisfaction"], "not_established")
+                counts[result["binding_status"]] += 1
+
+                if result["telemetry_status"] == "observed":
+                    self.assertIn("trace_id", result)
+                    self.assertIn("span_id", result)
+                else:
+                    self.assertNotIn("trace_id", result)
+                    self.assertNotIn("span_id", result)
+                    self.assertNotIn("parent_span_id", result)
+
+        expected = self.matrix["expected_behavior"]
+        self.assertEqual(len(self.matrix["cases"]), expected["normalized_cases"])
+        self.assertEqual(counts["exact"], expected["exact_bindings"])
+        self.assertEqual(counts["mismatch"], expected["mismatched_bindings"])
+        self.assertEqual(counts["not_evaluated"], expected["not_evaluated_bindings"])
+
+    def test_invalid_trace_and_span_ids_fail_closed(self):
+        failures = 0
+        for case in self.matrix["invalid_cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                adapter = self._adapter_for(case)
+                with self.assertRaisesRegex(ValueError, case["expected_error"]):
+                    normalize_trace_correlation(adapter, self.matrix["expected_context"])
+                failures += 1
+        self.assertEqual(failures, self.matrix["expected_behavior"]["invalid_id_cases"])
+
+    def test_raw_sensitive_adapter_fields_are_discarded(self):
+        adapter = copy.deepcopy(self.matrix["base_adapter_result"])
+        adapter.update(copy.deepcopy(self.matrix["raw_sensitive_field_probe"]))
+        result = normalize_trace_correlation(adapter, self.matrix["expected_context"])
+
+        forbidden = {
+            "memory_content",
+            "prompt",
+            "system_instructions",
+            "tool_request_payload",
+            "hidden_reasoning",
+            "rationale",
+            "full_receipt",
+        }
+        self.assertFalse(forbidden & result.keys())
+        preserved = sum(1 for key in self.matrix["raw_sensitive_field_probe"] if key in result)
+        self.assertEqual(preserved, self.matrix["expected_behavior"]["raw_sensitive_fields_preserved"])
+
+    def test_sampling_unknown_does_not_upgrade_evidence(self):
+        case = next(item for item in self.matrix["cases"] if item["case_id"] == "observed-sampling-unknown-exact")
+        result = normalize_trace_correlation(self._adapter_for(case), self.matrix["expected_context"])
+        self.assertEqual(result["sampling_state"], "unknown")
+        self.assertEqual(result["binding_status"], "exact")
+        self.assertEqual(result["execution_claim"], "not_established")
+
+    def test_missing_telemetry_is_not_non_execution_evidence(self):
+        case = next(item for item in self.matrix["cases"] if item["case_id"] == "telemetry-not-observed")
+        result = normalize_trace_correlation(self._adapter_for(case), self.matrix["expected_context"])
+        self.assertEqual(result["telemetry_status"], "not_observed")
+        self.assertEqual(result["binding_status"], "not_evaluated")
+        self.assertEqual(result["execution_claim"], "not_established")
+        self.assertNotIn("action_not_executed", result.values())
+
+    def test_execution_witness_remains_a_reference_not_a_trace_claim(self):
+        result = normalize_trace_correlation(
+            self.matrix["base_adapter_result"],
+            self.matrix["expected_context"],
+        )
+        self.assertEqual(result["execution_witness_ref"], "execution-witness:456")
+        self.assertEqual(result["execution_claim"], "not_established")
+
+    def test_unobserved_telemetry_cannot_carry_trace_ids(self):
+        adapter = copy.deepcopy(self.matrix["base_adapter_result"])
+        adapter["telemetry_status"] = "not_observed"
+        with self.assertRaisesRegex(ValueError, "must not claim trace or span identifiers"):
+            normalize_trace_correlation(adapter, self.matrix["expected_context"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/runtime-trace-correlation.schema.json
+++ b/schemas/runtime-trace-correlation.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/runtime-trace-correlation.schema.json",
+  "title": "Agent Memory Runtime Trace Correlation",
+  "description": "Content-minimized correlation between runtime trace/span identity and Agent Memory governance/evidence references. Correlation is evidence linkage, not memory authority, execution proof, or lifecycle satisfaction.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_version",
+    "correlation_id",
+    "telemetry_status",
+    "sampling_state",
+    "binding_status",
+    "binding_reasons",
+    "runtime_ref",
+    "action_ref",
+    "scope_ref",
+    "correlated_at",
+    "authority_effect",
+    "execution_claim",
+    "lifecycle_satisfaction"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "profile_version": { "const": "0.1.0" },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "telemetry_status": {
+      "type": "string",
+      "enum": ["observed", "not_observed", "telemetry_unavailable"]
+    },
+    "sampling_state": {
+      "type": "string",
+      "enum": ["sampled", "not_sampled", "unknown"]
+    },
+    "trace_id": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
+    "span_id": { "type": "string", "pattern": "^[0-9a-f]{16}$" },
+    "parent_span_id": { "type": "string", "pattern": "^[0-9a-f]{16}$" },
+    "binding_status": {
+      "type": "string",
+      "enum": ["exact", "mismatch", "not_evaluated"]
+    },
+    "binding_reasons": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "runtime_ref": { "type": "string", "minLength": 1 },
+    "service_ref": { "type": "string", "minLength": 1 },
+    "action_ref": { "type": "string", "minLength": 1 },
+    "input_identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "pama_decision_ref": { "type": "string", "minLength": 1 },
+    "composition_ref": { "type": "string", "minLength": 1 },
+    "execution_witness_ref": { "type": "string", "minLength": 1 },
+    "external_evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "policy_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "scope_ref": { "type": "string", "minLength": 1 },
+    "tenant_ref": { "type": "string", "minLength": 1 },
+    "project_ref": { "type": "string", "minLength": 1 },
+    "correlated_at": { "type": "string", "format": "date-time" },
+    "authority_effect": { "const": "none" },
+    "execution_claim": { "const": "not_established" },
+    "lifecycle_satisfaction": { "const": "not_established" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "telemetry_status": { "const": "observed" } },
+        "required": ["telemetry_status"]
+      },
+      "then": {
+        "required": ["trace_id", "span_id"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements #185 / P1-A: a content-minimized, vendor-neutral runtime trace correlation profile that can bind OpenTelemetry-style trace/span identity to Agent Memory governance/evidence references without importing telemetry as authority.

## Implemented

- strict correlation schema with observed/not-observed/unavailable telemetry states;
- independent sampling state (`sampled`, `not_sampled`, `unknown`);
- exact TraceId (32 hex/non-zero) and SpanId (16 hex/non-zero) validation;
- deterministic action/input/scope/tenant/project binding;
- explicit `exact`, `mismatch`, and `not_evaluated` correlation states;
- stable references to PAMA decision, composition, execution witness, external evidence, and policies without duplicating those artifacts;
- adapter-field minimization that discards raw memory, prompts, system instructions, tool payloads, hidden reasoning, and unknown peer/runtime fields;
- fixed non-authority semantics: `authority_effect = none`, `execution_claim = not_established`, `lifecycle_satisfaction = not_established`;
- adversarial fixtures/tests for wrong action/input/scope, telemetry absence, unavailable telemetry, unknown sampling, all-zero IDs, raw-sensitive-field injection, and witness-reference separation;
- pinned OpenTelemetry Semantic Conventions v1.42.0 as documentation/fixture reference only; no OTel SDK dependency is added.

## Core boundary

```text
trace correlation != memory authority
span success != semantic correctness
span completion != lifecycle satisfaction
sampled telemetry != complete execution evidence
```

## Stop line

No framework-specific instrumentation, collector/exporter deployment, raw trace persistence, upstream OTel semantic-convention proposal, or inference that missing telemetry means non-execution.

This PR remains draft until exact-head CI and bounded completion review pass.

Closes #185