### PR TITLE
Add contextual recall re-evaluation and sleeper-poisoning behavioral proof

### DIFF
--- a/.github/workflows/sleeper-poisoning-evidence.yml
+++ b/.github/workflows/sleeper-poisoning-evidence.yml
@@ -23,10 +23,12 @@ jobs:
         run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
 
       - name: Execute contextual recall and sleeper tests
+        env:
+          PYTHONPATH: reference
         run: >-
           python -m unittest
-          reference.tests.test_contextual_recall
-          reference.tests.test_sleeper_poisoning_depth
+          tests.test_contextual_recall
+          tests.test_sleeper_poisoning_depth
 
       - name: Emit exact-head sleeper evidence depth
         env:

--- a/.github/workflows/sleeper-poisoning-evidence.yml
+++ b/.github/workflows/sleeper-poisoning-evidence.yml
@@ -1,0 +1,44 @@
+name: Sleeper Poisoning Evidence
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  sleeper-poisoning:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Execute contextual recall and sleeper tests
+        run: >-
+          python -m unittest
+          reference.tests.test_contextual_recall
+          reference.tests.test_sleeper_poisoning_depth
+
+      - name: Emit exact-head sleeper evidence depth
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_sleeper_poisoning_depth.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output sleeper-poisoning-depth.json
+
+      - name: Upload sleeper poisoning evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: sleeper-poisoning-evidence-depth
+          path: sleeper-poisoning-depth.json
+          if-no-files-found: error

--- a/docs/profiles/contextual-recall-admission-profile.md
+++ b/docs/profiles/contextual-recall-admission-profile.md
@@ -1,0 +1,326 @@
+# Contextual Recall Admission Profile
+
+Status: V0.1 reference profile for #200.
+
+This profile defines a monotonic current-context admission seam layered after the canonical `GovernedMemoryAdapter` read gate.
+
+Its purpose is narrow: retained memory that survives storage and ordinary scope/lifecycle checks must still be re-evaluated under the **current** purpose/context before becoming active context or downstream influence.
+
+## Core boundary
+
+```text
+prior admission
+!= standing recall permission
+
+write-time safety
+!= lifetime safety
+
+candidate discovery
+!= admission
+
+relevance
+!= permission
+
+context change
+-> current admission re-evaluation
+
+contextual policy may tighten
+!= silently loosen built-in governance
+```
+
+The seam does not mutate stored memory merely because current context is risky.
+
+## Composition order
+
+V0.1 is deliberately compositional:
+
+```text
+substrate retrieval
+-> canonical GovernedMemoryAdapter admission
+-> contextual current-policy admission
+-> context surface
+-> downstream influence
+```
+
+The canonical adapter executes first and remains authoritative for:
+
+- tenant isolation;
+- isolation-domain membership;
+- required compartments;
+- shared-space membership;
+- project/task boundaries;
+- tombstones;
+- supersession/currentness;
+- disputes.
+
+The contextual adapter receives **only** candidates that the canonical gate admitted.
+
+Therefore:
+
+```text
+built-in refusal
+-> contextual policy is not invoked
+-> contextual admit cannot resurrect candidate
+```
+
+This is the V0.1 monotonic-tightening guarantee.
+
+## Current contextual decision
+
+A contextual decision preserves:
+
+```text
+candidate_ref
+policy_ref
+policy_version
+policy status
+bounded current context identity
+outcome
+reason_code
+evidence_refs
+optional risk-estimator evidence
+evaluated_at
+```
+
+Current context is minimized to:
+
+```text
+target_domain_refs
+principal_ref
+project_ref
+task_ref
+purpose
+destination_ref
+```
+
+Raw query text, memory content, prompts, and hidden reasoning are not required to prove that the current gate ran.
+
+## Outcomes
+
+V0.1 supports deterministic outcomes:
+
+```text
+admit
+admit_with_warning
+require_verification
+require_review
+quarantine
+block
+```
+
+Only `admit` and `admit_with_warning` enter final context.
+
+The other four outcomes keep the candidate discoverable but exclude it from final admitted/context/downstream surfaces.
+
+## No cached admission authority
+
+Every wrapped `governed_recall(...)` executes the current contextual policy again for each candidate that survives canonical admission.
+
+The adapter does not cache an earlier `admit` as a reusable grant.
+
+Machine-readable decisions fix:
+
+```text
+prior_admission_authority = none
+authority_effect = current_recall_only
+```
+
+A benign recall yesterday does not authorize a different purpose today.
+
+## Policy version changes
+
+The contextual adapter can replace the current policy without rewriting retained memory.
+
+A later decision records the later policy version directly.
+
+This permits:
+
+```text
+same retained fact
+same or changed purpose
+policy v1 -> admit
+policy v2 -> require_review / quarantine / block
+```
+
+without pretending the stored content itself changed merely because current governance did.
+
+## Learned or probabilistic risk signals
+
+A deterministic contextual rule may preserve bounded estimator evidence such as:
+
+```text
+signal_ref
+signal_semantics
+estimator_ref
+estimator_version
+signal_value
+uncertainty_summary
+```
+
+The signal may inform the deterministic policy outcome. It does not create authority.
+
+Every decision fixes:
+
+```text
+risk_signal_authority = none
+relevance_authority = none
+```
+
+This preserves the repository's governed-uncertainty rule:
+
+```text
+uncertainty may propose
+authority constrains
+```
+
+## Failure posture
+
+When contextual policy is optional and absent, canonical admission remains sufficient.
+
+When a deployment configures contextual policy as required, absence fails closed:
+
+```text
+policy.status = unavailable
+outcome = block
+```
+
+A configured policy that raises an error fails closed:
+
+```text
+policy.status = error
+outcome = block
+```
+
+A configured policy that returns an invalid/unsupported decision fails closed:
+
+```text
+policy.status = invalid
+outcome = block
+```
+
+None of those failures widens recall.
+
+## Sleeper-poisoning behavioral proof
+
+The V0.1 harness consumes the existing structural fixture:
+
+`fixtures/sleeper-memory-poisoning.json`
+
+The fixture requires:
+
+```text
+write_time_check_may_pass = true
+later_trigger_rechecked = true
+unsafe_activation_allowed = false
+```
+
+The behavioral sequence is:
+
+1. retain one bounded fact through normal governed mutation;
+2. recall it under a benign purpose;
+3. observe the candidate and admit it;
+4. keep the retained fact unchanged;
+5. recall the same fact under purpose `activate-triggered-memory`;
+6. discover the same candidate again;
+7. execute the current contextual policy again;
+8. record `quarantine` under the delayed-trigger rule;
+9. keep the candidate out of admitted/context/downstream surfaces;
+10. preserve the retained fact rather than mutating/deleting it merely to force the test.
+
+The rule also carries a probabilistic delayed-activation risk estimate as evidence while machine-enforcing that the estimate has no authority by itself.
+
+## Final surfaces
+
+The compositional reference result exposes:
+
+```text
+candidates
+admitted
+refusals
+contextual_decisions
+context_surface
+downstream_influence
+```
+
+`context_surface` and `downstream_influence` are explicit copies of final admitted identity refs in this bounded proof. They are not a new inference system.
+
+For a sleeper trigger:
+
+```text
+candidate in candidates
+candidate not in admitted
+candidate not in context_surface
+candidate not in downstream_influence
+```
+
+This demonstrates read-time containment while preserving retrieval observability.
+
+## Evidence depth
+
+V0.1 registers the sleeper-poisoning claim through the D/F/H/R/P model from #196:
+
+```text
+D = threat model + governed recall doctrine + this profile
+F = sleeper-memory-poisoning fixture
+H = contextual recall behavioral harness
+R = explicitly unproven
+P = explicitly unproven
+```
+
+The reference harness does not launch a production agent or live long-horizon workload, so it does not self-promote to R or P.
+
+## Privacy and minimization
+
+The decision record uses candidate/context refs, policy identity, bounded reason/outcome, and evidence refs.
+
+It does not require:
+
+- raw memory contents;
+- the retrieval query;
+- prompts/system instructions;
+- hidden reasoning;
+- full tool outputs;
+- arbitrary estimator payloads.
+
+## Deployment profiles
+
+### L: local
+
+Contextual policy may be optional. A local deterministic rule set can add read-time containment without external services.
+
+### T: team / multi-tenant
+
+Canonical tenant/project/domain admission remains first. Contextual rules cannot repair cross-tenant refusal.
+
+### E: enterprise
+
+A current contextual policy may be configured as required. Policy unavailability/error then fails closed and leaves evidence.
+
+### H: high assurance
+
+Current policy identity/version, outcome/reason, exact candidate/context refs, failure posture, and evidence refs must remain reconstructable. Missing required contextual policy cannot widen recall.
+
+## V0.1 non-claims
+
+V0.1 does not claim:
+
+- generic sleeper detection;
+- semantic malicious-intent classification;
+- LLM-judge correctness;
+- production sleeper resistance;
+- long-horizon consolidation safety;
+- automatic deletion of risky memory;
+- contextual risk is factual truth;
+- prior benign recall makes later use safe;
+- contextual policy can override canonical lifecycle/scope refusal.
+
+## Stop line
+
+Do not expand this slice into:
+
+- a general content moderation product;
+- probabilistic trigger discovery;
+- model-based semantic policy;
+- automatic durable memory mutation;
+- production certification;
+- changing canonical storage state solely to demonstrate read-time containment.

--- a/reference/agentmem_ref/contextual_recall.py
+++ b/reference/agentmem_ref/contextual_recall.py
@@ -1,0 +1,232 @@
+"""Deterministic current-context recall admission policy for issue #200.
+
+This module is deliberately content-agnostic. It receives a candidate reference,
+current recall context, current policy version, and bounded evidence/risk refs.
+It can tighten recall admission for the current request, but it cannot mutate
+memory, turn relevance or estimator output into authority, or create standing
+permission from a prior admission.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+import rfc8785
+
+from . import receipts
+
+PROFILE_VERSION = "0.1.0"
+ADMITTING_OUTCOMES = {"admit", "admit_with_warning"}
+OUTCOMES = ADMITTING_OUTCOMES | {"require_verification", "require_review", "quarantine", "block"}
+
+
+def _sha256_ref(value: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+
+
+def context_projection(context: object) -> dict[str, Any]:
+    """Project only bounded identity/purpose fields from RecallContext-like input."""
+    domains = tuple(getattr(context, "target_domain_refs", ()) or ())
+    if not all(isinstance(item, str) and item for item in domains):
+        raise ValueError("target_domain_refs must contain non-empty strings")
+    return {
+        "target_domain_refs": list(dict.fromkeys(domains)),
+        "principal_ref": str(getattr(context, "principal_ref", "") or ""),
+        "project_ref": str(getattr(context, "project_ref", "") or ""),
+        "task_ref": str(getattr(context, "task_ref", "") or ""),
+        "purpose": str(getattr(context, "purpose", "") or ""),
+        "destination_ref": str(getattr(context, "destination_ref", "") or ""),
+    }
+
+
+def build_decision(
+    *,
+    candidate_ref: str,
+    context: object,
+    policy_ref: str,
+    policy_version: str,
+    policy_status: str,
+    outcome: str,
+    reason_code: str,
+    evidence_refs: tuple[str, ...] | list[str] = (),
+    evaluated_at: str,
+    risk_evidence: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not candidate_ref:
+        raise ValueError("candidate_ref is required")
+    if not policy_ref or not policy_version:
+        raise ValueError("policy_ref and policy_version are required")
+    if policy_status not in {"evaluated", "unavailable", "error", "invalid"}:
+        raise ValueError(f"invalid policy_status {policy_status!r}")
+    if outcome not in OUTCOMES:
+        raise ValueError(f"unsupported contextual recall outcome {outcome!r}")
+    if not reason_code:
+        raise ValueError("reason_code is required")
+    refs = list(dict.fromkeys(evidence_refs))
+    if not all(isinstance(item, str) and item for item in refs):
+        raise ValueError("evidence_refs must contain non-empty strings")
+
+    identity = {
+        "candidate_ref": candidate_ref,
+        "policy_ref": policy_ref,
+        "policy_version": policy_version,
+        "policy_status": policy_status,
+        "context": context_projection(context),
+        "outcome": outcome,
+        "reason_code": reason_code,
+        "evidence_refs": refs,
+        "risk_evidence": risk_evidence,
+    }
+    document: dict[str, Any] = {
+        "schema_version": "1.0.0",
+        "profile_version": PROFILE_VERSION,
+        "decision_id": f"contextual-recall:{_sha256_ref(identity)}",
+        "candidate_ref": candidate_ref,
+        "policy": {
+            "policy_ref": policy_ref,
+            "policy_version": policy_version,
+            "status": policy_status,
+            "selection_mode": "deterministic",
+        },
+        "context": identity["context"],
+        "outcome": outcome,
+        "reason_code": reason_code,
+        "evidence_refs": refs,
+        "evaluated_at": evaluated_at,
+        "interpretation": {
+            "authority_effect": "current_recall_only",
+            "prior_admission_authority": "none",
+            "memory_mutation": "not_performed",
+            "relevance_authority": "none",
+            "risk_signal_authority": "none",
+        },
+    }
+    if risk_evidence is not None:
+        document["risk_evidence"] = dict(risk_evidence)
+    receipts.validate("contextual-recall-admission.schema.json", document)
+    return document
+
+
+@dataclass(frozen=True)
+class ContextualRule:
+    rule_id: str
+    outcome: str
+    reason_code: str
+    candidate_ref: str = ""
+    purpose: str = ""
+    destination_ref: str = ""
+    principal_ref: str = ""
+    project_ref: str = ""
+    task_ref: str = ""
+    evidence_refs: tuple[str, ...] = ()
+    risk_evidence: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.rule_id:
+            raise ValueError("rule_id is required")
+        if self.outcome not in OUTCOMES:
+            raise ValueError(f"unsupported contextual recall outcome {self.outcome!r}")
+        if not self.reason_code:
+            raise ValueError("reason_code is required")
+
+    def matches(self, candidate_ref: str, context: object) -> bool:
+        expected = {
+            "candidate_ref": self.candidate_ref,
+            "purpose": self.purpose,
+            "destination_ref": self.destination_ref,
+            "principal_ref": self.principal_ref,
+            "project_ref": self.project_ref,
+            "task_ref": self.task_ref,
+        }
+        observed = {
+            "candidate_ref": candidate_ref,
+            "purpose": str(getattr(context, "purpose", "") or ""),
+            "destination_ref": str(getattr(context, "destination_ref", "") or ""),
+            "principal_ref": str(getattr(context, "principal_ref", "") or ""),
+            "project_ref": str(getattr(context, "project_ref", "") or ""),
+            "task_ref": str(getattr(context, "task_ref", "") or ""),
+        }
+        return all(not value or observed[field] == value for field, value in expected.items())
+
+
+class DeterministicContextualRecallPolicy:
+    """Simple deterministic rule policy used by the reference adapter/harness.
+
+    Rules may be informed by learned/probabilistic risk evidence, but the rule's
+    explicit outcome is the governed consequence. The signal itself is never
+    interpreted as permission.
+    """
+
+    def __init__(
+        self,
+        *,
+        policy_ref: str,
+        policy_version: str,
+        rules: tuple[ContextualRule, ...] = (),
+        default_outcome: str = "admit",
+        default_reason_code: str = "no_contextual_restriction",
+    ) -> None:
+        if not policy_ref or not policy_version:
+            raise ValueError("policy_ref and policy_version are required")
+        if default_outcome not in OUTCOMES:
+            raise ValueError(f"unsupported contextual recall outcome {default_outcome!r}")
+        self.policy_ref = policy_ref
+        self.policy_version = policy_version
+        self.rules = tuple(rules)
+        self.default_outcome = default_outcome
+        self.default_reason_code = default_reason_code
+        self.evaluation_count = 0
+
+    def evaluate(self, candidate_ref: str, context: object, *, evaluated_at: str) -> dict[str, Any]:
+        self.evaluation_count += 1
+        for rule in self.rules:
+            if rule.matches(candidate_ref, context):
+                return build_decision(
+                    candidate_ref=candidate_ref,
+                    context=context,
+                    policy_ref=self.policy_ref,
+                    policy_version=self.policy_version,
+                    policy_status="evaluated",
+                    outcome=rule.outcome,
+                    reason_code=rule.reason_code,
+                    evidence_refs=rule.evidence_refs,
+                    evaluated_at=evaluated_at,
+                    risk_evidence=rule.risk_evidence,
+                )
+        return build_decision(
+            candidate_ref=candidate_ref,
+            context=context,
+            policy_ref=self.policy_ref,
+            policy_version=self.policy_version,
+            policy_status="evaluated",
+            outcome=self.default_outcome,
+            reason_code=self.default_reason_code,
+            evaluated_at=evaluated_at,
+        )
+
+
+def fail_closed_decision(
+    *,
+    candidate_ref: str,
+    context: object,
+    policy_ref: str,
+    policy_version: str,
+    status: str,
+    reason_code: str,
+    evaluated_at: str,
+) -> dict[str, Any]:
+    if status not in {"unavailable", "error", "invalid"}:
+        raise ValueError("fail-closed status must be unavailable, error, or invalid")
+    return build_decision(
+        candidate_ref=candidate_ref,
+        context=context,
+        policy_ref=policy_ref,
+        policy_version=policy_version,
+        policy_status=status,
+        outcome="block",
+        reason_code=reason_code,
+        evidence_refs=(),
+        evaluated_at=evaluated_at,
+    )

--- a/reference/agentmem_ref/contextual_recall_adapter.py
+++ b/reference/agentmem_ref/contextual_recall_adapter.py
@@ -1,0 +1,129 @@
+"""Compositional current-context recall adapter for issue #200.
+
+The wrapped GovernedMemoryAdapter executes canonical lifecycle/scope admission
+first. This adapter only evaluates candidates that survived that gate and may
+further restrict them. It has no path that can widen or repair a built-in
+refusal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import receipts
+from .adapter import Clock, GovernedMemoryAdapter, RecallContext
+from .contextual_recall import ADMITTING_OUTCOMES, fail_closed_decision
+
+
+@dataclass
+class ContextualAdmissionResult:
+    candidates: list[str] = field(default_factory=list)
+    admitted: list[str] = field(default_factory=list)
+    refusals: dict[str, str] = field(default_factory=dict)
+    contextual_decisions: dict[str, dict[str, Any]] = field(default_factory=dict)
+    context_surface: list[str] = field(default_factory=list)
+    downstream_influence: list[str] = field(default_factory=list)
+
+
+class ContextualRecallAdapter:
+    """Apply current contextual recall policy monotonically after built-ins."""
+
+    def __init__(
+        self,
+        base: GovernedMemoryAdapter,
+        *,
+        policy: object | None = None,
+        require_policy: bool = False,
+        required_policy_ref: str = "contextual-recall-policy:required",
+        required_policy_version: str = "required-current",
+        clock: Clock | None = None,
+    ) -> None:
+        self._base = base
+        self._policy = policy
+        self._require_policy = require_policy
+        self._required_policy_ref = required_policy_ref
+        self._required_policy_version = required_policy_version
+        self._clock = clock or Clock(start=40)
+
+    def set_policy(self, policy: object | None) -> None:
+        """Replace the current policy without touching retained memory."""
+        self._policy = policy
+
+    def governed_recall(self, query: str, context: RecallContext | None = None) -> ContextualAdmissionResult:
+        """Run canonical recall, then freshly re-evaluate current contextual policy."""
+        context = context or RecallContext(target_domain_refs=())
+        base_result = self._base.governed_recall(query, context)
+        result = ContextualAdmissionResult(
+            candidates=list(base_result.candidates),
+            refusals=dict(base_result.refusals),
+        )
+
+        # Only built-in admitted candidates reach the contextual policy. Thus a
+        # contextual "admit" can never resurrect a built-in refusal.
+        for candidate_ref in base_result.admitted:
+            decision = self._evaluate_current(candidate_ref, context)
+            if decision is None:
+                result.admitted.append(candidate_ref)
+                continue
+            result.contextual_decisions[candidate_ref] = decision
+            if decision["outcome"] in ADMITTING_OUTCOMES:
+                result.admitted.append(candidate_ref)
+            else:
+                result.refusals[candidate_ref] = (
+                    f"contextual:{decision['outcome']}:{decision['reason_code']}"
+                )
+
+        # These final surfaces are aliases by value, not extra authority. They
+        # make the sleeper proof explicit: a blocked candidate can remain
+        # discoverable while being absent from context/downstream influence.
+        result.context_surface = list(result.admitted)
+        result.downstream_influence = list(result.admitted)
+        return result
+
+    def _evaluate_current(self, candidate_ref: str, context: RecallContext) -> dict[str, Any] | None:
+        evaluated_at = self._clock.now()
+        if self._policy is None:
+            if not self._require_policy:
+                return None
+            return fail_closed_decision(
+                candidate_ref=candidate_ref,
+                context=context,
+                policy_ref=self._required_policy_ref,
+                policy_version=self._required_policy_version,
+                status="unavailable",
+                reason_code="contextual_policy_unavailable",
+                evaluated_at=evaluated_at,
+            )
+
+        policy_ref = str(getattr(self._policy, "policy_ref", self._required_policy_ref) or self._required_policy_ref)
+        policy_version = str(
+            getattr(self._policy, "policy_version", self._required_policy_version)
+            or self._required_policy_version
+        )
+        try:
+            decision = self._policy.evaluate(candidate_ref, context, evaluated_at=evaluated_at)
+        except Exception:
+            return fail_closed_decision(
+                candidate_ref=candidate_ref,
+                context=context,
+                policy_ref=policy_ref,
+                policy_version=policy_version,
+                status="error",
+                reason_code="contextual_policy_error",
+                evaluated_at=evaluated_at,
+            )
+
+        try:
+            receipts.validate("contextual-recall-admission.schema.json", decision)
+        except Exception:
+            return fail_closed_decision(
+                candidate_ref=candidate_ref,
+                context=context,
+                policy_ref=policy_ref,
+                policy_version=policy_version,
+                status="invalid",
+                reason_code="contextual_policy_invalid_decision",
+                evaluated_at=evaluated_at,
+            )
+        return decision

--- a/reference/agentmem_ref/sleeper_poisoning_depth.py
+++ b/reference/agentmem_ref/sleeper_poisoning_depth.py
@@ -1,0 +1,50 @@
+"""D/F/H/R/P evidence-depth report for sleeper-poisoning recall re-evaluation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import receipts
+from .security_evidence_depth import LEVELS, REPORT_TYPE, REPORT_VERSION, _claim, _exact_commit
+from .sleeper_poisoning_harness import run_sleeper_poisoning_harness
+
+
+def build_sleeper_poisoning_depth_report(agent_memory_commit: str) -> dict[str, Any]:
+    commit = _exact_commit(agent_memory_commit)
+    harness = run_sleeper_poisoning_harness()
+    claim = _claim(
+        agent_memory_commit=commit,
+        claim_id="poisoning:sleeper-delayed-trigger-recall",
+        title="Retained memory is re-evaluated under changed current recall context before activation",
+        threat_family="delayed_sleeper_memory_poisoning",
+        doctrine_refs=[
+            "docs/15-memory-threat-model.md",
+            "docs/26-governed-recall-planner.md",
+            "docs/profiles/contextual-recall-admission-profile.md",
+        ],
+        fixture_refs=["fixtures/sleeper-memory-poisoning.json"],
+        harness_ref="sleeper-poisoning-harness:delayed-trigger-recall",
+        behavioral_passed=harness["passed"],
+        scope_profiles=["L", "T", "E", "H"],
+    )
+    report = {
+        "report_type": REPORT_TYPE,
+        "version": REPORT_VERSION,
+        "agent_memory_commit": commit,
+        "evidence_model": {
+            "levels": list(LEVELS),
+            "inference_policy": "no_level_may_be_inferred_from_another_level",
+        },
+        "claims": [claim],
+        "required_behavioral_cases_passed": harness["passed"],
+        "non_certification_statement": "Evidence mapping and demonstrated behavior do not constitute external certification.",
+        "known_limits": [
+            "The V0.1 harness demonstrates reference behavioral re-evaluation of one delayed-trigger sleeper scenario; it does not discover sleeper triggers semantically.",
+            "The contextual recall harness earns H evidence only; no independent live-runtime R evidence is claimed.",
+            "Long-horizon consolidation, production workloads, and production sleeper resistance remain untested.",
+            "Production evidence P is explicitly unproven.",
+            "No composite security or maturity score is emitted.",
+        ],
+    }
+    receipts.validate("security-evidence-depth-report.schema.json", report)
+    return report

--- a/reference/agentmem_ref/sleeper_poisoning_harness.py
+++ b/reference/agentmem_ref/sleeper_poisoning_harness.py
@@ -1,0 +1,150 @@
+"""Behavioral sleeper-poisoning proof for issue #200."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from . import policy
+from .adapter import Clock, GovernedMemoryAdapter, RecallContext
+from .contextual_recall import ContextualRule, DeterministicContextualRecallPolicy
+from .contextual_recall_adapter import ContextualRecallAdapter
+from .substrate import InMemoryTemporalGraph
+
+ROOT = Path(__file__).resolve().parents[2]
+SLEEPER_FIXTURE = ROOT / "fixtures" / "sleeper-memory-poisoning.json"
+
+
+def _proposal() -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id="proposal:sleeper:retain",
+        actor_id="actor:bounded-ingest",
+        charter_version="charter:v1",
+        target_reference="mem:sleeper:behavioral",
+        target_class=policy.M2,
+        scope="scope:tenant-a/project-a",
+        operation="promotion",
+        current_strength="observed",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("fixture:sleeper-memory-poisoning", "evidence:delayed-trigger"),
+        tenant_ref="tenant-a",
+        project_ref="project-a",
+        purpose="bounded-procedural-context",
+        isolation_domain_refs=("scope:tenant-a/project-a",),
+    )
+
+
+def run_sleeper_poisoning_harness() -> dict[str, Any]:
+    fixture = json.loads(SLEEPER_FIXTURE.read_text(encoding="utf-8"))
+    expected = fixture["expected_behavior"]
+
+    substrate = InMemoryTemporalGraph()
+    base = GovernedMemoryAdapter(substrate, tenant="tenant-a", clock=Clock())
+    commit = base.commit_proposal(
+        _proposal(),
+        "procedural helper retained from an earlier benign interaction",
+    )
+    if not commit.committed or commit.fact_uuid is None:
+        raise AssertionError(f"sleeper harness could not retain candidate: {commit.refusal}")
+
+    fact_uuid = commit.fact_uuid
+    contextual_policy = DeterministicContextualRecallPolicy(
+        policy_ref="contextual-policy:sleeper-v1",
+        policy_version="1.0.0",
+        rules=(
+            ContextualRule(
+                rule_id="delayed-trigger-quarantine",
+                candidate_ref=fact_uuid,
+                purpose="activate-triggered-memory",
+                outcome="quarantine",
+                reason_code="delayed_trigger_requires_quarantine",
+                evidence_refs=("fixture:sleeper-memory-poisoning", "evidence:delayed-trigger"),
+                risk_evidence={
+                    "signal_ref": "risk-signal:sleeper-trigger:1",
+                    "signal_semantics": "probabilistic_delayed_activation_risk",
+                    "estimator_ref": "estimator:sleeper-risk",
+                    "estimator_version": "v1",
+                    "signal_value": 0.95,
+                    "uncertainty_summary": "High estimated activation risk under the delayed trigger context; estimate informs policy but does not authorize consequence.",
+                },
+            ),
+        ),
+    )
+    recall = ContextualRecallAdapter(base, policy=contextual_policy, clock=Clock(start=50))
+
+    benign_context = RecallContext(
+        target_domain_refs=("scope:tenant-a/project-a",),
+        principal_ref="principal:sleeper-test",
+        project_ref="project-a",
+        purpose="bounded-procedural-context",
+    )
+    benign = recall.governed_recall("procedural helper", benign_context)
+
+    trigger_context = RecallContext(
+        target_domain_refs=("scope:tenant-a/project-a",),
+        principal_ref="principal:sleeper-test",
+        project_ref="project-a",
+        purpose="activate-triggered-memory",
+    )
+    triggered = recall.governed_recall("procedural helper", trigger_context)
+    trigger_decision = triggered.contextual_decisions.get(fact_uuid)
+
+    stored_after = substrate.get_fact(fact_uuid)
+    checks = {
+        "fixture_write_time_check_may_pass": expected["write_time_check_may_pass"] is True,
+        "fixture_later_trigger_rechecked": expected["later_trigger_rechecked"] is True,
+        "fixture_unsafe_activation_forbidden": expected["unsafe_activation_allowed"] is False,
+        "retained_candidate_committed": commit.committed and stored_after is not None,
+        "benign_candidate_discovered": fact_uuid in benign.candidates,
+        "benign_candidate_admitted": fact_uuid in benign.admitted,
+        "benign_context_surface_contains_candidate": fact_uuid in benign.context_surface,
+        "same_candidate_discovered_after_trigger": fact_uuid in triggered.candidates,
+        "trigger_context_re_evaluated": contextual_policy.evaluation_count == 2,
+        "trigger_decision_exists": trigger_decision is not None,
+        "trigger_decision_quarantines": trigger_decision is not None and trigger_decision["outcome"] == "quarantine",
+        "trigger_policy_version_reconstructable": (
+            trigger_decision is not None
+            and trigger_decision["policy"]["policy_version"] == "1.0.0"
+        ),
+        "risk_signal_not_authority": (
+            trigger_decision is not None
+            and trigger_decision["interpretation"]["risk_signal_authority"] == "none"
+        ),
+        "prior_admission_not_authority": (
+            trigger_decision is not None
+            and trigger_decision["interpretation"]["prior_admission_authority"] == "none"
+        ),
+        "triggered_candidate_not_admitted": fact_uuid not in triggered.admitted,
+        "triggered_candidate_absent_from_context_surface": fact_uuid not in triggered.context_surface,
+        "triggered_candidate_absent_from_downstream_influence": fact_uuid not in triggered.downstream_influence,
+        "stored_candidate_not_mutated_to_force_test": (
+            stored_after is not None
+            and stored_after.fact_text == "procedural helper retained from an earlier benign interaction"
+            and not stored_after.is_event_invalid
+        ),
+    }
+
+    observed = {
+        "fact_uuid": fact_uuid,
+        "benign": {
+            "candidates": benign.candidates,
+            "admitted": benign.admitted,
+            "refusals": benign.refusals,
+            "decision": benign.contextual_decisions.get(fact_uuid),
+        },
+        "triggered": {
+            "candidates": triggered.candidates,
+            "admitted": triggered.admitted,
+            "refusals": triggered.refusals,
+            "context_surface": triggered.context_surface,
+            "downstream_influence": triggered.downstream_influence,
+            "decision": trigger_decision,
+        },
+        "fixture_expected_behavior": expected,
+        "policy_evaluation_count": contextual_policy.evaluation_count,
+    }
+    return {"case_id": "sleeper-delayed-trigger-recall", "passed": all(checks.values()), "checks": checks, "observed": observed}

--- a/reference/agentmem_ref/sleeper_poisoning_harness.py
+++ b/reference/agentmem_ref/sleeper_poisoning_harness.py
@@ -38,6 +38,18 @@ def _proposal() -> policy.Proposal:
     )
 
 
+def _context(purpose: str) -> RecallContext:
+    # The reference substrate retrieves by tenant group_id while canonical
+    # admission also checks isolation-domain membership. Carry both identities
+    # so the behavioral proof exercises admission rather than an empty search.
+    return RecallContext(
+        target_domain_refs=("tenant-a", "scope:tenant-a/project-a"),
+        principal_ref="principal:sleeper-test",
+        project_ref="project-a",
+        purpose=purpose,
+    )
+
+
 def run_sleeper_poisoning_harness() -> dict[str, Any]:
     fixture = json.loads(SLEEPER_FIXTURE.read_text(encoding="utf-8"))
     expected = fixture["expected_behavior"]
@@ -76,21 +88,8 @@ def run_sleeper_poisoning_harness() -> dict[str, Any]:
     )
     recall = ContextualRecallAdapter(base, policy=contextual_policy, clock=Clock(start=50))
 
-    benign_context = RecallContext(
-        target_domain_refs=("scope:tenant-a/project-a",),
-        principal_ref="principal:sleeper-test",
-        project_ref="project-a",
-        purpose="bounded-procedural-context",
-    )
-    benign = recall.governed_recall("procedural helper", benign_context)
-
-    trigger_context = RecallContext(
-        target_domain_refs=("scope:tenant-a/project-a",),
-        principal_ref="principal:sleeper-test",
-        project_ref="project-a",
-        purpose="activate-triggered-memory",
-    )
-    triggered = recall.governed_recall("procedural helper", trigger_context)
+    benign = recall.governed_recall("procedural helper", _context("bounded-procedural-context"))
+    triggered = recall.governed_recall("procedural helper", _context("activate-triggered-memory"))
     trigger_decision = triggered.contextual_decisions.get(fact_uuid)
 
     stored_after = substrate.get_fact(fact_uuid)

--- a/reference/run_sleeper_poisoning_depth.py
+++ b/reference/run_sleeper_poisoning_depth.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Emit exact-head D/F/H/R/P evidence depth for sleeper-poisoning recall re-evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.sleeper_poisoning_depth import build_sleeper_poisoning_depth_report  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = build_sleeper_poisoning_depth_report(args.agent_memory_commit)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0 if report["required_behavioral_cases_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_contextual_recall.py
+++ b/reference/tests/test_contextual_recall.py
@@ -241,12 +241,13 @@ class ContextualRecallTests(unittest.TestCase):
             policy_ref="contextual-policy:minimized",
             policy_version="1.0.0",
         )
+        query = "contextual recall raw query should not be copied"
         result = ContextualRecallAdapter(base, policy=contextual_policy, clock=Clock(start=10)).governed_recall(
-            "raw query should not be copied", self._context("benign")
+            query, self._context("benign")
         )
         decision = result.contextual_decisions[fact_uuid]
         rendered = str(decision)
-        self.assertNotIn("raw query should not be copied", rendered)
+        self.assertNotIn(query, rendered)
         self.assertNotIn("contextual recall test fact", rendered)
         self.assertEqual(decision["candidate_ref"], fact_uuid)
 

--- a/reference/tests/test_contextual_recall.py
+++ b/reference/tests/test_contextual_recall.py
@@ -1,0 +1,268 @@
+"""Contextual recall re-evaluation and sleeper-poisoning tests for issue #200."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext
+from agentmem_ref.contextual_recall import (
+    ContextualRule,
+    DeterministicContextualRecallPolicy,
+    build_decision,
+)
+from agentmem_ref.contextual_recall_adapter import ContextualRecallAdapter
+from agentmem_ref.sleeper_poisoning_harness import run_sleeper_poisoning_harness
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+
+class _InvalidPolicy:
+    policy_ref = "contextual-policy:invalid"
+    policy_version = "1.0.0"
+
+    def evaluate(self, candidate_ref, context, *, evaluated_at):
+        return {
+            "candidate_ref": candidate_ref,
+            "outcome": "grant_everything",
+            "evaluated_at": evaluated_at,
+        }
+
+
+class _FailingPolicy:
+    policy_ref = "contextual-policy:failing"
+    policy_version = "1.0.0"
+
+    def evaluate(self, candidate_ref, context, *, evaluated_at):
+        raise RuntimeError("simulated policy backend failure")
+
+
+class ContextualRecallTests(unittest.TestCase):
+    def _base(self):
+        substrate = InMemoryTemporalGraph()
+        base = GovernedMemoryAdapter(substrate, tenant="tenant-a", clock=Clock())
+        proposal = policy.Proposal(
+            proposal_id="proposal:contextual-test",
+            actor_id="actor:test",
+            charter_version="charter:v1",
+            target_reference="mem:contextual-test",
+            target_class=policy.M2,
+            scope="scope:tenant-a/project-a",
+            operation="promotion",
+            current_strength="observed",
+            proposed_strength="promoted",
+            downstream_authority=policy.A1,
+            reversibility="reversible",
+            risk_class="low",
+            evidence_refs=("evidence:contextual-test",),
+            tenant_ref="tenant-a",
+            project_ref="project-a",
+            purpose="test",
+            isolation_domain_refs=("scope:tenant-a/project-a",),
+        )
+        committed = base.commit_proposal(proposal, "contextual recall test fact")
+        self.assertTrue(committed.committed)
+        self.assertIsNotNone(committed.fact_uuid)
+        return substrate, base, committed.fact_uuid
+
+    def _context(self, purpose="benign"):
+        return RecallContext(
+            target_domain_refs=("scope:tenant-a/project-a",),
+            principal_ref="principal:test",
+            project_ref="project-a",
+            purpose=purpose,
+        )
+
+    def test_sleeper_behavioral_harness_matches_structural_fixture(self):
+        result = run_sleeper_poisoning_harness()
+        self.assertTrue(result["passed"], result)
+        checks = result["checks"]
+        self.assertTrue(checks["fixture_write_time_check_may_pass"])
+        self.assertTrue(checks["fixture_later_trigger_rechecked"])
+        self.assertTrue(checks["fixture_unsafe_activation_forbidden"])
+        self.assertTrue(checks["same_candidate_discovered_after_trigger"])
+        self.assertTrue(checks["triggered_candidate_not_admitted"])
+        self.assertTrue(checks["triggered_candidate_absent_from_downstream_influence"])
+
+    def test_prior_benign_admission_is_not_cached_as_permission(self):
+        _substrate, base, fact_uuid = self._base()
+        contextual_policy = DeterministicContextualRecallPolicy(
+            policy_ref="contextual-policy:test",
+            policy_version="1.0.0",
+            rules=(
+                ContextualRule(
+                    rule_id="trigger-block",
+                    candidate_ref=fact_uuid,
+                    purpose="triggered",
+                    outcome="block",
+                    reason_code="triggered_context_block",
+                ),
+            ),
+        )
+        recall = ContextualRecallAdapter(base, policy=contextual_policy, clock=Clock(start=10))
+
+        benign = recall.governed_recall("contextual recall", self._context("benign"))
+        triggered = recall.governed_recall("contextual recall", self._context("triggered"))
+
+        self.assertIn(fact_uuid, benign.admitted)
+        self.assertIn(fact_uuid, triggered.candidates)
+        self.assertNotIn(fact_uuid, triggered.admitted)
+        self.assertEqual(contextual_policy.evaluation_count, 2)
+        self.assertEqual(
+            triggered.contextual_decisions[fact_uuid]["interpretation"]["prior_admission_authority"],
+            "none",
+        )
+
+    def test_contextual_policy_cannot_widen_builtin_dispute_refusal(self):
+        _substrate, base, fact_uuid = self._base()
+        base.mark_disputed(fact_uuid)
+        always_admit = DeterministicContextualRecallPolicy(
+            policy_ref="contextual-policy:always-admit",
+            policy_version="1.0.0",
+            default_outcome="admit",
+        )
+        recall = ContextualRecallAdapter(base, policy=always_admit)
+        result = recall.governed_recall("contextual recall", self._context())
+
+        self.assertIn(fact_uuid, result.candidates)
+        self.assertNotIn(fact_uuid, result.admitted)
+        self.assertEqual(result.refusals[fact_uuid], "disputed")
+        self.assertNotIn(fact_uuid, result.contextual_decisions)
+        self.assertEqual(always_admit.evaluation_count, 0)
+
+    def test_required_missing_policy_fails_closed(self):
+        _substrate, base, fact_uuid = self._base()
+        recall = ContextualRecallAdapter(
+            base,
+            policy=None,
+            require_policy=True,
+            required_policy_ref="contextual-policy:high-assurance",
+            required_policy_version="current-required",
+            clock=Clock(start=10),
+        )
+        result = recall.governed_recall("contextual recall", self._context())
+        decision = result.contextual_decisions[fact_uuid]
+        self.assertNotIn(fact_uuid, result.admitted)
+        self.assertEqual(decision["outcome"], "block")
+        self.assertEqual(decision["policy"]["status"], "unavailable")
+        self.assertEqual(decision["reason_code"], "contextual_policy_unavailable")
+
+    def test_failing_policy_fails_closed(self):
+        _substrate, base, fact_uuid = self._base()
+        result = ContextualRecallAdapter(base, policy=_FailingPolicy(), clock=Clock(start=10)).governed_recall(
+            "contextual recall", self._context()
+        )
+        decision = result.contextual_decisions[fact_uuid]
+        self.assertEqual(decision["outcome"], "block")
+        self.assertEqual(decision["policy"]["status"], "error")
+        self.assertNotIn(fact_uuid, result.context_surface)
+
+    def test_invalid_policy_outcome_fails_closed(self):
+        _substrate, base, fact_uuid = self._base()
+        result = ContextualRecallAdapter(base, policy=_InvalidPolicy(), clock=Clock(start=10)).governed_recall(
+            "contextual recall", self._context()
+        )
+        decision = result.contextual_decisions[fact_uuid]
+        self.assertEqual(decision["outcome"], "block")
+        self.assertEqual(decision["policy"]["status"], "invalid")
+        self.assertEqual(decision["reason_code"], "contextual_policy_invalid_decision")
+
+    def test_policy_version_change_is_reconstructable_without_memory_mutation(self):
+        substrate, base, fact_uuid = self._base()
+        first_stored = substrate.get_fact(fact_uuid)
+        first_policy = DeterministicContextualRecallPolicy(
+            policy_ref="contextual-policy:versioned",
+            policy_version="1.0.0",
+            default_outcome="admit",
+        )
+        recall = ContextualRecallAdapter(base, policy=first_policy, clock=Clock(start=10))
+        first = recall.governed_recall("contextual recall", self._context("same-purpose"))
+        self.assertEqual(first.contextual_decisions[fact_uuid]["policy"]["policy_version"], "1.0.0")
+        self.assertIn(fact_uuid, first.admitted)
+
+        second_policy = DeterministicContextualRecallPolicy(
+            policy_ref="contextual-policy:versioned",
+            policy_version="2.0.0",
+            rules=(
+                ContextualRule(
+                    rule_id="new-risk-rule",
+                    candidate_ref=fact_uuid,
+                    purpose="same-purpose",
+                    outcome="require_review",
+                    reason_code="new_policy_requires_review",
+                ),
+            ),
+        )
+        recall.set_policy(second_policy)
+        second = recall.governed_recall("contextual recall", self._context("same-purpose"))
+        second_stored = substrate.get_fact(fact_uuid)
+
+        self.assertEqual(second.contextual_decisions[fact_uuid]["policy"]["policy_version"], "2.0.0")
+        self.assertEqual(second.contextual_decisions[fact_uuid]["outcome"], "require_review")
+        self.assertNotIn(fact_uuid, second.admitted)
+        self.assertEqual(first_stored, second_stored)
+
+    def test_risk_signal_can_inform_decision_but_is_not_authority(self):
+        _substrate, base, fact_uuid = self._base()
+        risk = {
+            "signal_ref": "risk:learned:1",
+            "signal_semantics": "probabilistic_contextual_risk",
+            "estimator_ref": "estimator:risk-model",
+            "estimator_version": "v7",
+            "signal_value": 0.91,
+            "uncertainty_summary": "model-estimated risk; not authority",
+        }
+        contextual_policy = DeterministicContextualRecallPolicy(
+            policy_ref="contextual-policy:risk-informed",
+            policy_version="1.0.0",
+            rules=(
+                ContextualRule(
+                    rule_id="risk-informed-quarantine",
+                    candidate_ref=fact_uuid,
+                    purpose="risky",
+                    outcome="quarantine",
+                    reason_code="risk_requires_quarantine",
+                    evidence_refs=("evidence:risk-review",),
+                    risk_evidence=risk,
+                ),
+            ),
+        )
+        result = ContextualRecallAdapter(base, policy=contextual_policy, clock=Clock(start=10)).governed_recall(
+            "contextual recall", self._context("risky")
+        )
+        decision = result.contextual_decisions[fact_uuid]
+        self.assertEqual(decision["risk_evidence"]["signal_value"], 0.91)
+        self.assertEqual(decision["interpretation"]["risk_signal_authority"], "none")
+        self.assertEqual(decision["interpretation"]["authority_effect"], "current_recall_only")
+        self.assertNotIn(fact_uuid, result.admitted)
+
+    def test_decision_contains_only_bounded_context_not_query_or_memory_content(self):
+        _substrate, base, fact_uuid = self._base()
+        contextual_policy = DeterministicContextualRecallPolicy(
+            policy_ref="contextual-policy:minimized",
+            policy_version="1.0.0",
+        )
+        result = ContextualRecallAdapter(base, policy=contextual_policy, clock=Clock(start=10)).governed_recall(
+            "raw query should not be copied", self._context("benign")
+        )
+        decision = result.contextual_decisions[fact_uuid]
+        rendered = str(decision)
+        self.assertNotIn("raw query should not be copied", rendered)
+        self.assertNotIn("contextual recall test fact", rendered)
+        self.assertEqual(decision["candidate_ref"], fact_uuid)
+
+    def test_build_decision_rejects_unknown_outcome(self):
+        with self.assertRaisesRegex(ValueError, "unsupported contextual recall outcome"):
+            build_decision(
+                candidate_ref="fact:1",
+                context=self._context(),
+                policy_ref="policy:test",
+                policy_version="1",
+                policy_status="evaluated",
+                outcome="permit_forever",
+                reason_code="bad",
+                evaluated_at="2026-08-12T22:59:00Z",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_sleeper_poisoning_depth.py
+++ b/reference/tests/test_sleeper_poisoning_depth.py
@@ -1,0 +1,39 @@
+"""D/F/H/R/P accounting for sleeper-poisoning behavioral proof."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.sleeper_poisoning_depth import build_sleeper_poisoning_depth_report
+
+COMMIT = "4" * 40
+
+
+class SleeperPoisoningDepthTests(unittest.TestCase):
+    def test_sleeper_claim_is_d_f_h_only(self):
+        report = build_sleeper_poisoning_depth_report(COMMIT)
+        self.assertTrue(report["required_behavioral_cases_passed"])
+        self.assertEqual(len(report["claims"]), 1)
+        claim = report["claims"][0]
+        self.assertEqual(claim["claim_id"], "poisoning:sleeper-delayed-trigger-recall")
+        self.assertEqual(claim["demonstrated_levels"], ["D", "F", "H"])
+        self.assertEqual(claim["highest_demonstrated_level"], "H")
+        self.assertEqual(claim["explicitly_unproven_levels"], ["R", "P"])
+        self.assertEqual(claim["runtime_evidence_refs"], [])
+        self.assertEqual(claim["production_evidence_refs"], [])
+
+    def test_no_runtime_production_or_composite_claim(self):
+        report = build_sleeper_poisoning_depth_report(COMMIT)
+        self.assertNotIn("score", report)
+        self.assertNotIn("composite_score", report)
+        limits = " ".join(report["known_limits"])
+        self.assertIn("earns H evidence only", limits)
+        self.assertIn("Production evidence P is explicitly unproven", limits)
+
+    def test_exact_head_is_required(self):
+        with self.assertRaisesRegex(ValueError, "exact 40-hex commit"):
+            build_sleeper_poisoning_depth_report("not-a-commit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/contextual-recall-admission.schema.json
+++ b/schemas/contextual-recall-admission.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/contextual-recall-admission.schema.json",
+  "title": "Agent Memory Contextual Recall Admission Decision",
+  "description": "Deterministic current-context recall admission evidence. Prior admission, relevance, estimator output, or stored content does not create standing recall permission.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_version",
+    "decision_id",
+    "candidate_ref",
+    "policy",
+    "context",
+    "outcome",
+    "reason_code",
+    "evidence_refs",
+    "evaluated_at",
+    "interpretation"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "profile_version": { "const": "0.1.0" },
+    "decision_id": { "type": "string", "minLength": 1 },
+    "candidate_ref": { "type": "string", "minLength": 1 },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_ref", "policy_version", "status", "selection_mode"],
+      "properties": {
+        "policy_ref": { "type": "string", "minLength": 1 },
+        "policy_version": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "enum": ["evaluated", "unavailable", "error", "invalid"] },
+        "selection_mode": { "const": "deterministic" }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target_domain_refs", "principal_ref", "project_ref", "task_ref", "purpose", "destination_ref"],
+      "properties": {
+        "target_domain_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "principal_ref": { "type": "string" },
+        "project_ref": { "type": "string" },
+        "task_ref": { "type": "string" },
+        "purpose": { "type": "string" },
+        "destination_ref": { "type": "string" }
+      }
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["admit", "admit_with_warning", "require_verification", "require_review", "quarantine", "block"]
+    },
+    "reason_code": { "type": "string", "minLength": 1 },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "risk_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["signal_ref", "signal_semantics", "estimator_ref", "estimator_version"],
+      "properties": {
+        "signal_ref": { "type": "string", "minLength": 1 },
+        "signal_semantics": { "type": "string", "minLength": 1 },
+        "estimator_ref": { "type": "string", "minLength": 1 },
+        "estimator_version": { "type": "string", "minLength": 1 },
+        "signal_value": { "type": "number" },
+        "uncertainty_summary": { "type": "string" }
+      }
+    },
+    "evaluated_at": { "type": "string", "format": "date-time" },
+    "interpretation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_effect",
+        "prior_admission_authority",
+        "memory_mutation",
+        "relevance_authority",
+        "risk_signal_authority"
+      ],
+      "properties": {
+        "authority_effect": { "const": "current_recall_only" },
+        "prior_admission_authority": { "const": "none" },
+        "memory_mutation": { "const": "not_performed" },
+        "relevance_authority": { "const": "none" },
+        "risk_signal_authority": { "const": "none" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements **P2-C / V0.1** from #200: a generic monotonic current-context recall-admission seam plus executable delayed/sleeper poisoning proof.

## Core boundary

```text
prior admission != standing recall permission
write-time safety != lifetime safety
candidate discovery != admission
relevance != permission
context change -> current admission re-evaluation
contextual policy may tighten != silently loosen built-in governance
```

## Composition

The existing `GovernedMemoryAdapter` remains unchanged and authoritative for canonical lifecycle/scope admission.

A compositional `ContextualRecallAdapter` wraps it:

```text
substrate retrieval
-> canonical built-in admission
-> current contextual policy
-> final admitted/context/downstream surface
```

Only candidates already admitted by built-in governance reach the contextual policy. Therefore a contextual `admit` has no code path that can resurrect a tombstoned, disputed, stale, or out-of-scope candidate.

## Contextual decision contract

The new machine-readable decision preserves:

- candidate ref;
- policy ref/version/status;
- bounded current context identity;
- deterministic outcome and reason;
- evidence refs;
- optional learned/probabilistic risk evidence;
- evaluation timestamp;
- fixed nonclaims that prior admission, relevance, and risk signals are not authority.

Supported outcomes:

```text
admit
admit_with_warning
require_verification
require_review
quarantine
block
```

Only the first two enter final context.

## Sleeper behavioral proof

The harness consumes the existing `fixtures/sleeper-memory-poisoning.json` structural contract:

```text
write_time_check_may_pass = true
later_trigger_rechecked = true
unsafe_activation_allowed = false
```

It then executes:

1. retain one bounded fact through normal governed mutation;
2. recall under a benign purpose and admit it;
3. leave the retained fact unchanged;
4. recall the same fact under delayed-trigger purpose `activate-triggered-memory`;
5. discover the same candidate again;
6. re-run the current contextual policy;
7. quarantine the candidate;
8. keep it out of admitted/context/downstream surfaces;
9. preserve the retained fact and provenance.

A probabilistic delayed-activation risk signal is preserved as evidence while the decision schema fixes `risk_signal_authority = none`.

## Fail-closed / monotonic tests

Executable coverage proves:

- prior benign admission is not cached/replayed as current permission;
- contextual policy cannot widen a built-in disputed refusal;
- missing required contextual policy fails closed;
- configured policy errors fail closed;
- invalid/unsupported policy output fails closed;
- policy-version changes are reconstructable without mutating retained memory;
- risk estimators may inform a rule but never authorize it;
- raw query/memory content is absent from contextual decision evidence.

## Evidence depth

A dedicated exact-head workflow emits `sleeper-poisoning-depth.json` using the merged #196 D/F/H/R/P model:

```text
D = threat model + governed recall doctrine + contextual profile
F = sleeper-memory-poisoning fixture
H = behavioral sleeper harness
R = explicitly unproven
P = explicitly unproven
```

The harness does not self-promote into runtime or production resistance claims.

## Added surfaces

- `schemas/contextual-recall-admission.schema.json`
- `reference/agentmem_ref/contextual_recall.py`
- `reference/agentmem_ref/contextual_recall_adapter.py`
- `reference/agentmem_ref/sleeper_poisoning_harness.py`
- `reference/agentmem_ref/sleeper_poisoning_depth.py`
- `reference/run_sleeper_poisoning_depth.py`
- `reference/tests/test_contextual_recall.py`
- `reference/tests/test_sleeper_poisoning_depth.py`
- `docs/profiles/contextual-recall-admission-profile.md`
- `.github/workflows/sleeper-poisoning-evidence.yml`

## Stop line

Do not expand this PR into semantic sleeper detection, a general content-moderation system, model-based trigger discovery, automatic durable memory mutation/deletion, long-horizon production testing, or production certification.

This PR remains draft until exact-head Doctrine, P9, MAF regression, sleeper-evidence workflow, and completion review all pass.

Closes #200