### PR TITLE
Preserve transformation provenance and block authority laundering

### DIFF
--- a/reference/agentmem_ref/transformation_evidence.py
+++ b/reference/agentmem_ref/transformation_evidence.py
@@ -1,0 +1,374 @@
+"""Vendor-neutral transformation evidence for issue #202.
+
+A transformation may create useful derived evidence, but it cannot replace the
+source basis with transformer reputation, turn confidence into authority, widen
+scope, create certification, or silently remain current after its source basis
+is invalidated.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from copy import deepcopy
+from typing import Any
+
+import rfc8785
+
+from . import receipts
+
+PROFILE_VERSION = "0.1.0"
+TRANSFORMATION_TYPES = {"summary", "consolidation", "extraction", "projection", "other"}
+MODES = {"deterministic", "probabilistic"}
+STATUSES = {"complete", "partial", "failed"}
+SOURCE_STATES = {"current", "disputed", "revoked", "superseded", "tombstoned", "deleted", "unknown"}
+EVIDENCE_CLASSES = {"ordinary", "negative", "adversarial", "correction", "incident"}
+SCOPE_RELATIONS = {"preserved", "narrowed"}
+
+
+def _ref(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _refs(name: str, value: object, *, required: bool = False) -> list[str]:
+    if value is None:
+        if required:
+            raise ValueError(f"{name} must contain at least one reference")
+        return []
+    if not isinstance(value, (list, tuple)) or not all(isinstance(item, str) and item for item in value):
+        raise ValueError(f"{name} must be a list of non-empty strings")
+    result = list(dict.fromkeys(value))
+    if required and not result:
+        raise ValueError(f"{name} must contain at least one reference")
+    return result
+
+
+def _digest(name: str, value: object) -> str:
+    text = _ref(name, value)
+    if len(text) != 71 or not text.startswith("sha256:") or any(ch not in "0123456789abcdef" for ch in text[7:]):
+        raise ValueError(f"{name} must be a lowercase sha256 digest reference")
+    return text
+
+
+def _sha256_ref(value: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+
+
+def _optional_ref(target: dict[str, Any], field: str, value: object) -> None:
+    if value is not None:
+        target[field] = _ref(field, value)
+
+
+def _normalize_source(source: object, index: int) -> dict[str, Any]:
+    if not isinstance(source, dict):
+        raise ValueError(f"sources[{index}] must be an object")
+    state = source.get("state")
+    if state not in SOURCE_STATES:
+        raise ValueError(f"sources[{index}].state is invalid")
+    evidence_class = source.get("evidence_class")
+    if evidence_class not in EVIDENCE_CLASSES:
+        raise ValueError(f"sources[{index}].evidence_class is invalid")
+    normalized: dict[str, Any] = {
+        "source_ref": _ref(f"sources[{index}].source_ref", source.get("source_ref")),
+        "evidence_refs": _refs(f"sources[{index}].evidence_refs", source.get("evidence_refs"), required=True),
+        "scope_ref": _ref(f"sources[{index}].scope_ref", source.get("scope_ref")),
+        "state": state,
+        "evidence_class": evidence_class,
+    }
+    _optional_ref(normalized, "tenant_ref", source.get("tenant_ref"))
+    _optional_ref(normalized, "project_ref", source.get("project_ref"))
+    return normalized
+
+
+def _normalize_uncertainty(value: object) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("uncertainty must be an object")
+    signal_value = value.get("signal_value")
+    if isinstance(signal_value, bool) or not isinstance(signal_value, (int, float)):
+        raise ValueError("uncertainty.signal_value must be numeric")
+    result = {
+        "signal_semantics": _ref("uncertainty.signal_semantics", value.get("signal_semantics")),
+        "estimator_ref": _ref("uncertainty.estimator_ref", value.get("estimator_ref")),
+        "estimator_version": _ref("uncertainty.estimator_version", value.get("estimator_version")),
+        "signal_value": signal_value,
+    }
+    _optional_ref(result, "uncertainty_summary", value.get("uncertainty_summary"))
+    return result
+
+
+def _scope_binding(
+    sources: list[dict[str, Any]],
+    derived_scope: dict[str, Any],
+    relation: str,
+    basis_refs: list[str],
+) -> tuple[str, str, list[str]]:
+    """Return relation, binding status, and reasons.
+
+    V0.1 does not infer a scope hierarchy from strings. Exact scope preservation
+    is directly provable. A narrower scope must be explicitly declared and
+    carry one or more basis references while retaining any source tenant/project
+    boundaries. Anything else is a mismatch and therefore invalid for current
+    derived use.
+    """
+    reasons: list[str] = []
+    derived_tenant = derived_scope.get("tenant_ref")
+    derived_project = derived_scope.get("project_ref")
+
+    source_tenants = {item.get("tenant_ref") for item in sources if item.get("tenant_ref")}
+    source_projects = {item.get("project_ref") for item in sources if item.get("project_ref")}
+    source_scopes = {item["scope_ref"] for item in sources}
+
+    if len(source_tenants) > 1:
+        reasons.append("source_tenant_conflict")
+    if len(source_projects) > 1:
+        reasons.append("source_project_conflict")
+    if source_tenants and derived_tenant not in source_tenants:
+        reasons.append("tenant_widening_or_mismatch")
+    if source_projects and derived_project not in source_projects:
+        reasons.append("project_widening_or_mismatch")
+
+    if relation == "preserved":
+        if len(source_scopes) != 1 or derived_scope["scope_ref"] not in source_scopes:
+            reasons.append("scope_not_preserved")
+        status = "exact"
+    elif relation == "narrowed":
+        if not basis_refs:
+            reasons.append("scope_narrowing_basis_missing")
+        if derived_scope["scope_ref"] in source_scopes:
+            reasons.append("narrowed_scope_must_differ_from_source_scope")
+        status = "narrowed"
+    else:
+        raise ValueError(f"invalid scope_relation {relation!r}")
+
+    if reasons:
+        return "mismatch", "mismatch", reasons
+    return relation, status, []
+
+
+def _currentness(sources: list[dict[str, Any]]) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    unknown = False
+    for source in sources:
+        state = source["state"]
+        if state == "current":
+            continue
+        if state == "unknown":
+            unknown = True
+            reasons.append(f"source_state_unknown:{source['source_ref']}")
+        else:
+            reasons.append(f"source_{state}:{source['source_ref']}")
+    if reasons and not all(item.startswith("source_state_unknown:") for item in reasons):
+        return "revalidation_required", reasons
+    if unknown:
+        return "unknown", reasons
+    return "current", []
+
+
+def _evidence_character(sources: list[dict[str, Any]]) -> str:
+    classes = {item["evidence_class"] for item in sources}
+    if classes.intersection({"negative", "adversarial"}):
+        return "negative_or_adversarial"
+    if classes.intersection({"correction", "incident"}):
+        return "correction_or_incident"
+    return "ordinary"
+
+
+def normalize_transformation_evidence(
+    transformation: dict[str, Any],
+    *,
+    parent_records: tuple[dict[str, Any], ...] = (),
+) -> dict[str, Any]:
+    """Normalize one transformation into bounded derived evidence.
+
+    `parent_records` are already-normalized transformation records. They are used
+    only to extend lineage. Transformer-provided authority-like fields are never
+    copied because the output is built from an explicit allowlist.
+    """
+    if not isinstance(transformation, dict):
+        raise ValueError("transformation must be an object")
+
+    transformation_type = transformation.get("transformation_type")
+    if transformation_type not in TRANSFORMATION_TYPES:
+        raise ValueError(f"invalid transformation_type {transformation_type!r}")
+    mode = transformation.get("mode")
+    if mode not in MODES:
+        raise ValueError(f"invalid mode {mode!r}")
+    status = transformation.get("status")
+    if status not in STATUSES:
+        raise ValueError(f"invalid status {status!r}")
+
+    raw_sources = transformation.get("sources")
+    if not isinstance(raw_sources, (list, tuple)) or not raw_sources:
+        raise ValueError("sources must contain at least one source object")
+    sources = [_normalize_source(item, index) for index, item in enumerate(raw_sources)]
+
+    for index, parent in enumerate(parent_records):
+        if not isinstance(parent, dict) or parent.get("schema_version") != "1.0.0" or "lineage" not in parent:
+            raise ValueError(f"parent_records[{index}] is not a normalized transformation record")
+
+    transformer = {
+        "transformer_ref": _ref("transformer_ref", transformation.get("transformer_ref")),
+        "transformer_version": _ref("transformer_version", transformation.get("transformer_version")),
+        "trust_evidence_refs": _refs("transformer_trust_evidence_refs", transformation.get("transformer_trust_evidence_refs")),
+    }
+
+    direct_source_refs = list(dict.fromkeys(item["source_ref"] for item in sources))
+    parent_transformation_refs = list(
+        dict.fromkeys(parent["transformation_id"] for parent in parent_records)
+    )
+    original_source_refs = list(direct_source_refs)
+    for parent in parent_records:
+        for source_ref in parent["lineage"]["original_source_refs"]:
+            if source_ref not in original_source_refs:
+                original_source_refs.append(source_ref)
+
+    scope_ref = _ref("derived_scope_ref", transformation.get("derived_scope_ref"))
+    derived_scope: dict[str, Any] = {"scope_ref": scope_ref}
+    _optional_ref(derived_scope, "tenant_ref", transformation.get("derived_tenant_ref"))
+    _optional_ref(derived_scope, "project_ref", transformation.get("derived_project_ref"))
+    relation = transformation.get("scope_relation", "preserved")
+    basis_refs = _refs("scope_basis_refs", transformation.get("scope_basis_refs"))
+    relation_out, binding_status, binding_reasons = _scope_binding(sources, derived_scope, relation, basis_refs)
+    derived_scope.update(
+        {
+            "relation": relation_out,
+            "basis_refs": basis_refs,
+            "binding_status": binding_status,
+        }
+    )
+
+    currentness_status, currentness_reasons = _currentness(sources)
+    uncertainty = _normalize_uncertainty(transformation.get("uncertainty"))
+
+    derived: dict[str, Any] = {
+        "derived_ref": _ref("derived_ref", transformation.get("derived_ref")),
+        "derived_evidence_ref": _ref("derived_evidence_ref", transformation.get("derived_evidence_ref")),
+        "derived_evidence_digest": _digest("derived_evidence_digest", transformation.get("derived_evidence_digest")),
+        "evidence_character": _evidence_character(sources),
+    }
+    if uncertainty is not None:
+        derived["uncertainty"] = uncertainty
+
+    applicability_reasons = list(binding_reasons)
+    if status != "complete":
+        applicability_reasons.append(f"transformation_{status}")
+    applicability_reasons.extend(currentness_reasons)
+
+    if binding_status == "mismatch":
+        applicability_status = "invalid"
+    elif status != "complete":
+        applicability_status = "incomplete"
+    elif currentness_status != "current":
+        applicability_status = "revalidation_required"
+    else:
+        applicability_status = "current"
+
+    body: dict[str, Any] = {
+        "transformation_id": _ref("transformation_id", transformation.get("transformation_id")),
+        "transformation_type": transformation_type,
+        "mode": mode,
+        "status": status,
+        "transformer": transformer,
+        "sources": sources,
+        "lineage": {
+            "direct_source_refs": direct_source_refs,
+            "original_source_refs": original_source_refs,
+            "parent_transformation_refs": parent_transformation_refs,
+        },
+        "derived": derived,
+        "scope": derived_scope,
+        "source_currentness": {
+            "status": currentness_status,
+            "reasons": currentness_reasons,
+        },
+        "applicability": {
+            "status": applicability_status,
+            "reasons": list(dict.fromkeys(applicability_reasons)),
+        },
+        "created_at": _ref("created_at", transformation.get("created_at")),
+        "interpretation": {
+            "transformation_authority_effect": "none",
+            "transformer_trust_is_source_trust": False,
+            "derived_confidence_authority": "none",
+            "certification_claim": "none",
+            "standing_policy_effect": "none",
+            "memory_admission": "not_established",
+        },
+    }
+
+    identity_body = deepcopy(body)
+    body["identity_digest"] = _sha256_ref(identity_body)
+    document = {
+        "schema_version": "1.0.0",
+        "profile_version": PROFILE_VERSION,
+        **body,
+    }
+    receipts.validate("transformation-evidence.schema.json", document)
+    return document
+
+
+def reevaluate_source_currentness(
+    record: dict[str, Any],
+    source_states: dict[str, str],
+) -> dict[str, Any]:
+    """Re-evaluate a normalized derived record against current source states.
+
+    This returns a new normalized record-like object and never rewrites source
+    history. It is deliberately conservative: an unknown or changed source
+    state can remove current applicability but cannot manufacture a stronger
+    derived status.
+    """
+    if not isinstance(record, dict) or record.get("schema_version") != "1.0.0":
+        raise ValueError("record must be normalized transformation evidence")
+    if not isinstance(source_states, dict):
+        raise ValueError("source_states must be an object")
+
+    updated = deepcopy(record)
+    reasons: list[str] = []
+    unknown = False
+    for source in updated["sources"]:
+        state = source_states.get(source["source_ref"], source["state"])
+        if state not in SOURCE_STATES:
+            raise ValueError(f"invalid current source state {state!r}")
+        source["state"] = state
+        if state == "current":
+            continue
+        if state == "unknown":
+            unknown = True
+            reasons.append(f"source_state_unknown:{source['source_ref']}")
+        else:
+            reasons.append(f"source_{state}:{source['source_ref']}")
+
+    if reasons and not all(item.startswith("source_state_unknown:") for item in reasons):
+        currentness_status = "revalidation_required"
+    elif unknown:
+        currentness_status = "unknown"
+    else:
+        currentness_status = "current"
+
+    updated["source_currentness"] = {"status": currentness_status, "reasons": reasons}
+    prior_binding_reasons = [
+        reason for reason in updated["applicability"]["reasons"]
+        if not reason.startswith("source_")
+    ]
+    combined_reasons = list(dict.fromkeys(prior_binding_reasons + reasons))
+    if updated["scope"]["binding_status"] == "mismatch":
+        applicability_status = "invalid"
+    elif updated["status"] != "complete":
+        applicability_status = "incomplete"
+    elif currentness_status != "current":
+        applicability_status = "revalidation_required"
+    else:
+        applicability_status = "current"
+    updated["applicability"] = {"status": applicability_status, "reasons": combined_reasons}
+
+    identity_body = {
+        key: value for key, value in updated.items()
+        if key not in {"schema_version", "profile_version", "identity_digest"}
+    }
+    updated["identity_digest"] = _sha256_ref(identity_body)
+    receipts.validate("transformation-evidence.schema.json", updated)
+    return updated

--- a/reference/agentmem_ref/transformation_laundering_harness.py
+++ b/reference/agentmem_ref/transformation_laundering_harness.py
@@ -1,0 +1,223 @@
+"""Behavioral transformation/authority-laundering proof for issue #202."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from . import policy
+from .adapter import Clock, GovernedMemoryAdapter
+from .substrate import InMemoryTemporalGraph
+from .transformation_evidence import normalize_transformation_evidence, reevaluate_source_currentness
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "fixtures" / "authority-laundering.json"
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+
+
+def _source(*, state: str = "current", evidence_class: str = "ordinary") -> dict[str, Any]:
+    return {
+        "source_ref": "memory:untrusted-origin",
+        "evidence_refs": ["fixture://untrusted-origin"],
+        "scope_ref": "scope:tenant-a/project-a",
+        "tenant_ref": "tenant-a",
+        "project_ref": "project-a",
+        "state": state,
+        "evidence_class": evidence_class,
+    }
+
+
+def _summary(**overrides: Any) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "transformation_id": "transform:summary:1",
+        "transformation_type": "summary",
+        "mode": "probabilistic",
+        "status": "complete",
+        "transformer_ref": "trusted-summary-service",
+        "transformer_version": "v1",
+        "transformer_trust_evidence_refs": ["evidence:transformer-reviewed"],
+        "sources": [_source()],
+        "derived_ref": "memory:derived-summary:1",
+        "derived_evidence_ref": "evidence:summary-transform",
+        "derived_evidence_digest": DIGEST_A,
+        "derived_scope_ref": "scope:tenant-a/project-a",
+        "derived_tenant_ref": "tenant-a",
+        "derived_project_ref": "project-a",
+        "scope_relation": "preserved",
+        "created_at": "2026-08-12T23:15:00Z",
+        "uncertainty": {
+            "signal_semantics": "summary_fidelity_confidence",
+            "estimator_ref": "estimator:trusted-summary-service",
+            "estimator_version": "v1",
+            "signal_value": 0.99,
+            "uncertainty_summary": "High transformer confidence is evidence about the derived output, not source authority.",
+        },
+        # Hostile/overreaching transformer claims. The normalizer must ignore them.
+        "pama_outcome": "allow",
+        "permitted_actions": ["crystallize_transformed_claim"],
+        "lifecycle_state": "crystallized",
+        "certification_status": "certified",
+        "memory_authority": "owner",
+        "raw_source_content": "sensitive source body must not be copied",
+        "hidden_reasoning": "private transformer reasoning must not be copied",
+    }
+    value.update(overrides)
+    return value
+
+
+def _pama_high_confidence_case(record: dict[str, Any]) -> dict[str, Any]:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant="tenant-a", clock=Clock())
+    proposal = policy.Proposal(
+        proposal_id="proposal:transformed-summary:crystallize",
+        actor_id="transformer:trusted-summary-service",
+        charter_version="charter:transformation-v1",
+        target_reference=record["derived"]["derived_ref"],
+        target_class=policy.M4,
+        scope=record["scope"]["scope_ref"],
+        operation="promotion",
+        current_strength="observed",
+        proposed_strength="crystallized",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="high",
+        evidence_refs=(record["derived"]["derived_evidence_ref"], *record["lineage"]["original_source_refs"]),
+        estimator_refs=("estimator:trusted-summary-service",),
+        estimator_versions=("v1",),
+        confidence=0.99,
+        tenant_ref="tenant-a",
+        project_ref="project-a",
+        purpose="authority-laundering-harness",
+    )
+    result = adapter.commit_proposal(proposal, "derived transformed claim")
+    writes = [entry for entry in substrate.write_log if entry[0] == "write_fact"]
+    checks = {
+        "high_confidence_not_committed": not result.committed and not writes,
+        "promotion_remains_prohibited": "promotion" in result.decision.prohibited_actions,
+        "review_or_verification_still_required": result.decision.outcome in {
+            policy.REQUIRE_REVIEW,
+            policy.REQUIRE_EXTERNAL_VERIFICATION,
+            policy.BLOCK,
+        },
+        "source_lineage_reaches_pama_evidence": "memory:untrusted-origin" in result.pama_decision["basis"]["evidence_refs"],
+    }
+    return {"passed": all(checks.values()), "checks": checks, "outcome": result.decision.outcome}
+
+
+def run_transformation_laundering_harness() -> dict[str, Any]:
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    expected = fixture["expected_behavior"]
+
+    first = normalize_transformation_evidence(_summary())
+
+    second = normalize_transformation_evidence(
+        {
+            "transformation_id": "transform:extraction:2",
+            "transformation_type": "extraction",
+            "mode": "deterministic",
+            "status": "complete",
+            "transformer_ref": "trusted-extraction-service",
+            "transformer_version": "v2",
+            "sources": [
+                {
+                    "source_ref": first["derived"]["derived_ref"],
+                    "evidence_refs": [first["derived"]["derived_evidence_ref"]],
+                    "scope_ref": first["scope"]["scope_ref"],
+                    "tenant_ref": "tenant-a",
+                    "project_ref": "project-a",
+                    "state": "current",
+                    "evidence_class": "ordinary",
+                }
+            ],
+            "derived_ref": "memory:derived-extraction:2",
+            "derived_evidence_ref": "evidence:derived-extraction:2",
+            "derived_evidence_digest": DIGEST_B,
+            "derived_scope_ref": "scope:tenant-a/project-a",
+            "derived_tenant_ref": "tenant-a",
+            "derived_project_ref": "project-a",
+            "scope_relation": "preserved",
+            "created_at": "2026-08-12T23:16:00Z",
+        },
+        parent_records=(first,),
+    )
+
+    revoked = reevaluate_source_currentness(first, {"memory:untrusted-origin": "revoked"})
+    tombstoned = reevaluate_source_currentness(first, {"memory:untrusted-origin": "tombstoned"})
+
+    widened = normalize_transformation_evidence(
+        _summary(
+            transformation_id="transform:summary:widened",
+            derived_ref="memory:derived-summary:widened",
+            derived_tenant_ref="tenant-b",
+            derived_project_ref="project-b",
+            derived_scope_ref="scope:tenant-b/project-b",
+        )
+    )
+
+    adversarial = normalize_transformation_evidence(
+        _summary(
+            transformation_id="transform:summary:adversarial",
+            sources=[_source(evidence_class="adversarial")],
+            derived_ref="memory:derived-summary:adversarial",
+        )
+    )
+
+    partial = normalize_transformation_evidence(
+        _summary(
+            transformation_id="transform:summary:partial",
+            status="partial",
+            derived_ref="memory:derived-summary:partial",
+        )
+    )
+
+    pama_case = _pama_high_confidence_case(first)
+    rendered = repr(first)
+    hostile_fields = (
+        "pama_outcome",
+        "permitted_actions",
+        "lifecycle_state",
+        "certification_status",
+        "memory_authority",
+        "raw_source_content",
+        "hidden_reasoning",
+    )
+
+    checks = {
+        "fixture_origin_preserved": expected["origin_preserved"] is True,
+        "fixture_transformation_grants_no_authority": expected["transformation_grants_authority"] is False,
+        "fixture_durable_promotion_forbidden": expected["durable_promotion_allowed"] is False,
+        "direct_origin_preserved": first["lineage"]["original_source_refs"] == ["memory:untrusted-origin"],
+        "transformer_trust_not_source_trust": first["interpretation"]["transformer_trust_is_source_trust"] is False,
+        "transformation_authority_none": first["interpretation"]["transformation_authority_effect"] == "none",
+        "confidence_authority_none": first["interpretation"]["derived_confidence_authority"] == "none",
+        "certification_none": first["interpretation"]["certification_claim"] == "none",
+        "hostile_authority_fields_discarded": all(field not in first for field in hostile_fields),
+        "raw_content_not_copied": "sensitive source body must not be copied" not in rendered,
+        "hidden_reasoning_not_copied": "private transformer reasoning must not be copied" not in rendered,
+        "multi_hop_original_lineage_preserved": "memory:untrusted-origin" in second["lineage"]["original_source_refs"],
+        "multi_hop_parent_preserved": first["transformation_id"] in second["lineage"]["parent_transformation_refs"],
+        "revocation_requires_revalidation": revoked["applicability"]["status"] == "revalidation_required",
+        "revocation_reason_preserved": any(reason.startswith("source_revoked:") for reason in revoked["source_currentness"]["reasons"]),
+        "tombstone_distinct_from_revocation": any(reason.startswith("source_tombstoned:") for reason in tombstoned["source_currentness"]["reasons"]),
+        "scope_widening_invalid": widened["scope"]["binding_status"] == "mismatch" and widened["applicability"]["status"] == "invalid",
+        "adversarial_evidence_not_neutralized": adversarial["derived"]["evidence_character"] == "negative_or_adversarial",
+        "partial_transform_not_current": partial["applicability"]["status"] == "incomplete",
+        "high_confidence_cannot_self_crystallize": pama_case["passed"],
+    }
+
+    return {
+        "case_id": "authority-laundering-through-transformation",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "observed": {
+            "first_transformation_id": first["transformation_id"],
+            "first_identity_digest": first["identity_digest"],
+            "second_original_source_refs": second["lineage"]["original_source_refs"],
+            "revoked_applicability": revoked["applicability"],
+            "tombstoned_currentness": tombstoned["source_currentness"],
+            "widened_scope": widened["scope"],
+            "pama_outcome": pama_case["outcome"],
+        },
+    }

--- a/reference/agentmem_ref/transformation_laundering_harness.py
+++ b/reference/agentmem_ref/transformation_laundering_harness.py
@@ -77,9 +77,9 @@ def _pama_high_confidence_case(record: dict[str, Any]) -> dict[str, Any]:
         target_reference=record["derived"]["derived_ref"],
         target_class=policy.M4,
         scope=record["scope"]["scope_ref"],
-        operation="promotion",
-        current_strength="observed",
-        proposed_strength="crystallized",
+        operation="crystallization",
+        current_strength="promoted",
+        proposed_strength="canonical",
         downstream_authority=policy.A1,
         reversibility="reversible",
         risk_class="high",
@@ -95,7 +95,7 @@ def _pama_high_confidence_case(record: dict[str, Any]) -> dict[str, Any]:
     writes = [entry for entry in substrate.write_log if entry[0] == "write_fact"]
     checks = {
         "high_confidence_not_committed": not result.committed and not writes,
-        "promotion_remains_prohibited": "promotion" in result.decision.prohibited_actions,
+        "crystallization_remains_prohibited": "crystallization" in result.decision.prohibited_actions,
         "review_or_verification_still_required": result.decision.outcome in {
             policy.REQUIRE_REVIEW,
             policy.REQUIRE_EXTERNAL_VERIFICATION,

--- a/reference/tests/test_transformation_evidence.py
+++ b/reference/tests/test_transformation_evidence.py
@@ -1,0 +1,203 @@
+"""Transformation provenance and authority-laundering tests for issue #202."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.transformation_evidence import (
+    normalize_transformation_evidence,
+    reevaluate_source_currentness,
+)
+from agentmem_ref.transformation_laundering_harness import run_transformation_laundering_harness
+
+DIGEST = "sha256:" + "c" * 64
+
+
+def source(**overrides):
+    value = {
+        "source_ref": "memory:source:1",
+        "evidence_refs": ["evidence:source:1"],
+        "scope_ref": "scope:tenant-a/project-a",
+        "tenant_ref": "tenant-a",
+        "project_ref": "project-a",
+        "state": "current",
+        "evidence_class": "ordinary",
+    }
+    value.update(overrides)
+    return value
+
+
+def transformation(**overrides):
+    value = {
+        "transformation_id": "transform:test:1",
+        "transformation_type": "summary",
+        "mode": "probabilistic",
+        "status": "complete",
+        "transformer_ref": "transformer:trusted",
+        "transformer_version": "v1",
+        "transformer_trust_evidence_refs": ["evidence:transformer:reviewed"],
+        "sources": [source()],
+        "derived_ref": "memory:derived:1",
+        "derived_evidence_ref": "evidence:derived:1",
+        "derived_evidence_digest": DIGEST,
+        "derived_scope_ref": "scope:tenant-a/project-a",
+        "derived_tenant_ref": "tenant-a",
+        "derived_project_ref": "project-a",
+        "scope_relation": "preserved",
+        "created_at": "2026-08-12T23:20:00Z",
+        "uncertainty": {
+            "signal_semantics": "summary_fidelity_confidence",
+            "estimator_ref": "estimator:summary",
+            "estimator_version": "v1",
+            "signal_value": 0.99,
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+class TransformationEvidenceTests(unittest.TestCase):
+    def test_authority_laundering_fixture_has_behavioral_proof(self):
+        result = run_transformation_laundering_harness()
+        self.assertTrue(result["passed"], result)
+        self.assertTrue(result["checks"]["direct_origin_preserved"])
+        self.assertTrue(result["checks"]["high_confidence_cannot_self_crystallize"])
+        self.assertTrue(result["checks"]["scope_widening_invalid"])
+
+    def test_trusted_transformer_never_substitutes_for_source_trust(self):
+        record = normalize_transformation_evidence(transformation())
+        interpretation = record["interpretation"]
+        self.assertFalse(interpretation["transformer_trust_is_source_trust"])
+        self.assertEqual(interpretation["transformation_authority_effect"], "none")
+        self.assertEqual(interpretation["derived_confidence_authority"], "none")
+        self.assertEqual(interpretation["certification_claim"], "none")
+        self.assertEqual(interpretation["memory_admission"], "not_established")
+        self.assertEqual(record["applicability"]["status"], "current")
+
+    def test_hostile_transformer_authority_fields_are_not_copied(self):
+        record = normalize_transformation_evidence(
+            transformation(
+                pama_outcome="allow",
+                permitted_actions=["crystallization"],
+                lifecycle_state="crystallized",
+                certification_status="certified",
+                authority_refs=["authority:self-issued"],
+                raw_source_content="do not retain me",
+                hidden_reasoning="also do not retain me",
+            )
+        )
+        rendered = repr(record)
+        for field in ("pama_outcome", "permitted_actions", "lifecycle_state", "certification_status", "authority_refs"):
+            self.assertNotIn(field, record)
+        self.assertNotIn("do not retain me", rendered)
+        self.assertNotIn("also do not retain me", rendered)
+
+    def test_missing_source_evidence_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "evidence_refs must contain"):
+            normalize_transformation_evidence(
+                transformation(sources=[source(evidence_refs=[])])
+            )
+
+    def test_multi_hop_lineage_keeps_original_and_immediate_parent(self):
+        first = normalize_transformation_evidence(transformation())
+        second = normalize_transformation_evidence(
+            transformation(
+                transformation_id="transform:test:2",
+                transformation_type="extraction",
+                mode="deterministic",
+                sources=[
+                    source(
+                        source_ref=first["derived"]["derived_ref"],
+                        evidence_refs=[first["derived"]["derived_evidence_ref"]],
+                    )
+                ],
+                derived_ref="memory:derived:2",
+                derived_evidence_ref="evidence:derived:2",
+            ),
+            parent_records=(first,),
+        )
+        self.assertIn("memory:source:1", second["lineage"]["original_source_refs"])
+        self.assertIn("memory:derived:1", second["lineage"]["direct_source_refs"])
+        self.assertEqual(second["lineage"]["parent_transformation_refs"], ["transform:test:1"])
+
+    def test_source_dispute_revocation_and_tombstone_require_revalidation(self):
+        record = normalize_transformation_evidence(transformation())
+        for state in ("disputed", "revoked", "superseded", "tombstoned", "deleted"):
+            with self.subTest(state=state):
+                updated = reevaluate_source_currentness(record, {"memory:source:1": state})
+                self.assertEqual(updated["source_currentness"]["status"], "revalidation_required")
+                self.assertEqual(updated["applicability"]["status"], "revalidation_required")
+                self.assertIn(f"source_{state}:memory:source:1", updated["source_currentness"]["reasons"])
+
+    def test_unknown_source_state_is_not_treated_as_current(self):
+        record = reevaluate_source_currentness(
+            normalize_transformation_evidence(transformation()),
+            {"memory:source:1": "unknown"},
+        )
+        self.assertEqual(record["source_currentness"]["status"], "unknown")
+        self.assertEqual(record["applicability"]["status"], "revalidation_required")
+
+    def test_scope_widening_or_cross_tenant_rebinding_is_invalid(self):
+        record = normalize_transformation_evidence(
+            transformation(
+                transformation_id="transform:test:widen",
+                derived_scope_ref="scope:tenant-b/project-b",
+                derived_tenant_ref="tenant-b",
+                derived_project_ref="project-b",
+            )
+        )
+        self.assertEqual(record["scope"]["binding_status"], "mismatch")
+        self.assertEqual(record["applicability"]["status"], "invalid")
+        self.assertIn("tenant_widening_or_mismatch", record["applicability"]["reasons"])
+
+    def test_explicit_scope_narrowing_requires_basis_evidence(self):
+        with self.assertRaisesRegex(ValueError, "scope_relation"):
+            normalize_transformation_evidence(transformation(scope_relation="broadened"))
+
+        missing_basis = normalize_transformation_evidence(
+            transformation(
+                transformation_id="transform:test:narrow-no-basis",
+                derived_ref="memory:derived:narrow-no-basis",
+                derived_scope_ref="scope:tenant-a/project-a/task-7",
+                scope_relation="narrowed",
+            )
+        )
+        self.assertEqual(missing_basis["scope"]["binding_status"], "mismatch")
+        self.assertEqual(missing_basis["applicability"]["status"], "invalid")
+
+        narrowed = normalize_transformation_evidence(
+            transformation(
+                transformation_id="transform:test:narrow",
+                derived_ref="memory:derived:narrow",
+                derived_scope_ref="scope:tenant-a/project-a/task-7",
+                scope_relation="narrowed",
+                scope_basis_refs=["policy:scope-narrowing:task-7"],
+            )
+        )
+        self.assertEqual(narrowed["scope"]["binding_status"], "narrowed")
+        self.assertEqual(narrowed["applicability"]["status"], "current")
+
+    def test_negative_and_adversarial_evidence_are_not_neutralized(self):
+        for evidence_class in ("negative", "adversarial"):
+            with self.subTest(evidence_class=evidence_class):
+                record = normalize_transformation_evidence(
+                    transformation(sources=[source(evidence_class=evidence_class)])
+                )
+                self.assertEqual(record["derived"]["evidence_character"], "negative_or_adversarial")
+
+    def test_partial_or_failed_transformation_is_not_current(self):
+        for status in ("partial", "failed"):
+            with self.subTest(status=status):
+                record = normalize_transformation_evidence(transformation(status=status))
+                self.assertEqual(record["applicability"]["status"], "incomplete")
+                self.assertIn(f"transformation_{status}", record["applicability"]["reasons"])
+
+    def test_deterministic_identity_for_same_inputs(self):
+        first = normalize_transformation_evidence(transformation())
+        second = normalize_transformation_evidence(transformation())
+        self.assertEqual(first, second)
+        self.assertEqual(first["identity_digest"], second["identity_digest"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/transformation-evidence.schema.json
+++ b/schemas/transformation-evidence.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/transformation-evidence.schema.json",
+  "title": "Agent Memory Transformation Evidence",
+  "description": "Vendor-neutral evidence for derived-state transformations. Transformation preserves source lineage and bounded scope but cannot create memory authority, certification, standing policy, or source trust.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_version",
+    "transformation_id",
+    "transformation_type",
+    "mode",
+    "status",
+    "transformer",
+    "sources",
+    "lineage",
+    "derived",
+    "scope",
+    "source_currentness",
+    "applicability",
+    "created_at",
+    "identity_digest",
+    "interpretation"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "profile_version": { "const": "0.1.0" },
+    "transformation_id": { "type": "string", "minLength": 1 },
+    "transformation_type": {
+      "type": "string",
+      "enum": ["summary", "consolidation", "extraction", "projection", "other"]
+    },
+    "mode": { "type": "string", "enum": ["deterministic", "probabilistic"] },
+    "status": { "type": "string", "enum": ["complete", "partial", "failed"] },
+    "transformer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transformer_ref", "transformer_version"],
+      "properties": {
+        "transformer_ref": { "type": "string", "minLength": 1 },
+        "transformer_version": { "type": "string", "minLength": 1 },
+        "trust_evidence_refs": { "$ref": "#/$defs/refList" }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/source" }
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["direct_source_refs", "original_source_refs", "parent_transformation_refs"],
+      "properties": {
+        "direct_source_refs": { "$ref": "#/$defs/refListNonEmpty" },
+        "original_source_refs": { "$ref": "#/$defs/refListNonEmpty" },
+        "parent_transformation_refs": { "$ref": "#/$defs/refList" }
+      }
+    },
+    "derived": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["derived_ref", "derived_evidence_ref", "derived_evidence_digest", "evidence_character"],
+      "properties": {
+        "derived_ref": { "type": "string", "minLength": 1 },
+        "derived_evidence_ref": { "type": "string", "minLength": 1 },
+        "derived_evidence_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "evidence_character": {
+          "type": "string",
+          "enum": ["ordinary", "negative_or_adversarial", "correction_or_incident"]
+        },
+        "uncertainty": { "$ref": "#/$defs/uncertainty" }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope_ref", "relation", "basis_refs", "binding_status"],
+      "properties": {
+        "scope_ref": { "type": "string", "minLength": 1 },
+        "tenant_ref": { "type": "string", "minLength": 1 },
+        "project_ref": { "type": "string", "minLength": 1 },
+        "relation": { "type": "string", "enum": ["preserved", "narrowed", "mismatch"] },
+        "basis_refs": { "$ref": "#/$defs/refList" },
+        "binding_status": { "type": "string", "enum": ["exact", "narrowed", "mismatch"] }
+      }
+    },
+    "source_currentness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reasons"],
+      "properties": {
+        "status": { "type": "string", "enum": ["current", "revalidation_required", "unknown"] },
+        "reasons": { "$ref": "#/$defs/refList" }
+      }
+    },
+    "applicability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reasons"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["current", "revalidation_required", "incomplete", "invalid"]
+        },
+        "reasons": { "$ref": "#/$defs/refList" }
+      }
+    },
+    "created_at": { "type": "string", "format": "date-time" },
+    "identity_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "interpretation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "transformation_authority_effect",
+        "transformer_trust_is_source_trust",
+        "derived_confidence_authority",
+        "certification_claim",
+        "standing_policy_effect",
+        "memory_admission"
+      ],
+      "properties": {
+        "transformation_authority_effect": { "const": "none" },
+        "transformer_trust_is_source_trust": { "const": false },
+        "derived_confidence_authority": { "const": "none" },
+        "certification_claim": { "const": "none" },
+        "standing_policy_effect": { "const": "none" },
+        "memory_admission": { "const": "not_established" }
+      }
+    }
+  },
+  "$defs": {
+    "refList": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "refListNonEmpty": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_ref", "evidence_refs", "scope_ref", "state", "evidence_class"],
+      "properties": {
+        "source_ref": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "$ref": "#/$defs/refListNonEmpty" },
+        "scope_ref": { "type": "string", "minLength": 1 },
+        "tenant_ref": { "type": "string", "minLength": 1 },
+        "project_ref": { "type": "string", "minLength": 1 },
+        "state": {
+          "type": "string",
+          "enum": ["current", "disputed", "revoked", "superseded", "tombstoned", "deleted", "unknown"]
+        },
+        "evidence_class": {
+          "type": "string",
+          "enum": ["ordinary", "negative", "adversarial", "correction", "incident"]
+        }
+      }
+    },
+    "uncertainty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["signal_semantics", "estimator_ref", "estimator_version", "signal_value"],
+      "properties": {
+        "signal_semantics": { "type": "string", "minLength": 1 },
+        "estimator_ref": { "type": "string", "minLength": 1 },
+        "estimator_version": { "type": "string", "minLength": 1 },
+        "signal_value": { "type": "number" },
+        "uncertainty_summary": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Begins **P2-D / V0.1** from #202: a vendor-neutral transformation-evidence seam plus executable authority-laundering proof.

This first slice is intentionally semantic-first. It establishes and tests the core invariants before adding the final evidence-depth report/profile/workflow plumbing.

## Core boundary

```text
trusted transformer != trusted source
transformation != certification
transformation != authority transition
derived confidence != permission
source invalidation cannot be hidden by derived usefulness
```

## Initial implementation

- `schemas/transformation-evidence.schema.json`
- `reference/agentmem_ref/transformation_evidence.py`
- `reference/agentmem_ref/transformation_laundering_harness.py`
- `reference/tests/test_transformation_evidence.py`

The branch has been merged forward onto current `main` including #201 / P2-C.

## Generic transformation record

The normalized record separates:

- source provenance/evidence/state;
- transformer identity/version and trust evidence;
- direct vs original multi-hop lineage;
- transformation type/mode/status;
- derived evidence identity/digest and uncertainty;
- derived evidence character;
- scope relation/binding;
- current source validity and revalidation posture;
- fixed authority/certification/policy nonclaims.

The output is built from an explicit allowlist. Transformer-supplied PAMA, permission, lifecycle, certification, raw source-content, and hidden-reasoning fields are not copied.

## Scope behavior

V0.1 refuses to infer hierarchy from strings.

- exact preservation is directly checked;
- explicit narrowing requires a distinct derived scope plus basis refs while retaining tenant/project boundaries;
- tenant/project widening or mismatch is invalid.

## Source currentness

Direct source states are explicit:

```text
current
disputed
revoked
superseded
tombstoned
deleted
unknown
```

Non-current source basis produces `revalidation_required`; tombstone/deletion remain distinguishable reasons.

## Behavioral laundering harness

The harness consumes `fixtures/authority-laundering.json` and proves initially:

- origin survives trusted summarization;
- transformer trust never substitutes for source trust;
- 0.99 derived confidence has no authority effect;
- high-confidence transformed output still cannot self-promote through the existing high-consequence PAMA path;
- hostile transformer authority/certification fields are discarded;
- multi-hop transformation retains original source lineage and immediate parent transformation refs;
- direct source revocation and tombstoning force revalidation;
- cross-tenant/project widening is invalid;
- adversarial/negative source evidence remains adversarial/negative after transformation;
- partial transformation is not current evidence;
- raw source content and hidden reasoning are not required in the normalized record.

## Current stop line

This draft does **not yet** claim #202 complete. Remaining work includes:

- profile documentation;
- D/F/H/R/P registration;
- exact-head evidence workflow/report artifact;
- stronger propagation of non-current original source state through a multi-hop derived chain;
- completion review after repository CI.

Do not expand this PR into summary-quality evaluation, LLM benchmarking, semantic truth adjudication, automatic rebuild/deletion, GraphRAG-specific core semantics, or production certification.

Refs #202