### PR TITLE
Add security evidence-depth ledger and poisoning behavioral harness

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -67,6 +67,22 @@ jobs:
           path: benchmark-security.json
           if-no-files-found: error
 
+      - name: Emit security evidence-depth report
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_security_evidence_depth.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --benchmark-security benchmark-security.json
+          --output security-evidence-depth.json
+
+      - name: Upload security evidence-depth report
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-evidence-depth-report
+          path: security-evidence-depth.json
+          if-no-files-found: error
+
       - name: Execute pinned Mem0 P6 comparator
         env:
           AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -150,6 +166,7 @@ jobs:
           docs/programs/runtime-evidence/deletion-completeness-evidence.md
           docs/programs/runtime-evidence/concurrency-conflict-evidence.md
           docs/programs/runtime-evidence/benchmark-security-scorecard.md
+          docs/programs/runtime-evidence/security-evidence-depth.md
           docs/programs/runtime-evidence/mem0-adversarial-comparator.md
           docs/programs/runtime-evidence/governed-interchange.md
           docs/programs/runtime-evidence/telemetry-minimization.md
@@ -182,10 +199,11 @@ jobs:
             echo "python -m unittest discover -s reference/tests -t reference"
             echo "python reference/run_concurrency_evidence.py --agent-memory-commit <exact-40-hex-commit> --output concurrency-evidence.json"
             echo "python reference/run_benchmark_security.py --agent-memory-commit <exact-40-hex-commit> --output benchmark-security.json"
+            echo "python reference/run_security_evidence_depth.py --agent-memory-commit <exact-40-hex-commit> --benchmark-security benchmark-security.json --output security-evidence-depth.json"
             echo "python -m venv /tmp/agent-memory-p6-mem0 && /tmp/agent-memory-p6-mem0/bin/python -m pip install mem0ai==2.0.18 jsonschema==4.26.0 && MEM0_TELEMETRY=false PYTHONPATH=reference /tmp/agent-memory-p6-mem0/bin/python reference/run_mem0_comparator.py --agent-memory-commit <exact-40-hex-commit> --output mem0-comparator.json"
             echo "python reference/run_deletion_completeness.py --agent-memory-commit <exact-40-hex-commit> --output deletion-completeness.json"
             echo "python -m venv /tmp/agent-memory-p45c-cmcp && /tmp/agent-memory-p45c-cmcp/bin/python -m pip install cmcp-runtime==0.4.0 agentrust-trace==0.8.0 agent-manifest==0.11.0 rfc8785==0.1.4 && PYTHONPATH=reference /tmp/agent-memory-p45c-cmcp/bin/python reference/run_trace_cmcp_comparator.py"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md GOVERNANCE.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/policies/AI_ASSISTED_CONTRIBUTIONS.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md docs/programs/runtime-evidence/deletion-completeness-evidence.md docs/programs/runtime-evidence/concurrency-conflict-evidence.md docs/programs/runtime-evidence/benchmark-security-scorecard.md docs/programs/runtime-evidence/mem0-adversarial-comparator.md docs/programs/runtime-evidence/governed-interchange.md docs/programs/runtime-evidence/telemetry-minimization.md docs/programs/runtime-evidence/systems-economic-characterization.md docs/programs/runtime-evidence/program-closeout-audit.md reference/README.md"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md GOVERNANCE.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/policies/AI_ASSISTED_CONTRIBUTIONS.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md docs/programs/runtime-evidence/deletion-completeness-evidence.md docs/programs/runtime-evidence/concurrency-conflict-evidence.md docs/programs/runtime-evidence/benchmark-security-scorecard.md docs/programs/runtime-evidence/security-evidence-depth.md docs/programs/runtime-evidence/mem0-adversarial-comparator.md docs/programs/runtime-evidence/governed-interchange.md docs/programs/runtime-evidence/telemetry-minimization.md docs/programs/runtime-evidence/systems-economic-characterization.md docs/programs/runtime-evidence/program-closeout-audit.md reference/README.md"
             echo "python scripts/validate_wiki_links.py wiki-src"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'

--- a/docs/programs/runtime-evidence/security-evidence-depth.md
+++ b/docs/programs/runtime-evidence/security-evidence-depth.md
@@ -1,0 +1,298 @@
+# Security Evidence Depth and Poisoning Boundary Harness
+
+Status: V0.1 runtime-evidence profile for #196.
+
+This profile makes a deliberately uncomfortable distinction machine-readable:
+
+```text
+security doctrine
+!= structural scenario
+!= behavioral proof
+!= runtime evidence
+!= production evidence
+```
+
+Agent Memory records those evidence depths independently as **D/F/H/R/P**.
+
+## Evidence levels
+
+| Level | Meaning | Minimum evidence |
+|---|---|---|
+| `D` | Documented doctrine | Canonical doctrine/reference explaining the bounded claim |
+| `F` | Structural fixture | Validated fixture or explicit machine-readable scenario |
+| `H` | Behavioral harness | Executable test/harness actually exercises the claimed behavior |
+| `R` | Runtime implementation evidence | Separately generated evidence from an implementation/runtime path bound to the exact implementation head |
+| `P` | Production evidence | Separately governed evidence from an actual production deployment |
+
+The levels are **not cumulative badges**.
+
+```text
+D + H
+!= D + F + H
+
+H
+!= R
+
+R
+!= P
+```
+
+If a level has no evidence, it remains explicitly unproven even when a stronger-looking but semantically different artifact exists elsewhere.
+
+## No composite security score
+
+V0.1 emits no scalar security, maturity, coverage, or certification score.
+
+A composite score would permit a strong result in one area to obscure a missing or failed security boundary in another. That is precisely the failure mode this ledger is designed to prevent.
+
+The report preserves:
+
+```text
+demonstrated_levels
+highest_demonstrated_level
+explicitly_unproven_levels
+```
+
+`highest_demonstrated_level` is navigation metadata only. It does not imply that lower levels exist or that the claim is generally mature.
+
+## Exact-head runtime evidence
+
+Runtime evidence must remain bound to the implementation it actually exercised.
+
+For the direct-poisoning case, V0.1 can consume the separately generated P5 benchmark-security artifact only when:
+
+- the artifact `agent_memory_commit` exactly equals the security-depth report head;
+- P5 hard gates passed;
+- `authority_from_confidence_count == 0`;
+- the corresponding confidence/authority case passed.
+
+Then, and only then, the direct-poisoning claim may demonstrate `R`.
+
+An otherwise valid runtime artifact from a different commit is preserved only as stale/historical runtime evidence. It does not prove current `R`.
+
+## Production evidence
+
+The reference repository does not collect production deployment evidence in this V0.1 slice.
+
+Therefore:
+
+```text
+P = explicitly unproven by default
+```
+
+Unit tests, CI success, protocol results, reference-runtime execution, benchmark artifacts, contributor statements, or standards mappings cannot manufacture `P`.
+
+## V0.1 poisoning boundaries
+
+The first behavioral harness covers three ingestion boundaries selected from #173 research.
+
+### 1. Direct untrusted external write
+
+The harness sends the same high-consequence M4 promotion through the real `GovernedMemoryAdapter` twice:
+
+```text
+confidence = 0.99
+confidence = 0.01
+```
+
+Both carry an untrusted source ref plus repeated/derived refs.
+
+The required behavior is:
+
+```text
+high confidence
+!= higher authority
+
+repetition / derived copies
+!= review discharge
+
+untrusted proposal
+-> PAMA evaluation
+-> requested promotion remains prohibited without required review
+-> zero substrate writes
+```
+
+The PAMA decision must preserve the supplied evidence references so blocking a mutation does not erase provenance.
+
+This extends the existing P5 confidence/authority hard gate into an explicit poisoning-ingestion claim.
+
+### 2. MCP ingestion
+
+The harness consumes the merged governed MCP profile using a successful `resources/read` result classified as `memory_candidate`.
+
+The peer also supplies hostile fields such as:
+
+```text
+pama_outcome = allow
+lifecycle_state = canonical
+memory_authority = owner
+```
+
+The required behavior is:
+
+```text
+MCP success
+-> protocol evidence / candidate only
+-> hostile authority fields discarded
+-> memory_admission = not_established
+-> authority_effect = none
+```
+
+This is `H` evidence against the Agent Memory MCP normalizer. It is not live MCP-host `R` evidence.
+
+### 3. A2A ingestion
+
+The harness consumes the merged non-authority-bearing A2A profile with an inbound Artifact classified as `memory_candidate`.
+
+It additionally exercises a peer task correlation carrying the correct local action/input identity but the wrong tenant/project scope.
+
+Required behavior:
+
+```text
+remote artifact
+-> candidate only
+-> peer identity != authority
+-> peer identity != semantic correctness
+-> hostile authority-transition fields discarded
+
+same task/action correlation + wrong tenant/project
+-> binding_mismatch
+```
+
+This is `H` evidence against the Agent Memory A2A normalizer. It is not live A2A-host `R` evidence.
+
+## Evidence report contract
+
+The generated report is validated by:
+
+- `schemas/security-evidence-depth-report.schema.json`
+- `reference/agentmem_ref/security_evidence_depth.py`
+- `reference/run_security_evidence_depth.py`
+- `reference/tests/test_security_evidence_depth.py`
+- `fixtures/security-evidence-depth-matrix.json`
+
+Each claim records:
+
+```text
+claim_id
+title
+threat_family
+doctrine_refs
+fixture_refs
+behavioral_harness_refs
+runtime_evidence_refs
+production_evidence_refs
+external_mappings
+demonstrated_levels
+highest_demonstrated_level
+explicitly_unproven_levels
+scope_profiles
+evaluated_head
+runtime_evidence_head when current R exists
+stale_runtime_evidence_refs when relevant
+behavioral_passed
+non_certification_statement
+```
+
+## External mappings and certification
+
+An external standard/control mapping may help users locate related security expectations. It cannot upgrade Agent Memory evidence depth and cannot imply certification.
+
+Every mapped control must carry:
+
+```text
+certification_claim = none
+```
+
+The schema/report is an evidence ledger, not an audit certificate.
+
+Future standards crosswalk work may populate source/version/control refs after research validates exact mapping semantics. V0.1 does not invent control IDs merely to make the report appear complete.
+
+## Failure behavior
+
+The ledger fails visibly rather than averaging failure away.
+
+Examples:
+
+```text
+D + F only
+-> H, R, P remain unproven
+
+behavioral case fails
+-> H removed for that claim
+-> report behavioral gate fails
+
+same behavioral case has independent R evidence
+-> R remains R
+-> failed H remains failed
+
+runtime artifact bound to older head
+-> stale_runtime_evidence_refs
+-> current R remains unproven
+
+no production artifact
+-> P remains unproven
+```
+
+This is intentional. Evidence dimensions describe different facts and may disagree.
+
+## Privacy and minimization
+
+The ledger stores evidence refs, digests, bounded outcomes, and exact source/head identity.
+
+It does not require:
+
+- raw poisoned memory contents;
+- production payloads;
+- credentials;
+- hidden reasoning;
+- complete MCP resource bodies;
+- complete A2A Message/Artifact bodies;
+- tenant/project display names when opaque refs suffice.
+
+## Deployment profiles
+
+### L: local / single-user
+
+Behavioral evidence can execute entirely against the local reference implementation and protocol normalizers.
+
+### T: team / multi-tenant
+
+The A2A poisoning case exercises tenant/project mismatch explicitly. Cross-scope evidence cannot be repaired by task or peer identity.
+
+### E: enterprise governed estate
+
+Runtime and future production evidence may be attached separately without collapsing implementation proof into deployment certification.
+
+### H: high assurance
+
+Exact head identity, source refs, independent evidence levels, explicit stale evidence, and non-certification semantics are required. Missing evidence remains missing.
+
+## V0.1 non-claims
+
+V0.1 does not claim:
+
+- comprehensive poisoning resistance;
+- sleeper-agent resistance;
+- long-horizon poisoning persistence measurement;
+- live MCP server runtime validation;
+- live A2A peer runtime validation;
+- production security validation;
+- OWASP, NIST, CSA, or other external certification;
+- one poisoning result generalizes to unrelated threat families;
+- `highest_demonstrated_level` is a maturity score.
+
+## Follow-on direction
+
+After this evidence-depth seam is stable, later P2 slices can add additional claims only when each has its own bounded evidence chain.
+
+High-value candidates from #173 include:
+
+- sleeper/delayed poisoning across retrieval and consolidation;
+- correction poisoning and adversarial supersession;
+- multi-source collusion/self-corroboration;
+- poisoning persistence after summarization/consolidation;
+- live protocol/runtime comparators;
+- exact versioned standards mappings.
+
+Each new claim must earn its own D/F/H/R/P evidence rather than inheriting depth from neighboring work.

--- a/fixtures/security-evidence-depth-matrix.json
+++ b/fixtures/security-evidence-depth-matrix.json
@@ -1,0 +1,105 @@
+{
+  "fixture_id": "security-evidence-depth-matrix",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "Security evidence depth must remain explicit across documented doctrine, structural fixtures, behavioral harnesses, runtime implementation evidence, and production evidence. Poisoning boundaries are demonstrated without inflating weaker evidence into stronger claims.",
+  "expected_behavior": {
+    "level_inference_allowed": false,
+    "composite_security_score_allowed": false,
+    "external_mapping_implies_certification": false,
+    "production_evidence_defaults_proven": false,
+    "protocol_success_upgrades_security_depth": false,
+    "failed_behavior_hidden_by_aggregation": false
+  },
+  "memory_unit": {
+    "id": "mem:security-evidence-depth",
+    "content_ref": "fixture://security-evidence-depth/reference",
+    "type": "evidence",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "security-evidence-depth-matrix",
+      "timestamp": "2026-08-12T22:40:00Z",
+      "source_refs": ["issue://196", "issue://173", "issue://170"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:security-depth-v01",
+        "kind": "security_evidence_depth_fixture",
+        "ref": "issue://196",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["evidence_depth", "poisoning_resistance", "non_certification"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "policy_refs": ["issue:196", "issue:173"],
+      "permitted_actions": ["collect_more_evidence", "defer"],
+      "prohibited_actions": ["promotion"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T22:40:00Z"
+  },
+  "evidence_levels": [
+    {"level": "D", "meaning": "documented_doctrine"},
+    {"level": "F", "meaning": "structural_fixture"},
+    {"level": "H", "meaning": "behavioral_harness"},
+    {"level": "R", "meaning": "runtime_implementation_evidence"},
+    {"level": "P", "meaning": "production_evidence"}
+  ],
+  "claims": [
+    {
+      "claim_id": "poisoning:direct-external-write",
+      "title": "Direct untrusted external content cannot self-authorize durable promotion",
+      "threat_family": "memory_poisoning",
+      "doctrine_refs": ["docs/15-memory-threat-model.md", "docs/04-governance-and-pama.md"],
+      "fixture_refs": ["fixtures/security-evidence-depth-matrix.json"],
+      "runtime_evidence_refs": ["reference/agentmem_ref/benchmark_security.py#authority_from_confidence"],
+      "scope_profiles": ["L", "T", "E", "H"]
+    },
+    {
+      "claim_id": "poisoning:mcp-ingestion",
+      "title": "MCP tool/resource output remains evidence or a memory candidate under normal admission",
+      "threat_family": "protocol_ingestion_poisoning",
+      "doctrine_refs": ["docs/15-memory-threat-model.md", "docs/profiles/mcp-interaction-evidence-profile.md"],
+      "fixture_refs": ["fixtures/mcp-interaction-evidence-matrix.json", "fixtures/security-evidence-depth-matrix.json"],
+      "runtime_evidence_refs": [],
+      "scope_profiles": ["L", "T", "E", "H"]
+    },
+    {
+      "claim_id": "poisoning:a2a-ingestion",
+      "title": "A2A peer Message/Artifact content remains evidence or a memory candidate under normal admission",
+      "threat_family": "cross_agent_ingestion_poisoning",
+      "doctrine_refs": ["docs/15-memory-threat-model.md", "docs/profiles/a2a-collaboration-evidence-profile.md"],
+      "fixture_refs": ["fixtures/a2a-collaboration-evidence-matrix.json", "fixtures/security-evidence-depth-matrix.json"],
+      "runtime_evidence_refs": [],
+      "scope_profiles": ["L", "T", "E", "H"]
+    }
+  ],
+  "negative_cases": [
+    {
+      "case_id": "documented-plus-fixture-does-not-imply-higher-levels",
+      "evidence_refs": {"D": ["doc:one"], "F": ["fixture:one"], "H": [], "R": [], "P": []},
+      "expected_demonstrated_levels": ["D", "F"],
+      "expected_unproven_levels": ["H", "R", "P"]
+    },
+    {
+      "case_id": "harness-pass-does-not-imply-production",
+      "evidence_refs": {"D": ["doc:one"], "F": ["fixture:one"], "H": ["harness:one"], "R": [], "P": []},
+      "expected_demonstrated_levels": ["D", "F", "H"],
+      "expected_unproven_levels": ["R", "P"]
+    },
+    {
+      "case_id": "noncontiguous-levels-remain-noncontiguous",
+      "evidence_refs": {"D": ["doc:one"], "F": [], "H": ["harness:one"], "R": [], "P": []},
+      "expected_demonstrated_levels": ["D", "H"],
+      "expected_unproven_levels": ["F", "R", "P"]
+    }
+  ]
+}

--- a/reference/agentmem_ref/security_evidence_depth.py
+++ b/reference/agentmem_ref/security_evidence_depth.py
@@ -1,0 +1,460 @@
+"""Security evidence-depth ledger and poisoning-boundary harness for issue #196.
+
+The D/F/H/R/P levels are independent evidence claims:
+
+D = documented doctrine
+F = structural fixture/scenario
+H = behavioral/conformance harness
+R = runtime implementation evidence
+P = production evidence
+
+No level is inferred from another. In particular, executing this module proves
+behavioral coverage only; runtime evidence is counted only when separately
+supplied and bound to the exact Agent Memory head, and production evidence is
+never manufactured by the reference implementation.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from . import policy, receipts
+from .a2a_collaboration import normalize_a2a_collaboration
+from .adapter import Clock, GovernedMemoryAdapter
+from .mcp_interaction import normalize_mcp_interaction
+from .substrate import InMemoryTemporalGraph
+
+LEVELS = ("D", "F", "H", "R", "P")
+LEVEL_RANK = {level: index for index, level in enumerate(LEVELS)}
+REPORT_TYPE = "agent-memory-security-evidence-depth"
+REPORT_VERSION = "1.0.0"
+
+
+def _exact_commit(value: str) -> str:
+    commit = value.lower()
+    if len(commit) != 40 or any(ch not in "0123456789abcdef" for ch in commit):
+        raise ValueError("agent_memory_commit must be an exact 40-hex commit")
+    return commit
+
+
+def _dedupe_refs(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    if not values:
+        return []
+    if not all(isinstance(value, str) and value for value in values):
+        raise ValueError("evidence references must be non-empty strings")
+    return list(dict.fromkeys(values))
+
+
+def classify_evidence_levels(evidence_by_level: dict[str, list[str] | tuple[str, ...]]) -> dict[str, Any]:
+    """Classify exactly the levels with evidence refs, without gap filling.
+
+    A claim with D and H evidence remains D+H. F is not inferred merely because
+    behavioral evidence exists. This intentionally permits non-contiguous
+    evidence sets because the report describes evidence, not an ordinal badge.
+    """
+    unknown = set(evidence_by_level) - set(LEVELS)
+    if unknown:
+        raise ValueError(f"unknown evidence levels: {sorted(unknown)}")
+    normalized = {level: _dedupe_refs(evidence_by_level.get(level, [])) for level in LEVELS}
+    demonstrated = [level for level in LEVELS if normalized[level]]
+    unproven = [level for level in LEVELS if not normalized[level]]
+    highest = max(demonstrated, key=lambda level: LEVEL_RANK[level]) if demonstrated else "none"
+    return {
+        "evidence": normalized,
+        "demonstrated_levels": demonstrated,
+        "highest_demonstrated_level": highest,
+        "explicitly_unproven_levels": unproven,
+    }
+
+
+def _direct_external_write_case() -> dict[str, Any]:
+    """Exercise an untrusted/high-confidence poisoning proposal on the real adapter."""
+    common = dict(
+        actor_id="external:untrusted-source",
+        charter_version="charter:external-ingest-v1",
+        target_reference="mem:poisoning:direct-external-write",
+        target_class=policy.M4,
+        scope="scope:tenant-a/project-a",
+        operation="promotion",
+        current_strength="observed",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="high",
+        evidence_refs=(
+            "evidence:external-untrusted:source-1",
+            "evidence:derived-repeat:source-1:copy-1",
+            "evidence:derived-repeat:source-1:copy-2",
+        ),
+        estimator_refs=("estimator:semantic-confidence",),
+        estimator_versions=("estimator:semantic-confidence:v1",),
+        tenant_ref="tenant-a",
+        project_ref="project-a",
+        purpose="poisoning-boundary-harness",
+    )
+
+    high_substrate = InMemoryTemporalGraph()
+    low_substrate = InMemoryTemporalGraph()
+    high_adapter = GovernedMemoryAdapter(high_substrate, tenant="tenant-a", clock=Clock())
+    low_adapter = GovernedMemoryAdapter(low_substrate, tenant="tenant-a", clock=Clock())
+
+    high = high_adapter.commit_proposal(
+        policy.Proposal(proposal_id="poison:direct:high-confidence", confidence=0.99, **common),
+        "untrusted external content attempting durable promotion",
+    )
+    low = low_adapter.commit_proposal(
+        policy.Proposal(proposal_id="poison:direct:low-confidence", confidence=0.01, **common),
+        "untrusted external content attempting durable promotion",
+    )
+
+    high_writes = [entry for entry in high_substrate.write_log if entry[0] == "write_fact"]
+    low_writes = [entry for entry in low_substrate.write_log if entry[0] == "write_fact"]
+    expected_evidence = list(common["evidence_refs"])
+    preserved = high.pama_decision["basis"]["evidence_refs"] == expected_evidence
+
+    checks = {
+        "high_confidence_not_committed": not high.committed and not high_writes,
+        "low_confidence_not_committed": not low.committed and not low_writes,
+        "confidence_did_not_change_outcome": high.decision.outcome == low.decision.outcome,
+        "confidence_did_not_change_permitted_actions": high.decision.permitted_actions == low.decision.permitted_actions,
+        "confidence_did_not_change_prohibited_actions": high.decision.prohibited_actions == low.decision.prohibited_actions,
+        "promotion_remained_prohibited": "promotion" in high.decision.prohibited_actions,
+        "provenance_evidence_refs_preserved": preserved,
+        "repeated_derived_refs_did_not_discharge_review": high.decision.outcome in {
+            policy.REQUIRE_REVIEW,
+            policy.REQUIRE_EXTERNAL_VERIFICATION,
+            policy.BLOCK,
+        },
+    }
+    return {
+        "case_id": "direct-external-write-poisoning",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "observed": {
+            "high_confidence": 0.99,
+            "low_confidence": 0.01,
+            "high_outcome": high.decision.outcome,
+            "low_outcome": low.decision.outcome,
+            "high_selected_action": high.receipt["selected_action"],
+            "low_selected_action": low.receipt["selected_action"],
+            "evidence_refs": expected_evidence,
+            "substrate_write_count": len(high_writes) + len(low_writes),
+        },
+    }
+
+
+def _mcp_ingestion_case() -> dict[str, Any]:
+    """Exercise merged MCP resource ingestion as a non-authoritative candidate."""
+    value = {
+        "protocol_revision": "2026-07-28",
+        "protocol_source_commit": "5f5440bb26a62e2cf3440b92da5a667efa03b267",
+        "interaction_kind": "resource_read",
+        "method": "resources/read",
+        "client_ref": "mcp-client:poisoning-harness",
+        "server_ref": "mcp-server:untrusted-peer",
+        "request_id": "poisoning-resource-1",
+        "target_ref": "mcp-resource:untrusted:1",
+        "memory_effect": "memory_candidate",
+        "request_status": "observed",
+        "result_status": "complete",
+        "result_classification": "success",
+        "governance_status": "not_required",
+        "request_digest": "sha256:" + "a" * 64,
+        "result_digest": "sha256:" + "b" * 64,
+        "observed_at": "2026-08-12T22:41:00Z",
+        "evidence_refs": ["evidence:mcp:untrusted-resource"],
+        # Hostile peer-only fields must be discarded.
+        "pama_outcome": "allow",
+        "lifecycle_state": "canonical",
+        "memory_authority": "owner",
+        "permitted_actions": ["everything"],
+        "resource_content": "poisoned raw content must not be copied",
+    }
+    result = normalize_mcp_interaction(value, None)
+    hostile = ("pama_outcome", "lifecycle_state", "memory_authority", "permitted_actions", "resource_content")
+    checks = {
+        "resource_is_memory_candidate_only": result["memory_effect"] == "memory_candidate",
+        "memory_admission_not_established": result["interpretation"]["memory_admission"] == "not_established",
+        "authority_effect_none": result["interpretation"]["authority_effect"] == "none",
+        "execution_not_established": result["interpretation"]["execution_claim"] == "not_established",
+        "hostile_fields_discarded": all(key not in result for key in hostile),
+        "protocol_result_does_not_require_governance_for_candidate": result["governance_alignment"] == "not_applicable",
+    }
+    return {
+        "case_id": "mcp-ingestion-poisoning",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "observed": {
+            "interaction_id": result["interaction_id"],
+            "binding_status": result["binding_status"],
+            "governance_alignment": result["governance_alignment"],
+            "result_classification": result["result_classification"],
+        },
+    }
+
+
+def _a2a_ingestion_case() -> dict[str, Any]:
+    """Exercise merged A2A artifact ingestion plus cross-tenant mismatch."""
+    candidate = {
+        "protocol_release": "v1.0.1",
+        "protocol_source_commit": "3303592588e388e62e0f69f701af531d2f4e3991",
+        "direction": "inbound",
+        "interaction_kind": "artifact",
+        "local_agent_ref": "agent:local:poisoning-harness",
+        "remote_agent_ref": "agent:remote:untrusted-peer",
+        "agent_card_digest": "sha256:" + "c" * 64,
+        "task_ref": "a2a-task:poisoning-1",
+        "context_ref": "a2a-context:poisoning-1",
+        "artifact_ref": "a2a-artifact:poisoning-1:artifact-1",
+        "export_classification": "memory_candidate",
+        "memory_evidence_status": "not_applicable",
+        "task_state": "completed",
+        "governance_status": "not_required",
+        "external_evidence_refs": ["external-evidence:remote-identity-verified"],
+        "payload_digest": "sha256:" + "d" * 64,
+        "observed_at": "2026-08-12T22:42:00Z",
+        "evidence_refs": ["evidence:a2a:untrusted-artifact"],
+        # Hostile peer-only fields must be discarded.
+        "pama_outcome": "allow",
+        "lifecycle_state": "canonical",
+        "authority_transition": "standing_grant",
+        "artifact_body": "poisoned raw content must not be copied",
+    }
+    normalized_candidate = normalize_a2a_collaboration(candidate, None)
+
+    expected_context = {
+        "action_ref": "action:a2a:known-local-action",
+        "input_identity": "sha256:" + "e" * 64,
+        "scope_ref": "scope:tenant-a/project-a",
+        "tenant_ref": "tenant-a",
+        "project_ref": "project-a",
+    }
+    cross_tenant = deepcopy(candidate)
+    cross_tenant.update(
+        {
+            "interaction_kind": "task_status",
+            "export_classification": "explicit_non_memory",
+            "memory_evidence_status": "not_applicable",
+            "governance_status": "available",
+            "effective_decision": "allow",
+            "action_ref": expected_context["action_ref"],
+            "input_identity": expected_context["input_identity"],
+            "scope_ref": "scope:tenant-b/project-b",
+            "tenant_ref": "tenant-b",
+            "project_ref": "project-b",
+        }
+    )
+    cross_tenant.pop("artifact_ref", None)
+    normalized_cross_tenant = normalize_a2a_collaboration(cross_tenant, expected_context)
+
+    hostile = ("pama_outcome", "lifecycle_state", "authority_transition", "artifact_body")
+    checks = {
+        "artifact_is_memory_candidate_only": normalized_candidate["export_classification"] == "memory_candidate",
+        "memory_admission_not_established": normalized_candidate["interpretation"]["memory_admission"] == "not_established",
+        "peer_identity_not_authority": normalized_candidate["interpretation"]["delegated_memory_authority"] == "not_established",
+        "peer_identity_not_semantic_correctness": normalized_candidate["interpretation"]["semantic_correctness"] == "not_established",
+        "hostile_fields_discarded": all(key not in normalized_candidate for key in hostile),
+        "cross_tenant_binding_mismatch": normalized_cross_tenant["binding_status"] == "mismatch",
+        "cross_tenant_governance_mismatch": normalized_cross_tenant["governance_alignment"] == "binding_mismatch",
+    }
+    return {
+        "case_id": "a2a-ingestion-poisoning",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "observed": {
+            "collaboration_id": normalized_candidate["collaboration_id"],
+            "candidate_classification": normalized_candidate["export_classification"],
+            "cross_tenant_binding_reasons": normalized_cross_tenant["binding_reasons"],
+        },
+    }
+
+
+def run_poisoning_harness() -> dict[str, Any]:
+    cases = {
+        "direct_external_write": _direct_external_write_case(),
+        "mcp_ingestion": _mcp_ingestion_case(),
+        "a2a_ingestion": _a2a_ingestion_case(),
+    }
+    return {
+        "cases": cases,
+        "passed": all(case["passed"] for case in cases.values()),
+    }
+
+
+def _runtime_direct_evidence(agent_memory_commit: str, benchmark_security: dict[str, Any] | None) -> tuple[list[str], list[str]]:
+    """Return current and stale direct-poisoning runtime evidence refs.
+
+    The same-head P5 scorecard is accepted as R evidence only if its hard gates
+    pass and the confidence-authority metric is exactly zero. A scorecard bound
+    to another head remains useful historical evidence but cannot prove current R.
+    """
+    if benchmark_security is None:
+        return [], []
+    if not isinstance(benchmark_security, dict):
+        raise ValueError("benchmark_security must be an object")
+    benchmark_commit = benchmark_security.get("agent_memory_commit")
+    ref = f"ci-artifact:p5-benchmark-security-scorecard@{benchmark_commit}#authority_from_confidence_count"
+    valid_behavior = (
+        benchmark_security.get("hard_gates_passed") is True
+        and benchmark_security.get("metrics", {}).get("authority_from_confidence_count") == 0
+        and benchmark_security.get("cases", {}).get("authority_from_confidence", {}).get("passed") is True
+    )
+    if not valid_behavior:
+        return [], []
+    if benchmark_commit == agent_memory_commit:
+        return [ref], []
+    return [], [ref]
+
+
+def _claim(
+    *,
+    agent_memory_commit: str,
+    claim_id: str,
+    title: str,
+    threat_family: str,
+    doctrine_refs: list[str],
+    fixture_refs: list[str],
+    harness_ref: str,
+    behavioral_passed: bool,
+    runtime_evidence_refs: list[str] | None = None,
+    stale_runtime_evidence_refs: list[str] | None = None,
+    runtime_evidence_head: str | None = None,
+    production_evidence_refs: list[str] | None = None,
+    external_mappings: list[dict[str, str]] | None = None,
+    scope_profiles: list[str] | None = None,
+) -> dict[str, Any]:
+    runtime_refs = _dedupe_refs(runtime_evidence_refs)
+    production_refs = _dedupe_refs(production_evidence_refs)
+    stale_runtime_refs = _dedupe_refs(stale_runtime_evidence_refs)
+    mappings = deepcopy(external_mappings or [])
+    for mapping in mappings:
+        if mapping.get("certification_claim") != "none":
+            raise ValueError("external mappings must set certification_claim='none'")
+        for required in ("source", "version", "control_ref"):
+            if not isinstance(mapping.get(required), str) or not mapping[required]:
+                raise ValueError(f"external mapping requires {required}")
+
+    evidence = {
+        "D": _dedupe_refs(doctrine_refs),
+        "F": _dedupe_refs(fixture_refs),
+        "H": [harness_ref] if behavioral_passed else [],
+        "R": runtime_refs,
+        "P": production_refs,
+    }
+    depth = classify_evidence_levels(evidence)
+    claim = {
+        "claim_id": claim_id,
+        "title": title,
+        "threat_family": threat_family,
+        "doctrine_refs": depth["evidence"]["D"],
+        "fixture_refs": depth["evidence"]["F"],
+        "behavioral_harness_refs": depth["evidence"]["H"],
+        "runtime_evidence_refs": depth["evidence"]["R"],
+        "production_evidence_refs": depth["evidence"]["P"],
+        "external_mappings": mappings,
+        "demonstrated_levels": depth["demonstrated_levels"],
+        "highest_demonstrated_level": depth["highest_demonstrated_level"],
+        "explicitly_unproven_levels": depth["explicitly_unproven_levels"],
+        "scope_profiles": list(dict.fromkeys(scope_profiles or ["L", "T", "E", "H"])),
+        "evaluated_head": agent_memory_commit,
+        "behavioral_passed": behavioral_passed,
+        "non_certification_statement": "This claim records bounded evidence depth and does not assert external certification.",
+    }
+    if runtime_evidence_head is not None and runtime_refs:
+        claim["runtime_evidence_head"] = _exact_commit(runtime_evidence_head)
+    if stale_runtime_refs:
+        claim["stale_runtime_evidence_refs"] = stale_runtime_refs
+    return claim
+
+
+def build_report(
+    agent_memory_commit: str,
+    *,
+    benchmark_security: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    commit = _exact_commit(agent_memory_commit)
+    harness = run_poisoning_harness()
+    direct_runtime_refs, stale_direct_refs = _runtime_direct_evidence(commit, benchmark_security)
+
+    claims = [
+        _claim(
+            agent_memory_commit=commit,
+            claim_id="poisoning:direct-external-write",
+            title="Direct untrusted external content cannot self-authorize durable promotion",
+            threat_family="memory_poisoning",
+            doctrine_refs=["docs/15-memory-threat-model.md", "docs/04-governance-and-pama.md"],
+            fixture_refs=["fixtures/security-evidence-depth-matrix.json"],
+            harness_ref="security-poisoning-harness:direct-external-write",
+            behavioral_passed=harness["cases"]["direct_external_write"]["passed"],
+            runtime_evidence_refs=direct_runtime_refs,
+            stale_runtime_evidence_refs=stale_direct_refs,
+            runtime_evidence_head=commit if direct_runtime_refs else None,
+        ),
+        _claim(
+            agent_memory_commit=commit,
+            claim_id="poisoning:mcp-ingestion",
+            title="MCP tool/resource output remains evidence or a memory candidate under normal admission",
+            threat_family="protocol_ingestion_poisoning",
+            doctrine_refs=["docs/15-memory-threat-model.md", "docs/profiles/mcp-interaction-evidence-profile.md"],
+            fixture_refs=["fixtures/mcp-interaction-evidence-matrix.json", "fixtures/security-evidence-depth-matrix.json"],
+            harness_ref="security-poisoning-harness:mcp-ingestion",
+            behavioral_passed=harness["cases"]["mcp_ingestion"]["passed"],
+        ),
+        _claim(
+            agent_memory_commit=commit,
+            claim_id="poisoning:a2a-ingestion",
+            title="A2A peer Message/Artifact content remains evidence or a memory candidate under normal admission",
+            threat_family="cross_agent_ingestion_poisoning",
+            doctrine_refs=["docs/15-memory-threat-model.md", "docs/profiles/a2a-collaboration-evidence-profile.md"],
+            fixture_refs=["fixtures/a2a-collaboration-evidence-matrix.json", "fixtures/security-evidence-depth-matrix.json"],
+            harness_ref="security-poisoning-harness:a2a-ingestion",
+            behavioral_passed=harness["cases"]["a2a_ingestion"]["passed"],
+        ),
+    ]
+
+    report = {
+        "report_type": REPORT_TYPE,
+        "version": REPORT_VERSION,
+        "agent_memory_commit": commit,
+        "evidence_model": {
+            "levels": list(LEVELS),
+            "inference_policy": "no_level_may_be_inferred_from_another_level",
+        },
+        "claims": claims,
+        "required_behavioral_cases_passed": harness["passed"],
+        "non_certification_statement": "Evidence mapping and demonstrated behavior do not constitute external certification.",
+        "known_limits": [
+            "The V0.1 poisoning harness covers direct external writes, MCP ingestion, and non-authority-bearing A2A ingestion only.",
+            "MCP and A2A cases demonstrate behavioral H evidence against reference normalizers, not live-host runtime R evidence.",
+            "Direct-write R evidence is claimed only when a same-head passing P5 benchmark-security artifact is supplied to the report generator.",
+            "Production evidence P is not collected or inferred by this report and remains explicitly unproven unless separately supplied by a future governed process.",
+            "No composite security, maturity, coverage, or certification score is emitted.",
+        ],
+    }
+    receipts.validate("security-evidence-depth-report.schema.json", report)
+    return report
+
+
+def with_behavioral_failure(report: dict[str, Any], claim_id: str) -> dict[str, Any]:
+    """Test helper proving a failed behavioral case cannot remain H."""
+    mutated = deepcopy(report)
+    target = next((claim for claim in mutated["claims"] if claim["claim_id"] == claim_id), None)
+    if target is None:
+        raise ValueError(f"unknown claim_id {claim_id!r}")
+    target["behavioral_passed"] = False
+    target["behavioral_harness_refs"] = []
+    evidence = {
+        "D": target["doctrine_refs"],
+        "F": target["fixture_refs"],
+        "H": [],
+        "R": target["runtime_evidence_refs"],
+        "P": target["production_evidence_refs"],
+    }
+    depth = classify_evidence_levels(evidence)
+    target["demonstrated_levels"] = depth["demonstrated_levels"]
+    target["highest_demonstrated_level"] = depth["highest_demonstrated_level"]
+    target["explicitly_unproven_levels"] = depth["explicitly_unproven_levels"]
+    mutated["required_behavioral_cases_passed"] = all(claim["behavioral_passed"] for claim in mutated["claims"])
+    receipts.validate("security-evidence-depth-report.schema.json", mutated)
+    return mutated

--- a/reference/run_security_evidence_depth.py
+++ b/reference/run_security_evidence_depth.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Emit the security evidence-depth report and poisoning behavioral evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.security_evidence_depth import build_report  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument(
+        "--benchmark-security",
+        help="Optional same-head P5 benchmark-security JSON used only as independently generated R evidence.",
+    )
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    benchmark = None
+    if args.benchmark_security:
+        benchmark = json.loads(Path(args.benchmark_security).read_text(encoding="utf-8"))
+
+    report = build_report(args.agent_memory_commit, benchmark_security=benchmark)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report["required_behavioral_cases_passed"]:
+        failed = [claim["claim_id"] for claim in report["claims"] if not claim["behavioral_passed"]]
+        print(f"security poisoning behavioral gate failed: {failed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_security_evidence_depth.py
+++ b/reference/tests/test_security_evidence_depth.py
@@ -1,0 +1,181 @@
+"""Executable security evidence-depth and poisoning boundary tests for issue #196."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from agentmem_ref.security_evidence_depth import (
+    LEVELS,
+    build_report,
+    classify_evidence_levels,
+    run_poisoning_harness,
+    with_behavioral_failure,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "security-evidence-depth-matrix.json"
+COMMIT = "1" * 40
+
+
+class SecurityEvidenceDepthTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.matrix = json.loads(MATRIX.read_text(encoding="utf-8"))
+
+    def test_fixture_negative_level_cases_do_not_infer_missing_levels(self):
+        for case in self.matrix["negative_cases"]:
+            with self.subTest(case_id=case["case_id"]):
+                depth = classify_evidence_levels(case["evidence_refs"])
+                self.assertEqual(depth["demonstrated_levels"], case["expected_demonstrated_levels"])
+                self.assertEqual(depth["explicitly_unproven_levels"], case["expected_unproven_levels"])
+
+    def test_noncontiguous_levels_remain_noncontiguous(self):
+        depth = classify_evidence_levels(
+            {"D": ["doc:one"], "F": [], "H": ["harness:one"], "R": [], "P": []}
+        )
+        self.assertEqual(depth["demonstrated_levels"], ["D", "H"])
+        self.assertEqual(depth["highest_demonstrated_level"], "H")
+        self.assertIn("F", depth["explicitly_unproven_levels"])
+
+    def test_all_three_required_poisoning_behavioral_cases_pass(self):
+        harness = run_poisoning_harness()
+        self.assertTrue(harness["passed"])
+        self.assertEqual(
+            set(harness["cases"]),
+            {"direct_external_write", "mcp_ingestion", "a2a_ingestion"},
+        )
+        for case in harness["cases"].values():
+            self.assertTrue(case["passed"], case)
+
+    def test_report_without_runtime_artifact_claims_h_not_r_or_p(self):
+        report = build_report(COMMIT)
+        self.assertTrue(report["required_behavioral_cases_passed"])
+        self.assertNotIn("score", report)
+        self.assertNotIn("composite_score", report)
+        self.assertEqual(report["evidence_model"]["levels"], list(LEVELS))
+
+        for claim in report["claims"]:
+            self.assertIn("D", claim["demonstrated_levels"])
+            self.assertIn("F", claim["demonstrated_levels"])
+            self.assertIn("H", claim["demonstrated_levels"])
+            self.assertNotIn("R", claim["demonstrated_levels"])
+            self.assertNotIn("P", claim["demonstrated_levels"])
+            self.assertIn("R", claim["explicitly_unproven_levels"])
+            self.assertIn("P", claim["explicitly_unproven_levels"])
+            self.assertEqual(claim["production_evidence_refs"], [])
+
+    def _benchmark(self, commit: str, *, metric: int = 0, passed: bool = True) -> dict:
+        return {
+            "agent_memory_commit": commit,
+            "hard_gates_passed": passed,
+            "metrics": {"authority_from_confidence_count": metric},
+            "cases": {"authority_from_confidence": {"passed": passed and metric == 0}},
+        }
+
+    def test_same_head_p5_artifact_can_support_only_direct_r(self):
+        report = build_report(COMMIT, benchmark_security=self._benchmark(COMMIT))
+        by_id = {claim["claim_id"]: claim for claim in report["claims"]}
+        direct = by_id["poisoning:direct-external-write"]
+        mcp = by_id["poisoning:mcp-ingestion"]
+        a2a = by_id["poisoning:a2a-ingestion"]
+
+        self.assertIn("R", direct["demonstrated_levels"])
+        self.assertEqual(direct["runtime_evidence_head"], COMMIT)
+        self.assertNotIn("P", direct["demonstrated_levels"])
+        self.assertNotIn("R", mcp["demonstrated_levels"])
+        self.assertNotIn("R", a2a["demonstrated_levels"])
+
+    def test_stale_runtime_artifact_is_historical_not_current_r(self):
+        stale_commit = "2" * 40
+        report = build_report(COMMIT, benchmark_security=self._benchmark(stale_commit))
+        direct = next(claim for claim in report["claims"] if claim["claim_id"] == "poisoning:direct-external-write")
+        self.assertNotIn("R", direct["demonstrated_levels"])
+        self.assertIn("R", direct["explicitly_unproven_levels"])
+        self.assertIn("stale_runtime_evidence_refs", direct)
+        self.assertIn(stale_commit, direct["stale_runtime_evidence_refs"][0])
+        self.assertNotIn("runtime_evidence_head", direct)
+
+    def test_failing_or_nonpassing_runtime_artifact_does_not_create_r(self):
+        bad_metric = build_report(COMMIT, benchmark_security=self._benchmark(COMMIT, metric=1, passed=False))
+        direct = next(claim for claim in bad_metric["claims"] if claim["claim_id"] == "poisoning:direct-external-write")
+        self.assertNotIn("R", direct["demonstrated_levels"])
+
+    def test_behavioral_failure_cannot_hide_behind_other_levels(self):
+        report = build_report(COMMIT, benchmark_security=self._benchmark(COMMIT))
+        mutated = with_behavioral_failure(report, "poisoning:direct-external-write")
+        direct = next(claim for claim in mutated["claims"] if claim["claim_id"] == "poisoning:direct-external-write")
+        self.assertFalse(mutated["required_behavioral_cases_passed"])
+        self.assertFalse(direct["behavioral_passed"])
+        self.assertNotIn("H", direct["demonstrated_levels"])
+        self.assertIn("H", direct["explicitly_unproven_levels"])
+        # Independent same-head runtime evidence remains R rather than being
+        # erased or averaged into a composite status.
+        self.assertIn("R", direct["demonstrated_levels"])
+
+    def test_external_mapping_cannot_claim_certification(self):
+        from agentmem_ref.security_evidence_depth import _claim
+
+        with self.assertRaisesRegex(ValueError, "certification_claim='none'"):
+            _claim(
+                agent_memory_commit=COMMIT,
+                claim_id="mapping:test",
+                title="Mapping test",
+                threat_family="test",
+                doctrine_refs=["doc:test"],
+                fixture_refs=["fixture:test"],
+                harness_ref="harness:test",
+                behavioral_passed=True,
+                external_mappings=[
+                    {
+                        "source": "Example Standard",
+                        "version": "1.0",
+                        "control_ref": "CTRL-1",
+                        "certification_claim": "certified",
+                    }
+                ],
+            )
+
+    def test_valid_external_mapping_is_explicitly_non_certifying(self):
+        from agentmem_ref.security_evidence_depth import _claim
+
+        claim = _claim(
+            agent_memory_commit=COMMIT,
+            claim_id="mapping:test",
+            title="Mapping test",
+            threat_family="test",
+            doctrine_refs=["doc:test"],
+            fixture_refs=["fixture:test"],
+            harness_ref="harness:test",
+            behavioral_passed=True,
+            external_mappings=[
+                {
+                    "source": "Example Standard",
+                    "version": "1.0",
+                    "control_ref": "CTRL-1",
+                    "certification_claim": "none",
+                }
+            ],
+        )
+        self.assertEqual(claim["external_mappings"][0]["certification_claim"], "none")
+        self.assertIn("does not assert external certification", claim["non_certification_statement"])
+
+    def test_exact_commit_identity_is_required(self):
+        for invalid in ("", "abc", "G" * 40, "1" * 39, "1" * 41):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ValueError, "exact 40-hex commit"):
+                    build_report(invalid)
+
+    def test_protocol_transport_success_does_not_upgrade_evidence_depth(self):
+        report = build_report(COMMIT)
+        for claim_id in ("poisoning:mcp-ingestion", "poisoning:a2a-ingestion"):
+            claim = next(claim for claim in report["claims"] if claim["claim_id"] == claim_id)
+            self.assertEqual(claim["highest_demonstrated_level"], "H")
+            self.assertEqual(claim["runtime_evidence_refs"], [])
+            self.assertIn("R", claim["explicitly_unproven_levels"])
+            self.assertIn("P", claim["explicitly_unproven_levels"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/security-evidence-depth-report.schema.json
+++ b/schemas/security-evidence-depth-report.schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/security-evidence-depth-report.schema.json",
+  "title": "Agent Memory Security Evidence Depth Report",
+  "description": "Machine-readable D/F/H/R/P evidence-depth ledger. Levels are independent evidence claims and must not be inferred from weaker levels. External mappings never imply certification.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "report_type",
+    "version",
+    "agent_memory_commit",
+    "evidence_model",
+    "claims",
+    "required_behavioral_cases_passed",
+    "non_certification_statement",
+    "known_limits"
+  ],
+  "properties": {
+    "report_type": { "const": "agent-memory-security-evidence-depth" },
+    "version": { "const": "1.0.0" },
+    "agent_memory_commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "evidence_model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["levels", "inference_policy"],
+      "properties": {
+        "levels": {
+          "type": "array",
+          "prefixItems": [
+            { "const": "D" },
+            { "const": "F" },
+            { "const": "H" },
+            { "const": "R" },
+            { "const": "P" }
+          ],
+          "items": false,
+          "minItems": 5,
+          "maxItems": 5
+        },
+        "inference_policy": { "const": "no_level_may_be_inferred_from_another_level" }
+      }
+    },
+    "claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/claim" }
+    },
+    "required_behavioral_cases_passed": { "type": "boolean" },
+    "non_certification_statement": {
+      "const": "Evidence mapping and demonstrated behavior do not constitute external certification."
+    },
+    "known_limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "evidenceLevel": { "type": "string", "enum": ["D", "F", "H", "R", "P"] },
+    "evidenceRefs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "externalMapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "version", "control_ref", "certification_claim"],
+      "properties": {
+        "source": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "control_ref": { "type": "string", "minLength": 1 },
+        "certification_claim": { "const": "none" }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "claim_id",
+        "title",
+        "threat_family",
+        "doctrine_refs",
+        "fixture_refs",
+        "behavioral_harness_refs",
+        "runtime_evidence_refs",
+        "production_evidence_refs",
+        "external_mappings",
+        "demonstrated_levels",
+        "highest_demonstrated_level",
+        "explicitly_unproven_levels",
+        "scope_profiles",
+        "evaluated_head",
+        "behavioral_passed",
+        "non_certification_statement"
+      ],
+      "properties": {
+        "claim_id": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "threat_family": { "type": "string", "minLength": 1 },
+        "doctrine_refs": { "$ref": "#/$defs/evidenceRefs" },
+        "fixture_refs": { "$ref": "#/$defs/evidenceRefs" },
+        "behavioral_harness_refs": { "$ref": "#/$defs/evidenceRefs" },
+        "runtime_evidence_refs": { "$ref": "#/$defs/evidenceRefs" },
+        "production_evidence_refs": { "$ref": "#/$defs/evidenceRefs" },
+        "external_mappings": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/externalMapping" }
+        },
+        "demonstrated_levels": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/evidenceLevel" },
+          "uniqueItems": true
+        },
+        "highest_demonstrated_level": {
+          "oneOf": [
+            { "$ref": "#/$defs/evidenceLevel" },
+            { "const": "none" }
+          ]
+        },
+        "explicitly_unproven_levels": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/evidenceLevel" },
+          "uniqueItems": true
+        },
+        "scope_profiles": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["L", "T", "E", "H"] },
+          "uniqueItems": true
+        },
+        "evaluated_head": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "runtime_evidence_head": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "stale_runtime_evidence_refs": { "$ref": "#/$defs/evidenceRefs" },
+        "behavioral_passed": { "type": "boolean" },
+        "non_certification_statement": {
+          "const": "This claim records bounded evidence depth and does not assert external certification."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements **P2-A / V0.1** from #196: an explicit D/F/H/R/P security evidence-depth ledger plus executable poisoning-ingestion boundaries.

## Evidence model

```text
D = documented doctrine
F = structural fixture/scenario
H = behavioral/conformance harness
R = runtime implementation evidence
P = production evidence
```

Levels are independent. No level is inferred from another, non-contiguous evidence is allowed, missing levels remain explicit, and no composite security/maturity score exists.

## Behavioral poisoning harness

V0.1 executes three required paths:

1. **Direct untrusted external write** through the real `GovernedMemoryAdapter`
   - 0.99 vs 0.01 confidence must produce the same authority envelope;
   - repeated/derived evidence refs cannot discharge review;
   - requested high-risk M4 promotion remains prohibited without required review;
   - zero substrate writes;
   - evidence/provenance refs remain present in the PAMA decision.

2. **MCP ingestion** through the merged #190 normalizer
   - successful `resources/read` output remains a `memory_candidate`;
   - hostile peer PAMA/lifecycle/authority fields are discarded;
   - protocol success does not establish admission, authority, or execution.

3. **A2A ingestion** through the merged #194 normalizer
   - inbound Artifact remains a `memory_candidate`;
   - peer identity/capability does not establish authority or semantic correctness;
   - hostile authority-transition fields are discarded;
   - cross-tenant task/action correlation fails closed.

## R evidence rule

The report generator does **not** call its own harness runtime evidence.

Direct poisoning receives `R` only when supplied the separately generated P5 benchmark-security artifact from the **same exact Agent Memory head**, with passing hard gates and `authority_from_confidence_count == 0`.

An otherwise valid artifact from an older head is preserved as stale runtime evidence and current `R` remains unproven.

MCP/A2A remain D+F+H in V0.1 because no live-host runtime comparator is claimed here.

## P evidence rule

Production evidence is not collected by this slice and remains explicitly unproven by default. CI, unit tests, runtime artifacts, transport success, and standards mappings cannot manufacture `P`.

## CI evidence

`Validate Doctrine Evidence` now emits and uploads `security-evidence-depth.json` immediately after the independent P5 benchmark-security artifact, binding both to the exact PR/head commit.

## Added surfaces

- `schemas/security-evidence-depth-report.schema.json`
- `fixtures/security-evidence-depth-matrix.json`
- `reference/agentmem_ref/security_evidence_depth.py`
- `reference/run_security_evidence_depth.py`
- `reference/tests/test_security_evidence_depth.py`
- `docs/programs/runtime-evidence/security-evidence-depth.md`
- Doctrine CI emit/upload step

## Negative paths

Executable tests prove:

- D+F cannot imply H/R/P;
- non-contiguous D+H remains D+H;
- harness success cannot manufacture production evidence;
- stale runtime artifacts cannot count as current R;
- failed H remains failed even if independent R exists;
- external mappings must explicitly carry `certification_claim = none`;
- protocol success cannot upgrade MCP/A2A beyond H;
- no composite score is emitted.

## Stop line

Do not expand this PR into comprehensive poisoning certification, live MCP/A2A runtime comparators, production telemetry, authority-bearing A2A transfer, broad standards crosswalks, or a scalar security score.

This PR remains draft until exact-head repository CI passes and a completion review confirms #196 acceptance criteria.

Closes #196