### PR TITLE
Bind approval evidence to exact governed action identity

### DIFF
--- a/docs/profiles/approval-evidence-profile.md
+++ b/docs/profiles/approval-evidence-profile.md
@@ -1,0 +1,174 @@
+# Exact-Identity Approval Evidence Profile
+
+Status: reference V0.1 implementation profile for issue #187 and the remaining approval-continuity boundary in #152.
+
+## Purpose
+
+This profile records and verifies a one-action approval decision without turning approval history into reusable authority.
+
+```text
+approval for action/state A
+!= approval for action/state B
+
+approval evidence
+!= standing grant
+
+approval recorded
+!= action executed
+```
+
+The approval artifact sits between decision composition and execution evidence:
+
+```text
+Agent Memory / external decision composition
+        |
+        v
+require_approval
+        |
+        v
+one-action approval evidence
+        |
+        v
+approval verification against exact identity/current state
+        |
+        v
+execution witness
+```
+
+Each layer remains independently reconstructable.
+
+## Contracts
+
+Approval evidence schema:
+
+`schemas/approval-evidence.schema.json`
+
+Verification result schema:
+
+`schemas/approval-verification-result.schema.json`
+
+Reference implementation:
+
+`reference/agentmem_ref/approval_evidence.py`
+
+Execution integration:
+
+`reference/agentmem_ref/enforcement_evidence.py`
+
+## Approval evidence
+
+The V0.1 artifact binds:
+
+- exact `input_identity`;
+- exact `composition_id`;
+- approving principal reference;
+- authority-evidence reference;
+- scope reference;
+- outcome (`approved`, `denied`, `revoked`);
+- approval mechanism/host reference;
+- issuance time;
+- optional expiry;
+- optional revocation time/evidence;
+- supporting evidence references.
+
+`reusable_authority` is fixed to `false`.
+
+A future standing grant, reusable approval, or autonomy-policy transition must be a separate governed authority artifact under #172/#153. Repetition of these records cannot self-ratify such a transition.
+
+## Verification
+
+Approval verification checks the artifact against the current decision composition and observation context.
+
+Possible states are:
+
+```text
+current
+denied
+stale
+invalid
+not_applicable
+```
+
+Only:
+
+```text
+status = current
+satisfies_required_approval = true
+```
+
+may satisfy a `require_approval` composition.
+
+Exact identity and scope mismatches are invalid. Expired/revoked approvals are stale. A denied approval is unsatisfied. An approval presented against `deny`, `allow`, or `warn` is `not_applicable`, because approval is not a generic bearer token that changes the underlying decision.
+
+## Execution witness integration
+
+Execution witnesses now report one of:
+
+```text
+absent
+unverified
+verified_current
+stale
+denied
+invalid
+not_applicable
+```
+
+A bare `approval_evidence_ref` remains `unverified`.
+
+For an effective `require_approval` decision:
+
+```text
+executed + verified_current approval -> consistent
+executed + bare/stale/denied/invalid approval -> unverifiable
+prevented/refused -> consistent
+```
+
+For an effective `deny`, even a valid approval artifact cannot widen authority:
+
+```text
+deny + approved evidence + executed -> violation
+```
+
+## Replay resistance
+
+The approval binds to the same deterministic `input_identity` used by the composition boundary. If proposal state, action identity, scope-bound inputs, or PAMA authority state changes such that `input_identity` changes, the prior approval cannot satisfy the new action.
+
+The execution witness also rejects an approval-verification result whose input/composition identity belongs to another decision.
+
+## Adversarial evidence
+
+Fixture:
+
+`fixtures/approval-evidence-matrix.json`
+
+Tests:
+
+`reference/tests/test_approval_evidence.py`
+
+The bounded V0.1 set covers:
+
+- current approved exact identity;
+- expiry;
+- revocation;
+- denial;
+- wrong input identity;
+- wrong composition identity;
+- approval presented against an effective deny;
+- state-change replay;
+- bare approval reference remaining unverified;
+- verified approval satisfying `require_approval` execution;
+- execution witness rejecting verification from a different composition.
+
+## Non-claims
+
+This profile does not prove:
+
+- that an approver should have been authorized merely because an authority reference exists;
+- production identity-provider validation;
+- reusable/standing authority;
+- execution merely because approval occurred;
+- lifecycle satisfaction;
+- remote approval UX or delivery guarantees.
+
+It proves only the bounded identity/current-state continuity represented and executed by the reference tests.

--- a/fixtures/approval-evidence-matrix.json
+++ b/fixtures/approval-evidence-matrix.json
@@ -1,0 +1,120 @@
+{
+  "fixture_id": "approval-evidence-matrix",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "One-action approval evidence proves exact decision/action continuity without becoming standing authority or execution proof.",
+  "expected_behavior": {
+    "verification_cases": 7,
+    "current_satisfying_cases": 1,
+    "stale_cases": 2,
+    "invalid_cases": 2,
+    "denied_cases": 1,
+    "not_applicable_cases": 1
+  },
+  "memory_unit": {
+    "id": "mem:approval-evidence",
+    "content_ref": "fixture://approval-evidence/action",
+    "type": "decision",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "approval-evidence-matrix",
+      "timestamp": "2026-08-12T21:35:00Z",
+      "source_refs": ["issue://187", "issue://152"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:approval-continuity",
+        "kind": "approval_continuity_fixture",
+        "ref": "issue://187",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["approval_continuity", "authority_separation"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "high",
+      "policy_refs": ["issue:187", "issue:152"],
+      "permitted_actions": ["collect_more_evidence", "defer", "enter_pending_verification"],
+      "prohibited_actions": ["promotion"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T21:35:00Z"
+  },
+  "scope_ref": "scope:tenant-a/project-a",
+  "observed_at": "2026-08-12T21:35:00Z",
+  "cases": [
+    {
+      "case_id": "current-approved-exact",
+      "composition_outcome": "require_review",
+      "approval_outcome": "approved",
+      "issued_at": "2026-08-12T21:00:00Z",
+      "expires_at": "2026-08-13T21:00:00Z",
+      "mutations": {},
+      "expected_status": "current",
+      "expected_satisfies": true
+    },
+    {
+      "case_id": "expired-approval",
+      "composition_outcome": "require_review",
+      "approval_outcome": "approved",
+      "issued_at": "2026-08-11T20:00:00Z",
+      "expires_at": "2026-08-12T20:00:00Z",
+      "mutations": {},
+      "expected_status": "stale",
+      "expected_satisfies": false
+    },
+    {
+      "case_id": "revoked-approval",
+      "composition_outcome": "require_review",
+      "approval_outcome": "revoked",
+      "issued_at": "2026-08-12T20:00:00Z",
+      "revoked_at": "2026-08-12T21:10:00Z",
+      "revocation_evidence_ref": "revocation:approval-1",
+      "mutations": {},
+      "expected_status": "stale",
+      "expected_satisfies": false
+    },
+    {
+      "case_id": "denied-approval",
+      "composition_outcome": "require_review",
+      "approval_outcome": "denied",
+      "issued_at": "2026-08-12T21:00:00Z",
+      "mutations": {},
+      "expected_status": "denied",
+      "expected_satisfies": false
+    },
+    {
+      "case_id": "wrong-input-identity",
+      "composition_outcome": "require_review",
+      "approval_outcome": "approved",
+      "issued_at": "2026-08-12T21:00:00Z",
+      "mutations": {"input_identity": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},
+      "expected_status": "invalid",
+      "expected_satisfies": false
+    },
+    {
+      "case_id": "wrong-composition-identity",
+      "composition_outcome": "require_review",
+      "approval_outcome": "approved",
+      "issued_at": "2026-08-12T21:00:00Z",
+      "mutations": {"composition_id": "decision-composition:other"},
+      "expected_status": "invalid",
+      "expected_satisfies": false
+    },
+    {
+      "case_id": "approval-cannot-widen-deny",
+      "composition_outcome": "block",
+      "approval_outcome": "approved",
+      "issued_at": "2026-08-12T21:00:00Z",
+      "mutations": {},
+      "expected_status": "not_applicable",
+      "expected_satisfies": false
+    }
+  ]
+}

--- a/reference/agentmem_ref/approval_evidence.py
+++ b/reference/agentmem_ref/approval_evidence.py
@@ -1,0 +1,168 @@
+"""Vendor-neutral one-action approval evidence for issue #187.
+
+Approval is evidence about one exact governed action/state identity. It is not a
+standing grant, cannot widen a stricter decision, and does not prove execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+
+import rfc8785
+
+from . import receipts
+
+APPROVAL_VERSION = "0.1.0"
+_OUTCOMES = {"approved", "denied", "revoked"}
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("approval timestamps must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _sha256_ref(value: dict) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+
+
+def build_approval_evidence(
+    composition: dict,
+    *,
+    principal_ref: str,
+    authority_evidence_ref: str,
+    scope_ref: str,
+    outcome: str,
+    mechanism_ref: str,
+    issued_at: str,
+    expires_at: str | None = None,
+    revoked_at: str | None = None,
+    revocation_evidence_ref: str | None = None,
+    evidence_refs: tuple[str, ...] = (),
+) -> dict:
+    """Create one-action approval evidence bound to a decision composition."""
+
+    receipts.validate("decision-composition-receipt.schema.json", composition)
+    for name, value in (
+        ("principal_ref", principal_ref),
+        ("authority_evidence_ref", authority_evidence_ref),
+        ("scope_ref", scope_ref),
+        ("mechanism_ref", mechanism_ref),
+        ("issued_at", issued_at),
+    ):
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{name} must be a non-empty string")
+    if outcome not in _OUTCOMES:
+        raise ValueError(f"invalid approval outcome {outcome!r}")
+
+    issued = _parse_time(issued_at)
+    if expires_at is not None and _parse_time(expires_at) < issued:
+        raise ValueError("approval expiry cannot precede issuance")
+    if revoked_at is not None and _parse_time(revoked_at) < issued:
+        raise ValueError("approval revocation cannot precede issuance")
+    if outcome == "revoked" and revoked_at is None:
+        raise ValueError("revoked approval requires revoked_at")
+    if revoked_at is not None and not revocation_evidence_ref:
+        raise ValueError("revoked_at requires revocation_evidence_ref")
+
+    body = {
+        "input_identity": composition["input_identity"],
+        "composition_id": composition["composition_id"],
+        "principal_ref": principal_ref,
+        "authority_evidence_ref": authority_evidence_ref,
+        "scope_ref": scope_ref,
+        "outcome": outcome,
+        "mechanism_ref": mechanism_ref,
+        "issued_at": issued_at,
+        "evidence_refs": list(dict.fromkeys(evidence_refs)),
+        "reusable_authority": False,
+    }
+    if expires_at is not None:
+        body["expires_at"] = expires_at
+    if revoked_at is not None:
+        body["revoked_at"] = revoked_at
+        body["revocation_evidence_ref"] = revocation_evidence_ref
+
+    document = {
+        "schema_version": "1.0.0",
+        "approval_version": APPROVAL_VERSION,
+        "approval_id": f"approval:{_sha256_ref(body)}",
+        **body,
+    }
+    receipts.validate("approval-evidence.schema.json", document)
+    return document
+
+
+def verify_approval_evidence(
+    approval: dict,
+    composition: dict,
+    *,
+    expected_scope_ref: str,
+    observed_at: str,
+) -> dict:
+    """Verify whether approval currently satisfies ``require_approval``.
+
+    Historical validity is preserved separately from current satisfaction. A
+    valid approval presented to an ``allow`` or ``deny`` composition is
+    ``not_applicable`` rather than treated as a magic authorization token.
+    """
+
+    receipts.validate("approval-evidence.schema.json", approval)
+    receipts.validate("decision-composition-receipt.schema.json", composition)
+    observed = _parse_time(observed_at)
+    reasons: list[str] = []
+
+    if approval["input_identity"] != composition["input_identity"]:
+        reasons.append("input_identity_mismatch")
+    if approval["composition_id"] != composition["composition_id"]:
+        reasons.append("composition_id_mismatch")
+    if approval["scope_ref"] != expected_scope_ref:
+        reasons.append("scope_ref_mismatch")
+
+    if reasons:
+        status = "invalid"
+        satisfied = False
+    elif composition["effective_decision"] != "require_approval":
+        status = "not_applicable"
+        satisfied = False
+        reasons.append(f"effective_decision:{composition['effective_decision']}")
+    elif approval["outcome"] == "denied":
+        status = "denied"
+        satisfied = False
+        reasons.append("approval_denied")
+    elif approval["outcome"] == "revoked":
+        status = "stale"
+        satisfied = False
+        reasons.append("approval_revoked")
+    elif _parse_time(approval["issued_at"]) > observed:
+        status = "invalid"
+        satisfied = False
+        reasons.append("approval_not_yet_issued")
+    elif approval.get("revoked_at") is not None and _parse_time(approval["revoked_at"]) <= observed:
+        status = "stale"
+        satisfied = False
+        reasons.append("approval_revoked")
+    elif approval.get("expires_at") is not None and _parse_time(approval["expires_at"]) < observed:
+        status = "stale"
+        satisfied = False
+        reasons.append("approval_expired")
+    else:
+        status = "current"
+        satisfied = approval["outcome"] == "approved"
+        if not satisfied:
+            reasons.append("approval_not_approved")
+
+    result = {
+        "schema_version": "0.1.0",
+        "approval_id": approval["approval_id"],
+        "input_identity": approval["input_identity"],
+        "composition_id": approval["composition_id"],
+        "status": status,
+        "satisfies_required_approval": satisfied,
+        "reasons": list(dict.fromkeys(reasons)),
+        "reusable_authority": False,
+    }
+    receipts.validate("approval-verification-result.schema.json", result)
+    return result

--- a/reference/agentmem_ref/enforcement_evidence.py
+++ b/reference/agentmem_ref/enforcement_evidence.py
@@ -1,8 +1,9 @@
 """Vendor-neutral enforcement evidence for issue #152 Phase 3.
 
 This module keeps configured governance, decision delivery, enforcement-point
-observation, and action execution/prevention as distinct evidence states.
-A decision receipt is never upgraded to execution proof by inference.
+observation, approval satisfaction, and action execution/prevention as distinct
+evidence states. A decision or approval receipt is never upgraded to execution
+proof by inference.
 """
 
 from __future__ import annotations
@@ -28,7 +29,12 @@ def _sha256_ref(value: dict) -> str:
     return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
 
 
-def _alignment(effective_decision: str, action_status: str, enforcement_point_status: str) -> str:
+def _alignment(
+    effective_decision: str,
+    action_status: str,
+    enforcement_point_status: str,
+    approval_evidence_status: str,
+) -> str:
     if enforcement_point_status != "reached" or action_status in {"unknown", "not_observed"}:
         return "unverifiable"
 
@@ -42,14 +48,42 @@ def _alignment(effective_decision: str, action_status: str, enforcement_point_st
             return "stricter_than_decision"
         return "unverifiable"
 
-    # ``require_approval`` cannot be upgraded to authorized execution merely
-    # because a witness sees execution. Approval validity is a separate check.
     if effective_decision == "require_approval":
         if action_status in {"prevented", "refused"}:
+            return "consistent"
+        if action_status == "executed" and approval_evidence_status == "verified_current":
             return "consistent"
         return "unverifiable"
 
     return "unverifiable"
+
+
+def _approval_status(
+    composition: dict,
+    approval_evidence_ref: str | None,
+    approval_verification: dict | None,
+) -> tuple[str | None, str]:
+    if approval_verification is None:
+        return approval_evidence_ref, "unverified" if approval_evidence_ref else "absent"
+
+    receipts.validate("approval-verification-result.schema.json", approval_verification)
+    if approval_verification["input_identity"] != composition["input_identity"]:
+        raise ValueError("approval verification input identity does not match composed decision")
+    if approval_verification["composition_id"] != composition["composition_id"]:
+        raise ValueError("approval verification composition identity does not match composed decision")
+
+    verified_ref = approval_verification["approval_id"]
+    if approval_evidence_ref is not None and approval_evidence_ref != verified_ref:
+        raise ValueError("approval evidence reference does not match verified approval")
+
+    status = approval_verification["status"]
+    if status == "current" and approval_verification["satisfies_required_approval"]:
+        witness_status = "verified_current"
+    elif status in {"stale", "denied", "invalid", "not_applicable"}:
+        witness_status = status
+    else:
+        witness_status = "invalid"
+    return verified_ref, witness_status
 
 
 def build_execution_witness(
@@ -65,13 +99,15 @@ def build_execution_witness(
     observed_at: str,
     observed_input_identity: str | None = None,
     approval_evidence_ref: str | None = None,
+    approval_verification: dict | None = None,
     evidence_refs: tuple[str, ...] = (),
 ) -> dict:
     """Bind an observed enforcement/execution event to a composed decision.
 
     The witness may record a policy violation rather than rejecting the event.
-    That distinction matters: evidence that an action executed despite ``deny``
-    is valuable negative evidence, not malformed evidence.
+    Approval satisfaction is only recognized from a separately verified result
+    bound to the same input and composition identities. A bare approval reference
+    remains explicitly unverified.
     """
 
     receipts.validate("decision-composition-receipt.schema.json", composition)
@@ -97,6 +133,12 @@ def build_execution_witness(
     if enforcement_point_status != "reached" and action_status in {"executed", "prevented", "refused"}:
         raise ValueError("action outcome cannot be claimed without observing the enforcement point")
 
+    approval_ref, approval_status = _approval_status(
+        composition,
+        approval_evidence_ref,
+        approval_verification,
+    )
+
     body = {
         "input_identity": identity,
         "composition_id": composition["composition_id"],
@@ -108,18 +150,23 @@ def build_execution_witness(
         "enforcement_point_status": enforcement_point_status,
         "action_status": action_status,
         "decision_alignment": _alignment(
-            composition["effective_decision"], action_status, enforcement_point_status
+            composition["effective_decision"],
+            action_status,
+            enforcement_point_status,
+            approval_status,
         ),
         "liveness_status": liveness_status,
+        "approval_evidence_status": approval_status,
         "observed_at": observed_at,
         "evidence_refs": list(dict.fromkeys(evidence_refs)),
         "non_claims": [
             "lifecycle_satisfaction_not_established",
             "execution_witness_does_not_create_memory_authority",
+            "approval_evidence_is_not_standing_authority",
         ],
     }
-    if approval_evidence_ref:
-        body["approval_evidence_ref"] = approval_evidence_ref
+    if approval_ref:
+        body["approval_evidence_ref"] = approval_ref
 
     witness = {
         "schema_version": "1.0.0",

--- a/reference/tests/test_approval_evidence.py
+++ b/reference/tests/test_approval_evidence.py
@@ -1,0 +1,254 @@
+"""Approval continuity tests for issue #187 / #152."""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from agentmem_ref import policy
+from agentmem_ref.approval_evidence import build_approval_evidence, verify_approval_evidence
+from agentmem_ref.enforcement_composition import PROVIDER_NONE, build_projection, compose
+from agentmem_ref.enforcement_evidence import build_execution_witness
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "approval-evidence-matrix.json"
+OPERATION = "promotion"
+
+
+def _proposal(*, proposal_id: str = "proposal:approval", state_snapshot: str = "state:v1") -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=proposal_id,
+        actor_id="agent:planner",
+        charter_version="charter:approval",
+        target_reference="mem:approval",
+        target_class=policy.M4,
+        scope="tenant-a",
+        operation=OPERATION,
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A3,
+        reversibility="reversible",
+        risk_class="high",
+        evidence_refs=("evidence:proposal",),
+        state_snapshot=state_snapshot,
+        tenant_ref="tenant-a",
+        purpose="approval-continuity",
+        isolation_domain_refs=("domain:project-a",),
+        required_isolation_domain_refs=("domain:project-a",),
+    )
+
+
+def _decision(outcome: str) -> policy.Decision:
+    if outcome == policy.REQUIRE_REVIEW:
+        permitted = ("enter_pending_verification", "collect_more_evidence", "defer")
+        prohibited = (OPERATION,)
+    elif outcome == policy.BLOCK:
+        permitted = ()
+        prohibited = (OPERATION, "enter_pending_verification")
+    else:
+        permitted = (OPERATION, "collect_more_evidence", "defer")
+        prohibited = ()
+    return policy.Decision(
+        outcome=outcome,
+        permitted_actions=permitted,
+        prohibited_actions=prohibited,
+        policy_version="ref-approval-test",
+    )
+
+
+def _composition(outcome: str, *, proposal: policy.Proposal | None = None) -> dict:
+    projection = build_projection(proposal or _proposal(), _decision(outcome))
+    return compose(projection, provider_mode=PROVIDER_NONE)
+
+
+def _approval(composition: dict, case: dict, scope_ref: str) -> dict:
+    return build_approval_evidence(
+        composition,
+        principal_ref="principal:human-reviewer",
+        authority_evidence_ref="authority:reviewer-role:v1",
+        scope_ref=scope_ref,
+        outcome=case["approval_outcome"],
+        mechanism_ref="approval-host:reference",
+        issued_at=case["issued_at"],
+        expires_at=case.get("expires_at"),
+        revoked_at=case.get("revoked_at"),
+        revocation_evidence_ref=case.get("revocation_evidence_ref"),
+        evidence_refs=(f"evidence:{case['case_id']}",),
+    )
+
+
+class ApprovalEvidenceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.matrix = json.loads(MATRIX.read_text(encoding="utf-8"))
+
+    def test_verification_matrix(self):
+        counts = {"current": 0, "stale": 0, "invalid": 0, "denied": 0, "not_applicable": 0}
+        for case in self.matrix["cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                composition = _composition(case["composition_outcome"])
+                approval = _approval(composition, case, self.matrix["scope_ref"])
+                approval.update(copy.deepcopy(case["mutations"]))
+                result = verify_approval_evidence(
+                    approval,
+                    composition,
+                    expected_scope_ref=self.matrix["scope_ref"],
+                    observed_at=self.matrix["observed_at"],
+                )
+                self.assertEqual(result["status"], case["expected_status"])
+                self.assertEqual(result["satisfies_required_approval"], case["expected_satisfies"])
+                self.assertFalse(result["reusable_authority"])
+                counts[result["status"]] += 1
+
+        expected = self.matrix["expected_behavior"]
+        self.assertEqual(len(self.matrix["cases"]), expected["verification_cases"])
+        self.assertEqual(counts["current"], expected["current_satisfying_cases"])
+        self.assertEqual(counts["stale"], expected["stale_cases"])
+        self.assertEqual(counts["invalid"], expected["invalid_cases"])
+        self.assertEqual(counts["denied"], expected["denied_cases"])
+        self.assertEqual(counts["not_applicable"], expected["not_applicable_cases"])
+
+    def test_verified_current_approval_can_satisfy_require_approval_execution(self):
+        composition = _composition(policy.REQUIRE_REVIEW)
+        case = self.matrix["cases"][0]
+        approval = _approval(composition, case, self.matrix["scope_ref"])
+        verification = verify_approval_evidence(
+            approval,
+            composition,
+            expected_scope_ref=self.matrix["scope_ref"],
+            observed_at=self.matrix["observed_at"],
+        )
+        witness = build_execution_witness(
+            composition,
+            action_ref="action:approved-execution",
+            witness_ref="runtime:audit:approved",
+            enforcement_mode="mechanical",
+            delivery_status="delivered",
+            enforcement_point_status="reached",
+            action_status="executed",
+            liveness_status="healthy",
+            observed_at=self.matrix["observed_at"],
+            approval_verification=verification,
+        )
+        self.assertEqual(witness["approval_evidence_ref"], approval["approval_id"])
+        self.assertEqual(witness["approval_evidence_status"], "verified_current")
+        self.assertEqual(witness["decision_alignment"], "consistent")
+
+    def test_bare_approval_reference_does_not_satisfy_require_approval(self):
+        composition = _composition(policy.REQUIRE_REVIEW)
+        witness = build_execution_witness(
+            composition,
+            action_ref="action:bare-ref",
+            witness_ref="runtime:audit:bare-ref",
+            enforcement_mode="cooperative",
+            delivery_status="delivered",
+            enforcement_point_status="reached",
+            action_status="executed",
+            liveness_status="healthy",
+            observed_at=self.matrix["observed_at"],
+            approval_evidence_ref="approval:unverified",
+        )
+        self.assertEqual(witness["approval_evidence_status"], "unverified")
+        self.assertEqual(witness["decision_alignment"], "unverifiable")
+
+    def test_expired_approval_remains_stale_in_execution_witness(self):
+        composition = _composition(policy.REQUIRE_REVIEW)
+        case = next(item for item in self.matrix["cases"] if item["case_id"] == "expired-approval")
+        approval = _approval(composition, case, self.matrix["scope_ref"])
+        verification = verify_approval_evidence(
+            approval,
+            composition,
+            expected_scope_ref=self.matrix["scope_ref"],
+            observed_at=self.matrix["observed_at"],
+        )
+        witness = build_execution_witness(
+            composition,
+            action_ref="action:expired-approval",
+            witness_ref="runtime:audit:expired",
+            enforcement_mode="cooperative",
+            delivery_status="delivered",
+            enforcement_point_status="reached",
+            action_status="executed",
+            liveness_status="healthy",
+            observed_at=self.matrix["observed_at"],
+            approval_verification=verification,
+        )
+        self.assertEqual(witness["approval_evidence_status"], "stale")
+        self.assertEqual(witness["decision_alignment"], "unverifiable")
+
+    def test_approval_cannot_widen_deny(self):
+        composition = _composition(policy.BLOCK)
+        case = next(item for item in self.matrix["cases"] if item["case_id"] == "approval-cannot-widen-deny")
+        approval = _approval(composition, case, self.matrix["scope_ref"])
+        verification = verify_approval_evidence(
+            approval,
+            composition,
+            expected_scope_ref=self.matrix["scope_ref"],
+            observed_at=self.matrix["observed_at"],
+        )
+        self.assertEqual(verification["status"], "not_applicable")
+        self.assertFalse(verification["satisfies_required_approval"])
+
+        witness = build_execution_witness(
+            composition,
+            action_ref="action:deny-still-executed",
+            witness_ref="runtime:audit:deny",
+            enforcement_mode="cooperative",
+            delivery_status="delivered",
+            enforcement_point_status="reached",
+            action_status="executed",
+            liveness_status="degraded",
+            observed_at=self.matrix["observed_at"],
+            approval_verification=verification,
+        )
+        self.assertEqual(witness["approval_evidence_status"], "not_applicable")
+        self.assertEqual(witness["decision_alignment"], "violation")
+
+    def test_approval_replay_against_changed_state_fails_identity_binding(self):
+        first_composition = _composition(policy.REQUIRE_REVIEW, proposal=_proposal(state_snapshot="state:v1"))
+        second_composition = _composition(policy.REQUIRE_REVIEW, proposal=_proposal(state_snapshot="state:v2"))
+        case = self.matrix["cases"][0]
+        approval = _approval(first_composition, case, self.matrix["scope_ref"])
+
+        verification = verify_approval_evidence(
+            approval,
+            second_composition,
+            expected_scope_ref=self.matrix["scope_ref"],
+            observed_at=self.matrix["observed_at"],
+        )
+        self.assertEqual(verification["status"], "invalid")
+        self.assertIn("input_identity_mismatch", verification["reasons"])
+        self.assertFalse(verification["satisfies_required_approval"])
+
+    def test_execution_witness_rejects_verification_from_other_composition(self):
+        first_composition = _composition(policy.REQUIRE_REVIEW, proposal=_proposal(proposal_id="proposal:first"))
+        second_composition = _composition(policy.REQUIRE_REVIEW, proposal=_proposal(proposal_id="proposal:second"))
+        case = self.matrix["cases"][0]
+        approval = _approval(first_composition, case, self.matrix["scope_ref"])
+        verification = verify_approval_evidence(
+            approval,
+            first_composition,
+            expected_scope_ref=self.matrix["scope_ref"],
+            observed_at=self.matrix["observed_at"],
+        )
+
+        with self.assertRaisesRegex(ValueError, "approval verification input identity"):
+            build_execution_witness(
+                second_composition,
+                action_ref="action:replay",
+                witness_ref="runtime:audit:replay",
+                enforcement_mode="mechanical",
+                delivery_status="delivered",
+                enforcement_point_status="reached",
+                action_status="executed",
+                liveness_status="healthy",
+                observed_at=self.matrix["observed_at"],
+                approval_verification=verification,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/approval-evidence.schema.json
+++ b/schemas/approval-evidence.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/approval-evidence.schema.json",
+  "title": "Agent Memory Approval Evidence",
+  "description": "Vendor-neutral one-action approval evidence bound to an exact decision-composition input identity. Approval evidence is not a standing grant and is not execution proof.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "approval_version",
+    "approval_id",
+    "input_identity",
+    "composition_id",
+    "principal_ref",
+    "authority_evidence_ref",
+    "scope_ref",
+    "outcome",
+    "mechanism_ref",
+    "issued_at",
+    "evidence_refs",
+    "reusable_authority"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "approval_version": { "const": "0.1.0" },
+    "approval_id": { "type": "string", "minLength": 1 },
+    "input_identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "composition_id": { "type": "string", "minLength": 1 },
+    "principal_ref": { "type": "string", "minLength": 1 },
+    "authority_evidence_ref": { "type": "string", "minLength": 1 },
+    "scope_ref": { "type": "string", "minLength": 1 },
+    "outcome": { "type": "string", "enum": ["approved", "denied", "revoked"] },
+    "mechanism_ref": { "type": "string", "minLength": 1 },
+    "issued_at": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "revoked_at": { "type": "string", "format": "date-time" },
+    "revocation_evidence_ref": { "type": "string", "minLength": 1 },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "reusable_authority": { "const": false }
+  }
+}

--- a/schemas/approval-verification-result.schema.json
+++ b/schemas/approval-verification-result.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/approval-verification-result.schema.json",
+  "title": "Agent Memory Approval Verification Result",
+  "description": "Deterministic verification of one-action approval evidence against the exact decision composition and current observation context.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "approval_id",
+    "input_identity",
+    "composition_id",
+    "status",
+    "satisfies_required_approval",
+    "reasons",
+    "reusable_authority"
+  ],
+  "properties": {
+    "schema_version": { "const": "0.1.0" },
+    "approval_id": { "type": "string", "minLength": 1 },
+    "input_identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "composition_id": { "type": "string", "minLength": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["current", "denied", "stale", "invalid", "not_applicable"]
+    },
+    "satisfies_required_approval": { "type": "boolean" },
+    "reasons": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "reusable_authority": { "const": false }
+  }
+}

--- a/schemas/execution-witness.schema.json
+++ b/schemas/execution-witness.schema.json
@@ -20,6 +20,7 @@
     "action_status",
     "decision_alignment",
     "liveness_status",
+    "approval_evidence_status",
     "observed_at",
     "evidence_refs",
     "non_claims"
@@ -61,6 +62,10 @@
       "enum": ["healthy", "degraded", "unavailable", "unknown"]
     },
     "approval_evidence_ref": { "type": "string", "minLength": 1 },
+    "approval_evidence_status": {
+      "type": "string",
+      "enum": ["absent", "unverified", "verified_current", "stale", "denied", "invalid", "not_applicable"]
+    },
     "observed_at": { "type": "string", "format": "date-time" },
     "evidence_refs": {
       "type": "array",


### PR DESCRIPTION
## Summary

Implements #187, the P0-D closure slice for #152: vendor-neutral one-action approval evidence with exact action/composition identity binding and deterministic current/stale/denied/invalid semantics.

## Implemented

- `approval-evidence` schema with exact `input_identity`, `composition_id`, principal, authority evidence, scope, outcome, issuance/expiry/revocation, mechanism, and evidence refs;
- `reusable_authority = false` as a fixed V0.1 invariant;
- deterministic approval verification result contract;
- current, denied, stale, invalid, and not-applicable approval states;
- execution-witness approval status: absent, unverified, verified_current, stale, denied, invalid, not_applicable;
- `require_approval + executed` is consistent only with a verified-current approval bound to the same decision identities;
- a bare approval ref remains unverified and cannot satisfy execution alignment;
- approval presented against effective `deny` cannot widen authority;
- replay against changed proposal/state or another composition fails identity continuity;
- adversarial fixtures/tests for expiry, revocation, denial, input/composition mismatch, deny widening, replay, and bare refs.

## Core invariant

```text
approval for action/state A != approval for action/state B
approval evidence != standing grant
approval recorded != action executed
```

## Stop line

No standing grants, reusable approval policy, remote approval UX, peer-specific approval API, policy mutation, or cross-organization delegation.

This PR remains draft until exact-head CI and completion review pass.

Closes #187
Refs #152