### PR TITLE
Bind unsafe multi-memory composition to security evidence depth

### DIFF
--- a/.github/workflows/unsafe-composition-evidence.yml
+++ b/.github/workflows/unsafe-composition-evidence.yml
@@ -1,0 +1,52 @@
+name: Unsafe Composition Evidence
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unsafe-composition:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Validate schemas and fixtures
+        run: python scripts/validate_schemas.py
+
+      - name: Execute existing and fixture-linked composition tests
+        env:
+          PYTHONPATH: reference
+        run: >-
+          python -m unittest
+          tests.test_composition_gate
+          tests.test_unsafe_composition_evidence
+
+      - name: Validate unsafe-composition profile links
+        run: python scripts/validate_markdown_links.py docs/profiles/unsafe-composition-evidence-profile.md
+
+      - name: Emit exact-head unsafe-composition evidence depth
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_unsafe_composition_depth.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output unsafe-composition-depth.json
+
+      - name: Upload unsafe composition evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsafe-composition-evidence-depth
+          path: unsafe-composition-depth.json
+          if-no-files-found: error

--- a/docs/profiles/unsafe-composition-evidence-profile.md
+++ b/docs/profiles/unsafe-composition-evidence-profile.md
@@ -1,0 +1,316 @@
+# Unsafe Multi-Memory Composition Evidence Profile
+
+Status: V0.1 evidence profile for #206.
+
+## Purpose
+
+This profile binds the existing Agent Memory set-level composition gate to the named unsafe-composition fixture and to the repository D/F/H/R/P evidence model.
+
+It does **not** introduce a new composition policy engine.
+
+The implementation already exists in:
+
+- [`../../reference/agentmem_ref/composition.py`](../../reference/agentmem_ref/composition.py)
+- the completed isolation/composition work from #68 and #132.
+
+The evidence boundary is:
+
+```text
+memory A individually admitted
++
+memory B individually admitted
+!=
+A + B permitted as one active context
+```
+
+Candidate-level admission and set-level context composition are distinct governed decisions.
+
+## Structural fixture
+
+[`../../fixtures/unsafe-multi-memory-composition.json`](../../fixtures/unsafe-multi-memory-composition.json) requires:
+
+```text
+individual_candidates_may_pass = true
+combined_context_admitted = false
+composition_governance_runs = true
+```
+
+and names these invariants:
+
+```text
+item_level_admission_not_sufficient
+composition_risk_checked
+unsafe_combination_not_injected
+```
+
+The V0.1 harness executes those statements rather than treating fixture validation as behavioral proof.
+
+## Existing set-level gate
+
+`evaluate_composition(...)` consumes:
+
+```text
+composition candidates
+actual admitted memory refs
+explicit composition constraints
+```
+
+Each candidate preserves:
+
+```text
+memory_ref
+domain_refs
+```
+
+A constraint preserves:
+
+```text
+constraint_ref
+prohibited_domain_set
+reason
+```
+
+A proposed composition is rejected if:
+
+- a requested candidate was not admitted by ordinary governed recall;
+- candidate domain provenance is unresolved;
+- a memory reference is duplicated;
+- an explicit prohibited domain set is fully present in the proposed context.
+
+The gate does not invent a universal rule that memories from different domains may never compose.
+
+## Explicit policy is required
+
+The behavioral harness proves the same two individually admitted memories are allowed when no set-level constraint applies.
+
+```text
+same memories
+same recall admission
+no composition constraint
+-> composition allowed
+```
+
+It also proves an unrelated constraint does not block them.
+
+Therefore the security claim is bounded:
+
+```text
+explicit current constraint + matching composition
+-> block
+```
+
+not:
+
+```text
+different domain refs
+-> always block
+```
+
+## Fixture-linked behavioral sequence
+
+The harness in [`../../reference/agentmem_ref/unsafe_composition_harness.py`](../../reference/agentmem_ref/unsafe_composition_harness.py) executes:
+
+```text
+memory A / domain red
+ -> governed write
+ -> governed recall
+ -> admitted
+
+memory B / domain blue
+ -> governed write
+ -> governed recall
+ -> admitted
+
+A + B
+ -> proposed composition
+ -> explicit red+blue constraint
+ -> existing composition gate
+ -> cross_domain_composition_prohibited
+```
+
+The observation preserves:
+
+```text
+candidate refs
+individually admitted refs
+domain refs
+violated constraint refs
+blocking reason
+assembled-context surface
+downstream-influence surface
+```
+
+## Final context and influence boundary
+
+A rejected composition produces:
+
+```text
+assembled_context = []
+downstream_influence = []
+```
+
+These are bounded identity surfaces in the reference harness. They do not model an entire downstream agent runtime.
+
+Their purpose is to make the important consequence explicit:
+
+```text
+composition rejected
+!= merely a warning attached to a still-injected context
+```
+
+The blocked set is not eligible for context assembly or downstream influence in this proof.
+
+## Ordering and ranking cannot bypass the gate
+
+Domain combinations are set-like. Tuple order carries no hierarchy.
+
+The harness reverses:
+
+- candidate order;
+- admitted-ref order;
+- prohibited-domain declaration order.
+
+The same explicit red+blue policy still rejects the composition.
+
+This means a ranker, retriever ordering difference, or caller tuple order cannot transform a prohibited set into an allowed one merely by permutation.
+
+## Ordinary recall remains authoritative
+
+The composition gate receives the memory refs actually admitted by governed recall.
+
+It cannot reintroduce a candidate that recall rejected.
+
+The harness marks one candidate disputed and repeats ordinary recall. That memory remains discoverable but is no longer admitted. A later composition attempt with both candidates then fails with:
+
+```text
+composition_candidate_not_admitted
+```
+
+Thus:
+
+```text
+composition policy may further restrict admitted candidates
+!= composition may repair or widen a recall refusal
+```
+
+## Other fail-closed paths
+
+The existing gate and V0.1 evidence cover:
+
+### Duplicate references
+
+```text
+same memory requested twice
+-> duplicate_memory_reference
+-> reject
+```
+
+### Unresolved scope/domain provenance
+
+```text
+candidate has no domain refs
+-> composition_candidate_scope_unresolved
+-> reject
+```
+
+### Unadmitted candidate
+
+```text
+candidate requested for composition
+candidate absent from admitted_memory_refs
+-> composition_candidate_not_admitted
+-> reject
+```
+
+### Unrelated constraint
+
+```text
+red + blue candidates
+red + green prohibition
+-> no match
+-> allowed
+```
+
+This last case is important because it prevents the evidence harness from turning one named unsafe pair into a generic cross-domain ban.
+
+## What this profile does not detect
+
+The V0.1 gate evaluates explicit deterministic constraints over candidate/domain provenance.
+
+It does not claim to discover every semantically unsafe combination.
+
+For example, it does not by itself infer that two individually harmless natural-language facts reconstruct a secret or create a dangerous instruction chain. A deployment may place probabilistic or learned composition-risk analysis before an explicit governed consequence, but such an estimator remains evidence/proposal input rather than authority.
+
+The general repository rule still applies:
+
+```text
+probabilistic discovery may vary
+governance consequence remains bounded
+```
+
+## Evidence depth
+
+The dedicated report reuses the repository-wide D/F/H/R/P schema:
+
+```text
+D = governed recall/isolation doctrine + this profile
+F = unsafe-multi-memory-composition fixture
+H = fixture-linked behavioral composition harness
+R = explicitly unproven by this slice
+P = explicitly unproven
+```
+
+Existing composition implementation and unit tests are not silently relabeled as runtime `R` evidence. This slice improves explicit evidence accounting only.
+
+`R` would require separately governed runtime evidence bound to an exact implementation/runtime environment.
+
+`P` would require separately supplied production evidence under a named deployment/configuration.
+
+## Privacy and minimization
+
+The composition evidence needs identity and policy refs, not raw memory contents.
+
+The harness/report preserve:
+
+- candidate refs;
+- domain refs;
+- admission state;
+- constraint refs;
+- reason;
+- evidence result.
+
+They do not require raw prompts, hidden reasoning, or complete memory bodies.
+
+## Deployment profiles
+
+### L: local
+
+A local runtime can apply explicit set-level constraints after ordinary recall. The gate remains useful even when all memory is stored on one machine.
+
+### T: team / multi-tenant
+
+Set-level composition is especially important where multiple legitimate project/domain routes may be simultaneously visible to a requester. Individual access to each item does not automatically authorize their joint context.
+
+### E: enterprise
+
+Policy/constraint identity and blocking reasons should remain reconstructable so a rejected composition can be audited without retaining sensitive assembled content.
+
+### H: high assurance
+
+The exact admitted set, candidate domain provenance, current constraint refs, set-level result, and final context/influence surface should remain independently reconstructable.
+
+## Non-claims
+
+V0.1 does not claim:
+
+- universal unsafe-composition detection;
+- universal prohibition on cross-domain composition;
+- semantic content safety classification;
+- model-based composition risk correctness;
+- runtime `R` evidence from unit/reference execution;
+- production `P` evidence;
+- external security certification.
+
+## Stop line
+
+Do not redesign the #68/#132 composition semantics in this evidence slice. If future work needs learned or semantic composition-risk detection, it should feed the existing governed set-level boundary rather than replacing it with an estimator decision.

--- a/reference/agentmem_ref/unsafe_composition_depth.py
+++ b/reference/agentmem_ref/unsafe_composition_depth.py
@@ -1,0 +1,75 @@
+"""D/F/H/R/P registration for unsafe multi-memory composition, issue #206."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import receipts
+from .security_evidence_depth import LEVELS, classify_evidence_levels
+from .unsafe_composition_harness import run_unsafe_composition_harness
+
+REPORT_TYPE = "agent-memory-security-evidence-depth"
+REPORT_VERSION = "1.0.0"
+
+
+def _exact_commit(value: str) -> str:
+    commit = value.lower()
+    if len(commit) != 40 or any(ch not in "0123456789abcdef" for ch in commit):
+        raise ValueError("agent_memory_commit must be an exact 40-hex commit")
+    return commit
+
+
+def build_unsafe_composition_depth_report(agent_memory_commit: str) -> dict[str, Any]:
+    commit = _exact_commit(agent_memory_commit)
+    harness = run_unsafe_composition_harness()
+    evidence = classify_evidence_levels(
+        {
+            "D": [
+                "docs/26-governed-recall-planner.md",
+                "docs/41-memory-isolation-domains-and-governed-crossing.md",
+                "docs/profiles/unsafe-composition-evidence-profile.md",
+            ],
+            "F": ["fixtures/unsafe-multi-memory-composition.json"],
+            "H": ["unsafe-composition-harness:set-level-admission"] if harness["passed"] else [],
+            "R": [],
+            "P": [],
+        }
+    )
+    claim = {
+        "claim_id": "poisoning:unsafe-multi-memory-composition",
+        "title": "Individually admitted memories remain subject to set-level composition governance",
+        "threat_family": "unsafe_context_composition",
+        "doctrine_refs": evidence["evidence"]["D"],
+        "fixture_refs": evidence["evidence"]["F"],
+        "behavioral_harness_refs": evidence["evidence"]["H"],
+        "runtime_evidence_refs": evidence["evidence"]["R"],
+        "production_evidence_refs": evidence["evidence"]["P"],
+        "external_mappings": [],
+        "demonstrated_levels": evidence["demonstrated_levels"],
+        "highest_demonstrated_level": evidence["highest_demonstrated_level"],
+        "explicitly_unproven_levels": evidence["explicitly_unproven_levels"],
+        "scope_profiles": ["L", "T", "E", "H"],
+        "evaluated_head": commit,
+        "behavioral_passed": harness["passed"],
+        "non_certification_statement": "This claim records bounded evidence depth and does not assert external certification.",
+    }
+    report = {
+        "report_type": REPORT_TYPE,
+        "version": REPORT_VERSION,
+        "agent_memory_commit": commit,
+        "evidence_model": {
+            "levels": list(LEVELS),
+            "inference_policy": "no_level_may_be_inferred_from_another_level",
+        },
+        "claims": [claim],
+        "required_behavioral_cases_passed": harness["passed"],
+        "non_certification_statement": "Evidence mapping and demonstrated behavior do not constitute external certification.",
+        "known_limits": [
+            "V0.1 exercises explicit deterministic set-level composition constraints only.",
+            "The harness proves bounded reference behavior and does not claim universal detection of semantically unsafe memory combinations.",
+            "Behavioral H evidence does not self-promote to runtime R evidence.",
+            "Production evidence P is not collected or inferred by this report.",
+        ],
+    }
+    receipts.validate("security-evidence-depth-report.schema.json", report)
+    return report

--- a/reference/agentmem_ref/unsafe_composition_harness.py
+++ b/reference/agentmem_ref/unsafe_composition_harness.py
@@ -1,0 +1,214 @@
+"""Fixture-linked unsafe multi-memory composition evidence for issue #206.
+
+This module does not redefine composition policy. It exercises the existing
+set-level gate from #132 against the named security fixture and makes the final
+assembled-context/downstream surfaces explicit for evidence accounting.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from . import policy
+from .adapter import Clock, GovernedMemoryAdapter, RecallContext
+from .composition import CompositionCandidate, CompositionConstraint, evaluate_composition
+from .substrate import InMemoryTemporalGraph
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "fixtures" / "unsafe-multi-memory-composition.json"
+TENANT = "tenant-a"
+DOMAIN_RED = "domain:composition-red"
+DOMAIN_BLUE = "domain:composition-blue"
+DOMAIN_GREEN = "domain:composition-green"
+QUERY = "rotation evidence shared composition token"
+
+
+def _proposal(reference: str, domain: str) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=f"composition-evidence:{reference}",
+        actor_id="agent:composition-evidence",
+        charter_version="charter:composition-evidence-v1",
+        target_reference=reference,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=(f"evidence:{reference}",),
+        tenant_ref=TENANT,
+        purpose="unsafe-composition-evidence",
+        isolation_domain_refs=(domain,),
+    )
+
+
+def _setup() -> tuple[GovernedMemoryAdapter, str, str]:
+    adapter = GovernedMemoryAdapter(InMemoryTemporalGraph(), tenant=TENANT, clock=Clock())
+    red = adapter.commit_proposal(_proposal("mem:composition-red", DOMAIN_RED), QUERY)
+    blue = adapter.commit_proposal(_proposal("mem:composition-blue", DOMAIN_BLUE), QUERY)
+    if not red.committed or not blue.committed or red.fact_uuid is None or blue.fact_uuid is None:
+        raise AssertionError("unsafe-composition harness setup could not commit both bounded memories")
+    return adapter, red.fact_uuid, blue.fact_uuid
+
+
+def _surface(result) -> tuple[list[str], list[str]]:
+    """Return bounded context/downstream identity surfaces for the composition.
+
+    The reference proof does not model a downstream agent. It records only
+    whether the composition gate made the requested memory set eligible for
+    assembly/influence. A rejected set therefore has no output surface.
+    """
+    if not result.allowed:
+        return [], []
+    assembled = list(result.memory_refs)
+    return assembled, list(assembled)
+
+
+def run_unsafe_composition_harness() -> dict[str, Any]:
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    expected = fixture["expected_behavior"]
+    adapter, red_uuid, blue_uuid = _setup()
+
+    recall = adapter.governed_recall(
+        QUERY,
+        RecallContext(
+            target_domain_refs=(DOMAIN_RED, DOMAIN_BLUE),
+            principal_ref="principal:composition-evidence",
+            purpose="unsafe-composition-evidence",
+        ),
+    )
+    candidates = (
+        CompositionCandidate(red_uuid, (DOMAIN_RED,)),
+        CompositionCandidate(blue_uuid, (DOMAIN_BLUE,)),
+    )
+    fixture_constraint = CompositionConstraint(
+        constraint_ref="fixture:memory-a-plus-memory-b",
+        prohibited_domain_set=(DOMAIN_RED, DOMAIN_BLUE),
+        reason="fixture-defined combined context is unsafe",
+    )
+
+    blocked = evaluate_composition(
+        candidates,
+        admitted_memory_refs=tuple(recall.admitted),
+        constraints=(fixture_constraint,),
+    )
+    assembled_context, downstream_influence = _surface(blocked)
+
+    no_constraint = evaluate_composition(
+        candidates,
+        admitted_memory_refs=tuple(recall.admitted),
+        constraints=(),
+    )
+    unrelated_constraint = evaluate_composition(
+        candidates,
+        admitted_memory_refs=tuple(recall.admitted),
+        constraints=(
+            CompositionConstraint(
+                constraint_ref="policy:red-green-only",
+                prohibited_domain_set=(DOMAIN_RED, DOMAIN_GREEN),
+                reason="unrelated domain combination",
+            ),
+        ),
+    )
+    reversed_candidates = tuple(reversed(candidates))
+    reversed_constraint = CompositionConstraint(
+        constraint_ref="fixture:memory-a-plus-memory-b",
+        prohibited_domain_set=(DOMAIN_BLUE, DOMAIN_RED),
+        reason="same set, reversed declaration order",
+    )
+    reversed_result = evaluate_composition(
+        reversed_candidates,
+        admitted_memory_refs=tuple(reversed(recall.admitted)),
+        constraints=(reversed_constraint,),
+    )
+    duplicate_result = evaluate_composition(
+        (candidates[0], candidates[0]),
+        admitted_memory_refs=tuple(recall.admitted),
+        constraints=(),
+    )
+    unresolved_result = evaluate_composition(
+        (
+            candidates[0],
+            CompositionCandidate(blue_uuid, ()),
+        ),
+        admitted_memory_refs=tuple(recall.admitted),
+        constraints=(),
+    )
+    unadmitted_result = evaluate_composition(
+        candidates,
+        admitted_memory_refs=(red_uuid,),
+        constraints=(),
+    )
+
+    # Prove a candidate denied by ordinary recall cannot be rescued by a set-level
+    # composition that would otherwise carry no explicit prohibition.
+    adapter.mark_disputed(blue_uuid)
+    denied_recall = adapter.governed_recall(
+        QUERY,
+        RecallContext(
+            target_domain_refs=(DOMAIN_RED, DOMAIN_BLUE),
+            principal_ref="principal:composition-evidence",
+            purpose="unsafe-composition-evidence",
+        ),
+    )
+    denied_candidate_result = evaluate_composition(
+        candidates,
+        admitted_memory_refs=tuple(denied_recall.admitted),
+        constraints=(),
+    )
+
+    checks = {
+        "fixture_individual_candidates_may_pass": expected["individual_candidates_may_pass"] is True,
+        "fixture_combined_context_not_admitted": expected["combined_context_admitted"] is False,
+        "fixture_composition_governance_runs": expected["composition_governance_runs"] is True,
+        "both_candidates_discovered": red_uuid in recall.candidates and blue_uuid in recall.candidates,
+        "both_candidates_individually_admitted": red_uuid in recall.admitted and blue_uuid in recall.admitted,
+        "unsafe_combination_rejected": not blocked.allowed,
+        "composition_reason_reconstructable": blocked.reason == "cross_domain_composition_prohibited",
+        "violated_constraint_reconstructable": blocked.violated_constraint_refs == ("fixture:memory-a-plus-memory-b",),
+        "domain_provenance_reconstructable": set(blocked.domain_refs) == {DOMAIN_RED, DOMAIN_BLUE},
+        "blocked_composition_has_no_assembled_context": assembled_context == [],
+        "blocked_composition_has_no_downstream_influence": downstream_influence == [],
+        "no_constraint_does_not_invent_block": no_constraint.allowed,
+        "unrelated_constraint_does_not_invent_block": unrelated_constraint.allowed,
+        "candidate_order_cannot_bypass_gate": not reversed_result.allowed,
+        "constraint_domain_order_is_semantically_set_like": reversed_result.reason == "cross_domain_composition_prohibited",
+        "duplicate_refs_fail_closed": not duplicate_result.allowed and duplicate_result.reason == "duplicate_memory_reference",
+        "unresolved_domain_fails_closed": (
+            not unresolved_result.allowed and unresolved_result.reason == "composition_candidate_scope_unresolved"
+        ),
+        "unadmitted_candidate_fails_closed": (
+            not unadmitted_result.allowed and unadmitted_result.reason == "composition_candidate_not_admitted"
+        ),
+        "ordinary_recall_denial_survives_composition": (
+            blue_uuid not in denied_recall.admitted
+            and denied_recall.refusals.get(blue_uuid) == "disputed"
+            and not denied_candidate_result.allowed
+            and denied_candidate_result.reason == "composition_candidate_not_admitted"
+        ),
+    }
+
+    return {
+        "case_id": "unsafe-multi-memory-composition",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "observed": {
+            "candidate_refs": [red_uuid, blue_uuid],
+            "individual_admitted_refs": list(recall.admitted),
+            "blocked": {
+                "reason": blocked.reason,
+                "domain_refs": list(blocked.domain_refs),
+                "violated_constraint_refs": list(blocked.violated_constraint_refs),
+                "assembled_context": assembled_context,
+                "downstream_influence": downstream_influence,
+            },
+            "no_constraint_allowed": no_constraint.allowed,
+            "unrelated_constraint_allowed": unrelated_constraint.allowed,
+            "reversed_order_allowed": reversed_result.allowed,
+            "denied_recall_refusals": denied_recall.refusals,
+        },
+    }

--- a/reference/run_unsafe_composition_depth.py
+++ b/reference/run_unsafe_composition_depth.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""Emit exact-head unsafe-composition evidence depth."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref.unsafe_composition_depth import build_unsafe_composition_depth_report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    report = build_unsafe_composition_depth_report(args.agent_memory_commit)
+    Path(args.output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/reference/tests/test_unsafe_composition_evidence.py
+++ b/reference/tests/test_unsafe_composition_evidence.py
@@ -1,0 +1,48 @@
+"""Fixture-linked unsafe composition evidence tests for issue #206."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.unsafe_composition_depth import build_unsafe_composition_depth_report
+from agentmem_ref.unsafe_composition_harness import run_unsafe_composition_harness
+
+
+class UnsafeCompositionEvidenceTests(unittest.TestCase):
+    def test_fixture_linked_behavioral_harness_passes(self):
+        result = run_unsafe_composition_harness()
+        self.assertTrue(result["passed"], result)
+        checks = result["checks"]
+        self.assertTrue(checks["both_candidates_individually_admitted"])
+        self.assertTrue(checks["unsafe_combination_rejected"])
+        self.assertTrue(checks["blocked_composition_has_no_assembled_context"])
+        self.assertTrue(checks["blocked_composition_has_no_downstream_influence"])
+        self.assertTrue(checks["no_constraint_does_not_invent_block"])
+        self.assertTrue(checks["unrelated_constraint_does_not_invent_block"])
+        self.assertTrue(checks["candidate_order_cannot_bypass_gate"])
+        self.assertTrue(checks["ordinary_recall_denial_survives_composition"])
+
+    def test_blocked_surface_is_explicitly_empty(self):
+        result = run_unsafe_composition_harness()["observed"]["blocked"]
+        self.assertEqual(result["assembled_context"], [])
+        self.assertEqual(result["downstream_influence"], [])
+        self.assertEqual(result["reason"], "cross_domain_composition_prohibited")
+        self.assertEqual(result["violated_constraint_refs"], ["fixture:memory-a-plus-memory-b"])
+
+    def test_evidence_depth_is_d_f_h_only(self):
+        report = build_unsafe_composition_depth_report("a" * 40)
+        self.assertTrue(report["required_behavioral_cases_passed"], report)
+        claim = report["claims"][0]
+        self.assertEqual(claim["demonstrated_levels"], ["D", "F", "H"])
+        self.assertEqual(claim["highest_demonstrated_level"], "H")
+        self.assertEqual(claim["explicitly_unproven_levels"], ["R", "P"])
+        self.assertEqual(claim["runtime_evidence_refs"], [])
+        self.assertEqual(claim["production_evidence_refs"], [])
+
+    def test_report_requires_exact_head(self):
+        with self.assertRaisesRegex(ValueError, "exact 40-hex"):
+            build_unsafe_composition_depth_report("main")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements **P2-E** from #206, the final high-yield poisoning/evidence gap identified by #173.

This PR does **not** redesign the composition gate already completed by #68/#132. It binds that existing implementation to the named `unsafe-multi-memory-composition` fixture, explicitly proves blocked compositions never become assembled/downstream context in the bounded reference harness, and records the result through D/F/H/R/P evidence depth.

## Core boundary

```text
memory A individually admitted
+
memory B individually admitted
!=
A + B permitted as one active context
```

## Behavioral sequence

The harness:

1. creates two same-tenant memories with distinct explicit domain provenance;
2. demonstrates both are individually admitted by normal governed recall;
3. proposes both to the existing `evaluate_composition(...)` gate;
4. applies an explicit red+blue set-level constraint corresponding to the fixture risk;
5. observes `cross_domain_composition_prohibited`;
6. preserves candidate refs, domain refs, violated constraint ref, and blocking reason;
7. emits empty `assembled_context` and `downstream_influence` surfaces for the rejected set.

## No universal cross-domain prohibition

The same pair is also exercised:

- with no composition constraint: allowed;
- with an unrelated red+green constraint: allowed.

Therefore this evidence does not invent a rule that distinct domains may never compose.

## Negative paths

The focused harness/tests also prove:

- reversing candidate/admitted order cannot bypass the gate;
- reversing prohibited-domain declaration order cannot bypass the gate;
- duplicate memory references fail closed;
- unresolved domain provenance fails closed;
- a candidate not admitted by recall fails closed;
- a candidate denied by ordinary recall as disputed cannot be rescued by later composition;
- blocked composition never reaches assembled-context or downstream-influence surfaces.

Existing `tests.test_composition_gate` remains in the focused workflow, so the original #132 behavior is regression-tested alongside the fixture-linked evidence.

## Evidence depth

A dedicated exact-head report uses the existing security evidence-depth schema:

```text
D = governed recall/isolation doctrine + evidence profile
F = unsafe-multi-memory-composition fixture
H = fixture-linked behavioral composition harness
R = explicitly unproven
P = explicitly unproven
```

Existing unit/reference execution is not silently relabeled runtime `R` evidence.

## Added surfaces

- `reference/agentmem_ref/unsafe_composition_harness.py`
- `reference/agentmem_ref/unsafe_composition_depth.py`
- `reference/run_unsafe_composition_depth.py`
- `reference/tests/test_unsafe_composition_evidence.py`
- `docs/profiles/unsafe-composition-evidence-profile.md`
- `.github/workflows/unsafe-composition-evidence.yml`

## Stop line

Do not expand this PR into new isolation semantics, a universal cross-domain prohibition, semantic/model-based composition-risk detection, or production certification.

This PR remains draft until the focused unsafe-composition gate plus Doctrine, P9, MAF, sleeper, and authority-laundering regressions pass at the exact head and completion review confirms #206.

Closes #206