### PR TITLE
Add append-only derivation currentness and governed scope propagation

### DIFF
--- a/.github/workflows/derivation-currentness-evidence.yml
+++ b/.github/workflows/derivation-currentness-evidence.yml
@@ -1,0 +1,53 @@
+name: Derivation Currentness Evidence
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  derivation-currentness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Validate schemas and fixtures
+        run: python scripts/validate_schemas.py
+
+      - name: Execute derivation regressions and currentness tests
+        env:
+          PYTHONPATH: reference
+        run: >-
+          python -m unittest
+          tests.test_derivation_evidence
+          tests.test_derivation_currentness
+          tests.test_derivation_currentness_depth
+
+      - name: Validate derivation currentness profile links
+        run: python scripts/validate_markdown_links.py docs/profiles/derivation-currentness-profile.md
+
+      - name: Emit exact-head derivation currentness evidence depth
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_derivation_currentness_depth.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output derivation-currentness-depth.json
+
+      - name: Upload derivation currentness evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: derivation-currentness-evidence-depth
+          path: derivation-currentness-depth.json
+          if-no-files-found: error

--- a/.github/workflows/derivation-currentness-evidence.yml
+++ b/.github/workflows/derivation-currentness-evidence.yml
@@ -32,6 +32,7 @@ jobs:
           python -m unittest
           tests.test_derivation_evidence
           tests.test_derivation_currentness
+          tests.test_derivation_completion_status
           tests.test_derivation_currentness_depth
 
       - name: Validate derivation currentness profile links

--- a/docs/profiles/derivation-currentness-profile.md
+++ b/docs/profiles/derivation-currentness-profile.md
@@ -1,0 +1,435 @@
+# Derivation Currentness and Scope Propagation Profile
+
+Status: V0.1 implementation profile for #210.
+
+## Purpose
+
+A derivation is historical evidence of what was transformed from which sources, by which transformer, under which scope, at a particular time.
+
+That historical record should not be rewritten when the world changes later.
+
+```text
+historical derivation
+!= mutable current-truth object
+```
+
+If a root source is later disputed, revoked, superseded, tombstoned, deleted, or placed under a narrower current scope, Agent Memory emits a **separate currentness evaluation**.
+
+```text
+source changes later
+-> derivation evidence remains intact
+-> current applicability is re-evaluated
+-> consequential use fails closed when currentness is not established
+```
+
+This profile completes the useful unfinished derived-state semantics that existed in #202 / draft PR #203 while retaining the canonical `derivation-evidence` model merged through #204 / PR #205.
+
+It deliberately does not introduce a second `transformation-evidence` ontology.
+
+## Two records, two jobs
+
+### Derivation evidence
+
+`schemas/derivation-evidence.schema.json`
+
+Answers:
+
+- what was derived;
+- from which root origins;
+- from which immediate source;
+- by which transformer/version;
+- under which scope;
+- with which evidence/confidence metadata.
+
+It is historical and identity-stable.
+
+### Derivation currentness evaluation
+
+`schemas/derivation-currentness-evaluation.schema.json`
+
+Answers:
+
+- what is the current state of every root origin;
+- what is the current scope/authority posture;
+- is this derivation currently applicable;
+- which reasons force revalidation or uncertainty.
+
+It is append-only evidence about the current applicability of the historical derivation.
+
+## Root-source accounting
+
+The currentness evaluator operates on `root_origin_refs`, not only `immediate_source_refs`.
+
+This matters for multi-hop derived state:
+
+```text
+source A
+ -> derivation B
+ -> derivation C
+```
+
+C's immediate source is B, but its root origin remains A.
+
+If A is later revoked:
+
+```text
+B remains historical evidence
+C remains historical evidence
+currentness(B) -> revalidation_required
+currentness(C) -> revalidation_required
+```
+
+A trusted transformer in B or C cannot hide the non-current root basis.
+
+## Source states
+
+Every expected root source is accounted for explicitly as one of:
+
+```text
+current
+disputed
+revoked
+superseded
+tombstoned
+deleted
+unknown
+```
+
+The evaluation preserves per-origin evidence refs and an evidence class.
+
+A missing root observation is represented as:
+
+```text
+observed = false
+state = unknown
+```
+
+and causes current applicability to remain `unknown`.
+
+An unrelated source observation is retained only in `unexpected_source_refs`. It cannot substitute for a missing expected root.
+
+## Applicability
+
+The aggregate applicability states are:
+
+```text
+current
+revalidation_required
+unknown
+```
+
+### Current
+
+Requires:
+
+- every root source explicitly observed as current;
+- current tenant/project identity compatible with the derivation;
+- scope observation established as unchanged/current.
+
+### Revalidation required
+
+Triggered by definite non-current evidence such as:
+
+- disputed source;
+- revoked source;
+- superseded source;
+- tombstoned source;
+- deleted source;
+- source scope reduction;
+- shared scope/membership revocation;
+- tenant/project mismatch;
+- a supposedly unchanged scope that no longer matches the historical scope.
+
+### Unknown
+
+Used where consequential current applicability cannot be established, for example:
+
+- missing root-source observation;
+- root state explicitly unknown;
+- current scope state unknown.
+
+`unknown` is not a permissive fallback.
+
+```text
+unknown currentness
+!= current
+```
+
+The evaluation records `revalidation_required = true` for both `unknown` and `revalidation_required`, because either posture requires further governed evidence before consequential use.
+
+## Deletion and tombstone distinction
+
+The evaluator preserves distinct reason codes:
+
+```text
+source_tombstoned:<ref>
+source_deleted:<ref>
+```
+
+These are not collapsed into a generic invalid bit.
+
+A tombstone may represent retained governance history around a removed/pruned value. Physical deletion is a different lifecycle fact. Derived-state handling may need that distinction later even though both currently require revalidation.
+
+## Evidence character
+
+Current source observations preserve an evidence class:
+
+```text
+ordinary
+negative
+adversarial
+correction
+incident
+```
+
+The evaluation exposes a bounded aggregate evidence character:
+
+```text
+ordinary
+negative_or_adversarial
+correction_or_incident
+```
+
+A trusted summarizer cannot neutralize adversarial or negative source evidence merely by restating it.
+
+```text
+trusted transformation of adversarial evidence
+!= ordinary corroboration
+```
+
+Evidence character is still evidence, not authority.
+
+## Currentness is not authority
+
+Every currentness evaluation fixes:
+
+```text
+authority_effect = none
+memory_admission = not_established
+certification_claim = none
+remote_mutation = not_established
+historical_derivation_mutated = false
+prior_authorization_reusable = false
+currentness_evidence_authority = none
+```
+
+A current result means only that the supplied source/scope observations establish current applicability under this bounded evaluation contract.
+
+It does not independently authorize:
+
+- durable promotion;
+- crystallization;
+- recall admission;
+- certification;
+- correction;
+- remote cleanup or deletion.
+
+Consequential behavior still crosses normal Agent Memory governance.
+
+## Currentness evaluations are append-only
+
+`evaluation_id` is deterministic over:
+
+- derivation ID;
+- ordered root observations;
+- current scope observation;
+- resulting applicability/evidence character;
+- evaluation timestamp;
+- fixed interpretation.
+
+A later source state therefore produces a new evaluation record rather than modifying the earlier derivation.
+
+Example:
+
+```text
+T1: source current
+ -> evaluation E1: current
+
+T2: source revoked
+ -> evaluation E2: revalidation_required
+
+historical derivation D remains unchanged
+E1 remains evidence of T1 evaluation
+E2 is current evidence at T2
+```
+
+## Explicit scope narrowing
+
+The canonical derivation contract now supports optional scope metadata:
+
+```text
+scope.relation = preserved | narrowed
+scope.basis_refs
+```
+
+Scope narrowing is intentionally **not** accepted from arbitrary transformer metadata.
+
+A caller must use the explicit `derive_from(..., narrowed_scope=..., scope_basis_refs=...)` API.
+
+V0.1 rules:
+
+```text
+new scope_ref must differ from source scope_ref
+basis refs required
+same tenant_ref required
+same project_ref required
+```
+
+This is an explicit operation, not string-based hierarchy inference.
+
+### What narrowing does not mean
+
+V0.1 does not attempt to prove that one opaque scope ref is mathematically a subset of another from its name.
+
+The caller supplies the narrowed scope plus bounded basis refs. Agent Memory preserves that evidence and enforces the non-widening tenant/project constraints it can evaluate deterministically.
+
+## Arbitrary scope overrides remain ignored
+
+A transformer may emit a payload that includes:
+
+```text
+scope = tenant-b / project-b / everything
+```
+
+That field is not consumed by `derive_from`.
+
+Only the explicit narrowing parameters can change the inherited scope.
+
+This keeps transformer convenience metadata from becoming scope authority.
+
+## Scope-reduction fixture
+
+The harness consumes:
+
+`fixtures/scope-reduction-propagates-to-derived-state.json`
+
+The fixture requires:
+
+```text
+source_scope_reduced = true
+derived_scope_recomputed = true
+old_derived_scope_current = false
+narrowing_required = true
+```
+
+Behavioral proof:
+
+1. a historical derivation is current under its original derived scope;
+2. a later source-scope reduction is supplied as current evidence;
+3. the old derivation evaluates `revalidation_required`;
+4. the old derivation remains byte/identity stable;
+5. a new child derivation is explicitly created under the narrower scope with basis refs;
+6. the narrowed child can then evaluate current under that narrowed current scope.
+
+The old record is not silently edited into the new scope.
+
+## Shared-revocation fixture
+
+The harness also consumes:
+
+`fixtures/shared-memory-revocation-propagation.json`
+
+The fixture requires:
+
+```text
+shared_membership_revoked = true
+future_shared_recall_admitted = false
+downstream_scope_recomputed = true
+old_downstream_scope_current = false
+remote_mutation_implied = false
+```
+
+Behavioral proof:
+
+1. the shared derivation is initially current;
+2. current shared membership/scope evidence becomes revoked;
+3. dependent derived applicability becomes `revalidation_required`;
+4. prior shared authorization is not reusable;
+5. the evaluation does not imply a remote mutation command;
+6. the historical derivation remains intact.
+
+Revocation creates a governance obligation to re-evaluate/rebuild/narrow, not an invented authority to mutate some remote system.
+
+## Confidence and transformer trust
+
+Currentness depends on current source and scope evidence.
+
+The harness/tests vary derivation confidence and transformer trust while holding current source state constant.
+
+Required result:
+
+```text
+confidence 0.99 + source revoked
+and
+confidence 0.01 + source revoked
+-> same revalidation posture
+```
+
+Likewise, trusted versus untrusted transformer identity cannot make a revoked source current.
+
+## Privacy and minimization
+
+The evaluation requires refs/state classifications, not raw source bodies.
+
+It does not require:
+
+- source text;
+- derived text;
+- prompts;
+- hidden reasoning;
+- credentials;
+- full transformation payloads.
+
+A source-state observation may use stable evidence refs instead.
+
+## Evidence depth
+
+The focused exact-head report registers three bounded claims:
+
+1. root-source currentness propagation across multi-hop derivation;
+2. source-scope reduction propagation;
+3. shared revocation propagation.
+
+Each is reported as:
+
+```text
+D + F + H
+R = explicitly unproven
+P = explicitly unproven
+```
+
+The structural fixtures are not runtime proof. The reference behavioral harness is not production proof.
+
+## Relationship to #202 / PR #203
+
+Draft PR #203 explored useful concepts including source lifecycle state, derived scope propagation, and multi-hop lineage, but it did so using a separate `transformation-evidence` schema beside the already-merged canonical `derivation-evidence` model.
+
+This profile intentionally consolidates those useful semantics into the canonical model:
+
+```text
+canonical derivation evidence
++
+append-only currentness evaluation
++
+explicit governed scope narrowing
+```
+
+Once #210 is merged and validated, #202/#203 can be closed as superseded rather than carrying two competing provenance abstractions.
+
+## Non-claims
+
+V0.1 does not claim:
+
+- automatic discovery of source revocation;
+- automatic derived-state rebuild/deletion;
+- generic scope hierarchy inference;
+- remote mutation authority;
+- currentness equals truth;
+- currentness equals admission authority;
+- runtime R evidence;
+- production P evidence;
+- external certification.
+
+## Stop line
+
+Keep historical derivation evidence immutable. When current source/scope state changes, append currentness evidence and route any rebuild, narrowing, deletion, admission, or other consequence through normal governance.

--- a/reference/agentmem_ref/derivation_currentness.py
+++ b/reference/agentmem_ref/derivation_currentness.py
@@ -155,6 +155,11 @@ def evaluate_derivation_currentness(
             unknown = True
         ordered.append(observation)
 
+    transformation_status = derivation["transformation"].get("status", "complete")
+    if transformation_status in {"partial", "failed"}:
+        reasons.append(f"transformation_{transformation_status}")
+        definite_revalidation = True
+
     current_scope = _normalize_scope_observation(scope_observation)
     historical_scope = derivation["scope"]
     if current_scope["tenant_ref"] != historical_scope["tenant_ref"]:

--- a/reference/agentmem_ref/derivation_currentness.py
+++ b/reference/agentmem_ref/derivation_currentness.py
@@ -1,0 +1,221 @@
+"""Append-only currentness evaluation for historical derivations, issue #210.
+
+A derivation record says what was transformed, from which root sources, under
+which scope, at a historical point in time. Later source revocation, dispute,
+supersession, deletion, tombstoning, or scope reduction must not rewrite that
+history. This module emits a separate currentness evaluation instead.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from . import receipts
+
+SOURCE_STATES = {
+    "current",
+    "disputed",
+    "revoked",
+    "superseded",
+    "tombstoned",
+    "deleted",
+    "unknown",
+}
+EVIDENCE_CLASSES = {"ordinary", "negative", "adversarial", "correction", "incident"}
+SCOPE_STATES = {"unchanged", "reduced", "revoked", "unknown"}
+NONCURRENT_STATES = {"disputed", "revoked", "superseded", "tombstoned", "deleted"}
+
+
+def _required_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _refs(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple)):
+        raise ValueError(f"{field} must be an array")
+    refs = list(dict.fromkeys(value))
+    if not all(isinstance(item, str) and item for item in refs):
+        raise ValueError(f"{field} must contain only non-empty strings")
+    return refs
+
+
+def _normalize_source_observation(value: dict[str, Any], index: int) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"source_observations[{index}] must be an object")
+    origin_ref = _required_string(value.get("origin_ref"), f"source_observations[{index}].origin_ref")
+    state = value.get("state")
+    if state not in SOURCE_STATES:
+        raise ValueError(f"source_observations[{index}].state is invalid")
+    evidence_class = value.get("evidence_class", "ordinary")
+    if evidence_class not in EVIDENCE_CLASSES:
+        raise ValueError(f"source_observations[{index}].evidence_class is invalid")
+    return {
+        "origin_ref": origin_ref,
+        "observed": True,
+        "state": state,
+        "evidence_class": evidence_class,
+        "evidence_refs": _refs(value.get("evidence_refs"), f"source_observations[{index}].evidence_refs"),
+    }
+
+
+def _missing_observation(origin_ref: str) -> dict[str, Any]:
+    return {
+        "origin_ref": origin_ref,
+        "observed": False,
+        "state": "unknown",
+        "evidence_class": "ordinary",
+        "evidence_refs": [],
+    }
+
+
+def _normalize_scope_observation(value: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("scope_observation must be an object")
+    status = value.get("status")
+    if status not in SCOPE_STATES:
+        raise ValueError("scope_observation.status is invalid")
+    return {
+        "status": status,
+        "current_scope_ref": _required_string(value.get("current_scope_ref"), "scope_observation.current_scope_ref"),
+        "tenant_ref": _required_string(value.get("tenant_ref"), "scope_observation.tenant_ref"),
+        "project_ref": _required_string(value.get("project_ref"), "scope_observation.project_ref"),
+        "evidence_refs": _refs(value.get("evidence_refs"), "scope_observation.evidence_refs"),
+    }
+
+
+def _evidence_character(observations: list[dict[str, Any]]) -> str:
+    classes = {item["evidence_class"] for item in observations if item["observed"]}
+    if classes.intersection({"negative", "adversarial"}):
+        return "negative_or_adversarial"
+    if classes.intersection({"correction", "incident"}):
+        return "correction_or_incident"
+    return "ordinary"
+
+
+def _evaluation_id(body: dict[str, Any]) -> str:
+    encoded = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def evaluate_derivation_currentness(
+    derivation: dict[str, Any],
+    *,
+    source_observations: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+    scope_observation: dict[str, Any],
+    evaluated_at: str,
+) -> dict[str, Any]:
+    """Evaluate current applicability without mutating historical derivation evidence.
+
+    Every root origin named by the derivation is evaluated independently. Extra
+    observations are retained only as unexpected refs and cannot substitute for
+    a missing root. Multi-hop child derivations naturally inherit the same root
+    list, so currentness propagates from original sources rather than only the
+    immediate parent derivation.
+    """
+    receipts.validate("derivation-evidence.schema.json", derivation)
+    evaluated_at = _required_string(evaluated_at, "evaluated_at")
+    if not isinstance(source_observations, (list, tuple)):
+        raise ValueError("source_observations must be an array")
+
+    normalized_input = [
+        _normalize_source_observation(item, index)
+        for index, item in enumerate(source_observations)
+    ]
+    by_origin: dict[str, dict[str, Any]] = {}
+    for item in normalized_input:
+        if item["origin_ref"] in by_origin:
+            raise ValueError(f"duplicate source observation for {item['origin_ref']}")
+        by_origin[item["origin_ref"]] = item
+
+    root_refs = list(derivation["root_origin_refs"])
+    root_set = set(root_refs)
+    unexpected = sorted(set(by_origin) - root_set)
+    ordered: list[dict[str, Any]] = []
+    reasons: list[str] = []
+    definite_revalidation = False
+    unknown = False
+
+    for root_ref in root_refs:
+        observation = by_origin.get(root_ref)
+        if observation is None:
+            observation = _missing_observation(root_ref)
+            reasons.append(f"missing_source_observation:{root_ref}")
+            unknown = True
+        elif observation["state"] in NONCURRENT_STATES:
+            reasons.append(f"source_{observation['state']}:{root_ref}")
+            definite_revalidation = True
+        elif observation["state"] == "unknown":
+            reasons.append(f"source_state_unknown:{root_ref}")
+            unknown = True
+        ordered.append(observation)
+
+    current_scope = _normalize_scope_observation(scope_observation)
+    historical_scope = derivation["scope"]
+    if current_scope["tenant_ref"] != historical_scope["tenant_ref"]:
+        reasons.append("scope_tenant_mismatch")
+        definite_revalidation = True
+    if current_scope["project_ref"] != historical_scope["project_ref"]:
+        reasons.append("scope_project_mismatch")
+        definite_revalidation = True
+
+    scope_status = current_scope["status"]
+    if scope_status == "unchanged":
+        if current_scope["current_scope_ref"] != historical_scope["scope_ref"]:
+            reasons.append("scope_changed_without_reduction_evidence")
+            definite_revalidation = True
+    elif scope_status == "reduced":
+        if current_scope["current_scope_ref"] == historical_scope["scope_ref"]:
+            reasons.append("scope_reduction_not_demonstrated")
+        else:
+            reasons.append("source_scope_reduced")
+        definite_revalidation = True
+    elif scope_status == "revoked":
+        reasons.append("source_scope_or_membership_revoked")
+        definite_revalidation = True
+    elif scope_status == "unknown":
+        reasons.append("scope_state_unknown")
+        unknown = True
+
+    if definite_revalidation:
+        status = "revalidation_required"
+    elif unknown:
+        status = "unknown"
+    else:
+        status = "current"
+
+    body = {
+        "derivation_id": derivation["derivation_id"],
+        "root_origin_refs": root_refs,
+        "source_observations": ordered,
+        "unexpected_source_refs": unexpected,
+        "scope_observation": current_scope,
+        "applicability": {
+            "status": status,
+            "revalidation_required": status != "current",
+            "reasons": list(dict.fromkeys(reasons)),
+        },
+        "evidence_character": _evidence_character(ordered),
+        "evaluated_at": evaluated_at,
+        "interpretation": {
+            "authority_effect": "none",
+            "memory_admission": "not_established",
+            "certification_claim": "none",
+            "remote_mutation": "not_established",
+            "historical_derivation_mutated": False,
+            "prior_authorization_reusable": False,
+            "currentness_evidence_authority": "none",
+        },
+    }
+    result = {
+        "schema_version": "1.0.0",
+        "evaluation_id": _evaluation_id(body),
+        **body,
+    }
+    receipts.validate("derivation-currentness-evaluation.schema.json", result)
+    return result

--- a/reference/agentmem_ref/derivation_currentness_depth.py
+++ b/reference/agentmem_ref/derivation_currentness_depth.py
@@ -1,0 +1,120 @@
+"""D/F/H/R/P registration for derivation currentness propagation, issue #210."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import receipts
+from .derivation_currentness_harness import run_derivation_currentness_harness
+from .security_evidence_depth import LEVELS, classify_evidence_levels
+
+REPORT_TYPE = "agent-memory-security-evidence-depth"
+REPORT_VERSION = "1.0.0"
+
+
+def _exact_commit(value: str) -> str:
+    commit = value.lower()
+    if len(commit) != 40 or any(ch not in "0123456789abcdef" for ch in commit):
+        raise ValueError("agent_memory_commit must be an exact 40-hex commit")
+    return commit
+
+
+def _claim(
+    *,
+    claim_id: str,
+    title: str,
+    threat_family: str,
+    fixture_refs: list[str],
+    harness_ref: str,
+    commit: str,
+    harness_passed: bool,
+) -> dict[str, Any]:
+    evidence = classify_evidence_levels(
+        {
+            "D": [
+                "docs/profiles/derivation-provenance-profile.md",
+                "docs/profiles/derivation-currentness-profile.md",
+                "docs/26-governed-recall-planner.md",
+            ],
+            "F": fixture_refs,
+            "H": [harness_ref] if harness_passed else [],
+            "R": [],
+            "P": [],
+        }
+    )
+    return {
+        "claim_id": claim_id,
+        "title": title,
+        "threat_family": threat_family,
+        "doctrine_refs": evidence["evidence"]["D"],
+        "fixture_refs": evidence["evidence"]["F"],
+        "behavioral_harness_refs": evidence["evidence"]["H"],
+        "runtime_evidence_refs": evidence["evidence"]["R"],
+        "production_evidence_refs": evidence["evidence"]["P"],
+        "external_mappings": [],
+        "demonstrated_levels": evidence["demonstrated_levels"],
+        "highest_demonstrated_level": evidence["highest_demonstrated_level"],
+        "explicitly_unproven_levels": evidence["explicitly_unproven_levels"],
+        "scope_profiles": ["L", "T", "E", "H"],
+        "evaluated_head": commit,
+        "behavioral_passed": harness_passed,
+        "non_certification_statement": "This claim records bounded evidence depth and does not assert external certification.",
+    }
+
+
+def build_derivation_currentness_depth_report(agent_memory_commit: str) -> dict[str, Any]:
+    commit = _exact_commit(agent_memory_commit)
+    harness = run_derivation_currentness_harness()
+    passed = harness["passed"]
+    report = {
+        "report_type": REPORT_TYPE,
+        "version": REPORT_VERSION,
+        "agent_memory_commit": commit,
+        "evidence_model": {
+            "levels": list(LEVELS),
+            "inference_policy": "no_level_may_be_inferred_from_another_level",
+        },
+        "claims": [
+            _claim(
+                claim_id="derived-state:root-currentness-propagation",
+                title="Current applicability of multi-hop derived state is re-evaluated against original root-source state",
+                threat_family="derived_state_currentness",
+                fixture_refs=[
+                    "fixtures/scope-reduction-propagates-to-derived-state.json",
+                    "fixtures/shared-memory-revocation-propagation.json",
+                ],
+                harness_ref="derivation-currentness-harness:root-state-propagation",
+                commit=commit,
+                harness_passed=passed,
+            ),
+            _claim(
+                claim_id="derived-state:scope-reduction-propagation",
+                title="Source scope reduction invalidates stale derived applicability until explicitly narrowed or rebuilt",
+                threat_family="derived_scope_currentness",
+                fixture_refs=["fixtures/scope-reduction-propagates-to-derived-state.json"],
+                harness_ref="derivation-currentness-harness:scope-reduction",
+                commit=commit,
+                harness_passed=passed,
+            ),
+            _claim(
+                claim_id="derived-state:shared-revocation-propagation",
+                title="Shared authority revocation requires derived applicability re-evaluation without fabricating remote mutation",
+                threat_family="shared_revocation_currentness",
+                fixture_refs=["fixtures/shared-memory-revocation-propagation.json"],
+                harness_ref="derivation-currentness-harness:shared-revocation",
+                commit=commit,
+                harness_passed=passed,
+            ),
+        ],
+        "required_behavioral_cases_passed": passed,
+        "non_certification_statement": "Evidence mapping and demonstrated behavior do not constitute external certification.",
+        "known_limits": [
+            "V0.1 evaluates currentness from explicitly supplied source/scope observations; it does not discover source-state changes automatically.",
+            "Scope narrowing is explicit and does not infer hierarchy from scope names.",
+            "Behavioral H evidence does not self-promote to runtime R evidence.",
+            "Production evidence P is not collected or inferred by this report.",
+            "Currentness evaluation does not itself authorize memory admission, mutation, certification, or remote cleanup.",
+        ],
+    }
+    receipts.validate("security-evidence-depth-report.schema.json", report)
+    return report

--- a/reference/agentmem_ref/derivation_currentness_harness.py
+++ b/reference/agentmem_ref/derivation_currentness_harness.py
@@ -1,0 +1,337 @@
+"""Behavioral derived-state currentness and scope propagation proof for #210."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+from .derivation_currentness import evaluate_derivation_currentness
+from .derivation_evidence import derive_from, normalize_derivation
+
+ROOT = Path(__file__).resolve().parents[2]
+SCOPE_REDUCTION_FIXTURE = ROOT / "fixtures" / "scope-reduction-propagates-to-derived-state.json"
+SHARED_REVOCATION_FIXTURE = ROOT / "fixtures" / "shared-memory-revocation-propagation.json"
+
+BASE_SCOPE = {
+    "scope_ref": "domain:shared-derived",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+}
+NARROW_SCOPE = {
+    "scope_ref": "domain:project-a-only",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+}
+SHARED_SCOPE = {
+    "scope_ref": "domain:shared-security",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+}
+
+
+def _source_derivation(*, confidence: float = 0.82, transformer_trust: str = "trusted") -> dict[str, Any]:
+    return normalize_derivation(
+        {
+            "root_origin_refs": ["uor:test:source-a", "uor:test:source-b"],
+            "immediate_source_refs": ["uor:test:source-a", "uor:test:source-b"],
+            "source_trust": "bounded_trusted",
+            "transformation": {
+                "method": "summary",
+                "transformer_ref": "transformer:summary-v1",
+                "transformer_version": "v1",
+                "transformer_trust": transformer_trust,
+                "output_ref": "derived:summary:shared",
+            },
+            "scope": BASE_SCOPE,
+            "evidence_refs": ["evidence:source-a", "evidence:source-b"],
+            "confidence": {
+                "signal_semantics": "summary_confidence",
+                "estimator_ref": "estimator:summary",
+                "estimator_version": "v1",
+                "value": confidence,
+            },
+            "created_at": "2026-08-12T20:00:00Z",
+        },
+        expected_scope=BASE_SCOPE,
+    )
+
+
+def _second_derivation(first: dict[str, Any]) -> dict[str, Any]:
+    return derive_from(
+        first,
+        {
+            "method": "compression",
+            "transformer_ref": "transformer:compress-v2",
+            "transformer_version": "v2",
+            "transformer_trust": "trusted",
+            "output_ref": "derived:summary:compressed",
+            "evidence_refs": ["evidence:compression"],
+            "confidence": {
+                "signal_semantics": "compression_confidence",
+                "estimator_ref": "estimator:compression",
+                "estimator_version": "v2",
+                "value": 0.97,
+            },
+            "created_at": "2026-08-12T20:01:00Z",
+            # Arbitrary transformer-provided scope is ignored by derive_from.
+            "scope": {
+                "scope_ref": "domain:everything",
+                "tenant_ref": "tenant-b",
+                "project_ref": "project-b",
+            },
+        },
+        expected_scope=BASE_SCOPE,
+    )
+
+
+def _observations(state_a: str = "current", state_b: str = "current", *, evidence_a: str = "ordinary") -> list[dict[str, Any]]:
+    return [
+        {
+            "origin_ref": "uor:test:source-a",
+            "state": state_a,
+            "evidence_class": evidence_a,
+            "evidence_refs": [f"evidence:source-a:{state_a}"],
+        },
+        {
+            "origin_ref": "uor:test:source-b",
+            "state": state_b,
+            "evidence_class": "ordinary",
+            "evidence_refs": [f"evidence:source-b:{state_b}"],
+        },
+    ]
+
+
+def _scope(status: str, scope_ref: str, evidence_ref: str) -> dict[str, Any]:
+    return {
+        "status": status,
+        "current_scope_ref": scope_ref,
+        "tenant_ref": "tenant-a",
+        "project_ref": "project-a",
+        "evidence_refs": [evidence_ref],
+    }
+
+
+def _shared_derivation() -> dict[str, Any]:
+    return normalize_derivation(
+        {
+            "root_origin_refs": ["uor:test:shared-source"],
+            "immediate_source_refs": ["uor:test:shared-source"],
+            "source_trust": "bounded_trusted",
+            "transformation": {
+                "method": "summary",
+                "transformer_ref": "transformer:shared-summary",
+                "transformer_version": "v1",
+                "transformer_trust": "trusted",
+                "output_ref": "derived:shared-summary",
+            },
+            "scope": SHARED_SCOPE,
+            "evidence_refs": ["evidence:shared-source"],
+            "created_at": "2026-08-12T20:02:00Z",
+        },
+        expected_scope=SHARED_SCOPE,
+    )
+
+
+def run_derivation_currentness_harness() -> dict[str, Any]:
+    scope_fixture = json.loads(SCOPE_REDUCTION_FIXTURE.read_text(encoding="utf-8"))
+    shared_fixture = json.loads(SHARED_REVOCATION_FIXTURE.read_text(encoding="utf-8"))
+
+    first = _source_derivation()
+    second = _second_derivation(first)
+    first_before = copy.deepcopy(first)
+    second_before = copy.deepcopy(second)
+
+    current_first = evaluate_derivation_currentness(
+        first,
+        source_observations=_observations(),
+        scope_observation=_scope("unchanged", BASE_SCOPE["scope_ref"], "evidence:scope:current"),
+        evaluated_at="2026-08-12T21:00:00Z",
+    )
+    current_second = evaluate_derivation_currentness(
+        second,
+        source_observations=_observations(),
+        scope_observation=_scope("unchanged", BASE_SCOPE["scope_ref"], "evidence:scope:current"),
+        evaluated_at="2026-08-12T21:00:01Z",
+    )
+
+    scope_reduced = evaluate_derivation_currentness(
+        second,
+        source_observations=_observations(),
+        scope_observation=_scope(
+            "reduced",
+            NARROW_SCOPE["scope_ref"],
+            "fixture://scope-reduction/source-a",
+        ),
+        evaluated_at="2026-08-12T21:01:00Z",
+    )
+    narrowed = derive_from(
+        second,
+        {
+            "method": "rebuild-under-current-scope",
+            "transformer_ref": "transformer:scope-reconciler",
+            "transformer_version": "v1",
+            "transformer_trust": "bounded_trusted",
+            "output_ref": "derived:summary:narrowed",
+            "evidence_refs": ["evidence:scope-reduction"],
+            "created_at": "2026-08-12T21:01:30Z",
+        },
+        expected_scope=NARROW_SCOPE,
+        narrowed_scope=NARROW_SCOPE,
+        scope_basis_refs=("fixture://scope-reduction/source-a",),
+    )
+    narrowed_current = evaluate_derivation_currentness(
+        narrowed,
+        source_observations=_observations(),
+        scope_observation=_scope("unchanged", NARROW_SCOPE["scope_ref"], "evidence:narrowed-scope-current"),
+        evaluated_at="2026-08-12T21:02:00Z",
+    )
+
+    revoked_first = evaluate_derivation_currentness(
+        first,
+        source_observations=_observations(state_a="revoked"),
+        scope_observation=_scope("unchanged", BASE_SCOPE["scope_ref"], "evidence:scope:current"),
+        evaluated_at="2026-08-12T21:03:00Z",
+    )
+    revoked_second = evaluate_derivation_currentness(
+        second,
+        source_observations=_observations(state_a="revoked"),
+        scope_observation=_scope("unchanged", BASE_SCOPE["scope_ref"], "evidence:scope:current"),
+        evaluated_at="2026-08-12T21:03:01Z",
+    )
+    tombstoned_second = evaluate_derivation_currentness(
+        second,
+        source_observations=_observations(state_a="tombstoned"),
+        scope_observation=_scope("unchanged", BASE_SCOPE["scope_ref"], "evidence:scope:current"),
+        evaluated_at="2026-08-12T21:03:02Z",
+    )
+    deleted_second = evaluate_derivation_currentness(
+        second,
+        source_observations=_observations(state_a="deleted"),
+        scope_observation=_scope("unchanged", BASE_SCOPE["scope_ref"], "evidence:scope:current"),
+        evaluated_at="2026-08-12T21:03:03Z",
+    )
+    adversarial_second = evaluate_derivation_currentness(
+        second,
+        source_observations=_observations(evidence_a="adversarial"),
+        scope_observation=_scope("unchanged", BASE_SCOPE["scope_ref"], "evidence:scope:current"),
+        evaluated_at="2026-08-12T21:03:04Z",
+    )
+
+    shared = _shared_derivation()
+    shared_before = copy.deepcopy(shared)
+    shared_current = evaluate_derivation_currentness(
+        shared,
+        source_observations=[
+            {
+                "origin_ref": "uor:test:shared-source",
+                "state": "current",
+                "evidence_class": "ordinary",
+                "evidence_refs": ["evidence:shared-source:current"],
+            }
+        ],
+        scope_observation=_scope("unchanged", SHARED_SCOPE["scope_ref"], "evidence:shared-membership:current"),
+        evaluated_at="2026-08-12T21:04:00Z",
+    )
+    shared_revoked = evaluate_derivation_currentness(
+        shared,
+        source_observations=[
+            {
+                "origin_ref": "uor:test:shared-source",
+                "state": "current",
+                "evidence_class": "ordinary",
+                "evidence_refs": ["evidence:shared-source:current"],
+            }
+        ],
+        scope_observation=_scope(
+            "revoked",
+            SHARED_SCOPE["scope_ref"],
+            "fixture://shared-membership/revoked-user-alice",
+        ),
+        evaluated_at="2026-08-12T21:04:01Z",
+    )
+
+    missing_with_extra = evaluate_derivation_currentness(
+        second,
+        source_observations=[
+            {
+                "origin_ref": "uor:test:source-a",
+                "state": "current",
+                "evidence_class": "ordinary",
+                "evidence_refs": ["evidence:source-a:current"],
+            },
+            {
+                "origin_ref": "uor:test:unrelated-source",
+                "state": "current",
+                "evidence_class": "ordinary",
+                "evidence_refs": ["evidence:unrelated"],
+            },
+        ],
+        scope_observation=_scope("unchanged", BASE_SCOPE["scope_ref"], "evidence:scope:current"),
+        evaluated_at="2026-08-12T21:05:00Z",
+    )
+
+    scope_expected = scope_fixture["expected_behavior"]
+    shared_expected = shared_fixture["expected_behavior"]
+    checks = {
+        "initial_first_derivation_current": current_first["applicability"]["status"] == "current",
+        "initial_second_derivation_current": current_second["applicability"]["status"] == "current",
+        "scope_fixture_source_scope_reduced": scope_expected["source_scope_reduced"] is True,
+        "scope_fixture_old_scope_not_current": scope_expected["old_derived_scope_current"] is False,
+        "scope_reduction_requires_revalidation": (
+            scope_reduced["applicability"]["status"] == "revalidation_required"
+            and "source_scope_reduced" in scope_reduced["applicability"]["reasons"]
+        ),
+        "explicit_narrowed_derivation_created": (
+            narrowed["scope"]["relation"] == "narrowed"
+            and narrowed["scope"]["scope_ref"] == NARROW_SCOPE["scope_ref"]
+            and narrowed["scope"]["basis_refs"] == ["fixture://scope-reduction/source-a"]
+        ),
+        "narrowed_derivation_can_be_current": narrowed_current["applicability"]["status"] == "current",
+        "multi_hop_root_lineage_preserved": second["root_origin_refs"] == first["root_origin_refs"],
+        "root_revocation_invalidates_first_currentness": revoked_first["applicability"]["status"] == "revalidation_required",
+        "root_revocation_propagates_to_second": (
+            revoked_second["applicability"]["status"] == "revalidation_required"
+            and "source_revoked:uor:test:source-a" in revoked_second["applicability"]["reasons"]
+        ),
+        "tombstone_reason_distinct": "source_tombstoned:uor:test:source-a" in tombstoned_second["applicability"]["reasons"],
+        "deletion_reason_distinct": "source_deleted:uor:test:source-a" in deleted_second["applicability"]["reasons"],
+        "negative_adversarial_character_survives": adversarial_second["evidence_character"] == "negative_or_adversarial",
+        "shared_fixture_membership_revoked": shared_expected["shared_membership_revoked"] is True,
+        "shared_fixture_old_scope_not_current": shared_expected["old_downstream_scope_current"] is False,
+        "shared_revocation_requires_revalidation": (
+            shared_current["applicability"]["status"] == "current"
+            and shared_revoked["applicability"]["status"] == "revalidation_required"
+            and "source_scope_or_membership_revoked" in shared_revoked["applicability"]["reasons"]
+        ),
+        "shared_revocation_is_not_remote_mutation": shared_revoked["interpretation"]["remote_mutation"] == "not_established",
+        "prior_authorization_not_reusable": shared_revoked["interpretation"]["prior_authorization_reusable"] is False,
+        "missing_root_remains_unknown_despite_extra_observation": (
+            missing_with_extra["applicability"]["status"] == "unknown"
+            and "uor:test:unrelated-source" in missing_with_extra["unexpected_source_refs"]
+            and "missing_source_observation:uor:test:source-b" in missing_with_extra["applicability"]["reasons"]
+        ),
+        "historical_first_derivation_unchanged": first == first_before,
+        "historical_second_derivation_unchanged": second == second_before,
+        "historical_shared_derivation_unchanged": shared == shared_before,
+        "currentness_has_no_authority_effect": revoked_second["interpretation"]["authority_effect"] == "none",
+        "currentness_does_not_establish_admission": revoked_second["interpretation"]["memory_admission"] == "not_established",
+    }
+
+    return {
+        "case_id": "derivation-currentness-and-scope-propagation",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "observed": {
+            "first_derivation_id": first["derivation_id"],
+            "second_derivation_id": second["derivation_id"],
+            "narrowed_derivation_id": narrowed["derivation_id"],
+            "scope_reduction_status": scope_reduced["applicability"],
+            "revoked_second_status": revoked_second["applicability"],
+            "tombstoned_second_status": tombstoned_second["applicability"],
+            "deleted_second_status": deleted_second["applicability"],
+            "shared_revocation_status": shared_revoked["applicability"],
+            "missing_with_extra_status": missing_with_extra["applicability"],
+        },
+    }

--- a/reference/agentmem_ref/derivation_evidence.py
+++ b/reference/agentmem_ref/derivation_evidence.py
@@ -21,6 +21,8 @@ from . import receipts
 PROFILE_VERSION = "0.1.0"
 TRUST_STATES = {"untrusted", "unknown", "bounded_trusted", "trusted"}
 SCOPE_RELATIONS = {"preserved", "narrowed"}
+TRANSFORMATION_MODES = {"deterministic", "probabilistic"}
+TRANSFORMATION_STATUSES = {"complete", "partial", "failed"}
 
 
 def _refs(values: Any, field: str, *, required: bool = False) -> list[str]:
@@ -47,6 +49,15 @@ def _trust(value: Any, field: str) -> str:
     if trust not in TRUST_STATES:
         raise ValueError(f"unsupported {field}: {trust!r}")
     return trust
+
+
+def _optional_enum(value: Any, field: str, allowed: set[str]) -> str | None:
+    if value is None:
+        return None
+    normalized = _required_string(value, field)
+    if normalized not in allowed:
+        raise ValueError(f"unsupported {field}: {normalized!r}")
+    return normalized
 
 
 def _confidence(value: Any) -> dict[str, Any] | None:
@@ -137,13 +148,20 @@ def normalize_derivation(value: dict[str, Any], expected_scope: dict[str, Any] |
     transform = value.get("transformation")
     if not isinstance(transform, dict):
         raise ValueError("transformation must be an object")
-    transformation = {
+    transformation: dict[str, Any] = {
         "method": _required_string(transform.get("method"), "transformation.method"),
         "transformer_ref": _required_string(transform.get("transformer_ref"), "transformation.transformer_ref"),
         "transformer_version": _required_string(transform.get("transformer_version"), "transformation.transformer_version"),
         "transformer_trust": _trust(transform.get("transformer_trust"), "transformation.transformer_trust"),
         "output_ref": _required_string(transform.get("output_ref"), "transformation.output_ref"),
     }
+    mode = _optional_enum(transform.get("mode"), "transformation.mode", TRANSFORMATION_MODES)
+    status = _optional_enum(transform.get("status"), "transformation.status", TRANSFORMATION_STATUSES)
+    if mode is not None:
+        transformation["mode"] = mode
+    if status is not None:
+        transformation["status"] = status
+
     confidence = _confidence(value.get("confidence"))
     created_at = _required_string(value.get("created_at"), "created_at")
     depth = value.get("derivation_depth", 1)
@@ -237,17 +255,23 @@ def derive_from(
 
     evidence_refs = _refs(transformation.get("evidence_refs"), "evidence_refs", required=True)
     child_scope = _governed_scope_for_child(source_derivation["scope"], narrowed_scope, scope_basis_refs)
+    child_transformation = {
+        "method": transformation.get("method"),
+        "transformer_ref": transformation.get("transformer_ref"),
+        "transformer_version": transformation.get("transformer_version"),
+        "transformer_trust": transformation.get("transformer_trust"),
+        "output_ref": transformation.get("output_ref"),
+    }
+    if transformation.get("mode") is not None:
+        child_transformation["mode"] = transformation.get("mode")
+    if transformation.get("status") is not None:
+        child_transformation["status"] = transformation.get("status")
+
     value = {
         "root_origin_refs": deepcopy(source_derivation["root_origin_refs"]),
         "immediate_source_refs": [source_derivation["derivation_id"]],
         "source_trust": source_derivation["source_trust"],
-        "transformation": {
-            "method": transformation.get("method"),
-            "transformer_ref": transformation.get("transformer_ref"),
-            "transformer_version": transformation.get("transformer_version"),
-            "transformer_trust": transformation.get("transformer_trust"),
-            "output_ref": transformation.get("output_ref"),
-        },
+        "transformation": child_transformation,
         "prior_derivation_refs": list(dict.fromkeys(
             source_derivation["prior_derivation_refs"] + [source_derivation["derivation_id"]]
         )),

--- a/reference/agentmem_ref/derivation_evidence.py
+++ b/reference/agentmem_ref/derivation_evidence.py
@@ -1,8 +1,12 @@
-"""Non-authoritative derivation/provenance envelope for issue #204.
+"""Non-authoritative derivation/provenance envelope for issues #204 and #210.
 
 A summary, restatement, compression, or other transformation may create useful
 new evidence. It may not create a new origin, independent corroboration, or
 memory authority merely because the transformer is trusted or confident.
+
+Historical derivation evidence remains immutable. Current applicability is
+handled separately by ``derivation_currentness`` rather than by rewriting this
+record after source state changes.
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ from . import receipts
 
 PROFILE_VERSION = "0.1.0"
 TRUST_STATES = {"untrusted", "unknown", "bounded_trusted", "trusted"}
+SCOPE_RELATIONS = {"preserved", "narrowed"}
 
 
 def _refs(values: Any, field: str, *, required: bool = False) -> list[str]:
@@ -60,17 +65,28 @@ def _confidence(value: Any) -> dict[str, Any] | None:
     }
 
 
-def _scope(value: Any) -> dict[str, str]:
+def _scope(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("scope must be an object")
-    return {
+    result: dict[str, Any] = {
         "scope_ref": _required_string(value.get("scope_ref"), "scope.scope_ref"),
         "tenant_ref": _required_string(value.get("tenant_ref"), "scope.tenant_ref"),
         "project_ref": _required_string(value.get("project_ref"), "scope.project_ref"),
     }
+    relation = value.get("relation")
+    if relation is not None:
+        if relation not in SCOPE_RELATIONS:
+            raise ValueError(f"unsupported scope.relation: {relation!r}")
+        result["relation"] = relation
+        basis_refs = _refs(value.get("basis_refs"), "scope.basis_refs", required=relation == "narrowed")
+        if basis_refs:
+            result["basis_refs"] = basis_refs
+    elif value.get("basis_refs") is not None:
+        raise ValueError("scope.basis_refs requires scope.relation")
+    return result
 
 
-def _binding(scope: dict[str, str], expected_scope: dict[str, str] | None) -> dict[str, Any]:
+def _binding(scope: dict[str, Any], expected_scope: dict[str, Any] | None) -> dict[str, Any]:
     if expected_scope is None:
         return {"status": "not_evaluated", "reasons": []}
     expected = _scope(expected_scope)
@@ -101,7 +117,7 @@ def _derivation_id(payload: dict[str, Any]) -> str:
     return "sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
-def normalize_derivation(value: dict[str, Any], expected_scope: dict[str, str] | None = None) -> dict[str, Any]:
+def normalize_derivation(value: dict[str, Any], expected_scope: dict[str, Any] | None = None) -> dict[str, Any]:
     """Normalize a first-order transformation while discarding authority-shaped input.
 
     Only the bounded fields below are consumed. Caller-supplied PAMA outcomes,
@@ -167,21 +183,60 @@ def normalize_derivation(value: dict[str, Any], expected_scope: dict[str, str] |
     return result
 
 
+def _governed_scope_for_child(
+    source_scope: dict[str, Any],
+    narrowed_scope: dict[str, Any] | None,
+    scope_basis_refs: tuple[str, ...] | list[str],
+) -> dict[str, Any]:
+    """Return preserved scope or an explicitly justified narrower scope.
+
+    V0.1 does not infer scope hierarchy from names. Narrowing is an explicit API
+    operation: the new scope ref must differ, tenant/project boundaries must
+    remain identical, and at least one basis ref is required. Arbitrary scope
+    fields inside transformer metadata are never consulted.
+    """
+    if narrowed_scope is None:
+        if scope_basis_refs:
+            raise ValueError("scope_basis_refs require narrowed_scope")
+        return deepcopy(source_scope)
+
+    proposed = _scope(narrowed_scope)
+    basis_refs = _refs(scope_basis_refs, "scope_basis_refs", required=True)
+    if proposed["scope_ref"] == source_scope["scope_ref"]:
+        raise ValueError("narrowed scope_ref must differ from source scope_ref")
+    if proposed["tenant_ref"] != source_scope["tenant_ref"]:
+        raise ValueError("derivation scope narrowing cannot change tenant_ref")
+    if proposed["project_ref"] != source_scope["project_ref"]:
+        raise ValueError("derivation scope narrowing cannot change project_ref")
+    return {
+        "scope_ref": proposed["scope_ref"],
+        "tenant_ref": proposed["tenant_ref"],
+        "project_ref": proposed["project_ref"],
+        "relation": "narrowed",
+        "basis_refs": basis_refs,
+    }
+
+
 def derive_from(
     source_derivation: dict[str, Any],
     transformation: dict[str, Any],
-    expected_scope: dict[str, str] | None = None,
+    expected_scope: dict[str, Any] | None = None,
+    *,
+    narrowed_scope: dict[str, Any] | None = None,
+    scope_basis_refs: tuple[str, ...] | list[str] = (),
 ) -> dict[str, Any]:
     """Create a later derivation without minting a new root origin.
 
-    The inherited source-trust and scope values are authoritative *as evidence
-    metadata only*. A caller cannot use the new transformer to rewrite them.
+    The inherited source-trust and scope values are evidence metadata only. A
+    caller cannot use transformer metadata to rewrite them. Scope may be
+    narrowed only through the explicit ``narrowed_scope`` API with basis refs.
     """
     receipts.validate("derivation-evidence.schema.json", source_derivation)
     if not isinstance(transformation, dict):
         raise ValueError("transformation must be an object")
 
     evidence_refs = _refs(transformation.get("evidence_refs"), "evidence_refs", required=True)
+    child_scope = _governed_scope_for_child(source_derivation["scope"], narrowed_scope, scope_basis_refs)
     value = {
         "root_origin_refs": deepcopy(source_derivation["root_origin_refs"]),
         "immediate_source_refs": [source_derivation["derivation_id"]],
@@ -197,7 +252,7 @@ def derive_from(
             source_derivation["prior_derivation_refs"] + [source_derivation["derivation_id"]]
         )),
         "derivation_depth": source_derivation["derivation_depth"] + 1,
-        "scope": deepcopy(source_derivation["scope"]),
+        "scope": child_scope,
         "evidence_refs": list(dict.fromkeys(source_derivation["evidence_refs"] + evidence_refs)),
         "confidence": transformation.get("confidence"),
         "created_at": transformation.get("created_at"),

--- a/reference/run_derivation_currentness_depth.py
+++ b/reference/run_derivation_currentness_depth.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""Emit exact-head derivation currentness evidence depth."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref.derivation_currentness_depth import build_derivation_currentness_depth_report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    report = build_derivation_currentness_depth_report(args.agent_memory_commit)
+    Path(args.output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/reference/tests/test_derivation_completion_status.py
+++ b/reference/tests/test_derivation_completion_status.py
@@ -1,0 +1,130 @@
+"""Transformation completion/mode regressions absorbed from draft #203 into #210."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.derivation_currentness import evaluate_derivation_currentness
+from agentmem_ref.derivation_evidence import derive_from, normalize_derivation
+
+SCOPE = {
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+}
+
+
+def _derivation(*, mode="deterministic", status="complete"):
+    return normalize_derivation(
+        {
+            "root_origin_refs": ["origin:a"],
+            "immediate_source_refs": ["origin:a"],
+            "source_trust": "bounded_trusted",
+            "transformation": {
+                "method": "summary",
+                "mode": mode,
+                "status": status,
+                "transformer_ref": "transformer:test",
+                "transformer_version": "v1",
+                "transformer_trust": "trusted",
+                "output_ref": f"derived:{mode}:{status}",
+            },
+            "scope": SCOPE,
+            "evidence_refs": ["evidence:a"],
+            "created_at": "2026-08-13T03:20:00Z",
+        },
+        expected_scope=SCOPE,
+    )
+
+
+def _evaluate(derivation, source_state="current"):
+    return evaluate_derivation_currentness(
+        derivation,
+        source_observations=[
+            {
+                "origin_ref": "origin:a",
+                "state": source_state,
+                "evidence_class": "ordinary",
+                "evidence_refs": [f"evidence:a:{source_state}"],
+            }
+        ],
+        scope_observation={
+            "status": "unchanged",
+            "current_scope_ref": SCOPE["scope_ref"],
+            "tenant_ref": SCOPE["tenant_ref"],
+            "project_ref": SCOPE["project_ref"],
+            "evidence_refs": ["evidence:scope:current"],
+        },
+        evaluated_at="2026-08-13T03:20:01Z",
+    )
+
+
+class DerivationCompletionStatusTests(unittest.TestCase):
+    def test_partial_transformation_is_not_current_evidence(self):
+        derivation = _derivation(mode="probabilistic", status="partial")
+        result = _evaluate(derivation)
+        self.assertEqual(derivation["transformation"]["mode"], "probabilistic")
+        self.assertEqual(derivation["transformation"]["status"], "partial")
+        self.assertEqual(result["applicability"]["status"], "revalidation_required")
+        self.assertIn("transformation_partial", result["applicability"]["reasons"])
+
+    def test_failed_transformation_is_not_current_evidence(self):
+        result = _evaluate(_derivation(status="failed"))
+        self.assertEqual(result["applicability"]["status"], "revalidation_required")
+        self.assertIn("transformation_failed", result["applicability"]["reasons"])
+
+    def test_complete_deterministic_and_probabilistic_transforms_share_authority_boundary(self):
+        deterministic = _evaluate(_derivation(mode="deterministic", status="complete"), source_state="revoked")
+        probabilistic = _evaluate(_derivation(mode="probabilistic", status="complete"), source_state="revoked")
+        self.assertEqual(deterministic["applicability"]["status"], "revalidation_required")
+        self.assertEqual(probabilistic["applicability"]["status"], "revalidation_required")
+        self.assertEqual(deterministic["applicability"]["reasons"], probabilistic["applicability"]["reasons"])
+        self.assertEqual(deterministic["interpretation"]["authority_effect"], "none")
+        self.assertEqual(probabilistic["interpretation"]["authority_effect"], "none")
+
+    def test_child_derivation_preserves_explicit_mode_and_status(self):
+        child = derive_from(
+            _derivation(),
+            {
+                "method": "projection",
+                "mode": "probabilistic",
+                "status": "partial",
+                "transformer_ref": "transformer:child",
+                "transformer_version": "v2",
+                "transformer_trust": "trusted",
+                "output_ref": "derived:child",
+                "evidence_refs": ["evidence:child"],
+                "created_at": "2026-08-13T03:20:02Z",
+            },
+            expected_scope=SCOPE,
+        )
+        self.assertEqual(child["transformation"]["mode"], "probabilistic")
+        self.assertEqual(child["transformation"]["status"], "partial")
+        self.assertEqual(_evaluate(child)["applicability"]["status"], "revalidation_required")
+
+    def test_legacy_derivation_without_mode_or_status_remains_schema_valid_and_defaults_complete(self):
+        legacy = normalize_derivation(
+            {
+                "root_origin_refs": ["origin:a"],
+                "immediate_source_refs": ["origin:a"],
+                "source_trust": "bounded_trusted",
+                "transformation": {
+                    "method": "summary",
+                    "transformer_ref": "transformer:legacy",
+                    "transformer_version": "v1",
+                    "transformer_trust": "trusted",
+                    "output_ref": "derived:legacy",
+                },
+                "scope": SCOPE,
+                "evidence_refs": ["evidence:a"],
+                "created_at": "2026-08-13T03:20:03Z",
+            },
+            expected_scope=SCOPE,
+        )
+        self.assertNotIn("mode", legacy["transformation"])
+        self.assertNotIn("status", legacy["transformation"])
+        self.assertEqual(_evaluate(legacy)["applicability"]["status"], "current")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_derivation_currentness.py
+++ b/reference/tests/test_derivation_currentness.py
@@ -1,0 +1,320 @@
+"""Derivation currentness and governed scope propagation tests for issue #210."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+
+from agentmem_ref.derivation_currentness import evaluate_derivation_currentness
+from agentmem_ref.derivation_currentness_harness import run_derivation_currentness_harness
+from agentmem_ref.derivation_evidence import derive_from, normalize_derivation
+
+
+SCOPE = {
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+}
+NARROW = {
+    "scope_ref": "scope:tenant-a/project-a/private",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+}
+
+
+def _derivation(*, confidence=0.8, transformer_trust="trusted"):
+    return normalize_derivation(
+        {
+            "root_origin_refs": ["origin:a", "origin:b"],
+            "immediate_source_refs": ["origin:a", "origin:b"],
+            "source_trust": "bounded_trusted",
+            "transformation": {
+                "method": "summary",
+                "transformer_ref": "transformer:test",
+                "transformer_version": "v1",
+                "transformer_trust": transformer_trust,
+                "output_ref": "derived:test",
+            },
+            "scope": SCOPE,
+            "evidence_refs": ["evidence:a", "evidence:b"],
+            "confidence": {
+                "signal_semantics": "summary_confidence",
+                "estimator_ref": "estimator:test",
+                "estimator_version": "v1",
+                "value": confidence,
+            },
+            "created_at": "2026-08-13T03:15:00Z",
+        },
+        expected_scope=SCOPE,
+    )
+
+
+def _observations(state_a="current", state_b="current", evidence_class_a="ordinary"):
+    return [
+        {
+            "origin_ref": "origin:a",
+            "state": state_a,
+            "evidence_class": evidence_class_a,
+            "evidence_refs": [f"evidence:a:{state_a}"],
+        },
+        {
+            "origin_ref": "origin:b",
+            "state": state_b,
+            "evidence_class": "ordinary",
+            "evidence_refs": [f"evidence:b:{state_b}"],
+        },
+    ]
+
+
+def _scope_observation(status="unchanged", scope_ref=SCOPE["scope_ref"], *, tenant="tenant-a", project="project-a"):
+    return {
+        "status": status,
+        "current_scope_ref": scope_ref,
+        "tenant_ref": tenant,
+        "project_ref": project,
+        "evidence_refs": [f"evidence:scope:{status}"],
+    }
+
+
+class DerivationCurrentnessTests(unittest.TestCase):
+    def test_fixture_linked_harness_passes(self):
+        result = run_derivation_currentness_harness()
+        self.assertTrue(result["passed"], result)
+        self.assertTrue(result["checks"]["scope_reduction_requires_revalidation"])
+        self.assertTrue(result["checks"]["root_revocation_propagates_to_second"])
+        self.assertTrue(result["checks"]["shared_revocation_requires_revalidation"])
+
+    def test_all_current_roots_and_unchanged_scope_are_current(self):
+        result = evaluate_derivation_currentness(
+            _derivation(),
+            source_observations=_observations(),
+            scope_observation=_scope_observation(),
+            evaluated_at="2026-08-13T03:16:00Z",
+        )
+        self.assertEqual(result["applicability"]["status"], "current")
+        self.assertFalse(result["applicability"]["revalidation_required"])
+        self.assertEqual(result["applicability"]["reasons"], [])
+
+    def test_missing_root_is_unknown_and_extra_source_cannot_substitute(self):
+        result = evaluate_derivation_currentness(
+            _derivation(),
+            source_observations=[
+                {
+                    "origin_ref": "origin:a",
+                    "state": "current",
+                    "evidence_class": "ordinary",
+                    "evidence_refs": ["evidence:a"],
+                },
+                {
+                    "origin_ref": "origin:unrelated",
+                    "state": "current",
+                    "evidence_class": "ordinary",
+                    "evidence_refs": ["evidence:unrelated"],
+                },
+            ],
+            scope_observation=_scope_observation(),
+            evaluated_at="2026-08-13T03:16:01Z",
+        )
+        self.assertEqual(result["applicability"]["status"], "unknown")
+        self.assertTrue(result["applicability"]["revalidation_required"])
+        self.assertIn("missing_source_observation:origin:b", result["applicability"]["reasons"])
+        self.assertEqual(result["unexpected_source_refs"], ["origin:unrelated"])
+        missing = next(item for item in result["source_observations"] if item["origin_ref"] == "origin:b")
+        self.assertFalse(missing["observed"])
+        self.assertEqual(missing["state"], "unknown")
+
+    def test_deleted_and_tombstoned_are_distinct_revalidation_reasons(self):
+        deleted = evaluate_derivation_currentness(
+            _derivation(),
+            source_observations=_observations(state_a="deleted"),
+            scope_observation=_scope_observation(),
+            evaluated_at="2026-08-13T03:16:02Z",
+        )
+        tombstoned = evaluate_derivation_currentness(
+            _derivation(),
+            source_observations=_observations(state_a="tombstoned"),
+            scope_observation=_scope_observation(),
+            evaluated_at="2026-08-13T03:16:03Z",
+        )
+        self.assertIn("source_deleted:origin:a", deleted["applicability"]["reasons"])
+        self.assertIn("source_tombstoned:origin:a", tombstoned["applicability"]["reasons"])
+        self.assertEqual(deleted["applicability"]["status"], "revalidation_required")
+        self.assertEqual(tombstoned["applicability"]["status"], "revalidation_required")
+
+    def test_multi_hop_child_uses_original_root_lineage_for_currentness(self):
+        first = _derivation()
+        child = derive_from(
+            first,
+            {
+                "method": "compression",
+                "transformer_ref": "transformer:child",
+                "transformer_version": "v2",
+                "transformer_trust": "trusted",
+                "output_ref": "derived:child",
+                "evidence_refs": ["evidence:child"],
+                "created_at": "2026-08-13T03:16:04Z",
+            },
+            expected_scope=SCOPE,
+        )
+        result = evaluate_derivation_currentness(
+            child,
+            source_observations=_observations(state_a="revoked"),
+            scope_observation=_scope_observation(),
+            evaluated_at="2026-08-13T03:16:05Z",
+        )
+        self.assertEqual(child["root_origin_refs"], ["origin:a", "origin:b"])
+        self.assertNotIn(first["derivation_id"], child["root_origin_refs"])
+        self.assertIn("source_revoked:origin:a", result["applicability"]["reasons"])
+        self.assertEqual(result["applicability"]["status"], "revalidation_required")
+
+    def test_negative_and_adversarial_source_character_survives_trusted_transform(self):
+        result = evaluate_derivation_currentness(
+            _derivation(transformer_trust="trusted"),
+            source_observations=_observations(evidence_class_a="adversarial"),
+            scope_observation=_scope_observation(),
+            evaluated_at="2026-08-13T03:16:06Z",
+        )
+        self.assertEqual(result["evidence_character"], "negative_or_adversarial")
+        self.assertEqual(result["interpretation"]["authority_effect"], "none")
+
+    def test_confidence_and_transformer_trust_do_not_change_currentness(self):
+        high = evaluate_derivation_currentness(
+            _derivation(confidence=0.99, transformer_trust="trusted"),
+            source_observations=_observations(state_a="revoked"),
+            scope_observation=_scope_observation(),
+            evaluated_at="2026-08-13T03:16:07Z",
+        )
+        low = evaluate_derivation_currentness(
+            _derivation(confidence=0.01, transformer_trust="untrusted"),
+            source_observations=_observations(state_a="revoked"),
+            scope_observation=_scope_observation(),
+            evaluated_at="2026-08-13T03:16:08Z",
+        )
+        self.assertEqual(high["applicability"]["status"], low["applicability"]["status"])
+        self.assertEqual(high["applicability"]["reasons"], low["applicability"]["reasons"])
+
+    def test_currentness_evaluation_does_not_mutate_historical_derivation(self):
+        derivation = _derivation()
+        before = copy.deepcopy(derivation)
+        result = evaluate_derivation_currentness(
+            derivation,
+            source_observations=_observations(state_a="superseded"),
+            scope_observation=_scope_observation(),
+            evaluated_at="2026-08-13T03:16:09Z",
+        )
+        self.assertEqual(derivation, before)
+        self.assertEqual(derivation["derivation_id"], before["derivation_id"])
+        self.assertFalse(result["interpretation"]["historical_derivation_mutated"])
+        self.assertFalse(result["interpretation"]["prior_authorization_reusable"])
+        self.assertEqual(result["interpretation"]["memory_admission"], "not_established")
+        self.assertEqual(result["interpretation"]["certification_claim"], "none")
+
+    def test_explicit_scope_narrowing_requires_basis_refs(self):
+        with self.assertRaisesRegex(ValueError, "scope_basis_refs"):
+            derive_from(
+                _derivation(),
+                {
+                    "method": "rebuild",
+                    "transformer_ref": "transformer:scope",
+                    "transformer_version": "v1",
+                    "transformer_trust": "trusted",
+                    "output_ref": "derived:narrowed",
+                    "evidence_refs": ["evidence:narrow"],
+                    "created_at": "2026-08-13T03:16:10Z",
+                },
+                narrowed_scope=NARROW,
+            )
+
+    def test_explicit_scope_narrowing_is_recorded_and_transformer_override_is_ignored(self):
+        child = derive_from(
+            _derivation(),
+            {
+                "method": "rebuild",
+                "transformer_ref": "transformer:scope",
+                "transformer_version": "v1",
+                "transformer_trust": "trusted",
+                "output_ref": "derived:narrowed",
+                "evidence_refs": ["evidence:narrow"],
+                "created_at": "2026-08-13T03:16:11Z",
+                "scope": {
+                    "scope_ref": "scope:tenant-b/all",
+                    "tenant_ref": "tenant-b",
+                    "project_ref": "project-b",
+                },
+            },
+            expected_scope=NARROW,
+            narrowed_scope=NARROW,
+            scope_basis_refs=("evidence:scope-reduction",),
+        )
+        self.assertEqual(child["scope"]["scope_ref"], NARROW["scope_ref"])
+        self.assertEqual(child["scope"]["tenant_ref"], "tenant-a")
+        self.assertEqual(child["scope"]["project_ref"], "project-a")
+        self.assertEqual(child["scope"]["relation"], "narrowed")
+        self.assertEqual(child["scope"]["basis_refs"], ["evidence:scope-reduction"])
+        self.assertEqual(child["binding"]["status"], "exact")
+
+    def test_scope_narrowing_cannot_change_tenant_or_project(self):
+        for bad_scope, message in (
+            (
+                {
+                    "scope_ref": "scope:tenant-b/private",
+                    "tenant_ref": "tenant-b",
+                    "project_ref": "project-a",
+                },
+                "tenant_ref",
+            ),
+            (
+                {
+                    "scope_ref": "scope:tenant-a/other-project/private",
+                    "tenant_ref": "tenant-a",
+                    "project_ref": "project-b",
+                },
+                "project_ref",
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, message):
+                derive_from(
+                    _derivation(),
+                    {
+                        "method": "rebuild",
+                        "transformer_ref": "transformer:scope",
+                        "transformer_version": "v1",
+                        "transformer_trust": "trusted",
+                        "output_ref": "derived:bad-narrow",
+                        "evidence_refs": ["evidence:narrow"],
+                        "created_at": "2026-08-13T03:16:12Z",
+                    },
+                    narrowed_scope=bad_scope,
+                    scope_basis_refs=("evidence:scope-reduction",),
+                )
+
+    def test_scope_narrowing_must_actually_change_scope_ref(self):
+        with self.assertRaisesRegex(ValueError, "must differ"):
+            derive_from(
+                _derivation(),
+                {
+                    "method": "rebuild",
+                    "transformer_ref": "transformer:scope",
+                    "transformer_version": "v1",
+                    "transformer_trust": "trusted",
+                    "output_ref": "derived:not-narrowed",
+                    "evidence_refs": ["evidence:narrow"],
+                    "created_at": "2026-08-13T03:16:13Z",
+                },
+                narrowed_scope=SCOPE,
+                scope_basis_refs=("evidence:scope-reduction",),
+            )
+
+    def test_duplicate_source_observation_is_rejected(self):
+        duplicated = _observations() + [_observations()[0]]
+        with self.assertRaisesRegex(ValueError, "duplicate source observation"):
+            evaluate_derivation_currentness(
+                _derivation(),
+                source_observations=duplicated,
+                scope_observation=_scope_observation(),
+                evaluated_at="2026-08-13T03:16:14Z",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_derivation_currentness_depth.py
+++ b/reference/tests/test_derivation_currentness_depth.py
@@ -1,0 +1,28 @@
+"""Evidence-depth assertions for issue #210."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.derivation_currentness_depth import build_derivation_currentness_depth_report
+
+
+class DerivationCurrentnessDepthTests(unittest.TestCase):
+    def test_all_claims_are_d_f_h_only(self):
+        report = build_derivation_currentness_depth_report("a" * 40)
+        self.assertTrue(report["required_behavioral_cases_passed"], report)
+        self.assertEqual(len(report["claims"]), 3)
+        for claim in report["claims"]:
+            self.assertEqual(claim["demonstrated_levels"], ["D", "F", "H"])
+            self.assertEqual(claim["highest_demonstrated_level"], "H")
+            self.assertEqual(claim["explicitly_unproven_levels"], ["R", "P"])
+            self.assertEqual(claim["runtime_evidence_refs"], [])
+            self.assertEqual(claim["production_evidence_refs"], [])
+
+    def test_report_requires_exact_head(self):
+        with self.assertRaisesRegex(ValueError, "exact 40-hex"):
+            build_derivation_currentness_depth_report("main")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/derivation-currentness-evaluation.schema.json
+++ b/schemas/derivation-currentness-evaluation.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/derivation-currentness-evaluation.schema.json",
+  "title": "Agent Memory Derivation Currentness Evaluation",
+  "description": "Append-only evaluation of whether historical derived evidence remains currently applicable given current root-source and scope state.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "evaluation_id",
+    "derivation_id",
+    "root_origin_refs",
+    "source_observations",
+    "unexpected_source_refs",
+    "scope_observation",
+    "applicability",
+    "evidence_character",
+    "evaluated_at",
+    "interpretation"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "evaluation_id": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "derivation_id": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "root_origin_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "source_observations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["origin_ref", "observed", "state", "evidence_class", "evidence_refs"],
+        "properties": {
+          "origin_ref": { "type": "string", "minLength": 1 },
+          "observed": { "type": "boolean" },
+          "state": {
+            "type": "string",
+            "enum": ["current", "disputed", "revoked", "superseded", "tombstoned", "deleted", "unknown"]
+          },
+          "evidence_class": {
+            "type": "string",
+            "enum": ["ordinary", "negative", "adversarial", "correction", "incident"]
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          }
+        }
+      }
+    },
+    "unexpected_source_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "scope_observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "current_scope_ref", "tenant_ref", "project_ref", "evidence_refs"],
+      "properties": {
+        "status": { "type": "string", "enum": ["unchanged", "reduced", "revoked", "unknown"] },
+        "current_scope_ref": { "type": "string", "minLength": 1 },
+        "tenant_ref": { "type": "string", "minLength": 1 },
+        "project_ref": { "type": "string", "minLength": 1 },
+        "evidence_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "applicability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "revalidation_required", "reasons"],
+      "properties": {
+        "status": { "type": "string", "enum": ["current", "revalidation_required", "unknown"] },
+        "revalidation_required": { "type": "boolean" },
+        "reasons": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "evidence_character": {
+      "type": "string",
+      "enum": ["ordinary", "negative_or_adversarial", "correction_or_incident"]
+    },
+    "evaluated_at": { "type": "string", "minLength": 1 },
+    "interpretation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_effect",
+        "memory_admission",
+        "certification_claim",
+        "remote_mutation",
+        "historical_derivation_mutated",
+        "prior_authorization_reusable",
+        "currentness_evidence_authority"
+      ],
+      "properties": {
+        "authority_effect": { "const": "none" },
+        "memory_admission": { "const": "not_established" },
+        "certification_claim": { "const": "none" },
+        "remote_mutation": { "const": "not_established" },
+        "historical_derivation_mutated": { "const": false },
+        "prior_authorization_reusable": { "const": false },
+        "currentness_evidence_authority": { "const": "none" }
+      }
+    }
+  }
+}

--- a/schemas/derivation-evidence.schema.json
+++ b/schemas/derivation-evidence.schema.json
@@ -67,8 +67,26 @@
       "properties": {
         "scope_ref": { "type": "string", "minLength": 1 },
         "tenant_ref": { "type": "string", "minLength": 1 },
-        "project_ref": { "type": "string", "minLength": 1 }
-      }
+        "project_ref": { "type": "string", "minLength": 1 },
+        "relation": { "type": "string", "enum": ["preserved", "narrowed"] },
+        "basis_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "relation": { "const": "narrowed" } },
+            "required": ["relation"]
+          },
+          "then": {
+            "required": ["basis_refs"],
+            "properties": { "basis_refs": { "minItems": 1 } }
+          }
+        }
+      ]
     },
     "evidence_refs": {
       "type": "array",

--- a/schemas/derivation-evidence.schema.json
+++ b/schemas/derivation-evidence.schema.json
@@ -45,6 +45,8 @@
       "required": ["method", "transformer_ref", "transformer_version", "transformer_trust", "output_ref"],
       "properties": {
         "method": { "type": "string", "minLength": 1 },
+        "mode": { "type": "string", "enum": ["deterministic", "probabilistic"] },
+        "status": { "type": "string", "enum": ["complete", "partial", "failed"] },
         "transformer_ref": { "type": "string", "minLength": 1 },
         "transformer_version": { "type": "string", "minLength": 1 },
         "transformer_trust": {


### PR DESCRIPTION
## Summary

Implements #210 and consolidates the valuable unfinished semantics from #202 / draft PR #203 into the **already-merged canonical derivation model** rather than introducing a competing transformation ontology.

## Core boundary

```text
historical derivation evidence
!= mutable current-truth object

source changes later
-> historical derivation remains intact
-> append currentness evaluation
-> current applicability may require revalidation
```

## Canonical consolidation

This PR extends `derivation-evidence` only additively for explicit scope metadata and adds a separate `derivation-currentness-evaluation` record.

It does **not** merge #203's parallel `transformation-evidence` schema/module.

## Append-only currentness evaluation

A currentness evaluation is bound to a historical `derivation_id` and accounts for every `root_origin_ref` independently.

Source states remain distinct:

```text
current
disputed
revoked
superseded
tombstoned
deleted
unknown
```

Missing expected root observations become explicit `unknown`. Unrelated extra observations are retained separately and cannot substitute for a missing root.

Aggregate applicability is:

```text
current
revalidation_required
unknown
```

Every evaluation fixes authority/admission/certification/remote-mutation nonclaims and never mutates the derivation record.

## Multi-hop propagation

The evaluator uses original `root_origin_refs`, not only the immediate parent derivation.

```text
source A -> derivation B -> derivation C
A later revoked
-> B history preserved
-> C history preserved
-> currentness(B) = revalidation_required
-> currentness(C) = revalidation_required
```

Trusted later transformation cannot hide non-current root basis.

## Evidence character

Per-root current observations preserve:

- ordinary
- negative
- adversarial
- correction
- incident

A trusted transformation cannot neutralize negative/adversarial basis into ordinary corroboration. Currentness evidence remains non-authoritative.

## Explicit governed scope narrowing

`derive_from(...)` now supports an explicit API-level narrowing path:

```text
narrowed_scope + scope_basis_refs
```

Rules:

- new scope ref must differ;
- basis refs are required;
- tenant must remain identical;
- project must remain identical in V0.1;
- arbitrary transformer-supplied `scope` fields remain ignored.

Narrowed derivations record:

```text
scope.relation = narrowed
scope.basis_refs = [...]
```

The change to `derivation-evidence.schema.json` is additive, so historical V0.1 records without these optional fields remain valid.

## Fixture-linked proof

### Scope reduction

Consumes `scope-reduction-propagates-to-derived-state.json` and proves:

- old derived scope is initially current;
- later source scope reduction makes old applicability `revalidation_required`;
- old derivation remains unchanged;
- a new explicitly narrowed derivation can be created with basis refs;
- that narrowed derivation can evaluate current under the narrower scope.

### Shared revocation

Consumes `shared-memory-revocation-propagation.json` and proves:

- shared derivation is initially current;
- membership/scope revocation makes dependent applicability `revalidation_required`;
- prior authorization is not reusable;
- revocation does not imply a fabricated remote mutation command;
- historical derivation remains intact.

## Additional negative paths

- missing root + unrelated extra observation remains unknown;
- deletion and tombstone remain distinct reasons;
- negative/adversarial character survives trusted derivation;
- confidence and transformer trust cannot change currentness posture;
- duplicate source observations are rejected;
- narrowing without basis refs is rejected;
- same-scope fake narrowing is rejected;
- cross-tenant/project narrowing is rejected;
- transformer scope overrides are ignored.

## Evidence depth

The dedicated exact-head report registers three bounded claims:

1. root-source currentness propagation;
2. derived scope-reduction propagation;
3. shared-revocation propagation.

All are intentionally:

```text
D + F + H
R = explicitly unproven
P = explicitly unproven
```

## Added/modified surfaces

- `schemas/derivation-currentness-evaluation.schema.json`
- additive update to `schemas/derivation-evidence.schema.json`
- `reference/agentmem_ref/derivation_currentness.py`
- `reference/agentmem_ref/derivation_currentness_harness.py`
- `reference/agentmem_ref/derivation_currentness_depth.py`
- additive update to `reference/agentmem_ref/derivation_evidence.py`
- `reference/run_derivation_currentness_depth.py`
- `reference/tests/test_derivation_currentness.py`
- `reference/tests/test_derivation_currentness_depth.py`
- `docs/profiles/derivation-currentness-profile.md`
- `.github/workflows/derivation-currentness-evidence.yml`

## Stop line

Do not turn currentness evaluation into mutable derivation state, automatic cleanup authority, generic scope hierarchy inference, or a second provenance ontology.

This PR remains draft until focused derivation-currentness evidence plus all repository-wide regression gates pass at the exact final head and #210 completion criteria are reviewed.

Closes #210