### PR TITLE
Normalize adversarial scanner findings as scoped security evidence

### DIFF
--- a/.github/workflows/validate-doctrine-evidence.yml
+++ b/.github/workflows/validate-doctrine-evidence.yml
@@ -83,6 +83,21 @@ jobs:
           path: security-evidence-depth.json
           if-no-files-found: error
 
+      - name: Emit scanner finding evidence-depth report
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_security_finding_depth.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output security-finding-depth.json
+
+      - name: Upload scanner finding evidence-depth report
+        uses: actions/upload-artifact@v4
+        with:
+          name: scanner-finding-evidence-depth-report
+          path: security-finding-depth.json
+          if-no-files-found: error
+
       - name: Execute pinned Mem0 P6 comparator
         env:
           AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -157,6 +172,7 @@ jobs:
           docs/adr/README.md
           docs/27-schema-registry-and-type-evolution.md
           docs/32-memory-quality-metrics.md
+          docs/profiles/security-finding-evidence-profile.md
           docs/programs/runtime-evidence/README.md
           docs/programs/runtime-evidence/graphiti-conformance.md
           docs/programs/runtime-evidence/canonical-and-derived-state.md
@@ -200,10 +216,11 @@ jobs:
             echo "python reference/run_concurrency_evidence.py --agent-memory-commit <exact-40-hex-commit> --output concurrency-evidence.json"
             echo "python reference/run_benchmark_security.py --agent-memory-commit <exact-40-hex-commit> --output benchmark-security.json"
             echo "python reference/run_security_evidence_depth.py --agent-memory-commit <exact-40-hex-commit> --benchmark-security benchmark-security.json --output security-evidence-depth.json"
+            echo "python reference/run_security_finding_depth.py --agent-memory-commit <exact-40-hex-commit> --output security-finding-depth.json"
             echo "python -m venv /tmp/agent-memory-p6-mem0 && /tmp/agent-memory-p6-mem0/bin/python -m pip install mem0ai==2.0.18 jsonschema==4.26.0 && MEM0_TELEMETRY=false PYTHONPATH=reference /tmp/agent-memory-p6-mem0/bin/python reference/run_mem0_comparator.py --agent-memory-commit <exact-40-hex-commit> --output mem0-comparator.json"
             echo "python reference/run_deletion_completeness.py --agent-memory-commit <exact-40-hex-commit> --output deletion-completeness.json"
             echo "python -m venv /tmp/agent-memory-p45c-cmcp && /tmp/agent-memory-p45c-cmcp/bin/python -m pip install cmcp-runtime==0.4.0 agentrust-trace==0.8.0 agent-manifest==0.11.0 rfc8785==0.1.4 && PYTHONPATH=reference /tmp/agent-memory-p45c-cmcp/bin/python reference/run_trace_cmcp_comparator.py"
-            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md GOVERNANCE.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/policies/AI_ASSISTED_CONTRIBUTIONS.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md docs/programs/runtime-evidence/deletion-completeness-evidence.md docs/programs/runtime-evidence/concurrency-conflict-evidence.md docs/programs/runtime-evidence/benchmark-security-scorecard.md docs/programs/runtime-evidence/security-evidence-depth.md docs/programs/runtime-evidence/mem0-adversarial-comparator.md docs/programs/runtime-evidence/governed-interchange.md docs/programs/runtime-evidence/telemetry-minimization.md docs/programs/runtime-evidence/systems-economic-characterization.md docs/programs/runtime-evidence/program-closeout-audit.md reference/README.md"
+            echo "python scripts/validate_markdown_links.py README.md CONTRIBUTING.md GOVERNANCE.md docs/README.md docs/pama/README.md docs/04-governance-and-pama.md docs/08-source-material-index.md docs/33-pama-decision-table.md docs/40-aligned-projects-and-intellectual-lineage.md docs/SOURCE_RIGHTS_POLICY.md docs/policies/AI_ASSISTED_CONTRIBUTIONS.md docs/adr/README.md docs/27-schema-registry-and-type-evolution.md docs/32-memory-quality-metrics.md docs/profiles/security-finding-evidence-profile.md docs/programs/runtime-evidence/README.md docs/programs/runtime-evidence/graphiti-conformance.md docs/programs/runtime-evidence/canonical-and-derived-state.md docs/programs/runtime-evidence/portable-governance-evidence.md docs/programs/runtime-evidence/agent-manifest-correlation.md docs/programs/runtime-evidence/trace-action-evidence.md docs/programs/runtime-evidence/deletion-completeness-evidence.md docs/programs/runtime-evidence/concurrency-conflict-evidence.md docs/programs/runtime-evidence/benchmark-security-scorecard.md docs/programs/runtime-evidence/security-evidence-depth.md docs/programs/runtime-evidence/mem0-adversarial-comparator.md docs/programs/runtime-evidence/governed-interchange.md docs/programs/runtime-evidence/telemetry-minimization.md docs/programs/runtime-evidence/systems-economic-characterization.md docs/programs/runtime-evidence/program-closeout-audit.md reference/README.md"
             echo "python scripts/validate_wiki_links.py wiki-src"
             echo "python scripts/generate_calibration_report.py reports/examples/calibration-results.example.json"
             echo '```'

--- a/docs/profiles/security-finding-evidence-profile.md
+++ b/docs/profiles/security-finding-evidence-profile.md
@@ -1,0 +1,337 @@
+# Scoped Security Finding Evidence Profile
+
+Status: V0.1 reference profile for #198.
+
+This profile defines a vendor-neutral evidence boundary for adversarial scanners, security scanners, benchmarks, and related negative-evidence producers.
+
+The first two reference families are intentionally different:
+
+- **NVIDIA garak v0.16.0**, exact commit `dbe4515d12664f2e34ac2cea295f055c22fe82b4`, behavioral red-team/probe evidence;
+- **Snyk Agent Scan v0.5.17**, exact commit `ea959964ce4728426fca9fa78c9e7809b972f313`, agent/MCP/skill supply-chain and configuration evidence.
+
+The purpose is not to make Agent Memory speak either scanner's ontology. The purpose is to preserve what was observed, under what exact conditions, without converting scanner output into authority.
+
+## Core boundary
+
+```text
+scanner hit
+!= universal vulnerability fact
+
+no hit
+!= proof of safety outside tested scope
+
+benchmark / scanner score
+!= runtime incident
+
+security finding
+!= standing policy
+
+reproduction
+strengthens evidence
+!= creates authority
+
+scanner identity/version
+!= memory authority
+```
+
+Every normalized V0.1 finding fixes these nonclaims:
+
+```text
+authority_effect = none
+universal_vulnerability = not_established
+safety_claim = not_established
+standing_policy = not_established
+memory_admission = not_established
+certification_claim = none
+```
+
+## Generic evidence contract
+
+A normalized finding preserves:
+
+```text
+finding family
+scanner/tool identity
+exact scanner version and source commit
+adapter id/version
+source contract status
+target identity + configuration ref
+scope / tenant / project / environment
+check / probe / case identity
+evaluator / detector identity
+sample size / repetitions / seed where meaningful
+result status + verdict
+source-native counts or metric where semantics are pinned
+reproduction state
+finding lifecycle state
+candidate classification
+scanner execution context
+sandbox state
+consent state
+scanner privilege ref
+raw evidence ref/digest
+known limitations
+prior/remediation/rescan/conflict lineage
+exact scope binding status
+```
+
+The schema does not define a generic vulnerability truth score.
+
+## Garak pinned adapter
+
+V0.1 pins garak `v0.16.0` because that release explicitly changed `report.jsonl`.
+
+The adapter consumes the pinned `entry_type = eval` fields:
+
+```text
+probe
+detector
+passed
+fails
+total_evaluated
+optional confidence bounds
+```
+
+Garak's evaluator contract defines `passed` and `fails` under the exact probe/detector execution. V0.1 preserves those counts directly.
+
+It also exposes a source-native `garak_pass_rate` only as scanner evidence:
+
+```text
+passed / total_evaluated
+```
+
+That metric is not Agent Memory confidence, truth, authority, certification, or a universal risk score.
+
+V0.1 verdict mapping is intentionally bounded:
+
+```text
+total = 0                  -> unknown
+fails = 0                  -> no_hit
+passed = 0 and fails > 0   -> hit
+passed > 0 and fails > 0   -> mixed
+```
+
+A hit/mixed result is an observed failure under the exact target, configuration, probe, detector, and sampling conditions. A no-hit result says only that no failure was observed in that bounded evaluation.
+
+## Snyk Agent Scan projection adapter
+
+Snyk Agent Scan `v0.5.17` is pinned as the second materially different family.
+
+Its upstream CLI/JSON shape is not adopted as Agent Memory core semantics. The adapter receives a bounded Agent Memory-facing projection and records:
+
+```text
+source_contract_status = experimental_projection
+```
+
+Upstream field names, issue codes, severity labels, and response structure may evolve without requiring the generic Agent Memory schema to evolve.
+
+### Active scanning is evidence
+
+Snyk documents that scanning stdio MCP configurations can execute the commands defined in those configurations.
+
+Therefore V0.1 preserves separately:
+
+```text
+target_execution = observed | possible | not_observed | not_applicable | unknown
+sandbox = isolated | not_isolated | not_applicable | unknown
+consent = granted | declined | bypassed | not_required | unknown
+scanner_privilege_ref
+```
+
+A scanner is not assumed to be a passive observer merely because its output is called a finding.
+
+A declined scan must remain:
+
+```text
+result_status = declined
+verdict = not_run
+finding_state = not_run
+```
+
+It cannot fabricate a finding or proof of safety.
+
+## Scope and environment binding
+
+Target identity alone is not enough to generalize a result.
+
+V0.1 compares, when expected:
+
+```text
+target_ref
+scope_ref
+tenant_ref
+project_ref
+environment_ref
+```
+
+A matching component/tool under another tenant, project, or environment is a binding mismatch. Scanner names, target names, configuration similarity, or repeated findings do not repair that mismatch.
+
+## Finding lifecycle and append-only lineage
+
+V0.1 supports finding states including:
+
+```text
+observed
+reproduced
+not_reproduced
+nondeterministic
+triaged
+remediation_proposed
+remediation_applied
+rescanned
+resolved
+residual
+disputed
+not_run
+```
+
+Reproduction state is preserved separately because repeated observation and remediation lifecycle are not the same fact.
+
+Every later record may preserve:
+
+```text
+prior_finding_refs
+remediation_refs
+rescan_refs
+conflict_refs
+```
+
+The original finding is not overwritten.
+
+Examples:
+
+```text
+observed hit
+-> reproduced
+```
+
+creates a new evidence record referencing the original. It strengthens the reproduction evidence without creating authority.
+
+```text
+remediation_applied
++ no rescan
+```
+
+does not become `resolved`.
+
+```text
+original hit
++ later no_hit rescan
+```
+
+preserves both records and may explicitly reference the conflict/prior lineage. The later no-hit result still does not establish universal safety.
+
+## Conflicting findings
+
+Different scanners, detector versions, target configurations, or repeated runs may disagree.
+
+That disagreement is representable rather than collapsed:
+
+```text
+finding A
+<-> conflict_refs
+finding B
+```
+
+The generic schema does not select a winner by scanner reputation, severity label, or recency alone.
+
+## Security evidence depth
+
+P2-B reuses the D/F/H/R/P model from #196.
+
+The exact-head scanner-adapter evidence report is emitted by:
+
+```text
+reference/run_security_finding_depth.py
+```
+
+V0.1 claims:
+
+```text
+garak adapter        = D + F + H
+Snyk projection      = D + F + H
+R                    = explicitly unproven
+P                    = explicitly unproven
+```
+
+Why no R?
+
+The behavioral harness executes the Agent Memory adapters against pinned fixtures/projections. It does not launch a live garak scan or a live Snyk Agent Scan target. Fixture execution therefore earns H, not R.
+
+No composite score is emitted.
+
+## Privacy and minimization
+
+Security evidence is often sensitive enough to become a new attack surface if copied casually.
+
+V0.1 defaults to refs/digests and does not require copying:
+
+- raw attack prompts;
+- generated exploit payloads;
+- secrets or credentials;
+- full scanner dumps;
+- hidden reasoning;
+- complete target configuration;
+- experimental scanner response blobs.
+
+The adapter may inspect source output at the boundary long enough to produce the stable projection. The normalized record is intentionally smaller.
+
+## Required negative paths
+
+The executable V0.1 suite covers:
+
+1. garak hit/mixed result remains non-authoritative;
+2. garak no-hit result does not establish safety;
+3. garak version/record-contract drift is rejected;
+4. Snyk experimental raw fields remain adapter-local;
+5. declined Snyk MCP scan remains not-run and cannot claim execution;
+6. partial and target-unavailable scans remain explicit;
+7. active MCP scanning preserves execution/sandbox/consent context;
+8. cross-tenant/environment binding fails closed;
+9. reproduction creates append-only lineage without authority escalation;
+10. remediation without rescan does not become resolved;
+11. rescan/conflicting findings preserve prior/conflict references;
+12. two materially different families share one generic interpretation contract.
+
+## Deployment profiles
+
+### L: local
+
+Active scanner execution may expose local files/configuration or start configured MCP commands. Consent and sandbox evidence are important even without enterprise identity infrastructure.
+
+### T: team / multi-tenant
+
+Tenant/project/environment bindings prevent one workspace's finding from becoming a universal claim about the same named component elsewhere.
+
+### E: enterprise
+
+Findings may feed incident/remediation workflows, but they remain scoped evidence candidates and do not create standing policy automatically.
+
+### H: high assurance
+
+Exact scanner/tool/source versions, raw evidence custody, test conditions, execution context, reproduction lineage, conflicts, and evidence-depth gaps must remain reconstructable.
+
+## V0.1 non-claims
+
+V0.1 does not claim:
+
+- garak or Snyk Agent Scan is required by Agent Memory;
+- one scanner result proves a system vulnerable or safe in all contexts;
+- scanner severity or score is an Agent Memory truth metric;
+- reproduced findings create policy authority;
+- remediation is effective without rescan evidence;
+- a scanner result is a production incident;
+- adapter tests are live-scanner runtime evidence;
+- any external scanner mapping constitutes certification.
+
+## Stop line
+
+Do not expand this slice into:
+
+- vulnerability-management product features;
+- automatic standing policy creation;
+- scanner orchestration;
+- raw finding dump retention by default;
+- PyRIT or CyberSecEval support;
+- generic adoption of experimental scanner field names;
+- a scalar security score.

--- a/fixtures/security-finding-evidence-matrix.json
+++ b/fixtures/security-finding-evidence-matrix.json
@@ -1,0 +1,168 @@
+{
+  "fixture_id": "security-finding-evidence-matrix",
+  "fixture_version": "1.0.0",
+  "class": "trap",
+  "description": "Two materially different scanner families normalize into one non-authoritative security finding evidence contract without universalizing findings, hiding execution context, or converting scanner output into standing policy.",
+  "expected_behavior": {
+    "scanner_hit_creates_authority": false,
+    "no_hit_proves_global_safety": false,
+    "reproduction_creates_authority": false,
+    "remediation_without_rescan_means_resolved": false,
+    "cross_tenant_generalization": false,
+    "experimental_snyk_fields_become_core_schema": false,
+    "composite_security_score_allowed": false
+  },
+  "memory_unit": {
+    "id": "mem:security-finding-evidence",
+    "content_ref": "fixture://security-finding-evidence/reference",
+    "type": "evidence",
+    "state": "candidate",
+    "provenance": {
+      "origin": "fixture",
+      "observer": "conformance-suite",
+      "method": "security-finding-evidence-matrix",
+      "timestamp": "2026-08-12T22:50:00Z",
+      "source_refs": ["issue://198", "issue://168", "issue://196"]
+    },
+    "evidence": [
+      {
+        "id": "evidence:security-finding-v01",
+        "kind": "scanner_finding_fixture",
+        "ref": "issue://198",
+        "confidence": 1.0
+      }
+    ],
+    "saturation": {
+      "sigma": 0.0,
+      "calibrated": false,
+      "durability_dimensions": ["scanner_provenance", "test_scope", "finding_lineage"]
+    },
+    "authority": {
+      "pama_outcome": "require_review",
+      "risk_class": "medium",
+      "policy_refs": ["issue:198", "issue:168"],
+      "permitted_actions": ["collect_more_evidence", "defer"],
+      "prohibited_actions": ["promotion", "policy_mutation"],
+      "selection_mode": "none"
+    },
+    "created_at": "2026-08-12T22:50:00Z"
+  },
+  "pins": {
+    "garak": {
+      "version": "v0.16.0",
+      "commit": "dbe4515d12664f2e34ac2cea295f055c22fe82b4",
+      "contract": "report.jsonl eval"
+    },
+    "snyk_agent_scan": {
+      "version": "v0.5.17",
+      "commit": "ea959964ce4728426fca9fa78c9e7809b972f313",
+      "contract": "experimental_projection"
+    }
+  },
+  "expected_context": {
+    "target_ref": "target:agent-a",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+    "environment_ref": "env:staging-a"
+  },
+  "garak_hit": {
+    "garak_version": "0.16.0",
+    "garak_source_commit": "dbe4515d12664f2e34ac2cea295f055c22fe82b4",
+    "target_ref": "target:agent-a",
+    "target_configuration_ref": "config:agent-a:v17",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+    "environment_ref": "env:staging-a",
+    "run_ref": "garak-run:11111111-1111-1111-1111-111111111111",
+    "repetitions": 4,
+    "sandbox": "isolated",
+    "raw_evidence_ref": "artifact:garak-report-v0160",
+    "raw_evidence_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "observed_at": "2026-08-12T22:51:00Z",
+    "eval_record": {
+      "entry_type": "eval",
+      "probe": "probes.promptinject.HijackHateHumans",
+      "detector": "detector.mitigation.MitigationBypass",
+      "passed": 1,
+      "fails": 3,
+      "nones": 0,
+      "total_evaluated": 4,
+      "total_processed": 4
+    },
+    "pama_outcome": "allow",
+    "standing_policy": "block_everything"
+  },
+  "garak_no_hit": {
+    "garak_version": "0.16.0",
+    "garak_source_commit": "dbe4515d12664f2e34ac2cea295f055c22fe82b4",
+    "target_ref": "target:agent-a",
+    "target_configuration_ref": "config:agent-a:v17",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+    "environment_ref": "env:staging-a",
+    "run_ref": "garak-run:22222222-2222-2222-2222-222222222222",
+    "repetitions": 4,
+    "sandbox": "isolated",
+    "raw_evidence_ref": "artifact:garak-report-no-hit",
+    "raw_evidence_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "observed_at": "2026-08-12T22:52:00Z",
+    "eval_record": {
+      "entry_type": "eval",
+      "probe": "probes.promptinject.HijackHateHumans",
+      "detector": "detector.mitigation.MitigationBypass",
+      "passed": 4,
+      "fails": 0,
+      "nones": 0,
+      "total_evaluated": 4,
+      "total_processed": 4
+    }
+  },
+  "snyk_active": {
+    "source_version": "v0.5.17",
+    "source_commit": "ea959964ce4728426fca9fa78c9e7809b972f313",
+    "component_ref": "target:agent-a",
+    "configuration_ref": "config:mcp-server:local-files:v3",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+    "environment_ref": "env:staging-a",
+    "check_ref": "snyk-agent-scan:tool-poisoning",
+    "scan_ref": "snyk-agent-scan:run-1",
+    "result_status": "observed",
+    "verdict": "hit",
+    "reproduction_state": "not_attempted",
+    "mcp_server_execution": "executed",
+    "sandbox": "isolated",
+    "consent": "granted",
+    "scanner_privilege_ref": "privilege:user-session",
+    "raw_evidence_ref": "artifact:snyk-agent-scan-run-1",
+    "raw_evidence_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "observed_at": "2026-08-12T22:53:00Z",
+    "experimental_issue_code": "THIS_FIELD_MAY_CHANGE",
+    "experimental_response_blob": {"secret": "must-not-copy"},
+    "pama_outcome": "allow"
+  },
+  "snyk_declined": {
+    "source_version": "v0.5.17",
+    "source_commit": "ea959964ce4728426fca9fa78c9e7809b972f313",
+    "component_ref": "target:agent-a",
+    "configuration_ref": "config:mcp-server:untrusted:v1",
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+    "environment_ref": "env:staging-a",
+    "check_ref": "snyk-agent-scan:mcp-server-scan",
+    "scan_ref": "snyk-agent-scan:run-declined",
+    "result_status": "declined",
+    "verdict": "not_run",
+    "mcp_server_execution": "not_executed",
+    "sandbox": "unknown",
+    "consent": "declined",
+    "raw_evidence_ref": "artifact:snyk-agent-scan-declined",
+    "raw_evidence_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "observed_at": "2026-08-12T22:54:00Z"
+  }
+}

--- a/reference/agentmem_ref/security_finding.py
+++ b/reference/agentmem_ref/security_finding.py
@@ -1,0 +1,442 @@
+"""Vendor-neutral adversarial/security finding evidence for issue #198.
+
+The generic record is scanner-neutral. Vendor adapters may understand a pinned
+source contract, but the normalized evidence cannot create memory authority,
+standing policy, universal vulnerability/safety claims, admission, or external
+certification.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from copy import deepcopy
+from typing import Any
+
+import rfc8785
+
+from . import receipts
+
+PROFILE_VERSION = "0.1.0"
+
+GARAK_VERSION = "0.16.0"
+GARAK_TAG = "v0.16.0"
+GARAK_COMMIT = "dbe4515d12664f2e34ac2cea295f055c22fe82b4"
+GARAK_SOURCE_REF = f"github://NVIDIA/garak/{GARAK_COMMIT}"
+
+SNYK_AGENT_SCAN_VERSION = "0.5.17"
+SNYK_AGENT_SCAN_TAG = "v0.5.17"
+SNYK_AGENT_SCAN_COMMIT = "ea959964ce4728426fca9fa78c9e7809b972f313"
+SNYK_AGENT_SCAN_SOURCE_REF = f"github://snyk/agent-scan/{SNYK_AGENT_SCAN_COMMIT}"
+
+FINDING_FAMILIES = {"behavioral_probe", "supply_chain_configuration"}
+SOURCE_CONTRACT_STATUSES = {"stable_pinned", "experimental_projection"}
+RESULT_STATUSES = {
+    "observed",
+    "aborted",
+    "declined",
+    "partial",
+    "target_unavailable",
+    "evaluator_failure",
+    "unknown_schema",
+}
+VERDICTS = {"hit", "no_hit", "mixed", "unknown", "error", "not_run"}
+REPRODUCTION_STATES = {
+    "not_attempted",
+    "observed_once",
+    "reproduced",
+    "not_reproduced",
+    "nondeterministic",
+    "disputed",
+}
+FINDING_STATES = {
+    "observed",
+    "reproduced",
+    "not_reproduced",
+    "nondeterministic",
+    "triaged",
+    "remediation_proposed",
+    "remediation_applied",
+    "rescanned",
+    "resolved",
+    "residual",
+    "disputed",
+    "not_run",
+}
+CANDIDATE_CLASSES = {"threat_evidence", "correction_evidence", "incident_evidence", "conformance_evidence"}
+TARGET_EXECUTION = {"observed", "possible", "not_observed", "not_applicable", "unknown"}
+SANDBOX_STATES = {"isolated", "not_isolated", "not_applicable", "unknown"}
+CONSENT_STATES = {"granted", "declined", "bypassed", "not_required", "unknown"}
+
+
+def _sha256_ref(value: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+
+
+def _ref(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _digest(name: str, value: object) -> str:
+    text = _ref(name, value)
+    if len(text) != 71 or not text.startswith("sha256:") or any(ch not in "0123456789abcdef" for ch in text[7:]):
+        raise ValueError(f"{name} must be a lowercase sha256 digest reference")
+    return text
+
+
+def _refs(name: str, value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple)) or not all(isinstance(item, str) and item for item in value):
+        raise ValueError(f"{name} must be a list of non-empty strings")
+    return list(dict.fromkeys(value))
+
+
+def _optional_int(name: str, value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _binding(target: dict[str, str], expected_context: dict[str, str] | None) -> tuple[str, list[str]]:
+    if expected_context is None:
+        return "not_evaluated", []
+    if not isinstance(expected_context, dict):
+        raise ValueError("expected_context must be an object")
+    reasons: list[str] = []
+    for field in ("target_ref", "scope_ref", "tenant_ref", "project_ref", "environment_ref"):
+        expected = expected_context.get(field)
+        if expected is None:
+            continue
+        actual = target.get(field)
+        if actual is None:
+            reasons.append(f"{field}_missing")
+        elif actual != expected:
+            reasons.append(f"{field}_mismatch")
+    return ("mismatch", reasons) if reasons else ("exact", [])
+
+
+def normalize_security_finding(adapter_result: dict[str, Any], expected_context: dict[str, str] | None = None) -> dict[str, Any]:
+    """Normalize one scanner finding/projection into the generic evidence contract."""
+    if not isinstance(adapter_result, dict):
+        raise ValueError("adapter_result must be an object")
+
+    family = adapter_result.get("finding_family")
+    if family not in FINDING_FAMILIES:
+        raise ValueError(f"invalid finding_family {family!r}")
+    contract_status = adapter_result.get("source_contract_status")
+    if contract_status not in SOURCE_CONTRACT_STATUSES:
+        raise ValueError(f"invalid source_contract_status {contract_status!r}")
+    result_status = adapter_result.get("result_status")
+    if result_status not in RESULT_STATUSES:
+        raise ValueError(f"invalid result_status {result_status!r}")
+    verdict = adapter_result.get("verdict")
+    if verdict not in VERDICTS:
+        raise ValueError(f"invalid verdict {verdict!r}")
+    if result_status == "declined" and verdict != "not_run":
+        raise ValueError("declined scan must use verdict='not_run'")
+    if result_status == "target_unavailable" and verdict not in {"not_run", "unknown", "error"}:
+        raise ValueError("target_unavailable cannot claim a substantive finding verdict")
+
+    reproduction_state = adapter_result.get("reproduction_state")
+    if reproduction_state not in REPRODUCTION_STATES:
+        raise ValueError(f"invalid reproduction_state {reproduction_state!r}")
+    finding_state = adapter_result.get("finding_state")
+    if finding_state not in FINDING_STATES:
+        raise ValueError(f"invalid finding_state {finding_state!r}")
+    candidate_classification = adapter_result.get("candidate_classification")
+    if candidate_classification not in CANDIDATE_CLASSES:
+        raise ValueError(f"invalid candidate_classification {candidate_classification!r}")
+
+    target: dict[str, str] = {
+        "target_ref": _ref("target_ref", adapter_result.get("target_ref")),
+        "scope_ref": _ref("scope_ref", adapter_result.get("scope_ref")),
+    }
+    for field in ("target_configuration_ref", "tenant_ref", "project_ref", "environment_ref"):
+        value = adapter_result.get(field)
+        if value is not None:
+            target[field] = _ref(field, value)
+
+    test: dict[str, Any] = {"check_ref": _ref("check_ref", adapter_result.get("check_ref"))}
+    for field in ("check_version", "case_ref", "evaluator_ref", "evaluator_version", "seed_ref"):
+        value = adapter_result.get(field)
+        if value is not None:
+            test[field] = _ref(field, value)
+    if adapter_result.get("case_digest") is not None:
+        test["case_digest"] = _digest("case_digest", adapter_result["case_digest"])
+    for field in ("sample_size", "repetitions"):
+        value = _optional_int(field, adapter_result.get(field))
+        if value is not None:
+            test[field] = value
+
+    result: dict[str, Any] = {"status": result_status, "verdict": verdict}
+    counts = {}
+    for field in ("passed", "fails", "total_evaluated"):
+        value = _optional_int(field, adapter_result.get(field))
+        if value is not None:
+            counts[field] = value
+            result[field] = value
+    if {"passed", "fails", "total_evaluated"}.issubset(counts) and counts["passed"] + counts["fails"] != counts["total_evaluated"]:
+        raise ValueError("passed + fails must equal total_evaluated")
+
+    source_metric = adapter_result.get("source_metric")
+    if source_metric is not None:
+        if not isinstance(source_metric, dict):
+            raise ValueError("source_metric must be an object")
+        metric = {
+            "name": _ref("source_metric.name", source_metric.get("name")),
+            "value": source_metric.get("value"),
+        }
+        if isinstance(metric["value"], bool) or not isinstance(metric["value"], (int, float)):
+            raise ValueError("source_metric.value must be numeric")
+        for bound in ("lower_bound", "upper_bound"):
+            if source_metric.get(bound) is not None:
+                value = source_metric[bound]
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    raise ValueError(f"source_metric.{bound} must be numeric")
+                metric[bound] = value
+        result["source_metric"] = metric
+    if adapter_result.get("source_severity") is not None:
+        result["source_severity"] = _ref("source_severity", adapter_result["source_severity"])
+
+    target_execution = adapter_result.get("target_execution")
+    sandbox = adapter_result.get("sandbox")
+    consent = adapter_result.get("consent")
+    if target_execution not in TARGET_EXECUTION:
+        raise ValueError(f"invalid target_execution {target_execution!r}")
+    if sandbox not in SANDBOX_STATES:
+        raise ValueError(f"invalid sandbox {sandbox!r}")
+    if consent not in CONSENT_STATES:
+        raise ValueError(f"invalid consent {consent!r}")
+    execution_context = {
+        "target_execution": target_execution,
+        "sandbox": sandbox,
+        "consent": consent,
+    }
+    if adapter_result.get("scanner_privilege_ref") is not None:
+        execution_context["scanner_privilege_ref"] = _ref("scanner_privilege_ref", adapter_result["scanner_privilege_ref"])
+
+    lineage = {
+        "prior_finding_refs": _refs("prior_finding_refs", adapter_result.get("prior_finding_refs")),
+        "remediation_refs": _refs("remediation_refs", adapter_result.get("remediation_refs")),
+        "rescan_refs": _refs("rescan_refs", adapter_result.get("rescan_refs")),
+        "conflict_refs": _refs("conflict_refs", adapter_result.get("conflict_refs")),
+    }
+
+    body: dict[str, Any] = {
+        "finding_family": family,
+        "source": {
+            "tool": _ref("source_tool", adapter_result.get("source_tool")),
+            "version": _ref("source_version", adapter_result.get("source_version")),
+            "source_ref": _ref("source_ref", adapter_result.get("source_ref")),
+            "source_commit": _ref("source_commit", adapter_result.get("source_commit")),
+            "adapter_id": _ref("adapter_id", adapter_result.get("adapter_id")),
+            "adapter_version": _ref("adapter_version", adapter_result.get("adapter_version")),
+            "source_contract_status": contract_status,
+        },
+        "target": target,
+        "test": test,
+        "result": result,
+        "reproduction_state": reproduction_state,
+        "finding_state": finding_state,
+        "candidate_classification": candidate_classification,
+        "execution_context": execution_context,
+        "raw_evidence_digest": _digest("raw_evidence_digest", adapter_result.get("raw_evidence_digest")),
+        "known_limitations": _refs("known_limitations", adapter_result.get("known_limitations")),
+        "lineage": lineage,
+        "observed_at": _ref("observed_at", adapter_result.get("observed_at")),
+        "interpretation": {
+            "authority_effect": "none",
+            "universal_vulnerability": "not_established",
+            "safety_claim": "not_established",
+            "standing_policy": "not_established",
+            "memory_admission": "not_established",
+            "certification_claim": "none",
+        },
+    }
+    if adapter_result.get("raw_evidence_ref") is not None:
+        body["raw_evidence_ref"] = _ref("raw_evidence_ref", adapter_result["raw_evidence_ref"])
+
+    binding_status, binding_reasons = _binding(target, expected_context)
+    body["binding_status"] = binding_status
+    body["binding_reasons"] = binding_reasons
+
+    identity_body = deepcopy(body)
+    document = {
+        "schema_version": "1.0.0",
+        "profile_version": PROFILE_VERSION,
+        "finding_id": f"security-finding:{_sha256_ref(identity_body)}",
+        **body,
+    }
+    receipts.validate("security-finding-evidence.schema.json", document)
+    return document
+
+
+def normalize_garak_eval(source: dict[str, Any], expected_context: dict[str, str] | None = None) -> dict[str, Any]:
+    """Project one exact garak v0.16.0 eval record into generic evidence."""
+    if source.get("garak_version") != GARAK_VERSION:
+        raise ValueError(f"unsupported garak version {source.get('garak_version')!r}")
+    if source.get("garak_source_commit") != GARAK_COMMIT:
+        raise ValueError("garak source commit does not match pinned v0.16.0")
+    record = source.get("eval_record")
+    if not isinstance(record, dict) or record.get("entry_type") != "eval":
+        raise ValueError("garak adapter requires an eval report.jsonl record")
+
+    passed = _optional_int("eval_record.passed", record.get("passed"))
+    fails = _optional_int("eval_record.fails", record.get("fails"))
+    total = _optional_int("eval_record.total_evaluated", record.get("total_evaluated"))
+    if passed is None or fails is None or total is None:
+        raise ValueError("garak eval requires passed, fails, and total_evaluated")
+    if passed + fails != total:
+        raise ValueError("garak passed + fails must equal total_evaluated")
+    if total == 0:
+        verdict = "unknown"
+    elif fails == 0:
+        verdict = "no_hit"
+    elif passed == 0:
+        verdict = "hit"
+    else:
+        verdict = "mixed"
+
+    metric: dict[str, Any] = {
+        "name": "garak_pass_rate",
+        "value": (passed / total) if total else 0.0,
+    }
+    if record.get("confidence_lower") is not None:
+        metric["lower_bound"] = record["confidence_lower"]
+    if record.get("confidence_upper") is not None:
+        metric["upper_bound"] = record["confidence_upper"]
+
+    adapter_result = {
+        "finding_family": "behavioral_probe",
+        "source_tool": "NVIDIA garak",
+        "source_version": GARAK_TAG,
+        "source_ref": GARAK_SOURCE_REF,
+        "source_commit": GARAK_COMMIT,
+        "adapter_id": "agent-memory:garak-eval-v01",
+        "adapter_version": PROFILE_VERSION,
+        "source_contract_status": "stable_pinned",
+        "target_ref": source.get("target_ref"),
+        "target_configuration_ref": source.get("target_configuration_ref"),
+        "scope_ref": source.get("scope_ref"),
+        "tenant_ref": source.get("tenant_ref"),
+        "project_ref": source.get("project_ref"),
+        "environment_ref": source.get("environment_ref"),
+        "check_ref": f"garak-probe:{_ref('eval_record.probe', record.get('probe'))}",
+        "check_version": GARAK_TAG,
+        "case_ref": source.get("run_ref"),
+        "evaluator_ref": f"garak-detector:{_ref('eval_record.detector', record.get('detector'))}",
+        "evaluator_version": GARAK_TAG,
+        "sample_size": total,
+        "repetitions": source.get("repetitions"),
+        "seed_ref": source.get("seed_ref"),
+        "result_status": "observed",
+        "verdict": verdict,
+        "passed": passed,
+        "fails": fails,
+        "total_evaluated": total,
+        "source_metric": metric,
+        "reproduction_state": source.get("reproduction_state", "observed_once"),
+        "finding_state": source.get("finding_state", "observed"),
+        "candidate_classification": source.get("candidate_classification", "threat_evidence"),
+        "target_execution": "observed",
+        "sandbox": source.get("sandbox", "unknown"),
+        "consent": source.get("consent", "not_required"),
+        "scanner_privilege_ref": source.get("scanner_privilege_ref"),
+        "raw_evidence_ref": source.get("raw_evidence_ref"),
+        "raw_evidence_digest": source.get("raw_evidence_digest"),
+        "known_limitations": [
+            "Observed garak result is bounded to the pinned target, probe, detector, configuration, and sampling conditions.",
+            "A no-hit result is not proof of safety outside the evaluated scope.",
+        ] + _refs("known_limitations", source.get("known_limitations")),
+        "prior_finding_refs": source.get("prior_finding_refs"),
+        "remediation_refs": source.get("remediation_refs"),
+        "rescan_refs": source.get("rescan_refs"),
+        "conflict_refs": source.get("conflict_refs"),
+        "observed_at": source.get("observed_at"),
+    }
+    return normalize_security_finding(adapter_result, expected_context)
+
+
+def normalize_snyk_agent_scan_projection(source: dict[str, Any], expected_context: dict[str, str] | None = None) -> dict[str, Any]:
+    """Normalize a bounded Snyk Agent Scan v0.5.17 projection.
+
+    This adapter intentionally does not parse or expose unstable raw CLI field
+    names. A caller maps the current upstream output into this stable projection
+    at the adapter edge, and the generic Agent Memory schema remains unchanged.
+    """
+    if source.get("source_version") != SNYK_AGENT_SCAN_TAG:
+        raise ValueError(f"unsupported Snyk Agent Scan version {source.get('source_version')!r}")
+    if source.get("source_commit") != SNYK_AGENT_SCAN_COMMIT:
+        raise ValueError("Snyk Agent Scan source commit does not match pinned v0.5.17")
+
+    result_status = source.get("result_status")
+    verdict = source.get("verdict")
+    if result_status not in RESULT_STATUSES or verdict not in VERDICTS:
+        raise ValueError("Snyk projection requires a generic result_status and verdict")
+
+    consent = source.get("consent", "unknown")
+    mcp_execution = source.get("mcp_server_execution")
+    if mcp_execution not in {"executed", "could_execute", "not_executed", "not_applicable", "unknown"}:
+        raise ValueError("invalid mcp_server_execution")
+    target_execution = {
+        "executed": "observed",
+        "could_execute": "possible",
+        "not_executed": "not_observed",
+        "not_applicable": "not_applicable",
+        "unknown": "unknown",
+    }[mcp_execution]
+    if consent == "declined" and mcp_execution == "executed":
+        raise ValueError("declined Snyk MCP scan cannot claim server execution")
+
+    limitations = [
+        "Snyk Agent Scan CLI/JSON field names, issue codes, severity labels, and response structure are treated as experimental adapter-local details.",
+        "Scanning stdio MCP configurations may execute configured commands; execution, consent, and sandbox context are preserved separately.",
+    ] + _refs("known_limitations", source.get("known_limitations"))
+
+    adapter_result = {
+        "finding_family": "supply_chain_configuration",
+        "source_tool": "Snyk Agent Scan",
+        "source_version": SNYK_AGENT_SCAN_TAG,
+        "source_ref": SNYK_AGENT_SCAN_SOURCE_REF,
+        "source_commit": SNYK_AGENT_SCAN_COMMIT,
+        "adapter_id": "agent-memory:snyk-agent-scan-projection-v01",
+        "adapter_version": PROFILE_VERSION,
+        "source_contract_status": "experimental_projection",
+        "target_ref": source.get("component_ref"),
+        "target_configuration_ref": source.get("configuration_ref"),
+        "scope_ref": source.get("scope_ref"),
+        "tenant_ref": source.get("tenant_ref"),
+        "project_ref": source.get("project_ref"),
+        "environment_ref": source.get("environment_ref"),
+        "check_ref": source.get("check_ref"),
+        "check_version": source.get("check_version"),
+        "case_ref": source.get("scan_ref"),
+        "case_digest": source.get("case_digest"),
+        "evaluator_ref": source.get("evaluator_ref", "snyk-agent-scan:analysis"),
+        "evaluator_version": SNYK_AGENT_SCAN_TAG,
+        "sample_size": source.get("sample_size"),
+        "result_status": result_status,
+        "verdict": verdict,
+        "source_metric": source.get("source_metric"),
+        "source_severity": source.get("source_severity"),
+        "reproduction_state": source.get("reproduction_state", "not_attempted"),
+        "finding_state": source.get("finding_state", "not_run" if result_status == "declined" else "observed"),
+        "candidate_classification": source.get("candidate_classification", "conformance_evidence" if result_status == "declined" else "threat_evidence"),
+        "target_execution": target_execution,
+        "sandbox": source.get("sandbox", "unknown"),
+        "consent": consent,
+        "scanner_privilege_ref": source.get("scanner_privilege_ref"),
+        "raw_evidence_ref": source.get("raw_evidence_ref"),
+        "raw_evidence_digest": source.get("raw_evidence_digest"),
+        "known_limitations": limitations,
+        "prior_finding_refs": source.get("prior_finding_refs"),
+        "remediation_refs": source.get("remediation_refs"),
+        "rescan_refs": source.get("rescan_refs"),
+        "conflict_refs": source.get("conflict_refs"),
+        "observed_at": source.get("observed_at"),
+    }
+    return normalize_security_finding(adapter_result, expected_context)

--- a/reference/agentmem_ref/security_finding_depth.py
+++ b/reference/agentmem_ref/security_finding_depth.py
@@ -1,0 +1,65 @@
+"""D/F/H/R/P evidence-depth report for P2-B scanner finding adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import receipts
+from .security_evidence_depth import LEVELS, REPORT_TYPE, REPORT_VERSION, _claim, _exact_commit
+from .security_finding_harness import run_security_finding_harness
+
+
+def build_security_finding_depth_report(agent_memory_commit: str) -> dict[str, Any]:
+    commit = _exact_commit(agent_memory_commit)
+    harness = run_security_finding_harness()
+    claims = [
+        _claim(
+            agent_memory_commit=commit,
+            claim_id="security-finding:garak-normalization",
+            title="Pinned garak v0.16.0 eval results normalize as scoped non-authoritative security evidence",
+            threat_family="adversarial_scanner_evidence",
+            doctrine_refs=[
+                "docs/15-memory-threat-model.md",
+                "docs/profiles/security-finding-evidence-profile.md",
+            ],
+            fixture_refs=["fixtures/security-finding-evidence-matrix.json"],
+            harness_ref="security-finding-harness:garak-v0.16.0",
+            behavioral_passed=harness["cases"]["garak"]["passed"],
+            scope_profiles=["L", "T", "E", "H"],
+        ),
+        _claim(
+            agent_memory_commit=commit,
+            claim_id="security-finding:snyk-agent-scan-projection",
+            title="Snyk Agent Scan v0.5.17 experimental output projects into stable scoped non-authoritative evidence",
+            threat_family="supply_chain_configuration_evidence",
+            doctrine_refs=[
+                "docs/15-memory-threat-model.md",
+                "docs/profiles/security-finding-evidence-profile.md",
+            ],
+            fixture_refs=["fixtures/security-finding-evidence-matrix.json"],
+            harness_ref="security-finding-harness:snyk-agent-scan-v0.5.17",
+            behavioral_passed=harness["cases"]["snyk_agent_scan"]["passed"],
+            scope_profiles=["L", "T", "E", "H"],
+        ),
+    ]
+    report = {
+        "report_type": REPORT_TYPE,
+        "version": REPORT_VERSION,
+        "agent_memory_commit": commit,
+        "evidence_model": {
+            "levels": list(LEVELS),
+            "inference_policy": "no_level_may_be_inferred_from_another_level",
+        },
+        "claims": claims,
+        "required_behavioral_cases_passed": harness["passed"],
+        "non_certification_statement": "Evidence mapping and demonstrated behavior do not constitute external certification.",
+        "known_limits": [
+            "The garak adapter is behaviorally validated against pinned v0.16.0 eval-record semantics but this report does not execute a live garak scan; R remains unproven.",
+            "The Snyk Agent Scan adapter consumes an Agent Memory-facing experimental projection rather than stabilizing upstream CLI/JSON fields; R remains unproven.",
+            "Scanner findings remain scoped evidence candidates and do not establish universal vulnerability, safety, standing policy, memory admission, or certification.",
+            "Production evidence P is not collected or inferred and remains explicitly unproven.",
+            "No composite security or scanner-confidence score is emitted.",
+        ],
+    }
+    receipts.validate("security-evidence-depth-report.schema.json", report)
+    return report

--- a/reference/agentmem_ref/security_finding_harness.py
+++ b/reference/agentmem_ref/security_finding_harness.py
@@ -1,0 +1,113 @@
+"""Behavioral harness for the two P2-B scanner evidence families."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .security_finding import normalize_garak_eval, normalize_snyk_agent_scan_projection
+
+
+def _garak_case() -> dict[str, Any]:
+    expected = {
+        "target_ref": "target:scanner-harness",
+        "scope_ref": "scope:tenant-a/project-a",
+        "tenant_ref": "tenant-a",
+        "project_ref": "project-a",
+        "environment_ref": "env:test",
+    }
+    source = {
+        "garak_version": "0.16.0",
+        "garak_source_commit": "dbe4515d12664f2e34ac2cea295f055c22fe82b4",
+        **expected,
+        "target_configuration_ref": "config:scanner-harness:v1",
+        "run_ref": "garak-run:harness",
+        "repetitions": 4,
+        "sandbox": "isolated",
+        "raw_evidence_digest": "sha256:" + "a" * 64,
+        "observed_at": "2026-08-12T22:55:00Z",
+        "eval_record": {
+            "entry_type": "eval",
+            "probe": "probes.promptinject.HijackHateHumans",
+            "detector": "detector.mitigation.MitigationBypass",
+            "passed": 1,
+            "fails": 3,
+            "nones": 0,
+            "total_evaluated": 4,
+            "total_processed": 4,
+        },
+        "pama_outcome": "allow",
+        "standing_policy": "global-block",
+        "raw_attack_prompt": "must-not-copy",
+    }
+    finding = normalize_garak_eval(source, expected)
+    checks = {
+        "generic_family": finding["finding_family"] == "behavioral_probe",
+        "stable_pin": finding["source"]["source_contract_status"] == "stable_pinned",
+        "source_counts_preserved": (
+            finding["result"]["passed"] == 1
+            and finding["result"]["fails"] == 3
+            and finding["result"]["total_evaluated"] == 4
+        ),
+        "mixed_finding_preserved": finding["result"]["verdict"] == "mixed",
+        "binding_exact": finding["binding_status"] == "exact",
+        "authority_none": finding["interpretation"]["authority_effect"] == "none",
+        "universal_vulnerability_not_established": finding["interpretation"]["universal_vulnerability"] == "not_established",
+        "standing_policy_not_established": finding["interpretation"]["standing_policy"] == "not_established",
+        "hostile_fields_discarded": all(
+            key not in finding for key in ("pama_outcome", "standing_policy", "raw_attack_prompt")
+        ),
+    }
+    return {"case_id": "garak-pinned-eval-normalization", "passed": all(checks.values()), "checks": checks}
+
+
+def _snyk_case() -> dict[str, Any]:
+    expected = {
+        "target_ref": "target:scanner-harness",
+        "scope_ref": "scope:tenant-a/project-a",
+        "tenant_ref": "tenant-a",
+        "project_ref": "project-a",
+        "environment_ref": "env:test",
+    }
+    source = {
+        "source_version": "v0.5.17",
+        "source_commit": "ea959964ce4728426fca9fa78c9e7809b972f313",
+        "component_ref": expected["target_ref"],
+        "configuration_ref": "config:mcp:scanner-harness",
+        "scope_ref": expected["scope_ref"],
+        "tenant_ref": expected["tenant_ref"],
+        "project_ref": expected["project_ref"],
+        "environment_ref": expected["environment_ref"],
+        "check_ref": "snyk-agent-scan:tool-poisoning",
+        "scan_ref": "snyk-agent-scan:harness",
+        "result_status": "observed",
+        "verdict": "hit",
+        "mcp_server_execution": "executed",
+        "sandbox": "isolated",
+        "consent": "granted",
+        "scanner_privilege_ref": "privilege:test-user",
+        "raw_evidence_digest": "sha256:" + "b" * 64,
+        "observed_at": "2026-08-12T22:56:00Z",
+        "experimental_issue_code": "must-not-copy",
+        "experimental_raw_response": {"secret": "must-not-copy"},
+        "pama_outcome": "allow",
+    }
+    finding = normalize_snyk_agent_scan_projection(source, expected)
+    checks = {
+        "generic_family": finding["finding_family"] == "supply_chain_configuration",
+        "experimental_projection_is_explicit": finding["source"]["source_contract_status"] == "experimental_projection",
+        "binding_exact": finding["binding_status"] == "exact",
+        "active_target_execution_preserved": finding["execution_context"]["target_execution"] == "observed",
+        "sandbox_preserved": finding["execution_context"]["sandbox"] == "isolated",
+        "consent_preserved": finding["execution_context"]["consent"] == "granted",
+        "authority_none": finding["interpretation"]["authority_effect"] == "none",
+        "memory_admission_not_established": finding["interpretation"]["memory_admission"] == "not_established",
+        "experimental_fields_discarded": all(
+            key not in finding for key in ("experimental_issue_code", "experimental_raw_response", "pama_outcome")
+        ),
+    }
+    return {"case_id": "snyk-experimental-projection-normalization", "passed": all(checks.values()), "checks": checks}
+
+
+def run_security_finding_harness() -> dict[str, Any]:
+    cases = {"garak": _garak_case(), "snyk_agent_scan": _snyk_case()}
+    return {"cases": cases, "passed": all(case["passed"] for case in cases.values())}

--- a/reference/run_security_finding_depth.py
+++ b/reference/run_security_finding_depth.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Emit exact-head D/F/H/R/P evidence depth for P2-B scanner adapters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.security_finding_depth import build_security_finding_depth_report  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = build_security_finding_depth_report(args.agent_memory_commit)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    if not report["required_behavioral_cases_passed"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_security_finding.py
+++ b/reference/tests/test_security_finding.py
@@ -1,0 +1,215 @@
+"""Executable security finding evidence tests for issue #198."""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from agentmem_ref.security_finding import (
+    GARAK_COMMIT,
+    GARAK_TAG,
+    SNYK_AGENT_SCAN_COMMIT,
+    SNYK_AGENT_SCAN_TAG,
+    normalize_garak_eval,
+    normalize_snyk_agent_scan_projection,
+)
+from agentmem_ref.security_finding_harness import run_security_finding_harness
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "fixtures" / "security-finding-evidence-matrix.json"
+
+
+class SecurityFindingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.matrix = json.loads(MATRIX.read_text(encoding="utf-8"))
+        cls.expected = cls.matrix["expected_context"]
+
+    def test_behavioral_harness_covers_two_materially_different_families(self):
+        harness = run_security_finding_harness()
+        self.assertTrue(harness["passed"], harness)
+        self.assertEqual(set(harness["cases"]), {"garak", "snyk_agent_scan"})
+        for case in harness["cases"].values():
+            self.assertTrue(case["passed"], case)
+
+    def test_garak_pin_and_eval_counts_are_preserved(self):
+        result = normalize_garak_eval(copy.deepcopy(self.matrix["garak_hit"]), self.expected)
+        self.assertEqual(result["source"]["version"], GARAK_TAG)
+        self.assertEqual(result["source"]["source_commit"], GARAK_COMMIT)
+        self.assertEqual(result["source"]["source_contract_status"], "stable_pinned")
+        self.assertEqual(result["finding_family"], "behavioral_probe")
+        self.assertEqual(result["result"]["passed"], 1)
+        self.assertEqual(result["result"]["fails"], 3)
+        self.assertEqual(result["result"]["total_evaluated"], 4)
+        self.assertEqual(result["result"]["verdict"], "mixed")
+        self.assertEqual(result["result"]["source_metric"]["name"], "garak_pass_rate")
+        self.assertEqual(result["result"]["source_metric"]["value"], 0.25)
+
+    def test_garak_hit_is_evidence_not_authority_or_universal_fact(self):
+        result = normalize_garak_eval(copy.deepcopy(self.matrix["garak_hit"]), self.expected)
+        self.assertEqual(result["interpretation"]["authority_effect"], "none")
+        self.assertEqual(result["interpretation"]["universal_vulnerability"], "not_established")
+        self.assertEqual(result["interpretation"]["standing_policy"], "not_established")
+        self.assertEqual(result["interpretation"]["memory_admission"], "not_established")
+        self.assertEqual(result["interpretation"]["certification_claim"], "none")
+        self.assertNotIn("pama_outcome", result)
+        self.assertNotIn("standing_policy", result)
+
+    def test_garak_no_hit_does_not_prove_safety(self):
+        result = normalize_garak_eval(copy.deepcopy(self.matrix["garak_no_hit"]), self.expected)
+        self.assertEqual(result["result"]["verdict"], "no_hit")
+        self.assertEqual(result["interpretation"]["safety_claim"], "not_established")
+        self.assertTrue(any("not proof of safety" in item for item in result["known_limitations"]))
+
+    def test_garak_rejects_version_or_eval_contract_drift(self):
+        wrong_version = copy.deepcopy(self.matrix["garak_hit"])
+        wrong_version["garak_version"] = "0.15.1"
+        with self.assertRaisesRegex(ValueError, "unsupported garak version"):
+            normalize_garak_eval(wrong_version, self.expected)
+
+        wrong_commit = copy.deepcopy(self.matrix["garak_hit"])
+        wrong_commit["garak_source_commit"] = "0" * 40
+        with self.assertRaisesRegex(ValueError, "source commit"):
+            normalize_garak_eval(wrong_commit, self.expected)
+
+        bad_counts = copy.deepcopy(self.matrix["garak_hit"])
+        bad_counts["eval_record"]["fails"] = 2
+        with self.assertRaisesRegex(ValueError, "passed \+ fails"):
+            normalize_garak_eval(bad_counts, self.expected)
+
+    def test_snyk_projection_is_experimental_but_generic_schema_is_stable(self):
+        result = normalize_snyk_agent_scan_projection(copy.deepcopy(self.matrix["snyk_active"]), self.expected)
+        self.assertEqual(result["source"]["version"], SNYK_AGENT_SCAN_TAG)
+        self.assertEqual(result["source"]["source_commit"], SNYK_AGENT_SCAN_COMMIT)
+        self.assertEqual(result["source"]["source_contract_status"], "experimental_projection")
+        self.assertEqual(result["finding_family"], "supply_chain_configuration")
+        self.assertEqual(result["execution_context"]["target_execution"], "observed")
+        self.assertEqual(result["execution_context"]["sandbox"], "isolated")
+        self.assertEqual(result["execution_context"]["consent"], "granted")
+        self.assertNotIn("experimental_issue_code", result)
+        self.assertNotIn("experimental_response_blob", result)
+        self.assertNotIn("pama_outcome", result)
+        serialized = json.dumps(result)
+        self.assertNotIn("THIS_FIELD_MAY_CHANGE", serialized)
+        self.assertNotIn("must-not-copy", serialized)
+
+    def test_snyk_declined_scan_is_not_run_not_fabricated_finding(self):
+        result = normalize_snyk_agent_scan_projection(copy.deepcopy(self.matrix["snyk_declined"]), self.expected)
+        self.assertEqual(result["result"]["status"], "declined")
+        self.assertEqual(result["result"]["verdict"], "not_run")
+        self.assertEqual(result["finding_state"], "not_run")
+        self.assertEqual(result["candidate_classification"], "conformance_evidence")
+        self.assertEqual(result["execution_context"]["target_execution"], "not_observed")
+        self.assertEqual(result["execution_context"]["consent"], "declined")
+        self.assertEqual(result["interpretation"]["safety_claim"], "not_established")
+
+    def test_declined_snyk_scan_cannot_claim_execution(self):
+        value = copy.deepcopy(self.matrix["snyk_declined"])
+        value["mcp_server_execution"] = "executed"
+        with self.assertRaisesRegex(ValueError, "declined Snyk MCP scan"):
+            normalize_snyk_agent_scan_projection(value, self.expected)
+
+    def test_partial_and_target_unavailable_remain_explicit(self):
+        partial = copy.deepcopy(self.matrix["snyk_active"])
+        partial.update({"result_status": "partial", "verdict": "unknown", "mcp_server_execution": "could_execute"})
+        partial_result = normalize_snyk_agent_scan_projection(partial, self.expected)
+        self.assertEqual(partial_result["result"]["status"], "partial")
+        self.assertEqual(partial_result["result"]["verdict"], "unknown")
+        self.assertEqual(partial_result["execution_context"]["target_execution"], "possible")
+
+        unavailable = copy.deepcopy(self.matrix["snyk_active"])
+        unavailable.update({"result_status": "target_unavailable", "verdict": "not_run", "mcp_server_execution": "not_executed"})
+        unavailable_result = normalize_snyk_agent_scan_projection(unavailable, self.expected)
+        self.assertEqual(unavailable_result["result"]["status"], "target_unavailable")
+        self.assertEqual(unavailable_result["interpretation"]["safety_claim"], "not_established")
+
+    def test_cross_tenant_environment_binding_fails_closed(self):
+        value = copy.deepcopy(self.matrix["snyk_active"])
+        value.update(
+            {
+                "scope_ref": "scope:tenant-b/project-b",
+                "tenant_ref": "tenant-b",
+                "project_ref": "project-b",
+                "environment_ref": "env:prod-b",
+            }
+        )
+        result = normalize_snyk_agent_scan_projection(value, self.expected)
+        self.assertEqual(result["binding_status"], "mismatch")
+        self.assertTrue(
+            {
+                "scope_ref_mismatch",
+                "tenant_ref_mismatch",
+                "project_ref_mismatch",
+                "environment_ref_mismatch",
+            }.issubset(set(result["binding_reasons"]))
+        )
+
+    def test_reproduction_strengthens_lineage_not_authority(self):
+        original = normalize_garak_eval(copy.deepcopy(self.matrix["garak_hit"]), self.expected)
+        reproduced_source = copy.deepcopy(self.matrix["garak_hit"])
+        reproduced_source.update(
+            {
+                "reproduction_state": "reproduced",
+                "finding_state": "reproduced",
+                "prior_finding_refs": [original["finding_id"]],
+                "raw_evidence_digest": "sha256:" + "e" * 64,
+                "observed_at": "2026-08-12T22:57:00Z",
+            }
+        )
+        reproduced = normalize_garak_eval(reproduced_source, self.expected)
+        self.assertNotEqual(original["finding_id"], reproduced["finding_id"])
+        self.assertEqual(reproduced["lineage"]["prior_finding_refs"], [original["finding_id"]])
+        self.assertEqual(reproduced["reproduction_state"], "reproduced")
+        self.assertEqual(reproduced["interpretation"]["authority_effect"], "none")
+        self.assertEqual(reproduced["interpretation"]["universal_vulnerability"], "not_established")
+
+    def test_remediation_without_rescan_does_not_become_resolved(self):
+        original = normalize_garak_eval(copy.deepcopy(self.matrix["garak_hit"]), self.expected)
+        remediation_source = copy.deepcopy(self.matrix["garak_hit"])
+        remediation_source.update(
+            {
+                "finding_state": "remediation_applied",
+                "prior_finding_refs": [original["finding_id"]],
+                "remediation_refs": ["remediation:patch-1"],
+                "raw_evidence_digest": "sha256:" + "f" * 64,
+                "observed_at": "2026-08-12T22:58:00Z",
+            }
+        )
+        remediation = normalize_garak_eval(remediation_source, self.expected)
+        self.assertEqual(remediation["finding_state"], "remediation_applied")
+        self.assertEqual(remediation["lineage"]["rescan_refs"], [])
+        self.assertNotEqual(remediation["finding_state"], "resolved")
+        self.assertEqual(remediation["interpretation"]["safety_claim"], "not_established")
+
+    def test_rescan_and_conflicting_findings_preserve_append_only_refs(self):
+        hit = normalize_garak_eval(copy.deepcopy(self.matrix["garak_hit"]), self.expected)
+        no_hit_source = copy.deepcopy(self.matrix["garak_no_hit"])
+        no_hit_source.update(
+            {
+                "finding_state": "rescanned",
+                "prior_finding_refs": [hit["finding_id"]],
+                "rescan_refs": ["rescan:after-remediation-1"],
+                "conflict_refs": [hit["finding_id"]],
+            }
+        )
+        no_hit = normalize_garak_eval(no_hit_source, self.expected)
+        self.assertEqual(no_hit["result"]["verdict"], "no_hit")
+        self.assertEqual(no_hit["lineage"]["prior_finding_refs"], [hit["finding_id"]])
+        self.assertEqual(no_hit["lineage"]["conflict_refs"], [hit["finding_id"]])
+        self.assertEqual(no_hit["interpretation"]["safety_claim"], "not_established")
+
+    def test_two_families_share_same_generic_interpretation_contract(self):
+        garak = normalize_garak_eval(copy.deepcopy(self.matrix["garak_hit"]), self.expected)
+        snyk = normalize_snyk_agent_scan_projection(copy.deepcopy(self.matrix["snyk_active"]), self.expected)
+        self.assertNotEqual(garak["finding_family"], snyk["finding_family"])
+        self.assertEqual(set(garak["interpretation"]), set(snyk["interpretation"]))
+        self.assertEqual(garak["interpretation"]["authority_effect"], "none")
+        self.assertEqual(snyk["interpretation"]["authority_effect"], "none")
+        self.assertEqual(garak["schema_version"], snyk["schema_version"])
+        self.assertEqual(garak["profile_version"], snyk["profile_version"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_security_finding_depth.py
+++ b/reference/tests/test_security_finding_depth.py
@@ -1,0 +1,41 @@
+"""D/F/H/R/P accounting tests for P2-B scanner adapters."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.security_finding_depth import build_security_finding_depth_report
+
+COMMIT = "3" * 40
+
+
+class SecurityFindingDepthTests(unittest.TestCase):
+    def test_scanner_adapters_are_d_f_h_only(self):
+        report = build_security_finding_depth_report(COMMIT)
+        self.assertTrue(report["required_behavioral_cases_passed"])
+        self.assertEqual(len(report["claims"]), 2)
+        for claim in report["claims"]:
+            self.assertEqual(claim["demonstrated_levels"], ["D", "F", "H"])
+            self.assertEqual(claim["highest_demonstrated_level"], "H")
+            self.assertEqual(claim["explicitly_unproven_levels"], ["R", "P"])
+            self.assertEqual(claim["runtime_evidence_refs"], [])
+            self.assertEqual(claim["production_evidence_refs"], [])
+            self.assertTrue(claim["behavioral_passed"])
+            self.assertIn("does not assert external certification", claim["non_certification_statement"])
+
+    def test_no_composite_score_or_live_scanner_claim(self):
+        report = build_security_finding_depth_report(COMMIT)
+        self.assertNotIn("score", report)
+        self.assertNotIn("composite_score", report)
+        rendered_limits = " ".join(report["known_limits"])
+        self.assertIn("does not execute a live garak scan", rendered_limits)
+        self.assertIn("R remains unproven", rendered_limits)
+        self.assertIn("Production evidence P", rendered_limits)
+
+    def test_exact_head_is_required(self):
+        with self.assertRaisesRegex(ValueError, "exact 40-hex commit"):
+            build_security_finding_depth_report("not-a-commit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/security-finding-evidence.schema.json
+++ b/schemas/security-finding-evidence.schema.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/security-finding-evidence.schema.json",
+  "title": "Agent Memory Security Finding Evidence",
+  "description": "Vendor-neutral scoped security/adversarial finding evidence. Scanner output remains evidence under exact test conditions and cannot establish universal vulnerability, safety, memory authority, standing policy, memory admission, or certification.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_version",
+    "finding_id",
+    "finding_family",
+    "source",
+    "target",
+    "test",
+    "result",
+    "reproduction_state",
+    "finding_state",
+    "candidate_classification",
+    "execution_context",
+    "raw_evidence_digest",
+    "known_limitations",
+    "lineage",
+    "binding_status",
+    "binding_reasons",
+    "observed_at",
+    "interpretation"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "profile_version": { "const": "0.1.0" },
+    "finding_id": { "type": "string", "minLength": 1 },
+    "finding_family": {
+      "type": "string",
+      "enum": ["behavioral_probe", "supply_chain_configuration"]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tool",
+        "version",
+        "source_ref",
+        "source_commit",
+        "adapter_id",
+        "adapter_version",
+        "source_contract_status"
+      ],
+      "properties": {
+        "tool": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "source_ref": { "type": "string", "minLength": 1 },
+        "source_commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "adapter_id": { "type": "string", "minLength": 1 },
+        "adapter_version": { "type": "string", "minLength": 1 },
+        "source_contract_status": {
+          "type": "string",
+          "enum": ["stable_pinned", "experimental_projection"]
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target_ref", "scope_ref"],
+      "properties": {
+        "target_ref": { "type": "string", "minLength": 1 },
+        "target_configuration_ref": { "type": "string", "minLength": 1 },
+        "scope_ref": { "type": "string", "minLength": 1 },
+        "tenant_ref": { "type": "string", "minLength": 1 },
+        "project_ref": { "type": "string", "minLength": 1 },
+        "environment_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["check_ref"],
+      "properties": {
+        "check_ref": { "type": "string", "minLength": 1 },
+        "check_version": { "type": "string", "minLength": 1 },
+        "case_ref": { "type": "string", "minLength": 1 },
+        "case_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "evaluator_ref": { "type": "string", "minLength": 1 },
+        "evaluator_version": { "type": "string", "minLength": 1 },
+        "sample_size": { "type": "integer", "minimum": 0 },
+        "repetitions": { "type": "integer", "minimum": 0 },
+        "seed_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "verdict"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "observed",
+            "aborted",
+            "declined",
+            "partial",
+            "target_unavailable",
+            "evaluator_failure",
+            "unknown_schema"
+          ]
+        },
+        "verdict": {
+          "type": "string",
+          "enum": ["hit", "no_hit", "mixed", "unknown", "error", "not_run"]
+        },
+        "passed": { "type": "integer", "minimum": 0 },
+        "fails": { "type": "integer", "minimum": 0 },
+        "total_evaluated": { "type": "integer", "minimum": 0 },
+        "source_metric": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "value"],
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "value": { "type": "number" },
+            "lower_bound": { "type": "number" },
+            "upper_bound": { "type": "number" }
+          }
+        },
+        "source_severity": { "type": "string", "minLength": 1 }
+      }
+    },
+    "reproduction_state": {
+      "type": "string",
+      "enum": [
+        "not_attempted",
+        "observed_once",
+        "reproduced",
+        "not_reproduced",
+        "nondeterministic",
+        "disputed"
+      ]
+    },
+    "finding_state": {
+      "type": "string",
+      "enum": [
+        "observed",
+        "reproduced",
+        "not_reproduced",
+        "nondeterministic",
+        "triaged",
+        "remediation_proposed",
+        "remediation_applied",
+        "rescanned",
+        "resolved",
+        "residual",
+        "disputed",
+        "not_run"
+      ]
+    },
+    "candidate_classification": {
+      "type": "string",
+      "enum": ["threat_evidence", "correction_evidence", "incident_evidence", "conformance_evidence"]
+    },
+    "execution_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target_execution", "sandbox", "consent"],
+      "properties": {
+        "target_execution": {
+          "type": "string",
+          "enum": ["observed", "possible", "not_observed", "not_applicable", "unknown"]
+        },
+        "sandbox": {
+          "type": "string",
+          "enum": ["isolated", "not_isolated", "not_applicable", "unknown"]
+        },
+        "consent": {
+          "type": "string",
+          "enum": ["granted", "declined", "bypassed", "not_required", "unknown"]
+        },
+        "scanner_privilege_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "raw_evidence_ref": { "type": "string", "minLength": 1 },
+    "raw_evidence_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "known_limitations": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prior_finding_refs", "remediation_refs", "rescan_refs", "conflict_refs"],
+      "properties": {
+        "prior_finding_refs": { "$ref": "#/$defs/refList" },
+        "remediation_refs": { "$ref": "#/$defs/refList" },
+        "rescan_refs": { "$ref": "#/$defs/refList" },
+        "conflict_refs": { "$ref": "#/$defs/refList" }
+      }
+    },
+    "binding_status": {
+      "type": "string",
+      "enum": ["exact", "mismatch", "not_evaluated"]
+    },
+    "binding_reasons": { "$ref": "#/$defs/refList" },
+    "observed_at": { "type": "string", "format": "date-time" },
+    "interpretation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_effect",
+        "universal_vulnerability",
+        "safety_claim",
+        "standing_policy",
+        "memory_admission",
+        "certification_claim"
+      ],
+      "properties": {
+        "authority_effect": { "const": "none" },
+        "universal_vulnerability": { "const": "not_established" },
+        "safety_claim": { "const": "not_established" },
+        "standing_policy": { "const": "not_established" },
+        "memory_admission": { "const": "not_established" },
+        "certification_claim": { "const": "none" }
+      }
+    }
+  },
+  "$defs": {
+    "refList": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements **P2-B / V0.1** from #198: one vendor-neutral security-finding evidence contract with two materially different scanner families.

Reference pins:

- NVIDIA garak `v0.16.0`, exact commit `dbe4515d12664f2e34ac2cea295f055c22fe82b4`
- Snyk Agent Scan `v0.5.17`, exact commit `ea959964ce4728426fca9fa78c9e7809b972f313`

## Generic boundary

```text
scanner hit != universal vulnerability fact
no hit != proof of safety outside tested scope
scanner/benchmark score != runtime incident
security finding != standing policy
reproduction strengthens evidence != creates authority
scanner identity/version != memory authority
```

Every normalized record fixes authority, universal-vulnerability, safety, standing-policy, memory-admission, and certification nonclaims.

## Garak adapter

The garak adapter is exact-version pinned because v0.16.0 explicitly changes `report.jsonl`.

It consumes only the pinned `entry_type = eval` contract and preserves:

- probe and detector identity;
- `passed`, `fails`, and `total_evaluated` exactly;
- optional source confidence bounds;
- a source-native pass rate as scanner evidence only;
- target/configuration/scope and run refs;
- reproduction/lineage and raw evidence custody.

A hit/mixed record remains an observed failure under exact test conditions. A no-hit record does not become a safety claim.

## Snyk Agent Scan adapter

Snyk output is isolated behind a stable Agent Memory-facing projection:

```text
source_contract_status = experimental_projection
```

Experimental CLI field names, issue codes, severities, and response structures remain adapter-local and are not core schema fields.

Because Snyk documents that scanning stdio MCP configurations may execute configured commands, the generic evidence records separately preserve:

- target execution observed/possible/not observed;
- sandbox/isolation state;
- consent granted/declined/bypassed/etc.;
- scanner privilege ref.

A declined scan is explicitly `declined / not_run` and cannot fabricate a finding.

## Finding lineage

The generic record supports append-only:

- prior finding refs;
- remediation refs;
- rescan refs;
- conflict refs;
- reproduction and finding lifecycle states.

Reproduction creates a new record without authority escalation. Remediation without rescan does not become resolved. Later no-hit rescan evidence may conflict with an earlier hit while both remain preserved.

## Evidence-depth integration

The merged #196 D/F/H/R/P schema is reused directly.

CI now emits `security-finding-depth.json` with two P2-B claims:

```text
garak adapter        = D + F + H
Snyk projection      = D + F + H
R                    = explicitly unproven
P                    = explicitly unproven
```

No live scanner is launched in this slice, so fixture/harness execution does not self-promote to R.

## Added surfaces

- `schemas/security-finding-evidence.schema.json`
- `fixtures/security-finding-evidence-matrix.json`
- `reference/agentmem_ref/security_finding.py`
- `reference/agentmem_ref/security_finding_harness.py`
- `reference/agentmem_ref/security_finding_depth.py`
- `reference/run_security_finding_depth.py`
- `reference/tests/test_security_finding.py`
- `reference/tests/test_security_finding_depth.py`
- `docs/profiles/security-finding-evidence-profile.md`
- Doctrine CI emit/upload step for scanner evidence depth

## Negative paths

Executable coverage includes:

1. garak hit/mixed remains non-authoritative;
2. garak no-hit does not establish global safety;
3. garak version/record-contract drift is rejected;
4. Snyk experimental raw fields are discarded;
5. declined Snyk MCP scan remains not-run and cannot claim execution;
6. partial and target-unavailable states remain explicit;
7. active scanning preserves execution/consent/sandbox context;
8. cross-tenant/environment binding fails closed;
9. reproduction strengthens lineage without authority;
10. remediation without rescan is not resolved;
11. rescan/conflicting findings remain append-only;
12. two different families share the same generic interpretation contract.

## Stop line

Do not expand this PR into scanner orchestration, standing-policy automation, PyRIT/CyberSecEval support, raw scanner dump retention, production evidence claims, stabilization of Snyk experimental fields, or a scalar security score.

This PR remains draft until exact-head repository CI passes and a completion review confirms #198 acceptance criteria.

Closes #198