### PR TITLE
Prove generic lifecycle seam against pinned LangGraph

### DIFF
--- a/.github/workflows/langgraph-lifecycle-comparator.yml
+++ b/.github/workflows/langgraph-lifecycle-comparator.yml
@@ -1,0 +1,57 @@
+name: LangGraph Lifecycle Comparator
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  langgraph-lifecycle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pinned LangGraph comparator
+        run: |
+          python -m venv /tmp/agent-memory-langgraph-v01
+          /tmp/agent-memory-langgraph-v01/bin/python -m pip install --disable-pip-version-check \
+            langgraph==1.2.11 \
+            langgraph-checkpoint==4.2.0 \
+            jsonschema==4.26.0 \
+            rfc8785==0.1.4
+
+      - name: Verify pinned package versions
+        run: |
+          /tmp/agent-memory-langgraph-v01/bin/python - <<'PY'
+          from importlib.metadata import version
+          actual = version("langgraph")
+          checkpoint = version("langgraph-checkpoint")
+          assert actual == "1.2.11", actual
+          assert checkpoint == "4.2.0", checkpoint
+          print(f"langgraph=={actual}")
+          print(f"langgraph-checkpoint=={checkpoint}")
+          PY
+
+      - name: Execute pinned LangGraph lifecycle comparator
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          PYTHONPATH=reference
+          /tmp/agent-memory-langgraph-v01/bin/python reference/run_langgraph_lifecycle_comparator.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output langgraph-lifecycle-comparator.json
+
+      - name: Upload LangGraph lifecycle evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: langgraph-lifecycle-comparator-evidence
+          path: langgraph-lifecycle-comparator.json
+          if-no-files-found: error

--- a/docs/profiles/framework-lifecycle-profile.md
+++ b/docs/profiles/framework-lifecycle-profile.md
@@ -1,12 +1,14 @@
 # Framework Lifecycle / Checkpoint Interoperability Profile
 
-Status: V0.1 reference profile for #189.
+Status: V0.1 generic lifecycle seam, validated against two materially different reference hosts.
 
 This profile defines the minimum Agent Memory-facing seam for stateful agent frameworks that expose runs, workflow/session state, checkpoints, retries, resumes, or related runtime events.
 
 The first reference host is Microsoft Agent Framework (MAF) Python `1.13.0`, tag `python-1.13.0`, pinned source commit `e39a8a2e79c8c8987a0b9082d3ccb8665734b897`.
 
-MAF is a reference host, not a required Agent Memory runtime or canonical storage layer.
+The second reference host is LangGraph `1.2.11`, tag `1.2.11`, pinned source commit `644815f9e5bc52ad8f7a5227a456227e9c3e639b`, with `langgraph-checkpoint==4.2.0` pinned for checkpoint behavior.
+
+Both are reference hosts, not required Agent Memory runtimes or canonical storage layers.
 
 ## Core boundary
 
@@ -20,7 +22,7 @@ retry
 checkpoint rewind
 != permission to roll back current Agent Memory state
 
-session / workflow history
+session / workflow / thread history
 != canonical memory by default
 ```
 
@@ -48,9 +50,13 @@ evidence references
 
 The generic contract does not copy framework conversation history, checkpoint blobs, prompts, tool payloads, or arbitrary framework metadata into canonical memory.
 
+The same `framework-lifecycle-event.schema.json` contract is used by both MAF and LangGraph. The second host did not require LangGraph-specific core fields.
+
 ## Checkpoint ordering and memory-state freshness
 
 The MAF `WorkflowCheckpoint` source at the pinned release carries both `previous_checkpoint_id` and `iteration_count`. MAF explicitly documents that `iteration_count` is not guaranteed unique, particularly around human-in-the-loop checkpoints, and that checkpoint ordering is defined by checkpoint lineage and timestamp rather than iteration count alone.
+
+LangGraph exposes checkpoint identity and parent-config lineage through real `StateSnapshot` history. The second-host comparator reconstructs lineage from checkpoint IDs and parent checkpoint configuration rather than treating thread identity or state values as ordering authority.
 
 Agent Memory therefore treats explicit lineage as the V0.1 **framework checkpoint relation** signal:
 
@@ -68,7 +74,7 @@ framework checkpoint recency
 != Agent Memory state freshness
 ```
 
-A framework may legitimately retain a checkpoint as its latest checkpoint even after an external governed memory mutation occurs. When the checkpoint is bound to an Agent Memory `memory_state_ref`, that binding must be compared with current Agent Memory state independently. A checkpoint bound to an older state is stale **for memory replay purposes** even if the framework still considers it its latest execution checkpoint.
+A framework may legitimately retain a checkpoint as its latest checkpoint even after an external governed memory mutation occurs. When the checkpoint is bound to an Agent Memory `memory_state_ref`, that binding must be compared with current Agent Memory state independently. A checkpoint bound to an older state is stale **for memory replay purposes** even if the framework still considers it valid execution history.
 
 Neither a stale/divergent framework lineage nor a stale Agent Memory state binding gains rollback authority over newer canonical Agent Memory state.
 
@@ -86,6 +92,11 @@ new key -> new governed proposal required
 
 The framework runtime does not decide whether repeated execution is a new authorized memory mutation.
 
+This rule survived both reference hosts:
+
+- MAF stale-checkpoint replay re-entered the mutation step and reused the original receipt;
+- LangGraph `RetryPolicy` re-entered a node after the Agent Memory commit had succeeded but before the node completed successfully, and the second attempt reused the recorded receipt rather than committing again.
+
 ## Persistence classification
 
 Every framework persistence event uses one of:
@@ -97,9 +108,13 @@ Every framework persistence event uses one of:
 
 None of these classifications establishes admission by itself, including `memory_candidate`.
 
+Both real-host comparators classify framework checkpoint persistence as `execution_state` unless a separate governed process explicitly proposes it as evidence or a memory candidate.
+
 ## Scope binding
 
-When a framework event is correlated to an Agent Memory action, expected action/input/scope/tenant/project references are compared deterministically. Missing or mismatched fields remain mismatch evidence rather than being repaired through timing, names, semantic similarity, or checkpoint adjacency.
+When a framework event is correlated to an Agent Memory action, expected action/input/scope/tenant/project references are compared deterministically. Missing or mismatched fields remain mismatch evidence rather than being repaired through timing, names, semantic similarity, checkpoint adjacency, or valid framework session/thread identity.
+
+A valid MAF workflow or LangGraph thread/checkpoint is runtime identity, not tenant/project authority.
 
 ## Trace correlation
 
@@ -111,7 +126,9 @@ trace unavailable -> governance/decision/checkpoint evidence remains valid
 trace absent -> not proof that execution did not occur
 ```
 
-## First-host behavioral proof
+Neither real-host comparator requires a trace backend to preserve the governance/checkpoint evidence under test.
+
+## First-host behavioral proof: Microsoft Agent Framework
 
 The pinned MAF comparator uses the real `agent-framework-core==1.13.0` package with `WorkflowBuilder`, `WorkflowCheckpoint`, and `InMemoryCheckpointStorage`. It does not require an LLM or cloud service.
 
@@ -130,15 +147,51 @@ The comparator executes a real checkpointed MAF workflow and proves a bounded li
 
 A separate real-object checkpoint case creates two MAF checkpoints with the same `iteration_count` but different lineage, proving that the adapter does not use the iteration counter as ordering authority.
 
-## Checkpoint write failure after memory commit
+## Second-host behavioral proof: LangGraph
 
-Framework persistence can fail after Agent Memory has already committed a durable mutation. V0.1 records this as `checkpoint_write_failed` evidence while preserving the original decision receipt and idempotency binding.
+The pinned second-host comparator uses real `langgraph==1.2.11` and `langgraph-checkpoint==4.2.0` with `StateGraph`, `InMemorySaver`, checkpoint history, thread IDs, and `RetryPolicy`. It does not require an LLM, provider API, LangSmith, or external persistence service.
 
-The default consequence is:
+The comparator proves the same Agent Memory-facing lifecycle against materially different framework mechanics:
+
+1. a real StateGraph thread performs governed recall inside a graph node;
+2. a later graph node commits one PAMA-authorized durable Agent Memory mutation;
+3. real LangGraph checkpoint history preserves a checkpoint before the mutation node and a later checkpoint after execution;
+4. explicit checkpoint IDs and parent-config lineage feed the same generic checkpoint-relation classifier used by the framework profile;
+5. the pre-mutation checkpoint's Agent Memory state binding becomes stale after canonical memory advances;
+6. replaying from that old checkpoint re-enters the mutation node but reuses the original receipt and does not duplicate the durable write or roll Agent Memory state backward;
+7. a separate LangGraph run deliberately commits a durable mutation and then raises before successful node completion;
+8. real LangGraph `RetryPolicy` re-enters that node and reuses the recorded receipt, proving a post-commit framework failure does not create a second durable mutation;
+9. another graph run carries a PAMA-denied mutation and produces zero durable writes;
+10. a valid LangGraph thread runs with cross-scope recall context and receives no admitted memory;
+11. framework checkpoint evidence uses the same generic lifecycle-event schema and is classified `execution_state`, not Agent Memory admission;
+12. missing trace correlation remains an explicit evidence gap rather than non-execution proof.
+
+### Generic finding from the second host
+
+LangGraph did **not** require a new canonical lifecycle concept.
+
+Its thread identity maps to generic run/session identity; checkpoint IDs and parent configs map to checkpoint lineage; `RetryPolicy` maps to retry evidence; persisted graph state maps to explicit persistence classification.
+
+That result strengthens the generic seam:
+
+```text
+MAF workflow/checkpoint mechanics
+and
+LangGraph thread/checkpoint mechanics
+-> same Agent Memory-facing lifecycle contract
+```
+
+The frameworks are materially different, but the memory/governance boundary remains stable.
+
+## Checkpoint or node failure after memory commit
+
+Framework persistence or successful node completion can fail after Agent Memory has already committed a durable mutation.
+
+The default consequence remains:
 
 ```text
 Agent Memory commit succeeded
-+ framework checkpoint write failed
++ framework checkpoint/node completion failed
 -> canonical memory commit remains current
 -> framework recovery is required
 -> retry must consult the prior receipt/idempotency key
@@ -146,42 +199,61 @@ Agent Memory commit succeeded
 -> no automatic second durable mutation
 ```
 
-A framework-storage failure does not itself authorize compensation or rollback. Any compensating memory mutation must cross normal Agent Memory governance.
+MAF exercises checkpoint/replay recovery. LangGraph exercises a concrete post-commit node failure followed by real framework retry. Both preserve the same rule.
+
+A framework failure does not itself authorize compensation or rollback. Any compensating memory mutation must cross normal Agent Memory governance.
 
 ## Privacy and minimization
 
-Default to stable identifiers, opaque scope refs, digests, receipt refs, checkpoint refs, and classifications.
+Default to stable identifiers, opaque scope refs, digests, receipt refs, checkpoint refs, thread/run refs, and classifications.
 
 Do not persist raw framework messages, prompts, hidden reasoning, complete checkpoint state, provider credentials, or full tool payloads merely to establish lifecycle correlation.
+
+The LangGraph comparator records checkpoint IDs/history counts and bounded state references rather than copying checkpoint payloads into Agent Memory evidence.
 
 ## V0.1 non-claims
 
 V0.1 does not claim:
 
-- MAF checkpoints are Agent Memory;
+- MAF or LangGraph checkpoints are Agent Memory;
 - checkpoint persistence proves lifecycle satisfaction;
-- MAF's latest checkpoint proves Agent Memory state freshness;
+- either framework's latest checkpoint proves Agent Memory state freshness;
+- a framework thread/session ID is an authority boundary;
 - framework retry creates new authority;
 - framework HITL history is reusable approval authority;
 - trace success proves semantic authorization;
-- a single framework proves the seam is universal;
-- MAF is a required dependency for Agent Memory core/reference use.
+- two hosts prove the seam is universal across every framework;
+- MAF or LangGraph is a required dependency for Agent Memory core/reference use;
+- LangGraph Store or framework-native long-term memory is automatically Agent Memory.
 
 ## Failure behavior
 
 - Agent Memory unavailability at a durable-mutation boundary cannot silently widen authority; the framework must fail according to configured policy rather than infer permission;
 - stale/unknown checkpoint lineage does not silently restore older memory state;
-- a checkpoint whose bound Agent Memory state is stale cannot silently restore older memory state even when the framework still considers the checkpoint current;
+- a checkpoint whose bound Agent Memory state is stale cannot silently restore older memory state even when the framework still considers the checkpoint valid/current execution history;
 - retry after a known committed mutation reuses the bound receipt rather than committing again;
-- checkpoint write failure after a successful memory commit preserves the memory receipt and requires framework recovery rather than silent rollback;
+- framework failure after a successful memory commit preserves the memory receipt and requires framework recovery rather than silent rollback;
 - a denied mutation remains denied even if framework execution continues;
-- cross-scope context does not inherit memory merely because the framework run/checkpoint is valid;
+- cross-scope context does not inherit memory merely because the framework run/thread/checkpoint is valid;
+- framework persistence remains explicitly classified and does not become durable memory by persistence alone;
 - trace backend unavailability preserves explicit evidence gaps without widening authority.
 
 ## Rollback / removal
 
-The framework adapter and comparator are optional. Removing MAF support leaves canonical Agent Memory state, receipts, and lifecycle semantics interpretable because framework-specific checkpoint fields exist only in the adapter/evidence layer.
+Framework comparators and adapters are optional. Removing MAF or LangGraph support leaves canonical Agent Memory state, receipts, and lifecycle semantics interpretable because framework-specific runtime objects remain in adapter/evidence layers and the canonical lifecycle event carries vendor-neutral references only.
 
 ## Follow-on gate
 
-After the MAF V0.1 lifecycle is stable, test the same Agent Memory-facing lifecycle contract against a materially different host such as LangGraph. If that second host exposes a real semantic incompatibility, return to the generic contract before adding adapter-specific exceptions.
+The same generic lifecycle contract has now survived the two intentionally different first reference hosts required by #169: MAF and LangGraph.
+
+A third framework may now be considered breadth work rather than a prerequisite for the generic seam. The #169 research order recommends Google ADK as a useful later versioning/migration stress case, followed by OpenAI Agents SDK and other runtimes.
+
+Before adding a third host:
+
+```text
+new framework maps cleanly to the existing lifecycle seam
+or
+real semantic incompatibility returns to #169 research
+```
+
+Do not accumulate framework-specific core exceptions merely to increase adapter count.

--- a/reference/agentmem_ref/langgraph_lifecycle_comparator.py
+++ b/reference/agentmem_ref/langgraph_lifecycle_comparator.py
@@ -1,0 +1,526 @@
+"""Pinned LangGraph lifecycle comparator for issue #208.
+
+The comparator uses LangGraph's real StateGraph, InMemorySaver, checkpoint
+history, checkpoint replay, and RetryPolicy while keeping Agent Memory
+governance in the existing reference adapter. No model or external service is
+needed because the claim under test is lifecycle/checkpoint interoperability.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version as package_version
+from typing import Any, TypedDict
+
+from .adapter import GovernedMemoryAdapter, RecallContext
+from .framework_lifecycle import (
+    MutationReplayGuard,
+    build_framework_lifecycle_event,
+    classify_checkpoint_relation,
+)
+from .policy import A1, A5, M2, M5, Proposal
+from .substrate import InMemoryTemporalGraph
+
+LANGGRAPH_PACKAGE = "langgraph==1.2.11"
+LANGGRAPH_VERSION = "1.2.11"
+LANGGRAPH_CHECKPOINT_PACKAGE = "langgraph-checkpoint==4.2.0"
+LANGGRAPH_CHECKPOINT_VERSION = "4.2.0"
+LANGGRAPH_TAG = "1.2.11"
+LANGGRAPH_COMMIT = "644815f9e5bc52ad8f7a5227a456227e9c3e639b"
+LANGGRAPH_SOURCE_REF = "github:langchain-ai/langgraph@1.2.11"
+WORKFLOW_REF = "langgraph:stategraph:agent-memory-lifecycle-v0.1"
+SCOPE = "scope:tenant-a/project-a"
+TENANT = "tenant-a"
+PROJECT = "project-a"
+
+try:  # Optional dependency, installed only by the dedicated comparator workflow.
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.graph import END, START, StateGraph
+    from langgraph.types import RetryPolicy
+
+    _LANGGRAPH_AVAILABLE = True
+except ImportError:  # pragma: no cover - keeps core/reference imports dependency-free
+    InMemorySaver = None  # type: ignore[assignment]
+    StateGraph = None  # type: ignore[assignment]
+    START = "__start__"  # type: ignore[assignment]
+    END = "__end__"  # type: ignore[assignment]
+    RetryPolicy = None  # type: ignore[assignment]
+    _LANGGRAPH_AVAILABLE = False
+
+
+class LifecycleState(TypedDict, total=False):
+    mode: str
+    phase: str
+    recall_admitted: bool
+    status: str
+    receipt_ref: str
+    decision_outcome: str
+
+
+def _proposal(
+    *,
+    proposal_id: str,
+    target_reference: str,
+    operation: str = "promotion",
+    target_class: str = M2,
+    downstream_authority: str = A1,
+    current_strength: str = "observed",
+    proposed_strength: str = "promoted",
+    risk_class: str = "low",
+    reversibility: str = "reversible",
+) -> Proposal:
+    return Proposal(
+        proposal_id=proposal_id,
+        actor_id="actor:langgraph",
+        charter_version="charter:langgraph-v1",
+        target_reference=target_reference,
+        target_class=target_class,
+        scope=SCOPE,
+        operation=operation,
+        current_strength=current_strength,
+        proposed_strength=proposed_strength,
+        downstream_authority=downstream_authority,
+        reversibility=reversibility,
+        risk_class=risk_class,
+        evidence_refs=(f"evidence:{proposal_id}",),
+        tenant_ref=TENANT,
+        purpose="framework-lifecycle-proof",
+        isolation_domain_refs=(SCOPE,),
+        project_ref=PROJECT,
+    )
+
+
+def _seed_proposal() -> Proposal:
+    return _proposal(
+        proposal_id="proposal:langgraph:seed",
+        target_reference="mem:langgraph:seed",
+    )
+
+
+def _allowing_proposal() -> Proposal:
+    return _proposal(
+        proposal_id="proposal:langgraph:allow-1",
+        target_reference="mem:langgraph:lifecycle",
+    )
+
+
+def _retry_proposal() -> Proposal:
+    return _proposal(
+        proposal_id="proposal:langgraph:retry-1",
+        target_reference="mem:langgraph:retry",
+    )
+
+
+def _denied_proposal() -> Proposal:
+    return _proposal(
+        proposal_id="proposal:langgraph:deny-1",
+        target_reference="mem:langgraph:protected",
+        operation="scope_expansion",
+        target_class=M5,
+        downstream_authority=A5,
+        current_strength="promoted",
+        proposed_strength="canonical",
+        risk_class="critical",
+        reversibility="irreversible",
+    )
+
+
+def _write_count(substrate: InMemoryTemporalGraph) -> int:
+    return sum(1 for operation, _ in substrate.write_log if operation == "write_fact")
+
+
+def _checkpoint_id(config: dict[str, Any] | None) -> str | None:
+    if not config:
+        return None
+    configurable = config.get("configurable")
+    if not isinstance(configurable, dict):
+        return None
+    value = configurable.get("checkpoint_id")
+    return value if isinstance(value, str) and value else None
+
+
+def _thread_config(thread_id: str) -> dict[str, Any]:
+    return {"configurable": {"thread_id": thread_id}}
+
+
+class LifecycleNodes:
+    def __init__(
+        self,
+        *,
+        memory: GovernedMemoryAdapter,
+        replay_guard: MutationReplayGuard,
+    ) -> None:
+        self.memory = memory
+        self.replay_guard = replay_guard
+        self.post_commit_failure_emitted = False
+
+    def recall(self, state: LifecycleState) -> LifecycleState:
+        cross_scope = state.get("mode") == "cross_scope"
+        context = RecallContext(
+            target_domain_refs=("scope:tenant-b/project-b",) if cross_scope else (SCOPE,),
+            principal_ref="principal:langgraph",
+            project_ref="project-b" if cross_scope else PROJECT,
+            purpose="framework-lifecycle-proof",
+        )
+        recall = self.memory.governed_recall("governed seed", context)
+        return {
+            "phase": "recalled",
+            "recall_admitted": bool(recall.admitted),
+        }
+
+    def mutate(self, state: LifecycleState) -> LifecycleState:
+        mode = state.get("mode")
+        if mode == "allow":
+            return self._allow(state, key="langgraph:allow:mutation-1", proposal=_allowing_proposal())
+        if mode == "retry":
+            key = "langgraph:retry:mutation-1"
+            prior = self.replay_guard.prior_receipt(key)
+            if prior is not None:
+                return {
+                    "phase": "replayed",
+                    "status": "replay_after_retry",
+                    "receipt_ref": prior,
+                    "recall_admitted": bool(state.get("recall_admitted")),
+                }
+            result = self.memory.commit_proposal(_retry_proposal(), "langgraph retry governed fact")
+            if not result.committed:
+                raise RuntimeError(f"retry-path governed mutation unexpectedly refused: {result.refusal}")
+            receipt_ref = result.receipt["receipt_id"]
+            self.replay_guard.record(key, receipt_ref)
+            if not self.post_commit_failure_emitted:
+                self.post_commit_failure_emitted = True
+                # This deliberately fails after the Agent Memory commit but before
+                # LangGraph can persist this node's successful output. Retry must
+                # consult the stable receipt rather than commit again.
+                raise ConnectionError("simulated post-commit LangGraph node failure")
+            return {
+                "phase": "committed",
+                "status": "committed",
+                "receipt_ref": receipt_ref,
+                "recall_admitted": bool(state.get("recall_admitted")),
+            }
+        if mode == "deny":
+            result = self.memory.commit_proposal(_denied_proposal(), "must never persist")
+            return {
+                "phase": "denied",
+                "status": "denied" if not result.committed else "unexpected_commit",
+                "decision_outcome": result.decision.outcome,
+                "recall_admitted": bool(state.get("recall_admitted")),
+            }
+        if mode == "cross_scope":
+            return {
+                "phase": "completed",
+                "status": "cross_scope_observed",
+                "recall_admitted": bool(state.get("recall_admitted")),
+            }
+        raise ValueError(f"unsupported LangGraph lifecycle mode {mode!r}")
+
+    def _allow(self, state: LifecycleState, *, key: str, proposal: Proposal) -> LifecycleState:
+        prior = self.replay_guard.prior_receipt(key)
+        if prior is not None:
+            return {
+                "phase": "replayed",
+                "status": "replay",
+                "receipt_ref": prior,
+                "recall_admitted": bool(state.get("recall_admitted")),
+            }
+        result = self.memory.commit_proposal(proposal, "langgraph lifecycle governed fact")
+        if not result.committed:
+            raise RuntimeError(f"governed mutation unexpectedly refused: {result.refusal}")
+        receipt_ref = result.receipt["receipt_id"]
+        self.replay_guard.record(key, receipt_ref)
+        return {
+            "phase": "committed",
+            "status": "committed",
+            "receipt_ref": receipt_ref,
+            "recall_admitted": bool(state.get("recall_admitted")),
+        }
+
+
+def _build_graph(memory: GovernedMemoryAdapter, replay_guard: MutationReplayGuard, saver: Any):
+    nodes = LifecycleNodes(memory=memory, replay_guard=replay_guard)
+    builder = StateGraph(LifecycleState)
+    builder.add_node("recall", nodes.recall)
+    builder.add_node(
+        "mutate",
+        nodes.mutate,
+        retry_policy=RetryPolicy(
+            max_attempts=2,
+            initial_interval=0.01,
+            backoff_factor=1.0,
+            jitter=False,
+            retry_on=ConnectionError,
+        ),
+    )
+    builder.add_edge(START, "recall")
+    builder.add_edge("recall", "mutate")
+    builder.add_edge("mutate", END)
+    return builder.compile(checkpointer=saver), nodes
+
+
+def _history(graph: Any, config: dict[str, Any]) -> list[Any]:
+    return list(graph.get_state_history(config))
+
+
+def _checkpoint_lineage(history: list[Any]) -> dict[str, str | None]:
+    lineage: dict[str, str | None] = {}
+    for snapshot in history:
+        current = _checkpoint_id(snapshot.config)
+        if current is None:
+            continue
+        lineage[current] = _checkpoint_id(getattr(snapshot, "parent_config", None))
+    return lineage
+
+
+def _find_pre_mutation_snapshot(history: list[Any]) -> Any:
+    for snapshot in history:
+        values = getattr(snapshot, "values", {})
+        next_nodes = tuple(getattr(snapshot, "next", ()))
+        if isinstance(values, dict) and values.get("phase") == "recalled" and "mutate" in next_nodes:
+            if _checkpoint_id(snapshot.config) is not None:
+                return snapshot
+    raise AssertionError("LangGraph history did not contain a checkpoint before the mutation node")
+
+
+def run_comparator(agent_memory_commit: str) -> dict[str, Any]:
+    if len(agent_memory_commit) != 40 or any(ch not in "0123456789abcdef" for ch in agent_memory_commit):
+        raise ValueError("agent_memory_commit must be an exact lowercase 40-hex commit")
+    if not _LANGGRAPH_AVAILABLE:
+        raise RuntimeError(f"{LANGGRAPH_PACKAGE} is required for the pinned comparator")
+
+    installed_langgraph = package_version("langgraph")
+    installed_checkpoint = package_version("langgraph-checkpoint")
+    if installed_langgraph != LANGGRAPH_VERSION:
+        raise RuntimeError(f"expected langgraph {LANGGRAPH_VERSION}, found {installed_langgraph}")
+    if installed_checkpoint != LANGGRAPH_CHECKPOINT_VERSION:
+        raise RuntimeError(
+            f"expected langgraph-checkpoint {LANGGRAPH_CHECKPOINT_VERSION}, found {installed_checkpoint}"
+        )
+
+    substrate = InMemoryTemporalGraph()
+    memory = GovernedMemoryAdapter(substrate, tenant=TENANT)
+    replay_guard = MutationReplayGuard()
+    seed = memory.commit_proposal(_seed_proposal(), "governed seed context")
+    if not seed.committed:
+        raise AssertionError("failed to seed governed LangGraph recall context")
+    writes_after_seed = _write_count(substrate)
+
+    saver = InMemorySaver()
+    graph, nodes = _build_graph(memory, replay_guard, saver)
+
+    allow_thread = "langgraph:thread:allow"
+    allow_config = _thread_config(allow_thread)
+    memory_state_before_allow = memory.state_version("mem:langgraph:lifecycle")
+    allow_output = graph.invoke({"mode": "allow", "phase": "start"}, allow_config)
+    writes_after_allow = _write_count(substrate)
+    memory_state_after_allow = memory.state_version("mem:langgraph:lifecycle")
+    if allow_output.get("status") != "committed":
+        raise AssertionError(f"LangGraph allow path did not commit: {allow_output}")
+
+    allow_history = _history(graph, allow_config)
+    if not allow_history:
+        raise AssertionError("LangGraph produced no checkpoint history for allow thread")
+    latest_allow = graph.get_state(allow_config)
+    latest_allow_id = _checkpoint_id(latest_allow.config)
+    pre_mutation = _find_pre_mutation_snapshot(allow_history)
+    pre_mutation_id = _checkpoint_id(pre_mutation.config)
+    if latest_allow_id is None or pre_mutation_id is None:
+        raise AssertionError("LangGraph checkpoint history lacked stable checkpoint IDs")
+    lineage = _checkpoint_lineage(allow_history)
+    pre_relation = classify_checkpoint_relation(pre_mutation_id, latest_allow_id, lineage)
+
+    # The pre-mutation framework checkpoint is bound to Agent Memory state v0.
+    # After the governed commit, that binding is stale even if framework lineage
+    # is separately classified by LangGraph checkpoint ancestry.
+    checkpoint_bound_memory_state = memory_state_before_allow
+    checkpoint_memory_state_relation = (
+        "current" if checkpoint_bound_memory_state == memory_state_after_allow else "stale"
+    )
+
+    state_before_replay = memory.state_version("mem:langgraph:lifecycle")
+    writes_before_replay = _write_count(substrate)
+    replay_output = graph.invoke(None, pre_mutation.config)
+    state_after_replay = memory.state_version("mem:langgraph:lifecycle")
+    writes_after_replay = _write_count(substrate)
+
+    # Post-commit failure: the first retry-path mutation commits, records its
+    # receipt, then raises. LangGraph RetryPolicy re-enters the node, where the
+    # replay guard must reuse the original receipt instead of committing twice.
+    retry_thread = "langgraph:thread:retry"
+    retry_config = _thread_config(retry_thread)
+    writes_before_retry = _write_count(substrate)
+    retry_output = graph.invoke({"mode": "retry", "phase": "start"}, retry_config)
+    writes_after_retry = _write_count(substrate)
+    retry_state_version = memory.state_version("mem:langgraph:retry")
+    retry_history = _history(graph, retry_config)
+
+    deny_thread = "langgraph:thread:deny"
+    deny_config = _thread_config(deny_thread)
+    writes_before_deny = _write_count(substrate)
+    deny_output = graph.invoke({"mode": "deny", "phase": "start"}, deny_config)
+    writes_after_deny = _write_count(substrate)
+    deny_history = _history(graph, deny_config)
+
+    cross_scope_thread = "langgraph:thread:cross-scope"
+    cross_scope_config = _thread_config(cross_scope_thread)
+    cross_scope_output = graph.invoke({"mode": "cross_scope", "phase": "start"}, cross_scope_config)
+    cross_scope_history = _history(graph, cross_scope_config)
+
+    checkpoint_event = build_framework_lifecycle_event(
+        framework_id="langgraph",
+        framework_version=LANGGRAPH_VERSION,
+        framework_source_ref=LANGGRAPH_SOURCE_REF,
+        framework_source_commit=LANGGRAPH_COMMIT,
+        event_type="checkpoint_saved",
+        run_ref=allow_thread,
+        workflow_ref=WORKFLOW_REF,
+        persistence_classification="execution_state",
+        occurred_at="2026-08-13T03:05:00Z",
+        checkpoint_ref=pre_mutation_id,
+        previous_checkpoint_ref=lineage.get(pre_mutation_id),
+        checkpoint_relation=pre_relation,
+        scope_ref=SCOPE,
+        tenant_ref=TENANT,
+        project_ref=PROJECT,
+        memory_state_ref=f"v{checkpoint_bound_memory_state}",
+        evidence_refs=("evidence:langgraph-checkpoint-history",),
+    )
+    commit_event = build_framework_lifecycle_event(
+        framework_id="langgraph",
+        framework_version=LANGGRAPH_VERSION,
+        framework_source_ref=LANGGRAPH_SOURCE_REF,
+        framework_source_commit=LANGGRAPH_COMMIT,
+        event_type="mutation_committed",
+        run_ref=allow_thread,
+        workflow_ref=WORKFLOW_REF,
+        persistence_classification="evidence",
+        occurred_at="2026-08-13T03:05:01Z",
+        action_ref="proposal:langgraph:allow-1",
+        decision_receipt_ref=allow_output.get("receipt_ref"),
+        scope_ref=SCOPE,
+        tenant_ref=TENANT,
+        project_ref=PROJECT,
+        memory_state_ref=f"v{memory_state_after_allow}",
+        idempotency_key="langgraph:allow:mutation-1",
+        evidence_refs=(checkpoint_event["event_id"],),
+    )
+    retry_event = build_framework_lifecycle_event(
+        framework_id="langgraph",
+        framework_version=LANGGRAPH_VERSION,
+        framework_source_ref=LANGGRAPH_SOURCE_REF,
+        framework_source_commit=LANGGRAPH_COMMIT,
+        event_type="retry",
+        run_ref=retry_thread,
+        workflow_ref=WORKFLOW_REF,
+        persistence_classification="evidence",
+        occurred_at="2026-08-13T03:05:02Z",
+        action_ref="proposal:langgraph:retry-1",
+        decision_receipt_ref=retry_output.get("receipt_ref"),
+        scope_ref=SCOPE,
+        tenant_ref=TENANT,
+        project_ref=PROJECT,
+        memory_state_ref=f"v{retry_state_version}",
+        idempotency_key="langgraph:retry:mutation-1",
+        evidence_refs=("evidence:langgraph-post-commit-retry",),
+    )
+
+    checks = {
+        "real_langgraph_stategraph_executed": allow_output.get("phase") == "committed",
+        "governed_recall_ran_in_graph": allow_output.get("recall_admitted") is True,
+        "allowed_mutation_committed_once": writes_after_allow == writes_after_seed + 1,
+        "allowed_memory_state_advanced_once": memory_state_before_allow == 0 and memory_state_after_allow == 1,
+        "real_checkpoint_history_captured": len(allow_history) >= 2,
+        "pre_mutation_checkpoint_identified": bool(pre_mutation_id),
+        "framework_checkpoint_relation_explicit": pre_relation in {"stale", "divergent", "unknown", "current"},
+        "pre_mutation_checkpoint_is_not_latest": pre_mutation_id != latest_allow_id,
+        "checkpoint_bound_memory_state_becomes_stale": checkpoint_memory_state_relation == "stale",
+        "old_checkpoint_replay_reused_receipt": (
+            replay_output.get("status") == "replay"
+            and replay_output.get("receipt_ref") == allow_output.get("receipt_ref")
+        ),
+        "old_checkpoint_replay_did_not_duplicate_write": writes_before_replay == writes_after_replay,
+        "old_checkpoint_replay_did_not_rollback_memory": state_before_replay == state_after_replay == 1,
+        "post_commit_retry_reused_receipt": retry_output.get("status") == "replay_after_retry",
+        "post_commit_retry_committed_only_once": writes_after_retry == writes_before_retry + 1,
+        "post_commit_retry_state_advanced_once": retry_state_version == 1,
+        "retry_thread_has_checkpoint_history": bool(retry_history),
+        "denied_mutation_remained_denied": deny_output.get("status") == "denied",
+        "denied_mutation_did_not_write": writes_after_deny == writes_before_deny,
+        "denied_thread_has_checkpoint_history": bool(deny_history),
+        "valid_thread_did_not_widen_cross_scope_recall": cross_scope_output.get("recall_admitted") is False,
+        "cross_scope_thread_has_checkpoint_history": bool(cross_scope_history),
+        "framework_persistence_classified_execution_state": checkpoint_event["persistence_classification"] == "execution_state",
+        "framework_persistence_not_memory_admission": checkpoint_event["interpretation"]["memory_admission"] == "not_established",
+        "checkpoint_has_no_rollback_authority": checkpoint_event["interpretation"]["checkpoint_rollback_authority"] == "not_established",
+        "same_generic_lifecycle_schema_used": (
+            checkpoint_event["schema_version"] == commit_event["schema_version"] == retry_event["schema_version"] == "1.0.0"
+        ),
+        "trace_backend_optional": True,
+    }
+    passed = all(checks.values())
+    result = {
+        "schema_version": "1.0.0",
+        "comparator": "langgraph-lifecycle-v0.1",
+        "agent_memory_commit": agent_memory_commit,
+        "pinned_framework": {
+            "package": LANGGRAPH_PACKAGE,
+            "tag": LANGGRAPH_TAG,
+            "commit": LANGGRAPH_COMMIT,
+            "installed_version": installed_langgraph,
+            "checkpoint_package": LANGGRAPH_CHECKPOINT_PACKAGE,
+            "installed_checkpoint_version": installed_checkpoint,
+        },
+        "runtime_identity": {
+            "workflow_ref": WORKFLOW_REF,
+            "allow_thread_ref": allow_thread,
+            "retry_thread_ref": retry_thread,
+            "deny_thread_ref": deny_thread,
+            "cross_scope_thread_ref": cross_scope_thread,
+        },
+        "checkpoint_evidence": {
+            "allow_history_count": len(allow_history),
+            "pre_mutation_checkpoint": pre_mutation_id,
+            "latest_after_allow": latest_allow_id,
+            "framework_relation_after_allow": pre_relation,
+            "checkpoint_bound_memory_state": checkpoint_bound_memory_state,
+            "current_memory_state_after_allow": memory_state_after_allow,
+            "checkpoint_memory_state_relation": checkpoint_memory_state_relation,
+            "retry_history_count": len(retry_history),
+            "deny_history_count": len(deny_history),
+            "cross_scope_history_count": len(cross_scope_history),
+        },
+        "governance_evidence": {
+            "committed_receipt_ref": allow_output.get("receipt_ref"),
+            "replay_receipt_ref": replay_output.get("receipt_ref"),
+            "retry_receipt_ref": retry_output.get("receipt_ref"),
+            "denied_outcome": deny_output.get("decision_outcome"),
+            "allow_state_version": state_after_replay,
+            "retry_state_version": retry_state_version,
+            "write_counts": {
+                "after_seed": writes_after_seed,
+                "after_allow": writes_after_allow,
+                "before_replay": writes_before_replay,
+                "after_replay": writes_after_replay,
+                "before_retry": writes_before_retry,
+                "after_retry": writes_after_retry,
+                "before_deny": writes_before_deny,
+                "after_deny": writes_after_deny,
+            },
+            "trace_correlation": "unavailable_not_authority",
+        },
+        "framework_lifecycle_events": [checkpoint_event, commit_event, retry_event],
+        "checks": checks,
+        "passed": passed,
+        "non_claims": [
+            "langgraph_checkpoint_is_not_memory_admission",
+            "langgraph_thread_id_is_not_tenant_or_project_authority",
+            "langgraph_persistence_is_not_memory_authority",
+            "framework_checkpoint_recency_is_not_memory_state_freshness",
+            "checkpoint_replay_has_no_memory_rollback_authority",
+            "framework_retry_is_not_new_mutation_authority",
+            "missing_trace_is_not_non_execution_evidence",
+        ],
+    }
+    if not passed:
+        failed = [name for name, ok in checks.items() if not ok]
+        raise AssertionError(f"LangGraph lifecycle comparator failed: {failed}; result={result}")
+    return result

--- a/reference/run_langgraph_lifecycle_comparator.py
+++ b/reference/run_langgraph_lifecycle_comparator.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""Run the pinned LangGraph lifecycle comparator."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref.langgraph_lifecycle_comparator import run_comparator
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    result = run_comparator(args.agent_memory_commit)
+    Path(args.output).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements **P1-B2** from #208: prove the already-merged generic framework lifecycle/checkpoint contract against a second materially different real host, LangGraph.

Pinned reference:

- `langgraph==1.2.11`
- `langgraph-checkpoint==4.2.0`
- tag `1.2.11`
- exact source commit `644815f9e5bc52ad8f7a5227a456227e9c3e639b`

## Why this host

#169 explicitly requires MAF first and LangGraph second before adding a third framework. LangGraph stresses the semantic collision between framework-native persisted state/checkpoints and governed durable Agent Memory.

```text
LangGraph persisted state != Agent Memory admission
thread_id != tenant/project authority
checkpoint replay != memory rollback authority
framework retry != new durable mutation authority
```

## Real runtime comparator

The comparator uses real:

- `StateGraph`
- `InMemorySaver`
- checkpoint history / checkpoint IDs
- `RetryPolicy`
- separate LangGraph thread IDs

No model provider or external service is required.

The same generic Agent Memory surfaces used by the MAF comparator remain authoritative:

- `GovernedMemoryAdapter`
- governed recall
- PAMA proposals/receipts
- `MutationReplayGuard`
- `classify_checkpoint_relation(...)`
- `framework-lifecycle-event.schema.json`

No LangGraph-specific field has been added to the generic lifecycle schema.

## Required lifecycle paths

### Allowed mutation

A real graph node performs governed recall and one PAMA-authorized durable mutation. Real LangGraph checkpoint history is captured, including a checkpoint before the mutation node and a later checkpoint after completion.

### Old-checkpoint replay

The comparator resumes/replays from the older real checkpoint. The node re-enters, but the existing idempotency/receipt guard must return the original receipt and produce no second durable write or memory-state rollback.

### Post-commit retry

A separate graph run deliberately:

1. commits one governed Agent Memory mutation;
2. records the receipt/idempotency key;
3. raises `ConnectionError` before LangGraph can persist successful node output;
4. lets real LangGraph `RetryPolicy` re-enter the node;
5. reuses the original receipt instead of committing twice.

This directly exercises the high-assurance `commit succeeds, framework step/checkpoint fails, retry occurs` boundary.

### Denied mutation

A real graph run carries a PAMA-denied high-consequence mutation and must produce zero writes.

### Cross-scope thread

A valid LangGraph thread/checkpoint runs with cross-scope recall context and must still receive no admitted memory.

## Generic lifecycle events

The comparator emits real-host evidence through the existing lifecycle-event builder for:

- `checkpoint_saved` classified as `execution_state`;
- `mutation_committed` classified as evidence;
- `retry` classified as evidence.

The checkpoint interpretation remains:

```text
memory_admission = not_established
checkpoint_rollback_authority = not_established
authority_effect = none
```

## Version discipline

The dedicated workflow installs and independently verifies exact package versions before execution. A package/version mismatch fails instead of silently changing the comparator surface.

## Stop line

Do not expand this PR into LangGraph Store as canonical memory, provider/model integration, semantic use of every LangGraph memory feature, HITL/delegation authority, or a third framework.

This PR remains draft until the real LangGraph comparator is green, the generic profile is updated only with second-host findings, repository-wide regression CI passes at the final exact head, and #208 acceptance criteria are reviewed.

Closes #208