### PR TITLE
Add governed MCP tool and resource interaction evidence profile

### DIFF
--- a/docs/profiles/mcp-interaction-evidence-profile.md
+++ b/docs/profiles/mcp-interaction-evidence-profile.md
@@ -1,0 +1,323 @@
+# Governed MCP Interaction Evidence Profile
+
+Status: V0.1 reference profile for #190.
+
+This profile defines the minimum Agent Memory-facing evidence seam for Model Context Protocol (MCP) tool and resource interactions. MCP is a runtime/wire protocol input, not Agent Memory authority, memory admission, execution proof, or lifecycle doctrine.
+
+The V0.1 reference is pinned to:
+
+- Model Context Protocol stable revision `2026-07-28`
+- repository `modelcontextprotocol/modelcontextprotocol`
+- source commit `5f5440bb26a62e2cf3440b92da5a667efa03b267`
+
+The exact source revision is evidence metadata. MCP remains optional and replaceable.
+
+## Core boundary
+
+```text
+MCP transport success
+!= Agent Memory authorization
+
+MCP server identity
+!= memory authority
+
+MCP tool result
+!= execution witness
+!= durable memory
+
+MCP resource content
+!= admitted memory
+
+MCP interaction evidence
+!= lifecycle satisfaction
+```
+
+A successful MCP exchange proves only what the observed protocol evidence actually supports.
+
+## V0.1 protocol surface
+
+V0.1 covers exactly two MCP interactions:
+
+```text
+tools/call
+resources/read
+```
+
+The pinned specification defines `tools/call` as a JSON-RPC request to invoke a server-exposed tool and `resources/read` as a JSON-RPC request to retrieve resource contents.
+
+The profile does not reproduce complete MCP requests or results. It preserves the minimum evidence needed to correlate an interaction with Agent Memory governance and scope.
+
+## Why request ID is not authority
+
+MCP uses JSON-RPC request IDs to correlate requests and responses. The pinned tool specification also requires a new JSON-RPC request ID when a `tools/call` interaction continues after an `input_required` result.
+
+Therefore:
+
+```text
+same logical activity
+may use multiple MCP request IDs
+
+request ID
+= correlation evidence
+!= action identity
+!= approval
+!= authority token
+```
+
+Agent Memory durable-mutation identity remains bound through `action_ref`, `input_identity`, and scope rather than through MCP request ID reuse.
+
+## Why server and tool names are not global identity
+
+The pinned MCP tool specification states that tool-name uniqueness is scoped to a single server. It also notes that the server `name` from `serverInfo` is not guaranteed globally unique and should not be relied upon for disambiguation.
+
+V0.1 therefore requires an adapter-supplied stable `server_ref` and a server-scoped `target_ref`.
+
+For example:
+
+```text
+server_ref = mcp-server:memory-tools-a
+target_ref = mcp-tool:mcp-server:memory-tools-a:memory.update
+```
+
+These are correlation references, not memory authority.
+
+## Generic evidence envelope
+
+The normalized evidence surface preserves:
+
+```text
+MCP revision / exact source commit
+client / server opaque refs
+session / transport refs when available
+JSON-RPC request id
+interaction kind and method
+server-scoped tool/resource target ref
+memory effect classification
+request observed state
+result observed state and classification
+request / result digests
+Agent Memory action / input identity when applicable
+scope / tenant / project refs
+PAMA / composition / approval / execution refs when available
+runtime trace-correlation ref when available
+bounded evidence refs
+```
+
+Unknown peer fields are discarded.
+
+## Memory effect classification
+
+Each interaction is classified as one of:
+
+- `none`: no Agent Memory admission or durable-mutation path is being proposed;
+- `memory_candidate`: MCP content may be offered to normal Agent Memory admission later;
+- `durable_mutation`: the interaction may participate in a durable Agent Memory mutation and therefore requires governed identity/scope binding.
+
+`memory_candidate` is not admission.
+
+```text
+resource/tool output
+-> evidence or candidate
+-> normal Agent Memory admission/governance
+
+resource/tool output
+!= canonical memory
+```
+
+## Exact durable-mutation binding
+
+A `durable_mutation` interaction must bind to at least:
+
+```text
+action_ref
+input_identity
+scope_ref
+```
+
+Expected tenant/project bindings are compared when provided.
+
+Missing or mismatched binding is explicit:
+
+```text
+binding_status = mismatch
+governance_alignment = binding_mismatch
+```
+
+Timing, request ID, tool name, result similarity, or server display identity must not repair an identity mismatch.
+
+## Governance availability and monotonicity
+
+For a durable mutation, governance may be `available` or `unavailable`. It may not be declared `not_required`.
+
+When governance is unavailable:
+
+```text
+governance_alignment = blocked_governance_unavailable
+```
+
+The protocol adapter does not infer permission from MCP transport or tool success.
+
+When a stricter Agent Memory composition says `deny`, an observed successful MCP result is recorded as:
+
+```text
+result_classification = success
+effective_decision = deny
+governance_alignment = result_observed_under_deny
+```
+
+That is conflict/incident evidence. It is not retroactive authorization.
+
+When the effective decision is `require_approval`, MCP `input_required`, user interaction, or a successful result does not prove approval satisfaction. Approval remains the exact-identity approval-evidence boundary defined separately by Agent Memory.
+
+## Result states
+
+V0.1 keeps protocol observation separate from interpretation:
+
+```text
+result_status:
+  complete
+  input_required
+  mcp_error
+  unavailable
+  not_observed
+
+result_classification:
+  success
+  tool_error
+  protocol_error
+  input_required
+  unavailable
+  not_observed
+```
+
+Observed result-like states carry a digest. Unavailable or unobserved results do not fabricate one.
+
+An MCP protocol error may preserve the integer JSON-RPC error code as bounded evidence.
+
+## Execution evidence remains separate
+
+MCP result evidence is not an Agent Memory execution witness.
+
+```text
+MCP request/result observed
+!= enforcement point observed
+!= action execution verified
+```
+
+When an Agent Memory `execution_witness_ref` exists, V0.1 may correlate it. When it does not, the profile preserves:
+
+```text
+execution_claim = not_established
+```
+
+Missing trace correlation is handled the same way. It is an evidence gap, not proof of non-execution.
+
+## Resource reads
+
+The pinned MCP resource specification defines `resources/read` as retrieval of resource contents identified by URI. Resources can contain text or binary data and may return multiple content items.
+
+Agent Memory does not need those bodies in its durable protocol evidence record.
+
+V0.1 preserves a stable `target_ref`, request/result digests, result classification, and bounded provenance references. Content may separately enter normal evidence/admission processing if policy requires it.
+
+## Privacy and minimization
+
+Default posture:
+
+```text
+refs / IDs / digests / classifications first
+raw payloads only in a separately governed system when actually required
+```
+
+The normalized V0.1 record does not require or copy:
+
+- raw prompts or system instructions;
+- complete tool arguments;
+- complete tool result payloads;
+- resource bodies;
+- hidden reasoning;
+- access tokens, authorization headers, credentials, or secrets;
+- server/client runtime objects;
+- tenant/project display names when opaque refs suffice.
+
+The pinned MCP tool specification separately warns against exposing sensitive parameters through transport headers. Agent Memory does not treat transport metadata as a safe durable-content channel.
+
+## Required negative paths
+
+The executable V0.1 matrix covers:
+
+1. successful MCP tool result after Agent Memory `deny` remains conflict evidence, not authorization;
+2. resource-read content is not automatically admitted durable memory;
+3. wrong Agent Memory input identity produces a binding mismatch;
+4. the same request/tool identity in another tenant/project does not correlate across scope;
+5. server/governance unavailability remains explicit and cannot widen durable-mutation authority;
+6. peer-supplied PAMA/lifecycle/permission fields are discarded;
+7. missing trace/execution witness remains an explicit evidence gap rather than non-execution proof;
+8. removing the MCP adapter leaves canonical Agent Memory records interpretable through generic refs/digests/governance evidence.
+
+Additional tests cover exact spec pinning, method/kind mismatch, protocol errors, `input_required`, deterministic normalization, and payload minimization.
+
+## Deployment profiles
+
+V0.1 supports these assumptions:
+
+### L: local / single-user
+
+- stdio or local MCP server use is allowed;
+- no enterprise identity provider is required;
+- governance evidence may remain local;
+- raw payload retention is not required.
+
+### T: team / multi-tenant
+
+- explicit tenant/project binding is supported;
+- same tool/request identifiers cannot cross-correlate by similarity;
+- opaque references are preferred over display names.
+
+### E: enterprise governed estate
+
+- external PAMA/composition/approval/execution references may be correlated;
+- gateway/transport success cannot widen Agent Memory authority;
+- unavailability remains explicit.
+
+### H: high assurance
+
+- exact MCP revision and source commit are reconstructable;
+- durable-mutation identity binding is deterministic;
+- evidence gaps and non-claims remain explicit;
+- request/result payloads are represented by digests rather than copied by default.
+
+Cross-organization delegated authority is not a V0.1 target.
+
+## V0.1 non-claims
+
+V0.1 does not claim:
+
+- an MCP server is Agent Memory-conformant;
+- MCP authentication or server identity grants PAMA authority;
+- a successful tool call proves authorized execution;
+- MCP resource content is durable memory;
+- an MCP request ID is a durable action identity;
+- `input_required` is approval evidence;
+- MCP tool annotations are trusted governance input;
+- trace absence proves an action did not occur;
+- protocol evidence satisfies Agent Memory lifecycle obligations;
+- MCP is required for Agent Memory implementations.
+
+## Rollback / removal
+
+The MCP adapter/profile is optional. Removing it leaves canonical Agent Memory state and governance receipts interpretable because the normalized record references Agent Memory identities and receipts instead of embedding MCP runtime objects or making MCP identifiers canonical memory authority.
+
+## Stop line
+
+Do not expand V0.1 into:
+
+- an MCP client or server framework;
+- arbitrary MCP method coverage;
+- A2A/cross-agent delegation;
+- upstream MCP protocol extensions;
+- MCP authentication as PAMA authority;
+- raw payload persistence;
+- claims that MCP execution evidence proves lifecycle satisfaction.
+
+A2A belongs in a separate implementation slice after the MCP boundary is stable.

--- a/fixtures/mcp-interaction-evidence-matrix.json
+++ b/fixtures/mcp-interaction-evidence-matrix.json
@@ -1,0 +1,190 @@
+{
+  "fixture_id": "mcp-interaction-evidence-matrix",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "MCP tool/resource interactions remain protocol evidence only. Transport success, server identity, request IDs, successful tool results, and resource contents cannot create Agent Memory authority, execution proof, durable admission, or lifecycle satisfaction.",
+  "expected_behavior": {
+    "mcp_success_widens_denied_authority": false,
+    "resource_read_auto_admits_memory": false,
+    "cross_scope_correlation": false,
+    "raw_payload_required": false,
+    "request_id_is_authority": false,
+    "server_identity_is_authority": false,
+    "missing_trace_implies_non_execution": false,
+    "adapter_removal_invalidates_canonical_memory": false
+  },
+  "memory_unit": {
+    "id": "mem:mcp-interaction-evidence",
+    "content_ref": "fixture://mcp-interaction-evidence/reference",
+    "type": "evidence",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "mcp-interaction-evidence-matrix",
+      "timestamp": "2026-08-12T22:20:00Z",
+      "source_refs": [
+        "issue://190",
+        "github://modelcontextprotocol/modelcontextprotocol/5f5440bb26a62e2cf3440b92da5a667efa03b267"
+      ]
+    },
+    "evidence": [
+      {
+        "id": "evidence:mcp-v01",
+        "kind": "protocol_interaction_fixture",
+        "ref": "issue://190",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["protocol_interaction", "identity_binding", "scope_isolation"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "policy_refs": ["issue:190", "issue:175"],
+      "permitted_actions": ["collect_more_evidence", "defer"],
+      "prohibited_actions": ["promotion"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T22:20:00Z"
+  },
+  "pinned_reference": {
+    "protocol": "Model Context Protocol",
+    "revision": "2026-07-28",
+    "commit": "5f5440bb26a62e2cf3440b92da5a667efa03b267",
+    "repository": "modelcontextprotocol/modelcontextprotocol"
+  },
+  "expected_context": {
+    "action_ref": "action:mcp:memory-update",
+    "input_identity": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a"
+  },
+  "base_adapter_result": {
+    "protocol_revision": "2026-07-28",
+    "protocol_source_commit": "5f5440bb26a62e2cf3440b92da5a667efa03b267",
+    "protocol_source_ref": "github://modelcontextprotocol/modelcontextprotocol/5f5440bb26a62e2cf3440b92da5a667efa03b267/docs/specification/2026-07-28",
+    "interaction_kind": "tool_call",
+    "method": "tools/call",
+    "client_ref": "mcp-client:local-agent",
+    "server_ref": "mcp-server:memory-tools-a",
+    "session_ref": "mcp-session:alpha",
+    "transport_ref": "mcp-transport:stdio:alpha",
+    "request_id": 7,
+    "target_ref": "mcp-tool:mcp-server:memory-tools-a:memory.update",
+    "memory_effect": "durable_mutation",
+    "request_status": "observed",
+    "result_status": "complete",
+    "result_classification": "success",
+    "governance_status": "available",
+    "effective_decision": "allow",
+    "action_ref": "action:mcp:memory-update",
+    "input_identity": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+    "pama_decision_ref": "decision:pama:mcp-1",
+    "composition_ref": "decision-composition:mcp-1",
+    "execution_witness_ref": "execution-witness:mcp-1",
+    "trace_correlation_ref": "runtime-trace-correlation:mcp-1",
+    "request_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "result_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "observed_at": "2026-08-12T22:21:00Z",
+    "evidence_refs": ["evidence:mcp-request-7", "evidence:mcp-result-7"]
+  },
+  "cases": [
+    {
+      "case_id": "tool-success-exact-binding",
+      "overrides": {},
+      "remove": [],
+      "expected_binding": "exact",
+      "expected_alignment": "within_governance"
+    },
+    {
+      "case_id": "successful-result-after-deny",
+      "overrides": {"effective_decision": "deny"},
+      "remove": [],
+      "expected_binding": "exact",
+      "expected_alignment": "result_observed_under_deny"
+    },
+    {
+      "case_id": "resource-read-is-not-memory-admission",
+      "overrides": {
+        "interaction_kind": "resource_read",
+        "method": "resources/read",
+        "target_ref": "mcp-resource:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "memory_effect": "memory_candidate",
+        "governance_status": "not_required",
+        "request_id": "resource-2"
+      },
+      "remove": [
+        "effective_decision",
+        "action_ref",
+        "input_identity",
+        "scope_ref",
+        "tenant_ref",
+        "project_ref",
+        "pama_decision_ref",
+        "composition_ref",
+        "execution_witness_ref",
+        "trace_correlation_ref"
+      ],
+      "expected_binding": "not_evaluated",
+      "expected_alignment": "not_applicable"
+    },
+    {
+      "case_id": "wrong-agent-memory-input-identity",
+      "overrides": {
+        "input_identity": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      },
+      "remove": [],
+      "expected_binding": "mismatch",
+      "expected_alignment": "within_governance"
+    },
+    {
+      "case_id": "cross-tenant-same-tool-and-request-id",
+      "overrides": {
+        "scope_ref": "scope:tenant-b/project-b",
+        "tenant_ref": "tenant-b",
+        "project_ref": "project-b"
+      },
+      "remove": [],
+      "expected_binding": "mismatch",
+      "expected_alignment": "within_governance"
+    },
+    {
+      "case_id": "server-unavailable-governance-unavailable",
+      "overrides": {
+        "governance_status": "unavailable",
+        "result_status": "unavailable",
+        "result_classification": "unavailable"
+      },
+      "remove": ["effective_decision", "result_digest", "execution_witness_ref", "trace_correlation_ref"],
+      "expected_binding": "exact",
+      "expected_alignment": "blocked_governance_unavailable"
+    },
+    {
+      "case_id": "peer-supplied-authority-fields-ignored",
+      "overrides": {
+        "pama_outcome": "allow",
+        "lifecycle_state": "canonical",
+        "permitted_actions": ["everything"],
+        "memory_authority": "owner"
+      },
+      "remove": [],
+      "expected_binding": "exact",
+      "expected_alignment": "within_governance"
+    },
+    {
+      "case_id": "missing-trace-is-explicit-gap-not-non-execution",
+      "overrides": {},
+      "remove": ["trace_correlation_ref", "execution_witness_ref"],
+      "expected_binding": "exact",
+      "expected_alignment": "within_governance"
+    }
+  ]
+}

--- a/fixtures/mcp-interaction-evidence-matrix.json
+++ b/fixtures/mcp-interaction-evidence-matrix.json
@@ -143,7 +143,7 @@
       },
       "remove": [],
       "expected_binding": "mismatch",
-      "expected_alignment": "within_governance"
+      "expected_alignment": "binding_mismatch"
     },
     {
       "case_id": "cross-tenant-same-tool-and-request-id",
@@ -154,7 +154,7 @@
       },
       "remove": [],
       "expected_binding": "mismatch",
-      "expected_alignment": "within_governance"
+      "expected_alignment": "binding_mismatch"
     },
     {
       "case_id": "server-unavailable-governance-unavailable",

--- a/reference/agentmem_ref/mcp_interaction.py
+++ b/reference/agentmem_ref/mcp_interaction.py
@@ -1,0 +1,291 @@
+"""Governed Model Context Protocol interaction evidence for issue #190.
+
+MCP supplies transport/runtime facts about tool and resource interactions.  This
+module preserves those facts as minimized evidence without treating request IDs,
+server identity, successful results, or resource content as Agent Memory
+authority, execution proof, durable memory, or lifecycle satisfaction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+import rfc8785
+
+from . import receipts
+
+PROFILE_VERSION = "0.1.0"
+MCP_REVISION = "2026-07-28"
+MCP_SOURCE_COMMIT = "5f5440bb26a62e2cf3440b92da5a667efa03b267"
+MCP_SOURCE_REF = (
+    "github://modelcontextprotocol/modelcontextprotocol/"
+    + MCP_SOURCE_COMMIT
+    + "/docs/specification/2026-07-28"
+)
+
+INTERACTION_METHODS = {
+    "tool_call": "tools/call",
+    "resource_read": "resources/read",
+}
+MEMORY_EFFECTS = {"none", "memory_candidate", "durable_mutation"}
+REQUEST_STATUSES = {"observed", "not_observed"}
+RESULT_STATUSES = {"complete", "input_required", "mcp_error", "unavailable", "not_observed"}
+RESULT_CLASSIFICATIONS = {
+    "success",
+    "tool_error",
+    "protocol_error",
+    "input_required",
+    "unavailable",
+    "not_observed",
+}
+GOVERNANCE_STATUSES = {"available", "unavailable", "not_required"}
+EFFECTIVE_DECISIONS = {"allow", "warn", "require_approval", "deny"}
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _sha256_ref(value: dict) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+
+
+def _require_ref(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _require_digest(name: str, value: object) -> str:
+    if not isinstance(value, str) or not _DIGEST_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a lowercase sha256 digest reference")
+    return value
+
+
+def _require_request_id(value: object) -> str | int:
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise ValueError("request_id must be a non-empty string or integer")
+    if isinstance(value, str) and not value:
+        raise ValueError("request_id must be a non-empty string or integer")
+    return value
+
+
+def _validate_result_combination(result_status: str, result_classification: str, result_digest: object) -> str | None:
+    allowed = {
+        "complete": {"success", "tool_error"},
+        "input_required": {"input_required"},
+        "mcp_error": {"protocol_error"},
+        "unavailable": {"unavailable"},
+        "not_observed": {"not_observed"},
+    }
+    if result_classification not in allowed[result_status]:
+        raise ValueError(
+            f"result_classification {result_classification!r} is inconsistent with result_status {result_status!r}"
+        )
+    if result_status in {"complete", "input_required", "mcp_error"}:
+        return _require_digest("result_digest", result_digest)
+    if result_digest is not None:
+        raise ValueError("unavailable/not_observed results must not claim a result_digest")
+    return None
+
+
+def _binding(adapter_result: dict, expected_context: dict | None, memory_effect: str) -> tuple[str, list[str]]:
+    if expected_context is None:
+        if memory_effect == "durable_mutation":
+            return "mismatch", ["expected_context_missing"]
+        return "not_evaluated", []
+    if not isinstance(expected_context, dict):
+        raise ValueError("expected_context must be an object when provided")
+
+    reasons: list[str] = []
+    fields = ("action_ref", "input_identity", "scope_ref", "tenant_ref", "project_ref")
+    for field in fields:
+        expected = expected_context.get(field)
+        if expected is None:
+            continue
+        observed = adapter_result.get(field)
+        if observed is None:
+            reasons.append(f"{field}_missing")
+        elif observed != expected:
+            reasons.append(f"{field}_mismatch")
+
+    if memory_effect == "durable_mutation":
+        for required in ("action_ref", "input_identity", "scope_ref"):
+            if expected_context.get(required) is None:
+                reasons.append(f"expected_{required}_missing")
+            elif adapter_result.get(required) is None and f"{required}_missing" not in reasons:
+                reasons.append(f"{required}_missing")
+
+    return ("mismatch", reasons) if reasons else ("exact", [])
+
+
+def _governance_alignment(
+    *,
+    memory_effect: str,
+    governance_status: str,
+    effective_decision: str | None,
+    result_status: str,
+) -> str:
+    if memory_effect != "durable_mutation":
+        return "not_applicable" if governance_status == "not_required" else "not_evaluated"
+    if governance_status != "available":
+        return "blocked_governance_unavailable"
+    assert effective_decision is not None
+    if effective_decision == "deny":
+        if result_status in {"complete", "input_required", "mcp_error"}:
+            return "result_observed_under_deny"
+        return "within_governance"
+    if effective_decision == "require_approval":
+        # MCP evidence cannot prove approval satisfaction.  That remains the
+        # execution-witness/approval-evidence boundary from #187/#152.
+        return "approval_not_established"
+    return "within_governance"
+
+
+def normalize_mcp_interaction(adapter_result: dict, expected_context: dict | None = None) -> dict:
+    """Normalize one MCP tools/call or resources/read interaction.
+
+    Unknown peer/runtime fields are intentionally discarded.  Callers may pass
+    raw arguments/results to their own adapter long enough to compute digests,
+    but this normalizer neither requires nor copies those payloads.
+    """
+
+    if not isinstance(adapter_result, dict):
+        raise ValueError("adapter_result must be an object")
+
+    revision = adapter_result.get("protocol_revision")
+    source_commit = adapter_result.get("protocol_source_commit")
+    if revision != MCP_REVISION:
+        raise ValueError(f"unsupported MCP protocol revision {revision!r}")
+    if source_commit != MCP_SOURCE_COMMIT:
+        raise ValueError("MCP protocol source commit does not match the pinned stable revision")
+
+    interaction_kind = adapter_result.get("interaction_kind")
+    if interaction_kind not in INTERACTION_METHODS:
+        raise ValueError(f"invalid interaction_kind {interaction_kind!r}")
+    method = adapter_result.get("method")
+    if method != INTERACTION_METHODS[interaction_kind]:
+        raise ValueError(f"method {method!r} does not match interaction_kind {interaction_kind!r}")
+
+    memory_effect = adapter_result.get("memory_effect")
+    if memory_effect not in MEMORY_EFFECTS:
+        raise ValueError(f"invalid memory_effect {memory_effect!r}")
+    request_status = adapter_result.get("request_status")
+    if request_status not in REQUEST_STATUSES:
+        raise ValueError(f"invalid request_status {request_status!r}")
+    result_status = adapter_result.get("result_status")
+    if result_status not in RESULT_STATUSES:
+        raise ValueError(f"invalid result_status {result_status!r}")
+    result_classification = adapter_result.get("result_classification")
+    if result_classification not in RESULT_CLASSIFICATIONS:
+        raise ValueError(f"invalid result_classification {result_classification!r}")
+    if request_status == "not_observed" and result_status not in {"not_observed", "unavailable"}:
+        raise ValueError("an unobserved request cannot claim an observed MCP result")
+
+    governance_status = adapter_result.get("governance_status")
+    if governance_status not in GOVERNANCE_STATUSES:
+        raise ValueError(f"invalid governance_status {governance_status!r}")
+    effective_decision = adapter_result.get("effective_decision")
+    if governance_status == "available":
+        if effective_decision not in EFFECTIVE_DECISIONS:
+            raise ValueError("available governance requires a valid effective_decision")
+    elif effective_decision is not None:
+        raise ValueError("effective_decision requires governance_status='available'")
+    if memory_effect == "durable_mutation" and governance_status == "not_required":
+        raise ValueError("durable mutation cannot declare governance not required")
+
+    result_digest = _validate_result_combination(
+        result_status,
+        result_classification,
+        adapter_result.get("result_digest"),
+    )
+    mcp_error_code = adapter_result.get("mcp_error_code")
+    if result_status == "mcp_error":
+        if isinstance(mcp_error_code, bool) or not isinstance(mcp_error_code, int):
+            raise ValueError("mcp_error result requires integer mcp_error_code")
+    elif mcp_error_code is not None:
+        raise ValueError("mcp_error_code is only valid for mcp_error results")
+
+    body: dict = {
+        "protocol": {
+            "name": "mcp",
+            "revision": MCP_REVISION,
+            "source_ref": _require_ref(
+                "protocol_source_ref",
+                adapter_result.get("protocol_source_ref", MCP_SOURCE_REF),
+            ),
+            "source_commit": MCP_SOURCE_COMMIT,
+        },
+        "interaction_kind": interaction_kind,
+        "method": method,
+        "client_ref": _require_ref("client_ref", adapter_result.get("client_ref")),
+        "server_ref": _require_ref("server_ref", adapter_result.get("server_ref")),
+        "request_id": _require_request_id(adapter_result.get("request_id")),
+        "target_ref": _require_ref("target_ref", adapter_result.get("target_ref")),
+        "memory_effect": memory_effect,
+        "request_status": request_status,
+        "result_status": result_status,
+        "result_classification": result_classification,
+        "governance_status": governance_status,
+        "request_digest": _require_digest("request_digest", adapter_result.get("request_digest")),
+        "observed_at": _require_ref("observed_at", adapter_result.get("observed_at")),
+        "evidence_refs": list(dict.fromkeys(adapter_result.get("evidence_refs", ()))),
+        "interpretation": {
+            "authority_effect": "none",
+            "memory_admission": "not_established",
+            "execution_claim": "not_established",
+            "lifecycle_satisfaction": "not_established",
+            "request_id_authority": "none",
+            "server_identity_authority": "none",
+        },
+    }
+    if not all(isinstance(value, str) and value for value in body["evidence_refs"]):
+        raise ValueError("evidence_refs must contain non-empty strings")
+
+    if effective_decision is not None:
+        body["effective_decision"] = effective_decision
+    if result_digest is not None:
+        body["result_digest"] = result_digest
+    if mcp_error_code is not None:
+        body["mcp_error_code"] = mcp_error_code
+
+    optional_refs = (
+        "session_ref",
+        "transport_ref",
+        "action_ref",
+        "input_identity",
+        "scope_ref",
+        "tenant_ref",
+        "project_ref",
+        "pama_decision_ref",
+        "composition_ref",
+        "approval_evidence_ref",
+        "execution_witness_ref",
+        "trace_correlation_ref",
+    )
+    for name in optional_refs:
+        value = adapter_result.get(name)
+        if value is None:
+            continue
+        if name == "input_identity":
+            body[name] = _require_digest(name, value)
+        else:
+            body[name] = _require_ref(name, value)
+
+    binding_status, binding_reasons = _binding(adapter_result, expected_context, memory_effect)
+    body["binding_status"] = binding_status
+    body["binding_reasons"] = binding_reasons
+    body["governance_alignment"] = _governance_alignment(
+        memory_effect=memory_effect,
+        governance_status=governance_status,
+        effective_decision=effective_decision,
+        result_status=result_status,
+    )
+
+    identity_body = {key: value for key, value in body.items() if key != "observed_at"}
+    document = {
+        "schema_version": "1.0.0",
+        "profile_version": PROFILE_VERSION,
+        "interaction_id": f"mcp-interaction:{_sha256_ref(identity_body)}",
+        **body,
+    }
+    receipts.validate("mcp-interaction-evidence.schema.json", document)
+    return document

--- a/reference/agentmem_ref/mcp_interaction.py
+++ b/reference/agentmem_ref/mcp_interaction.py
@@ -273,12 +273,15 @@ def normalize_mcp_interaction(adapter_result: dict, expected_context: dict | Non
     binding_status, binding_reasons = _binding(adapter_result, expected_context, memory_effect)
     body["binding_status"] = binding_status
     body["binding_reasons"] = binding_reasons
-    body["governance_alignment"] = _governance_alignment(
-        memory_effect=memory_effect,
-        governance_status=governance_status,
-        effective_decision=effective_decision,
-        result_status=result_status,
-    )
+    if memory_effect == "durable_mutation" and binding_status == "mismatch":
+        body["governance_alignment"] = "binding_mismatch"
+    else:
+        body["governance_alignment"] = _governance_alignment(
+            memory_effect=memory_effect,
+            governance_status=governance_status,
+            effective_decision=effective_decision,
+            result_status=result_status,
+        )
 
     identity_body = {key: value for key, value in body.items() if key != "observed_at"}
     document = {

--- a/reference/tests/test_mcp_interaction.py
+++ b/reference/tests/test_mcp_interaction.py
@@ -1,0 +1,213 @@
+"""Executable governed MCP interaction cases for issue #190."""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from agentmem_ref.mcp_interaction import (
+    MCP_REVISION,
+    MCP_SOURCE_COMMIT,
+    normalize_mcp_interaction,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "mcp-interaction-evidence-matrix.json"
+
+
+class MCPInteractionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.matrix = json.loads(MATRIX.read_text(encoding="utf-8"))
+
+    def _case_input(self, case: dict) -> dict:
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value.update(copy.deepcopy(case.get("overrides", {})))
+        for key in case.get("remove", []):
+            value.pop(key, None)
+        return value
+
+    def _normalize_case(self, case: dict) -> dict:
+        expected_context = None if case["case_id"] == "resource-read-is-not-memory-admission" else self.matrix["expected_context"]
+        return normalize_mcp_interaction(self._case_input(case), expected_context)
+
+    def test_fixture_matrix(self):
+        for case in self.matrix["cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                result = self._normalize_case(case)
+                self.assertEqual(result["schema_version"], "1.0.0")
+                self.assertEqual(result["profile_version"], "0.1.0")
+                self.assertEqual(result["protocol"]["revision"], MCP_REVISION)
+                self.assertEqual(result["protocol"]["source_commit"], MCP_SOURCE_COMMIT)
+                self.assertEqual(result["binding_status"], case["expected_binding"])
+                self.assertEqual(result["governance_alignment"], case["expected_alignment"])
+                self.assertEqual(result["interpretation"]["authority_effect"], "none")
+                self.assertEqual(result["interpretation"]["memory_admission"], "not_established")
+                self.assertEqual(result["interpretation"]["execution_claim"], "not_established")
+                self.assertEqual(result["interpretation"]["lifecycle_satisfaction"], "not_established")
+                self.assertEqual(result["interpretation"]["request_id_authority"], "none")
+                self.assertEqual(result["interpretation"]["server_identity_authority"], "none")
+
+    def test_successful_mcp_result_under_deny_is_conflict_evidence_not_authorization(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "successful-result-after-deny")
+        result = self._normalize_case(case)
+        self.assertEqual(result["result_classification"], "success")
+        self.assertEqual(result["effective_decision"], "deny")
+        self.assertEqual(result["governance_alignment"], "result_observed_under_deny")
+        self.assertEqual(result["interpretation"]["execution_claim"], "not_established")
+        self.assertEqual(result["interpretation"]["authority_effect"], "none")
+
+    def test_resource_read_is_only_a_memory_candidate(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "resource-read-is-not-memory-admission")
+        result = self._normalize_case(case)
+        self.assertEqual(result["interaction_kind"], "resource_read")
+        self.assertEqual(result["method"], "resources/read")
+        self.assertEqual(result["memory_effect"], "memory_candidate")
+        self.assertEqual(result["interpretation"]["memory_admission"], "not_established")
+        for key in ("action_ref", "input_identity", "pama_decision_ref", "composition_ref"):
+            self.assertNotIn(key, result)
+
+    def test_wrong_identity_and_cross_scope_fail_closed(self):
+        for case_id, expected_reasons in {
+            "wrong-agent-memory-input-identity": {"input_identity_mismatch"},
+            "cross-tenant-same-tool-and-request-id": {
+                "scope_ref_mismatch",
+                "tenant_ref_mismatch",
+                "project_ref_mismatch",
+            },
+        }.items():
+            case = next(case for case in self.matrix["cases"] if case["case_id"] == case_id)
+            result = self._normalize_case(case)
+            self.assertEqual(result["binding_status"], "mismatch")
+            self.assertEqual(result["governance_alignment"], "binding_mismatch")
+            self.assertTrue(expected_reasons.issubset(set(result["binding_reasons"])))
+
+    def test_durable_mutation_governance_unavailable_is_explicitly_blocked(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "server-unavailable-governance-unavailable")
+        result = self._normalize_case(case)
+        self.assertEqual(result["result_status"], "unavailable")
+        self.assertEqual(result["governance_status"], "unavailable")
+        self.assertEqual(result["governance_alignment"], "blocked_governance_unavailable")
+        self.assertNotIn("effective_decision", result)
+        self.assertNotIn("result_digest", result)
+
+    def test_peer_supplied_authority_fields_are_discarded(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "peer-supplied-authority-fields-ignored")
+        result = self._normalize_case(case)
+        for hostile in ("pama_outcome", "lifecycle_state", "permitted_actions", "memory_authority"):
+            self.assertNotIn(hostile, result)
+        self.assertEqual(result["interpretation"]["authority_effect"], "none")
+
+    def test_missing_trace_or_execution_witness_does_not_claim_non_execution(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "missing-trace-is-explicit-gap-not-non-execution")
+        result = self._normalize_case(case)
+        self.assertNotIn("trace_correlation_ref", result)
+        self.assertNotIn("execution_witness_ref", result)
+        self.assertEqual(result["interpretation"]["execution_claim"], "not_established")
+
+    def test_raw_payload_and_sensitive_fields_are_never_copied(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value.update(
+            {
+                "arguments": {"secret": "do-not-copy"},
+                "result_payload": {"raw": "do-not-copy"},
+                "resource_content": "do-not-copy",
+                "authorization": "Bearer do-not-copy",
+                "hidden_reasoning": "do-not-copy",
+                "serverInfo": {"name": "not-an-authority-token"},
+            }
+        )
+        result = normalize_mcp_interaction(value, self.matrix["expected_context"])
+        for key in (
+            "arguments",
+            "result_payload",
+            "resource_content",
+            "authorization",
+            "hidden_reasoning",
+            "serverInfo",
+        ):
+            self.assertNotIn(key, result)
+        serialized = json.dumps(result)
+        self.assertNotIn("do-not-copy", serialized)
+
+    def test_protocol_pin_is_exact(self):
+        self.assertEqual(self.matrix["pinned_reference"]["revision"], MCP_REVISION)
+        self.assertEqual(self.matrix["pinned_reference"]["commit"], MCP_SOURCE_COMMIT)
+
+        wrong_revision = copy.deepcopy(self.matrix["base_adapter_result"])
+        wrong_revision["protocol_revision"] = "2025-11-25"
+        with self.assertRaisesRegex(ValueError, "unsupported MCP protocol revision"):
+            normalize_mcp_interaction(wrong_revision, self.matrix["expected_context"])
+
+        wrong_commit = copy.deepcopy(self.matrix["base_adapter_result"])
+        wrong_commit["protocol_source_commit"] = "0" * 40
+        with self.assertRaisesRegex(ValueError, "source commit"):
+            normalize_mcp_interaction(wrong_commit, self.matrix["expected_context"])
+
+    def test_method_must_match_interaction_kind(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value["method"] = "resources/read"
+        with self.assertRaisesRegex(ValueError, "does not match interaction_kind"):
+            normalize_mcp_interaction(value, self.matrix["expected_context"])
+
+    def test_durable_mutation_cannot_opt_out_of_governance(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value["governance_status"] = "not_required"
+        value.pop("effective_decision")
+        with self.assertRaisesRegex(ValueError, "governance not required"):
+            normalize_mcp_interaction(value, self.matrix["expected_context"])
+
+    def test_durable_mutation_without_expected_context_is_mismatch(self):
+        result = normalize_mcp_interaction(copy.deepcopy(self.matrix["base_adapter_result"]), None)
+        self.assertEqual(result["binding_status"], "mismatch")
+        self.assertEqual(result["binding_reasons"], ["expected_context_missing"])
+        self.assertEqual(result["governance_alignment"], "binding_mismatch")
+
+    def test_input_required_is_not_approval_evidence(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value["result_status"] = "input_required"
+        value["result_classification"] = "input_required"
+        value["effective_decision"] = "require_approval"
+        value.pop("approval_evidence_ref", None)
+        result = normalize_mcp_interaction(value, self.matrix["expected_context"])
+        self.assertEqual(result["governance_alignment"], "approval_not_established")
+        self.assertNotIn("approval_evidence_ref", result)
+
+    def test_mcp_error_requires_error_code_and_digest(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value["result_status"] = "mcp_error"
+        value["result_classification"] = "protocol_error"
+        value["mcp_error_code"] = -32602
+        result = normalize_mcp_interaction(value, self.matrix["expected_context"])
+        self.assertEqual(result["mcp_error_code"], -32602)
+        self.assertIn("result_digest", result)
+
+        missing_code = copy.deepcopy(value)
+        missing_code.pop("mcp_error_code")
+        with self.assertRaisesRegex(ValueError, "requires integer mcp_error_code"):
+            normalize_mcp_interaction(missing_code, self.matrix["expected_context"])
+
+    def test_normalization_is_deterministic(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        first = normalize_mcp_interaction(value, self.matrix["expected_context"])
+        second = normalize_mcp_interaction(copy.deepcopy(value), copy.deepcopy(self.matrix["expected_context"]))
+        self.assertEqual(first, second)
+
+    def test_adapter_removal_proof_uses_only_generic_evidence_fields(self):
+        result = normalize_mcp_interaction(
+            copy.deepcopy(self.matrix["base_adapter_result"]),
+            self.matrix["expected_context"],
+        )
+        self.assertEqual(result["protocol"]["name"], "mcp")
+        self.assertIn("request_digest", result)
+        self.assertIn("result_digest", result)
+        self.assertIn("action_ref", result)
+        self.assertIn("composition_ref", result)
+        self.assertNotIn("mcp_client_object", result)
+        self.assertNotIn("mcp_server_object", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/mcp-interaction-evidence.schema.json
+++ b/schemas/mcp-interaction-evidence.schema.json
@@ -94,6 +94,7 @@
         "result_observed_under_deny",
         "approval_not_established",
         "blocked_governance_unavailable",
+        "binding_mismatch",
         "not_applicable",
         "not_evaluated"
       ]

--- a/schemas/mcp-interaction-evidence.schema.json
+++ b/schemas/mcp-interaction-evidence.schema.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/mcp-interaction-evidence.schema.json",
+  "title": "Agent Memory MCP Interaction Evidence",
+  "description": "Content-minimized evidence for MCP tools/call and resources/read interactions. MCP transport, server identity, request IDs, results, and resource content do not establish Agent Memory authority, execution proof, memory admission, or lifecycle satisfaction.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_version",
+    "interaction_id",
+    "protocol",
+    "interaction_kind",
+    "method",
+    "client_ref",
+    "server_ref",
+    "request_id",
+    "target_ref",
+    "memory_effect",
+    "request_status",
+    "result_status",
+    "result_classification",
+    "governance_status",
+    "governance_alignment",
+    "binding_status",
+    "binding_reasons",
+    "request_digest",
+    "observed_at",
+    "evidence_refs",
+    "interpretation"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "profile_version": { "const": "0.1.0" },
+    "interaction_id": { "type": "string", "minLength": 1 },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "revision", "source_ref", "source_commit"],
+      "properties": {
+        "name": { "const": "mcp" },
+        "revision": { "const": "2026-07-28" },
+        "source_ref": { "type": "string", "minLength": 1 },
+        "source_commit": { "const": "5f5440bb26a62e2cf3440b92da5a667efa03b267" }
+      }
+    },
+    "interaction_kind": {
+      "type": "string",
+      "enum": ["tool_call", "resource_read"]
+    },
+    "method": {
+      "type": "string",
+      "enum": ["tools/call", "resources/read"]
+    },
+    "client_ref": { "type": "string", "minLength": 1 },
+    "server_ref": { "type": "string", "minLength": 1 },
+    "session_ref": { "type": "string", "minLength": 1 },
+    "transport_ref": { "type": "string", "minLength": 1 },
+    "request_id": {
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        { "type": "integer" }
+      ]
+    },
+    "target_ref": { "type": "string", "minLength": 1 },
+    "memory_effect": {
+      "type": "string",
+      "enum": ["none", "memory_candidate", "durable_mutation"]
+    },
+    "request_status": {
+      "type": "string",
+      "enum": ["observed", "not_observed"]
+    },
+    "result_status": {
+      "type": "string",
+      "enum": ["complete", "input_required", "mcp_error", "unavailable", "not_observed"]
+    },
+    "result_classification": {
+      "type": "string",
+      "enum": ["success", "tool_error", "protocol_error", "input_required", "unavailable", "not_observed"]
+    },
+    "governance_status": {
+      "type": "string",
+      "enum": ["available", "unavailable", "not_required"]
+    },
+    "effective_decision": {
+      "type": "string",
+      "enum": ["allow", "warn", "require_approval", "deny"]
+    },
+    "governance_alignment": {
+      "type": "string",
+      "enum": [
+        "within_governance",
+        "result_observed_under_deny",
+        "approval_not_established",
+        "blocked_governance_unavailable",
+        "not_applicable",
+        "not_evaluated"
+      ]
+    },
+    "binding_status": {
+      "type": "string",
+      "enum": ["exact", "mismatch", "not_evaluated"]
+    },
+    "binding_reasons": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "action_ref": { "type": "string", "minLength": 1 },
+    "input_identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "scope_ref": { "type": "string", "minLength": 1 },
+    "tenant_ref": { "type": "string", "minLength": 1 },
+    "project_ref": { "type": "string", "minLength": 1 },
+    "pama_decision_ref": { "type": "string", "minLength": 1 },
+    "composition_ref": { "type": "string", "minLength": 1 },
+    "approval_evidence_ref": { "type": "string", "minLength": 1 },
+    "execution_witness_ref": { "type": "string", "minLength": 1 },
+    "trace_correlation_ref": { "type": "string", "minLength": 1 },
+    "request_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "result_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "mcp_error_code": { "type": "integer" },
+    "observed_at": { "type": "string", "format": "date-time" },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "interpretation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_effect",
+        "memory_admission",
+        "execution_claim",
+        "lifecycle_satisfaction",
+        "request_id_authority",
+        "server_identity_authority"
+      ],
+      "properties": {
+        "authority_effect": { "const": "none" },
+        "memory_admission": { "const": "not_established" },
+        "execution_claim": { "const": "not_established" },
+        "lifecycle_satisfaction": { "const": "not_established" },
+        "request_id_authority": { "const": "none" },
+        "server_identity_authority": { "const": "none" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "interaction_kind": { "const": "tool_call" } },
+        "required": ["interaction_kind"]
+      },
+      "then": {
+        "properties": { "method": { "const": "tools/call" } }
+      }
+    },
+    {
+      "if": {
+        "properties": { "interaction_kind": { "const": "resource_read" } },
+        "required": ["interaction_kind"]
+      },
+      "then": {
+        "properties": { "method": { "const": "resources/read" } }
+      }
+    },
+    {
+      "if": {
+        "properties": { "memory_effect": { "const": "durable_mutation" } },
+        "required": ["memory_effect"]
+      },
+      "then": {
+        "required": ["action_ref", "input_identity", "scope_ref"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "governance_status": { "const": "available" } },
+        "required": ["governance_status"]
+      },
+      "then": {
+        "required": ["effective_decision"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements the bounded **P1-C / V0.1 governed MCP interaction profile** from #190 against the Model Context Protocol stable revision `2026-07-28`.

Pinned source:

- repository: `modelcontextprotocol/modelcontextprotocol`
- stable revision: `2026-07-28`
- source commit: `5f5440bb26a62e2cf3440b92da5a667efa03b267`

## Core boundary

```text
MCP transport success != Agent Memory authorization
MCP server identity != memory authority
tool result != durable memory
resource content != admitted memory
MCP interaction evidence != lifecycle satisfaction
```

V0.1 covers exactly:

- `tools/call`
- `resources/read`

The normalized evidence envelope preserves protocol/request/result correlation, stable client/server/target refs, exact Agent Memory action/input/scope binding when durable memory may be affected, governance references, optional approval/execution/trace refs, result classification, and request/result digests.

It intentionally does **not** copy complete tool arguments, results, resource bodies, prompts, secrets, hidden reasoning, or arbitrary MCP/runtime fields.

## Authority and identity behavior

- durable-memory interactions cannot declare governance `not_required`;
- missing governance blocks the durable-mutation posture rather than widening it;
- a successful MCP result under Agent Memory `deny` is recorded as conflict evidence, never retroactive authorization;
- `require_approval` remains unsatisfied by MCP evidence alone;
- wrong action/input/scope/tenant/project binding becomes `binding_mismatch`;
- MCP request IDs are correlation only;
- tool target identity is server-scoped because MCP tool names are only unique within a server and server display names are not globally unique.

## Negative paths

The fixture/test matrix covers all #190 required cases:

1. successful tool result after Agent Memory deny;
2. resource read not auto-admitted as memory;
3. wrong Agent Memory input identity;
4. cross-tenant same tool/request identity;
5. server/governance unavailable;
6. hostile peer-supplied PAMA/lifecycle fields;
7. missing trace/execution witness;
8. adapter removal / generic evidence interpretability.

Additional tests cover exact protocol pinning, method/kind mismatch, protocol errors, `input_required`, deterministic normalization, and raw-payload minimization.

## Added surfaces

- `schemas/mcp-interaction-evidence.schema.json`
- `reference/agentmem_ref/mcp_interaction.py`
- `reference/tests/test_mcp_interaction.py`
- `fixtures/mcp-interaction-evidence-matrix.json`
- `docs/profiles/mcp-interaction-evidence-profile.md`

## Stop line

Do not expand this PR into an MCP client/server implementation, broad MCP method coverage, A2A delegation, upstream protocol fields, MCP identity as PAMA authority, or raw payload persistence.

This PR remains draft until exact-head repository CI passes and a completion review confirms #190 acceptance criteria.

Closes #190