### PR TITLE
Add non-authority-bearing governed A2A collaboration profile

### DIFF
--- a/docs/profiles/a2a-collaboration-evidence-profile.md
+++ b/docs/profiles/a2a-collaboration-evidence-profile.md
@@ -1,0 +1,368 @@
+# Governed A2A Collaboration Evidence Profile
+
+Status: V0.1 reference profile for #194.
+
+This profile defines the minimum Agent Memory-facing evidence seam for Agent2Agent (A2A) collaboration while deliberately refusing authority-bearing cross-agent memory transfer.
+
+The V0.1 reference is pinned to:
+
+- repository `a2aproject/A2A`
+- stable release `v1.0.1`
+- source commit `3303592588e388e62e0f69f701af531d2f4e3991`
+- normative protocol source `specification/a2a.proto`
+
+A2A is a transport/task interoperability input, not Agent Memory authority or lifecycle doctrine.
+
+## Core boundary
+
+```text
+A2A Agent Card
+!= delegated authority
+
+A2A peer identity
+!= memory authority
+
+A2A task acceptance or completion
+!= permission to mutate Agent Memory
+
+A2A Message / Artifact
+!= admitted memory
+
+A2A task completion
+!= Agent Memory execution witness
+!= lifecycle satisfaction
+
+cross-agent context transfer
+!= authority transfer
+```
+
+## Why A2A fits the Agent Memory boundary
+
+The pinned A2A specification is designed for collaboration between independent, potentially opaque agent systems without requiring access to each other's internal memory, tools, or reasoning.
+
+That is compatible with Agent Memory minimization:
+
+```text
+collaborate by exchanging bounded context/evidence
+rather than exporting the memory substrate
+```
+
+V0.1 therefore treats A2A as a collaboration evidence plane around Agent Memory, not a shared canonical memory implementation.
+
+## A2A protocol facts used by V0.1
+
+The pinned normative model defines:
+
+- `AgentCard` as discovery metadata describing a remote agent, capabilities, skills, endpoint, and authentication requirements;
+- `Message` as a communication turn with a unique message ID and optional task/context association;
+- `Task` as a server-generated unit of work with task ID, context ID, status, artifacts, and optional history;
+- `Artifact` as a task-scoped output containing one or more content parts;
+- task lifecycle states including `SUBMITTED`, `WORKING`, `COMPLETED`, `FAILED`, `CANCELED`, `INPUT_REQUIRED`, `REJECTED`, and `AUTH_REQUIRED`;
+- multiple protocol bindings over a common canonical model.
+
+These protocol identities are useful correlation evidence. They are not Agent Memory permission objects.
+
+## V0.1 interaction surface
+
+The normalized profile recognizes four bounded interaction kinds:
+
+```text
+task_request
+task_status
+message
+artifact
+```
+
+Direction is explicit:
+
+```text
+outbound
+inbound
+```
+
+A V0.1 `task_request` is outbound. A V0.1 artifact observation is inbound.
+
+## Export classification
+
+Every collaboration record uses one of:
+
+- `explicit_non_memory`: protocol/task evidence that is not proposed as memory;
+- `context_projection`: minimized Agent Memory-derived context exported for a governed collaboration;
+- `memory_candidate`: inbound peer content that may be offered to normal Agent Memory admission later.
+
+No V0.1 classification transfers Agent Memory mutation authority to a remote peer.
+
+```text
+context_projection
+!= authority grant
+
+memory_candidate
+!= memory admission
+```
+
+## Agent Card and peer identity
+
+Agent Cards and remote identity evidence can answer useful questions such as:
+
+- which remote endpoint/capability description was used;
+- which Agent Card version/digest was observed;
+- which remote identity/attestation evidence was associated with the interaction.
+
+They do not answer:
+
+- whether peer output is true;
+- whether the peer may mutate local durable memory;
+- whether the peer inherits local PAMA authority;
+- whether a task result should become canonical memory.
+
+V0.1 therefore preserves stable remote-agent and Agent Card refs/digests while fixing:
+
+```text
+agent_card_authority = none
+delegated_memory_authority = not_established
+semantic_correctness = not_established
+```
+
+External identity/attestation evidence may be correlated through the existing external-evidence boundary. Verification remains evidence, not authority.
+
+## Exact Agent Memory binding
+
+Outbound `context_projection` records must bind to at least:
+
+```text
+action_ref
+input_identity
+scope_ref
+```
+
+Tenant/project references are compared when supplied.
+
+The binding cannot be repaired by:
+
+- matching task IDs;
+- matching context IDs;
+- matching Agent Card names or capabilities;
+- timing proximity;
+- semantic similarity;
+- remote task success.
+
+A mismatch is explicit:
+
+```text
+binding_status = mismatch
+governance_alignment = binding_mismatch
+```
+
+Inbound A2A events may also be correlated to a known local governed action. That correlation remains separate from whether the inbound content is memory.
+
+## Exported memory evidence currentness
+
+When an outbound context projection depends on Agent Memory state, V0.1 records:
+
+```text
+current
+historical
+stale
+revoked
+unknown
+```
+
+Historical, stale, or revoked state may remain useful as provenance or historical context, but cannot masquerade as current authority:
+
+```text
+memory_evidence_status = stale | revoked | historical
+-> governance_alignment = historical_only
+-> delegated_memory_authority = not_established
+```
+
+Correction and revocation references may be preserved without copying the underlying memory graph.
+
+## Local governance remains monotonic
+
+For outbound Agent Memory-derived context, governance may be `available` or `unavailable`. It may not be declared `not_required`.
+
+```text
+governance unavailable
+-> blocked_governance_unavailable
+```
+
+A2A transport does not infer permission.
+
+If local Agent Memory governance says `deny` but an inbound task reports progress/completion anyway, record the contradiction:
+
+```text
+effective_decision = deny
+task_state = completed | working | ...
+governance_alignment = remote_result_under_deny
+```
+
+That is incident/conflict evidence, not retroactive authorization.
+
+If local governance requires approval, A2A task acceptance, `INPUT_REQUIRED`, `AUTH_REQUIRED`, remote identity, or task completion does not establish the Agent Memory approval evidence:
+
+```text
+governance_alignment = approval_not_established
+```
+
+Approval remains a separately verified exact-action artifact.
+
+## Task state is protocol state, not lifecycle satisfaction
+
+A2A task states describe the remote collaboration lifecycle.
+
+A completed A2A task can mean the remote agent reports its task complete. It does not prove that:
+
+- a local enforcement point observed the intended consequence;
+- a local durable memory mutation was authorized;
+- a correction/revocation obligation was satisfied;
+- Agent Memory lifecycle obligations completed.
+
+V0.1 therefore fixes:
+
+```text
+task_completion_authority = none
+execution_claim = not_established
+lifecycle_satisfaction = not_established
+```
+
+When stronger execution/trace evidence exists, it may be correlated through existing refs. Missing trace evidence remains a gap, not proof of non-execution.
+
+## Inbound messages and artifacts
+
+A2A Messages and Artifacts may contain useful evidence or candidate information.
+
+Their content enters Agent Memory only through normal admission:
+
+```text
+A2A Message / Artifact
+-> bounded evidence or memory_candidate
+-> provenance / scope / trust / PAMA / lifecycle processing
+
+A2A Message / Artifact
+!= canonical memory
+```
+
+Peer-supplied fields named `pama_outcome`, `permission`, `authority`, `lifecycle_state`, `standing_grant`, or similar are not canonical merely because they arrived in a structured peer payload.
+
+The V0.1 normalizer uses a fixed allowlist and discards unknown peer fields.
+
+## Privacy and minimization
+
+The normalized collaboration record defaults to:
+
+```text
+stable refs
+opaque scope IDs
+digests
+bounded task state
+governance/evidence refs
+correction/revocation refs
+```
+
+It does not require or copy:
+
+- the full canonical memory graph;
+- raw hidden reasoning or internal plans;
+- system prompts;
+- unrelated remembered state;
+- full Message parts;
+- full Artifact content;
+- complete Agent Card documents after a stable digest/ref is available;
+- credentials/authentication headers or tokens;
+- tenant/project display names when opaque refs suffice.
+
+This preserves A2A's opaque-agent design rather than defeating it by turning interoperability into state exfiltration.
+
+## Required negative paths
+
+The executable V0.1 matrix covers:
+
+1. powerful Agent Card skills/capabilities do not establish Agent Memory authority;
+2. completed remote task under local `deny` remains conflict evidence, not authorization;
+3. hostile peer PAMA/lifecycle/standing-grant fields cannot mutate canonical state;
+4. inbound Artifact content is a candidate, not automatic durable memory;
+5. identical task/context identity across another tenant/project cannot cross-correlate;
+6. valid remote identity evidence does not establish semantic correctness or memory authority;
+7. stale/revoked outbound memory evidence remains historical-only;
+8. missing trace/execution evidence remains an evidence gap, not negative proof;
+9. peer or governance unavailability cannot widen authority;
+10. adapter removal leaves canonical Agent Memory state interpretable.
+
+Additional tests cover exact release pinning, direction/kind constraints, approval non-equivalence, deterministic normalization, and raw-content minimization.
+
+## Deployment profiles
+
+### L: local / single-user
+
+- local A2A peers may collaborate without enterprise identity infrastructure;
+- opaque refs/digests remain sufficient for protocol evidence;
+- full memory export is not required.
+
+### T: team / multi-tenant
+
+- tenant/project binding is explicit;
+- peer task/context IDs do not bypass isolation;
+- inbound candidates remain scoped before admission.
+
+### E: enterprise governed estate
+
+- external peer identity/attestation evidence may be correlated;
+- local PAMA/composition/approval outcomes remain authoritative for Agent Memory consequences;
+- remote task success cannot widen them.
+
+### H: high assurance
+
+- exact A2A release/source commit is reconstructable;
+- Agent Memory-derived exports bind deterministically to action/input/scope;
+- stale/revoked source evidence is explicit;
+- raw content is represented by digest/ref by default;
+- authority nonclaims remain machine-enforced by schema.
+
+## V0.1 non-claims
+
+V0.1 does not claim:
+
+- A2A identity/authentication grants Agent Memory authority;
+- Agent Cards are authorization documents;
+- remote agents receive reusable Agent Memory grants;
+- cross-agent context transfer is inheritance of authority;
+- task acceptance/completion proves authorized local execution;
+- peer Messages/Artifacts are trusted or true;
+- peer output is automatically durable memory;
+- A2A task state satisfies Agent Memory lifecycle obligations;
+- A2A is required by Agent Memory implementations.
+
+## Rollback / removal
+
+The A2A adapter/profile is optional. Removing it leaves canonical Agent Memory state, decisions, corrections, revocations, and evidence interpretable because the normalized collaboration record references generic Agent Memory identities/receipts rather than embedding A2A runtime objects or making A2A identifiers canonical authority.
+
+## Follow-on gate for authority-bearing transfer
+
+Reusable or standing cross-agent authority is explicitly outside V0.1.
+
+A future profile may consider authority-bearing transfer only after research #165/#172 produces an accepted implementation contract for:
+
+```text
+explicit authority-transition event
+exact scope/action/material-condition binding
+expiry
+revocation
+human ratification where required
+recursive-learning prevention
+proof that reusable authority was actually created
+```
+
+Historical approval or a successful A2A collaboration is insufficient.
+
+## Stop line
+
+Do not expand this profile into:
+
+- an A2A client/server/SDK implementation;
+- reusable cross-agent grants;
+- automatic authority inheritance;
+- cA2A as a mandatory dependency;
+- upstream A2A protocol extensions;
+- full memory-graph export;
+- raw peer payload persistence;
+- claims that A2A task completion proves Agent Memory lifecycle satisfaction.

--- a/fixtures/a2a-collaboration-evidence-matrix.json
+++ b/fixtures/a2a-collaboration-evidence-matrix.json
@@ -1,0 +1,278 @@
+{
+  "fixture_id": "a2a-collaboration-evidence-matrix",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "A2A peer discovery, tasks, messages, and artifacts remain non-authority-bearing collaboration evidence. Cross-agent transport and task success cannot create Agent Memory authority, admission, semantic correctness, execution proof, or lifecycle satisfaction.",
+  "expected_behavior": {
+    "agent_card_capability_grants_memory_authority": false,
+    "remote_task_success_widens_local_deny": false,
+    "peer_payload_mutates_pama": false,
+    "peer_artifact_auto_admits_memory": false,
+    "cross_tenant_task_correlation": false,
+    "valid_remote_identity_establishes_semantic_correctness": false,
+    "stale_memory_evidence_becomes_current_authority": false,
+    "missing_trace_implies_non_execution": false,
+    "peer_unavailability_widens_authority": false,
+    "adapter_removal_invalidates_canonical_memory": false
+  },
+  "memory_unit": {
+    "id": "mem:a2a-collaboration-evidence",
+    "content_ref": "fixture://a2a-collaboration-evidence/reference",
+    "type": "evidence",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "a2a-collaboration-evidence-matrix",
+      "timestamp": "2026-08-12T22:34:00Z",
+      "source_refs": [
+        "issue://194",
+        "github://a2aproject/A2A/3303592588e388e62e0f69f701af531d2f4e3991"
+      ]
+    },
+    "evidence": [
+      {
+        "id": "evidence:a2a-v01",
+        "kind": "protocol_collaboration_fixture",
+        "ref": "issue://194",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["cross_agent_transport", "scope_binding", "non_authority_transfer"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "policy_refs": ["issue:194", "issue:175"],
+      "permitted_actions": ["collect_more_evidence", "defer"],
+      "prohibited_actions": ["promotion"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T22:34:00Z"
+  },
+  "pinned_reference": {
+    "protocol": "Agent2Agent",
+    "release": "v1.0.1",
+    "commit": "3303592588e388e62e0f69f701af531d2f4e3991",
+    "repository": "a2aproject/A2A",
+    "normative_source": "specification/a2a.proto"
+  },
+  "expected_context": {
+    "action_ref": "action:a2a:collaborate-1",
+    "input_identity": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a"
+  },
+  "base_adapter_result": {
+    "protocol_release": "v1.0.1",
+    "protocol_source_commit": "3303592588e388e62e0f69f701af531d2f4e3991",
+    "protocol_source_ref": "github://a2aproject/A2A/3303592588e388e62e0f69f701af531d2f4e3991/specification/a2a.proto",
+    "direction": "outbound",
+    "interaction_kind": "task_request",
+    "local_agent_ref": "agent:local:planner",
+    "remote_agent_ref": "agent:remote:researcher",
+    "agent_card_ref": "a2a-agent-card:https://peer.example/.well-known/agent-card.json",
+    "agent_card_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "task_ref": "a2a-task:task-123",
+    "context_ref": "a2a-context:context-456",
+    "message_ref": "a2a-message:message-789",
+    "export_classification": "context_projection",
+    "memory_evidence_status": "current",
+    "task_state": "submitted",
+    "governance_status": "available",
+    "effective_decision": "allow",
+    "action_ref": "action:a2a:collaborate-1",
+    "input_identity": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+    "pama_decision_ref": "decision:pama:a2a-1",
+    "composition_ref": "decision-composition:a2a-1",
+    "approval_evidence_ref": "approval:a2a-1",
+    "execution_witness_ref": "execution-witness:a2a-1",
+    "trace_correlation_ref": "runtime-trace-correlation:a2a-1",
+    "external_evidence_refs": ["external-evidence:remote-identity-1"],
+    "correction_refs": ["correction:memory-source-1"],
+    "revocation_refs": [],
+    "payload_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "observed_at": "2026-08-12T22:35:00Z",
+    "evidence_refs": ["evidence:a2a-request", "evidence:a2a-scope-binding"]
+  },
+  "cases": [
+    {
+      "case_id": "agent-card-capabilities-are-not-authority",
+      "overrides": {
+        "agent_card_capabilities": ["admin", "memory.write", "governance.override"],
+        "agent_card_skills": ["everything"],
+        "delegated_memory_authority": "owner"
+      },
+      "remove": [],
+      "use_expected_context": true,
+      "expected_binding": "exact",
+      "expected_alignment": "within_governance"
+    },
+    {
+      "case_id": "completed-remote-task-under-local-deny",
+      "overrides": {
+        "direction": "inbound",
+        "interaction_kind": "task_status",
+        "export_classification": "explicit_non_memory",
+        "memory_evidence_status": "not_applicable",
+        "task_state": "completed",
+        "effective_decision": "deny"
+      },
+      "remove": [],
+      "use_expected_context": true,
+      "expected_binding": "exact",
+      "expected_alignment": "remote_result_under_deny"
+    },
+    {
+      "case_id": "inbound-artifact-hostile-authority-fields-ignored",
+      "overrides": {
+        "direction": "inbound",
+        "interaction_kind": "artifact",
+        "artifact_ref": "a2a-artifact:task-123:artifact-1",
+        "export_classification": "memory_candidate",
+        "memory_evidence_status": "not_applicable",
+        "task_state": "completed",
+        "governance_status": "not_required",
+        "pama_outcome": "allow",
+        "lifecycle_state": "canonical",
+        "permitted_actions": ["everything"],
+        "authority_transition": "standing_grant"
+      },
+      "remove": [
+        "effective_decision",
+        "action_ref",
+        "input_identity",
+        "scope_ref",
+        "tenant_ref",
+        "project_ref",
+        "pama_decision_ref",
+        "composition_ref",
+        "approval_evidence_ref",
+        "execution_witness_ref",
+        "trace_correlation_ref",
+        "correction_refs"
+      ],
+      "use_expected_context": false,
+      "expected_binding": "not_evaluated",
+      "expected_alignment": "not_applicable"
+    },
+    {
+      "case_id": "inbound-artifact-is-not-memory-admission",
+      "overrides": {
+        "direction": "inbound",
+        "interaction_kind": "artifact",
+        "artifact_ref": "a2a-artifact:task-123:artifact-2",
+        "export_classification": "memory_candidate",
+        "memory_evidence_status": "not_applicable",
+        "task_state": "completed",
+        "governance_status": "not_required"
+      },
+      "remove": [
+        "effective_decision",
+        "action_ref",
+        "input_identity",
+        "scope_ref",
+        "tenant_ref",
+        "project_ref",
+        "pama_decision_ref",
+        "composition_ref",
+        "approval_evidence_ref",
+        "execution_witness_ref",
+        "trace_correlation_ref",
+        "correction_refs"
+      ],
+      "use_expected_context": false,
+      "expected_binding": "not_evaluated",
+      "expected_alignment": "not_applicable"
+    },
+    {
+      "case_id": "cross-tenant-task-correlation-mismatch",
+      "overrides": {
+        "direction": "inbound",
+        "interaction_kind": "task_status",
+        "export_classification": "explicit_non_memory",
+        "memory_evidence_status": "not_applicable",
+        "task_state": "working",
+        "scope_ref": "scope:tenant-b/project-b",
+        "tenant_ref": "tenant-b",
+        "project_ref": "project-b"
+      },
+      "remove": [],
+      "use_expected_context": true,
+      "expected_binding": "mismatch",
+      "expected_alignment": "binding_mismatch"
+    },
+    {
+      "case_id": "verified-remote-identity-does-not-prove-correctness",
+      "overrides": {
+        "direction": "inbound",
+        "interaction_kind": "message",
+        "message_ref": "a2a-message:peer-response-1",
+        "export_classification": "explicit_non_memory",
+        "memory_evidence_status": "not_applicable",
+        "task_state": "working",
+        "governance_status": "not_required",
+        "external_evidence_refs": ["external-evidence:verified-remote-agent"]
+      },
+      "remove": [
+        "effective_decision",
+        "action_ref",
+        "input_identity",
+        "scope_ref",
+        "tenant_ref",
+        "project_ref",
+        "pama_decision_ref",
+        "composition_ref",
+        "approval_evidence_ref",
+        "execution_witness_ref",
+        "trace_correlation_ref",
+        "correction_refs"
+      ],
+      "use_expected_context": false,
+      "expected_binding": "not_evaluated",
+      "expected_alignment": "not_applicable"
+    },
+    {
+      "case_id": "stale-outbound-memory-evidence-is-historical-only",
+      "overrides": {"memory_evidence_status": "stale"},
+      "remove": [],
+      "use_expected_context": true,
+      "expected_binding": "exact",
+      "expected_alignment": "historical_only"
+    },
+    {
+      "case_id": "missing-trace-and-execution-remain-evidence-gaps",
+      "overrides": {},
+      "remove": ["trace_correlation_ref", "execution_witness_ref"],
+      "use_expected_context": true,
+      "expected_binding": "exact",
+      "expected_alignment": "within_governance"
+    },
+    {
+      "case_id": "remote-unavailable-governance-unavailable",
+      "overrides": {
+        "task_state": "unavailable",
+        "governance_status": "unavailable"
+      },
+      "remove": ["effective_decision", "execution_witness_ref", "trace_correlation_ref"],
+      "use_expected_context": true,
+      "expected_binding": "exact",
+      "expected_alignment": "blocked_governance_unavailable"
+    },
+    {
+      "case_id": "adapter-removal-preserves-generic-evidence",
+      "overrides": {},
+      "remove": [],
+      "use_expected_context": true,
+      "expected_binding": "exact",
+      "expected_alignment": "within_governance"
+    }
+  ]
+}

--- a/reference/agentmem_ref/a2a_collaboration.py
+++ b/reference/agentmem_ref/a2a_collaboration.py
@@ -1,0 +1,274 @@
+"""Non-authority-bearing Agent2Agent collaboration evidence for issue #194.
+
+A2A supplies peer discovery, message, task, context, and artifact facts. This
+module normalizes those facts without letting transport/task identity become
+Agent Memory authority, durable admission, semantic correctness, execution
+proof, or lifecycle satisfaction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+import rfc8785
+
+from . import receipts
+
+PROFILE_VERSION = "0.1.0"
+A2A_RELEASE = "v1.0.1"
+A2A_SOURCE_COMMIT = "3303592588e388e62e0f69f701af531d2f4e3991"
+A2A_SOURCE_REF = f"github://a2aproject/A2A/{A2A_SOURCE_COMMIT}/specification/a2a.proto"
+
+DIRECTIONS = {"outbound", "inbound"}
+INTERACTION_KINDS = {"task_request", "task_status", "message", "artifact"}
+EXPORT_CLASSES = {"explicit_non_memory", "context_projection", "memory_candidate"}
+MEMORY_EVIDENCE_STATUSES = {"current", "historical", "stale", "revoked", "unknown", "not_applicable"}
+TASK_STATES = {
+    "unspecified",
+    "submitted",
+    "working",
+    "completed",
+    "failed",
+    "canceled",
+    "input_required",
+    "rejected",
+    "auth_required",
+    "unavailable",
+    "not_observed",
+}
+GOVERNANCE_STATUSES = {"available", "unavailable", "not_required"}
+EFFECTIVE_DECISIONS = {"allow", "warn", "require_approval", "deny"}
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _sha256_ref(value: dict) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+
+
+def _require_ref(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _require_digest(name: str, value: object) -> str:
+    if not isinstance(value, str) or not _DIGEST_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a lowercase sha256 digest reference")
+    return value
+
+
+def _string_list(name: str, value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple)) or not all(isinstance(item, str) and item for item in value):
+        raise ValueError(f"{name} must be a list of non-empty strings")
+    return list(dict.fromkeys(value))
+
+
+def _binding(adapter_result: dict, expected_context: dict | None, export_classification: str) -> tuple[str, list[str]]:
+    if expected_context is None:
+        if export_classification == "context_projection":
+            return "mismatch", ["expected_context_missing"]
+        return "not_evaluated", []
+    if not isinstance(expected_context, dict):
+        raise ValueError("expected_context must be an object when provided")
+
+    reasons: list[str] = []
+    for field in ("action_ref", "input_identity", "scope_ref", "tenant_ref", "project_ref"):
+        expected = expected_context.get(field)
+        if expected is None:
+            continue
+        actual = adapter_result.get(field)
+        if actual is None:
+            reasons.append(f"{field}_missing")
+        elif actual != expected:
+            reasons.append(f"{field}_mismatch")
+
+    if export_classification == "context_projection":
+        for required in ("action_ref", "input_identity", "scope_ref"):
+            if expected_context.get(required) is None:
+                reasons.append(f"expected_{required}_missing")
+            elif adapter_result.get(required) is None and f"{required}_missing" not in reasons:
+                reasons.append(f"{required}_missing")
+
+    return ("mismatch", reasons) if reasons else ("exact", [])
+
+
+def _alignment(
+    *,
+    direction: str,
+    export_classification: str,
+    memory_evidence_status: str,
+    governance_status: str,
+    effective_decision: str | None,
+    task_state: str,
+    binding_status: str,
+) -> str:
+    if export_classification == "context_projection" and binding_status == "mismatch":
+        return "binding_mismatch"
+    if export_classification != "context_projection":
+        return "not_applicable" if governance_status == "not_required" else "not_evaluated"
+    if memory_evidence_status in {"historical", "stale", "revoked"}:
+        return "historical_only"
+    if governance_status != "available":
+        return "blocked_governance_unavailable"
+    assert effective_decision is not None
+    if effective_decision == "deny":
+        if direction == "inbound" and task_state not in {"unavailable", "not_observed", "rejected"}:
+            return "remote_result_under_deny"
+        return "within_governance"
+    if effective_decision == "require_approval":
+        return "approval_not_established"
+    return "within_governance"
+
+
+def normalize_a2a_collaboration(adapter_result: dict, expected_context: dict | None = None) -> dict:
+    """Normalize one bounded A2A collaboration event.
+
+    The adapter may inspect raw Agent Cards, Messages, Tasks, or Artifacts long
+    enough to compute stable refs/digests. This function intentionally accepts
+    and emits only minimized evidence fields.
+    """
+
+    if not isinstance(adapter_result, dict):
+        raise ValueError("adapter_result must be an object")
+    if adapter_result.get("protocol_release") != A2A_RELEASE:
+        raise ValueError(f"unsupported A2A release {adapter_result.get('protocol_release')!r}")
+    if adapter_result.get("protocol_source_commit") != A2A_SOURCE_COMMIT:
+        raise ValueError("A2A protocol source commit does not match the pinned stable release")
+
+    direction = adapter_result.get("direction")
+    if direction not in DIRECTIONS:
+        raise ValueError(f"invalid direction {direction!r}")
+    interaction_kind = adapter_result.get("interaction_kind")
+    if interaction_kind not in INTERACTION_KINDS:
+        raise ValueError(f"invalid interaction_kind {interaction_kind!r}")
+    if interaction_kind == "task_request" and direction != "outbound":
+        raise ValueError("task_request must be outbound")
+    if interaction_kind == "artifact" and direction != "inbound":
+        raise ValueError("artifact observation must be inbound in V0.1")
+
+    export_classification = adapter_result.get("export_classification")
+    if export_classification not in EXPORT_CLASSES:
+        raise ValueError(f"invalid export_classification {export_classification!r}")
+    if export_classification == "context_projection" and direction != "outbound":
+        raise ValueError("context_projection must be outbound in V0.1")
+    if export_classification == "memory_candidate" and direction != "inbound":
+        raise ValueError("memory_candidate must be inbound in V0.1")
+
+    memory_evidence_status = adapter_result.get("memory_evidence_status")
+    if memory_evidence_status not in MEMORY_EVIDENCE_STATUSES:
+        raise ValueError(f"invalid memory_evidence_status {memory_evidence_status!r}")
+    if export_classification != "context_projection" and memory_evidence_status not in {"not_applicable", "unknown"}:
+        raise ValueError("memory evidence currentness only applies to outbound context projections")
+
+    task_state = adapter_result.get("task_state")
+    if task_state not in TASK_STATES:
+        raise ValueError(f"invalid task_state {task_state!r}")
+
+    governance_status = adapter_result.get("governance_status")
+    if governance_status not in GOVERNANCE_STATUSES:
+        raise ValueError(f"invalid governance_status {governance_status!r}")
+    effective_decision = adapter_result.get("effective_decision")
+    if governance_status == "available":
+        if effective_decision not in EFFECTIVE_DECISIONS:
+            raise ValueError("available governance requires a valid effective_decision")
+    elif effective_decision is not None:
+        raise ValueError("effective_decision requires governance_status='available'")
+    if export_classification == "context_projection" and governance_status == "not_required":
+        raise ValueError("outbound memory-derived context cannot declare governance not required")
+
+    body: dict = {
+        "protocol": {
+            "name": "a2a",
+            "release": A2A_RELEASE,
+            "source_ref": _require_ref(
+                "protocol_source_ref",
+                adapter_result.get("protocol_source_ref", A2A_SOURCE_REF),
+            ),
+            "source_commit": A2A_SOURCE_COMMIT,
+        },
+        "direction": direction,
+        "interaction_kind": interaction_kind,
+        "local_agent_ref": _require_ref("local_agent_ref", adapter_result.get("local_agent_ref")),
+        "remote_agent_ref": _require_ref("remote_agent_ref", adapter_result.get("remote_agent_ref")),
+        "agent_card_digest": _require_digest("agent_card_digest", adapter_result.get("agent_card_digest")),
+        "export_classification": export_classification,
+        "memory_evidence_status": memory_evidence_status,
+        "task_state": task_state,
+        "governance_status": governance_status,
+        "payload_digest": _require_digest("payload_digest", adapter_result.get("payload_digest")),
+        "observed_at": _require_ref("observed_at", adapter_result.get("observed_at")),
+        "evidence_refs": _string_list("evidence_refs", adapter_result.get("evidence_refs")),
+        "interpretation": {
+            "authority_effect": "none",
+            "delegated_memory_authority": "not_established",
+            "memory_admission": "not_established",
+            "semantic_correctness": "not_established",
+            "execution_claim": "not_established",
+            "lifecycle_satisfaction": "not_established",
+            "agent_card_authority": "none",
+            "task_completion_authority": "none",
+        },
+    }
+
+    if effective_decision is not None:
+        body["effective_decision"] = effective_decision
+
+    optional_refs = (
+        "agent_card_ref",
+        "task_ref",
+        "context_ref",
+        "message_ref",
+        "artifact_ref",
+        "action_ref",
+        "scope_ref",
+        "tenant_ref",
+        "project_ref",
+        "pama_decision_ref",
+        "composition_ref",
+        "approval_evidence_ref",
+        "execution_witness_ref",
+        "trace_correlation_ref",
+    )
+    for name in optional_refs:
+        value = adapter_result.get(name)
+        if value is not None:
+            body[name] = _require_ref(name, value)
+
+    if adapter_result.get("input_identity") is not None:
+        body["input_identity"] = _require_digest("input_identity", adapter_result["input_identity"])
+
+    for name in ("external_evidence_refs", "correction_refs", "revocation_refs"):
+        values = _string_list(name, adapter_result.get(name))
+        if values:
+            body[name] = values
+
+    if interaction_kind == "message" and "message_ref" not in body:
+        raise ValueError("message interaction requires message_ref")
+    if interaction_kind == "artifact" and "artifact_ref" not in body:
+        raise ValueError("artifact interaction requires artifact_ref")
+
+    binding_status, binding_reasons = _binding(adapter_result, expected_context, export_classification)
+    body["binding_status"] = binding_status
+    body["binding_reasons"] = binding_reasons
+    body["governance_alignment"] = _alignment(
+        direction=direction,
+        export_classification=export_classification,
+        memory_evidence_status=memory_evidence_status,
+        governance_status=governance_status,
+        effective_decision=effective_decision,
+        task_state=task_state,
+        binding_status=binding_status,
+    )
+
+    identity_body = {key: value for key, value in body.items() if key != "observed_at"}
+    document = {
+        "schema_version": "1.0.0",
+        "profile_version": PROFILE_VERSION,
+        "collaboration_id": f"a2a-collaboration:{_sha256_ref(identity_body)}",
+        **body,
+    }
+    receipts.validate("a2a-collaboration-evidence.schema.json", document)
+    return document

--- a/reference/agentmem_ref/a2a_collaboration.py
+++ b/reference/agentmem_ref/a2a_collaboration.py
@@ -105,22 +105,29 @@ def _alignment(
     task_state: str,
     binding_status: str,
 ) -> str:
-    if export_classification == "context_projection" and binding_status == "mismatch":
+    if binding_status == "mismatch" and governance_status != "not_required":
         return "binding_mismatch"
-    if export_classification != "context_projection":
-        return "not_applicable" if governance_status == "not_required" else "not_evaluated"
-    if memory_evidence_status in {"historical", "stale", "revoked"}:
-        return "historical_only"
-    if governance_status != "available":
-        return "blocked_governance_unavailable"
-    assert effective_decision is not None
-    if effective_decision == "deny":
+
+    # A remote protocol result may be governance-relevant even when the content
+    # itself is explicit non-memory. Export/memory classification and action
+    # governance are deliberately separate axes.
+    if governance_status == "available" and effective_decision == "deny":
         if direction == "inbound" and task_state not in {"unavailable", "not_observed", "rejected"}:
             return "remote_result_under_deny"
+        if export_classification == "context_projection":
+            return "within_governance"
+
+    if export_classification == "context_projection":
+        if memory_evidence_status in {"historical", "stale", "revoked"}:
+            return "historical_only"
+        if governance_status != "available":
+            return "blocked_governance_unavailable"
+        assert effective_decision is not None
+        if effective_decision == "require_approval":
+            return "approval_not_established"
         return "within_governance"
-    if effective_decision == "require_approval":
-        return "approval_not_established"
-    return "within_governance"
+
+    return "not_applicable" if governance_status == "not_required" else "not_evaluated"
 
 
 def normalize_a2a_collaboration(adapter_result: dict, expected_context: dict | None = None) -> dict:

--- a/reference/tests/test_a2a_collaboration.py
+++ b/reference/tests/test_a2a_collaboration.py
@@ -1,0 +1,232 @@
+"""Executable non-authority-bearing A2A collaboration cases for issue #194."""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from agentmem_ref.a2a_collaboration import (
+    A2A_RELEASE,
+    A2A_SOURCE_COMMIT,
+    normalize_a2a_collaboration,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "a2a-collaboration-evidence-matrix.json"
+
+
+class A2ACollaborationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.matrix = json.loads(MATRIX.read_text(encoding="utf-8"))
+
+    def _input_for(self, case: dict) -> dict:
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value.update(copy.deepcopy(case.get("overrides", {})))
+        for key in case.get("remove", []):
+            value.pop(key, None)
+        return value
+
+    def _normalize_case(self, case: dict) -> dict:
+        expected = self.matrix["expected_context"] if case.get("use_expected_context") else None
+        return normalize_a2a_collaboration(self._input_for(case), expected)
+
+    def test_fixture_matrix(self):
+        for case in self.matrix["cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                result = self._normalize_case(case)
+                self.assertEqual(result["schema_version"], "1.0.0")
+                self.assertEqual(result["profile_version"], "0.1.0")
+                self.assertEqual(result["protocol"]["release"], A2A_RELEASE)
+                self.assertEqual(result["protocol"]["source_commit"], A2A_SOURCE_COMMIT)
+                self.assertEqual(result["binding_status"], case["expected_binding"])
+                self.assertEqual(result["governance_alignment"], case["expected_alignment"])
+                self.assertEqual(result["interpretation"]["authority_effect"], "none")
+                self.assertEqual(result["interpretation"]["delegated_memory_authority"], "not_established")
+                self.assertEqual(result["interpretation"]["memory_admission"], "not_established")
+                self.assertEqual(result["interpretation"]["semantic_correctness"], "not_established")
+                self.assertEqual(result["interpretation"]["execution_claim"], "not_established")
+                self.assertEqual(result["interpretation"]["lifecycle_satisfaction"], "not_established")
+                self.assertEqual(result["interpretation"]["agent_card_authority"], "none")
+                self.assertEqual(result["interpretation"]["task_completion_authority"], "none")
+
+    def test_agent_card_capabilities_cannot_create_authority(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "agent-card-capabilities-are-not-authority")
+        result = self._normalize_case(case)
+        for hostile in ("agent_card_capabilities", "agent_card_skills", "delegated_memory_authority"):
+            self.assertNotIn(hostile, result)
+        self.assertEqual(result["interpretation"]["agent_card_authority"], "none")
+        self.assertEqual(result["interpretation"]["delegated_memory_authority"], "not_established")
+
+    def test_completed_remote_task_under_deny_is_conflict_not_authorization(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "completed-remote-task-under-local-deny")
+        result = self._normalize_case(case)
+        self.assertEqual(result["task_state"], "completed")
+        self.assertEqual(result["effective_decision"], "deny")
+        self.assertEqual(result["governance_alignment"], "remote_result_under_deny")
+        self.assertEqual(result["interpretation"]["execution_claim"], "not_established")
+        self.assertEqual(result["interpretation"]["task_completion_authority"], "none")
+
+    def test_peer_authority_fields_are_discarded(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "inbound-artifact-hostile-authority-fields-ignored")
+        result = self._normalize_case(case)
+        for hostile in ("pama_outcome", "lifecycle_state", "permitted_actions", "authority_transition"):
+            self.assertNotIn(hostile, result)
+        self.assertEqual(result["export_classification"], "memory_candidate")
+        self.assertEqual(result["interpretation"]["memory_admission"], "not_established")
+
+    def test_inbound_artifact_is_candidate_not_admission(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "inbound-artifact-is-not-memory-admission")
+        result = self._normalize_case(case)
+        self.assertEqual(result["direction"], "inbound")
+        self.assertEqual(result["interaction_kind"], "artifact")
+        self.assertEqual(result["export_classification"], "memory_candidate")
+        self.assertEqual(result["interpretation"]["memory_admission"], "not_established")
+        self.assertIn("artifact_ref", result)
+        self.assertNotIn("pama_decision_ref", result)
+
+    def test_cross_tenant_task_correlation_fails_closed(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "cross-tenant-task-correlation-mismatch")
+        result = self._normalize_case(case)
+        self.assertEqual(result["binding_status"], "mismatch")
+        self.assertEqual(result["governance_alignment"], "binding_mismatch")
+        self.assertTrue(
+            {"scope_ref_mismatch", "tenant_ref_mismatch", "project_ref_mismatch"}.issubset(
+                set(result["binding_reasons"])
+            )
+        )
+
+    def test_verified_remote_identity_is_not_semantic_correctness(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "verified-remote-identity-does-not-prove-correctness")
+        result = self._normalize_case(case)
+        self.assertEqual(result["external_evidence_refs"], ["external-evidence:verified-remote-agent"])
+        self.assertEqual(result["interpretation"]["semantic_correctness"], "not_established")
+        self.assertEqual(result["interpretation"]["delegated_memory_authority"], "not_established")
+
+    def test_stale_or_revoked_outbound_memory_evidence_is_historical_only(self):
+        base = copy.deepcopy(self.matrix["base_adapter_result"])
+        for status in ("historical", "stale", "revoked"):
+            with self.subTest(status=status):
+                value = copy.deepcopy(base)
+                value["memory_evidence_status"] = status
+                result = normalize_a2a_collaboration(value, self.matrix["expected_context"])
+                self.assertEqual(result["governance_alignment"], "historical_only")
+                self.assertEqual(result["interpretation"]["delegated_memory_authority"], "not_established")
+
+    def test_missing_trace_and_execution_witness_remain_unknown_not_negative_proof(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "missing-trace-and-execution-remain-evidence-gaps")
+        result = self._normalize_case(case)
+        self.assertNotIn("trace_correlation_ref", result)
+        self.assertNotIn("execution_witness_ref", result)
+        self.assertEqual(result["interpretation"]["execution_claim"], "not_established")
+        self.assertEqual(result["interpretation"]["lifecycle_satisfaction"], "not_established")
+
+    def test_peer_unavailability_does_not_widen_authority(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "remote-unavailable-governance-unavailable")
+        result = self._normalize_case(case)
+        self.assertEqual(result["task_state"], "unavailable")
+        self.assertEqual(result["governance_status"], "unavailable")
+        self.assertEqual(result["governance_alignment"], "blocked_governance_unavailable")
+        self.assertNotIn("effective_decision", result)
+
+    def test_raw_peer_content_and_memory_graph_are_never_copied(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value.update(
+            {
+                "full_memory_graph": {"secret": "do-not-copy"},
+                "message_parts": [{"text": "do-not-copy"}],
+                "artifact_body": {"raw": "do-not-copy"},
+                "system_prompt": "do-not-copy",
+                "hidden_reasoning": "do-not-copy",
+                "authorization": "Bearer do-not-copy",
+                "agent_card": {"skills": ["do-not-copy"]},
+            }
+        )
+        result = normalize_a2a_collaboration(value, self.matrix["expected_context"])
+        serialized = json.dumps(result)
+        self.assertNotIn("do-not-copy", serialized)
+        for key in (
+            "full_memory_graph",
+            "message_parts",
+            "artifact_body",
+            "system_prompt",
+            "hidden_reasoning",
+            "authorization",
+            "agent_card",
+        ):
+            self.assertNotIn(key, result)
+
+    def test_release_pin_is_exact(self):
+        self.assertEqual(self.matrix["pinned_reference"]["release"], A2A_RELEASE)
+        self.assertEqual(self.matrix["pinned_reference"]["commit"], A2A_SOURCE_COMMIT)
+
+        wrong_release = copy.deepcopy(self.matrix["base_adapter_result"])
+        wrong_release["protocol_release"] = "v0.3.0"
+        with self.assertRaisesRegex(ValueError, "unsupported A2A release"):
+            normalize_a2a_collaboration(wrong_release, self.matrix["expected_context"])
+
+        wrong_commit = copy.deepcopy(self.matrix["base_adapter_result"])
+        wrong_commit["protocol_source_commit"] = "0" * 40
+        with self.assertRaisesRegex(ValueError, "source commit"):
+            normalize_a2a_collaboration(wrong_commit, self.matrix["expected_context"])
+
+    def test_context_projection_requires_governance_and_exact_context(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value["governance_status"] = "not_required"
+        value.pop("effective_decision")
+        with self.assertRaisesRegex(ValueError, "cannot declare governance not required"):
+            normalize_a2a_collaboration(value, self.matrix["expected_context"])
+
+        result = normalize_a2a_collaboration(copy.deepcopy(self.matrix["base_adapter_result"]), None)
+        self.assertEqual(result["binding_status"], "mismatch")
+        self.assertEqual(result["binding_reasons"], ["expected_context_missing"])
+        self.assertEqual(result["governance_alignment"], "binding_mismatch")
+
+    def test_require_approval_is_not_satisfied_by_task_or_peer_interaction(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        value["effective_decision"] = "require_approval"
+        value.pop("approval_evidence_ref", None)
+        result = normalize_a2a_collaboration(value, self.matrix["expected_context"])
+        self.assertEqual(result["governance_alignment"], "approval_not_established")
+        self.assertNotIn("approval_evidence_ref", result)
+
+    def test_direction_and_kind_constraints(self):
+        invalid_request = copy.deepcopy(self.matrix["base_adapter_result"])
+        invalid_request["direction"] = "inbound"
+        with self.assertRaisesRegex(ValueError, "task_request must be outbound"):
+            normalize_a2a_collaboration(invalid_request, self.matrix["expected_context"])
+
+        invalid_artifact = copy.deepcopy(self.matrix["base_adapter_result"])
+        invalid_artifact.update(
+            {
+                "interaction_kind": "artifact",
+                "artifact_ref": "a2a-artifact:bad",
+                "export_classification": "explicit_non_memory",
+                "memory_evidence_status": "not_applicable",
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "artifact observation must be inbound"):
+            normalize_a2a_collaboration(invalid_artifact, self.matrix["expected_context"])
+
+    def test_normalization_is_deterministic(self):
+        value = copy.deepcopy(self.matrix["base_adapter_result"])
+        first = normalize_a2a_collaboration(value, self.matrix["expected_context"])
+        second = normalize_a2a_collaboration(copy.deepcopy(value), copy.deepcopy(self.matrix["expected_context"]))
+        self.assertEqual(first, second)
+
+    def test_adapter_removal_proof_retains_generic_evidence_only(self):
+        case = next(case for case in self.matrix["cases"] if case["case_id"] == "adapter-removal-preserves-generic-evidence")
+        result = self._normalize_case(case)
+        self.assertEqual(result["protocol"]["name"], "a2a")
+        self.assertIn("action_ref", result)
+        self.assertIn("input_identity", result)
+        self.assertIn("payload_digest", result)
+        self.assertIn("pama_decision_ref", result)
+        self.assertNotIn("a2a_client_object", result)
+        self.assertNotIn("a2a_server_object", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/a2a-collaboration-evidence.schema.json
+++ b/schemas/a2a-collaboration-evidence.schema.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/a2a-collaboration-evidence.schema.json",
+  "title": "Agent Memory A2A Collaboration Evidence",
+  "description": "Content-minimized evidence for non-authority-bearing Agent2Agent collaboration. Agent Cards, peer identity, task state, messages, artifacts, and transport success do not establish delegated Agent Memory authority, memory admission, semantic correctness, execution proof, or lifecycle satisfaction.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_version",
+    "collaboration_id",
+    "protocol",
+    "direction",
+    "interaction_kind",
+    "local_agent_ref",
+    "remote_agent_ref",
+    "agent_card_digest",
+    "export_classification",
+    "memory_evidence_status",
+    "task_state",
+    "governance_status",
+    "governance_alignment",
+    "binding_status",
+    "binding_reasons",
+    "payload_digest",
+    "observed_at",
+    "evidence_refs",
+    "interpretation"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "profile_version": { "const": "0.1.0" },
+    "collaboration_id": { "type": "string", "minLength": 1 },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "release", "source_ref", "source_commit"],
+      "properties": {
+        "name": { "const": "a2a" },
+        "release": { "const": "v1.0.1" },
+        "source_ref": { "type": "string", "minLength": 1 },
+        "source_commit": { "const": "3303592588e388e62e0f69f701af531d2f4e3991" }
+      }
+    },
+    "direction": { "type": "string", "enum": ["outbound", "inbound"] },
+    "interaction_kind": {
+      "type": "string",
+      "enum": ["task_request", "task_status", "message", "artifact"]
+    },
+    "local_agent_ref": { "type": "string", "minLength": 1 },
+    "remote_agent_ref": { "type": "string", "minLength": 1 },
+    "agent_card_ref": { "type": "string", "minLength": 1 },
+    "agent_card_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "task_ref": { "type": "string", "minLength": 1 },
+    "context_ref": { "type": "string", "minLength": 1 },
+    "message_ref": { "type": "string", "minLength": 1 },
+    "artifact_ref": { "type": "string", "minLength": 1 },
+    "export_classification": {
+      "type": "string",
+      "enum": ["explicit_non_memory", "context_projection", "memory_candidate"]
+    },
+    "memory_evidence_status": {
+      "type": "string",
+      "enum": ["current", "historical", "stale", "revoked", "unknown", "not_applicable"]
+    },
+    "task_state": {
+      "type": "string",
+      "enum": [
+        "unspecified",
+        "submitted",
+        "working",
+        "completed",
+        "failed",
+        "canceled",
+        "input_required",
+        "rejected",
+        "auth_required",
+        "unavailable",
+        "not_observed"
+      ]
+    },
+    "governance_status": {
+      "type": "string",
+      "enum": ["available", "unavailable", "not_required"]
+    },
+    "effective_decision": {
+      "type": "string",
+      "enum": ["allow", "warn", "require_approval", "deny"]
+    },
+    "governance_alignment": {
+      "type": "string",
+      "enum": [
+        "within_governance",
+        "remote_result_under_deny",
+        "approval_not_established",
+        "blocked_governance_unavailable",
+        "binding_mismatch",
+        "historical_only",
+        "not_applicable",
+        "not_evaluated"
+      ]
+    },
+    "binding_status": {
+      "type": "string",
+      "enum": ["exact", "mismatch", "not_evaluated"]
+    },
+    "binding_reasons": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "action_ref": { "type": "string", "minLength": 1 },
+    "input_identity": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "scope_ref": { "type": "string", "minLength": 1 },
+    "tenant_ref": { "type": "string", "minLength": 1 },
+    "project_ref": { "type": "string", "minLength": 1 },
+    "pama_decision_ref": { "type": "string", "minLength": 1 },
+    "composition_ref": { "type": "string", "minLength": 1 },
+    "approval_evidence_ref": { "type": "string", "minLength": 1 },
+    "execution_witness_ref": { "type": "string", "minLength": 1 },
+    "trace_correlation_ref": { "type": "string", "minLength": 1 },
+    "external_evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "correction_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "revocation_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "payload_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "observed_at": { "type": "string", "format": "date-time" },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "interpretation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_effect",
+        "delegated_memory_authority",
+        "memory_admission",
+        "semantic_correctness",
+        "execution_claim",
+        "lifecycle_satisfaction",
+        "agent_card_authority",
+        "task_completion_authority"
+      ],
+      "properties": {
+        "authority_effect": { "const": "none" },
+        "delegated_memory_authority": { "const": "not_established" },
+        "memory_admission": { "const": "not_established" },
+        "semantic_correctness": { "const": "not_established" },
+        "execution_claim": { "const": "not_established" },
+        "lifecycle_satisfaction": { "const": "not_established" },
+        "agent_card_authority": { "const": "none" },
+        "task_completion_authority": { "const": "none" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "interaction_kind": { "const": "task_request" } },
+        "required": ["interaction_kind"]
+      },
+      "then": { "properties": { "direction": { "const": "outbound" } } }
+    },
+    {
+      "if": {
+        "properties": { "interaction_kind": { "const": "artifact" } },
+        "required": ["interaction_kind"]
+      },
+      "then": { "required": ["artifact_ref"] }
+    },
+    {
+      "if": {
+        "properties": { "interaction_kind": { "const": "message" } },
+        "required": ["interaction_kind"]
+      },
+      "then": { "required": ["message_ref"] }
+    },
+    {
+      "if": {
+        "properties": { "export_classification": { "const": "context_projection" } },
+        "required": ["export_classification"]
+      },
+      "then": { "required": ["action_ref", "input_identity", "scope_ref"] }
+    },
+    {
+      "if": {
+        "properties": { "governance_status": { "const": "available" } },
+        "required": ["governance_status"]
+      },
+      "then": { "required": ["effective_decision"] }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements **P1-C2 / V0.1** from #194: a non-authority-bearing Agent2Agent collaboration evidence profile.

Pinned A2A reference:

- repository: `a2aproject/A2A`
- stable release: `v1.0.1`
- exact source commit: `3303592588e388e62e0f69f701af531d2f4e3991`
- normative source: `specification/a2a.proto`

## Core boundary

```text
A2A Agent Card != delegated authority
A2A peer identity != memory authority
A2A task acceptance/completion != permission to mutate Agent Memory
A2A Message / Artifact != admitted memory
A2A task completion != Agent Memory lifecycle satisfaction
cross-agent context transfer != authority transfer
```

V0.1 intentionally does **not** implement reusable cross-agent grants or authority-bearing memory transfer. #165/#172 remain research umbrellas; those semantics require a separate future authority-transition contract.

## V0.1 surface

The generic normalized envelope covers:

- exact A2A release/source identity;
- local/remote agent refs and Agent Card ref/digest;
- task/context/message/artifact refs;
- inbound/outbound direction;
- `task_request`, `task_status`, `message`, and `artifact` interactions;
- `explicit_non_memory`, `context_projection`, and `memory_candidate` classification;
- exact Agent Memory action/input/scope binding for outbound context projections;
- task state using the A2A 1.0.x lifecycle vocabulary;
- local PAMA/composition/approval refs when applicable;
- external identity/attestation evidence refs when available;
- correction/revocation/currentness evidence;
- optional execution/trace refs;
- minimized payload/evidence digests.

The normalizer never requires the full memory graph, complete peer Message/Artifact bodies, hidden reasoning, prompts, or credentials.

## Negative paths

The executable matrix covers all #194 required cases:

1. powerful Agent Card capabilities do not grant Agent Memory authority;
2. completed remote task under local `deny` remains conflict evidence;
3. peer-supplied PAMA/lifecycle/standing-grant fields are discarded;
4. inbound Artifact is a memory candidate, not automatic admission;
5. cross-tenant task/context correlation fails closed;
6. verified remote identity does not prove semantic correctness or authority;
7. stale/revoked outbound memory evidence remains historical-only;
8. missing trace/execution evidence remains an evidence gap;
9. peer/governance unavailability cannot widen authority;
10. adapter removal leaves canonical Agent Memory state interpretable.

Additional tests cover exact release pinning, approval non-equivalence, direction/kind constraints, deterministic normalization, and raw-content minimization.

## Added surfaces

- `schemas/a2a-collaboration-evidence.schema.json`
- `reference/agentmem_ref/a2a_collaboration.py`
- `reference/tests/test_a2a_collaboration.py`
- `fixtures/a2a-collaboration-evidence-matrix.json`
- `docs/profiles/a2a-collaboration-evidence-profile.md`

## Stop line

Do not expand this PR into an A2A client/server/SDK, reusable cross-agent grants, cA2A dependency adoption, upstream protocol fields, full memory-graph export, or claims that remote task completion proves Agent Memory execution/lifecycle satisfaction.

This PR remains draft until exact-head repository CI passes and a completion review confirms #194 acceptance criteria.

Closes #194