### PR TITLE
Add typed and digested derivation output custody

### DIFF
--- a/.github/workflows/derivation-output-custody.yml
+++ b/.github/workflows/derivation-output-custody.yml
@@ -1,0 +1,40 @@
+name: Derivation Output Custody
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  derivation-output-custody:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Validate schemas and fixtures
+        run: python scripts/validate_schemas.py
+
+      - name: Execute derivation custody and compatibility tests
+        env:
+          PYTHONPATH: reference
+        run: >-
+          python -m unittest
+          tests.test_derivation_evidence
+          tests.test_derivation_output_custody
+          tests.test_derivation_currentness
+          tests.test_derivation_completion_status
+          tests.test_derivation_currentness_depth
+
+      - name: Validate output custody profile links
+        run: python scripts/validate_markdown_links.py docs/profiles/derivation-output-custody-profile.md

--- a/docs/profiles/derivation-output-custody-profile.md
+++ b/docs/profiles/derivation-output-custody-profile.md
@@ -1,0 +1,155 @@
+# Derivation Output Custody Profile
+
+Status: V0.1 canonical custody extension for #212.
+
+## Purpose
+
+A derivation may need to prove which transformed artifact was produced without copying that artifact into the provenance envelope.
+
+The canonical `derivation-evidence` transformation block therefore supports an optional typed and digested custody pair:
+
+```text
+output_ref
+output_type
+output_digest
+```
+
+`output_ref` remains the backward-compatible minimum. When either `output_type` or `output_digest` is supplied, both are required.
+
+## V0.1 digest contract
+
+`output_digest` uses:
+
+```text
+sha256:<64 lowercase hexadecimal characters>
+```
+
+The digest establishes bounded byte-custody evidence for the referenced transformed artifact.
+
+It does **not** establish:
+
+```text
+integrity match != semantic correctness
+integrity match != truth
+integrity match != authority
+integrity match != certification
+integrity match != memory admission
+```
+
+A faithfully hashed bad summary is still a faithfully hashed bad summary. Computers are very good at being precisely wrong.
+
+## Privacy and minimization
+
+The provenance envelope records only type/ref/digest metadata.
+
+Caller fields such as:
+
+```text
+raw_output
+output_payload
+prompt
+hidden_reasoning
+full_transformed_content
+```
+
+have no output path through `normalize_derivation(...)` or `derive_from(...)`.
+
+Raw transformed content may be retained elsewhere under normal memory/evidence policy when required. This custody profile does not require it.
+
+## Backward compatibility
+
+Historical V0.1 derivations containing only:
+
+```text
+transformation.output_ref
+```
+
+remain valid.
+
+Typed/digested custody is additive rather than a schema migration that invalidates earlier evidence.
+
+## Pair completeness
+
+Partial custody claims fail closed:
+
+```text
+output_type without output_digest -> reject
+output_digest without output_type -> reject
+malformed digest -> reject
+```
+
+This prevents a record from looking reconstructable while silently omitting one half of the custody claim.
+
+## Identity behavior
+
+The normalized transformation block participates in deterministic `derivation_id` generation.
+
+Therefore:
+
+```text
+same source + same transformation + same output type/ref/digest
+-> same derivation identity
+
+same source + same transformation + changed output digest
+-> different derivation identity
+```
+
+A different digest means the transformation evidence refers to different output bytes. It does not mean the later output has more authority.
+
+## Child derivations
+
+`derive_from(...)` carries typed/digested custody for each new transformation independently.
+
+A child derivation still preserves the original root-source lineage from the canonical derivation model.
+
+```text
+root source A
+ -> derived artifact B(type/ref/digest)
+ -> derived artifact C(type/ref/digest)
+
+root origin of C = A
+```
+
+B and C do not become independent corroborating origins merely because both have integrity digests.
+
+## Relationship to currentness
+
+Typed/digested output custody does not alter the currentness model from #210.
+
+A derivation whose root source is revoked, superseded, tombstoned, deleted, disputed, or otherwise non-current still requires revalidation regardless of output digest integrity.
+
+Likewise, a complete typed/digested transformation whose sources remain current may evaluate current under the bounded currentness contract, but that result still does not establish memory authority or admission.
+
+## Relationship to #202 / PR #203
+
+Issue #202 requested transformed output type/ref/digest custody. Draft PR #203 implemented that requirement inside a separate `transformation-evidence` ontology.
+
+The canonical implementation path is now:
+
+```text
+#204 / PR #205
+  -> canonical derivation provenance + authority-laundering containment
+
+#210 / PR #211
+  -> append-only source currentness + governed scope propagation + transform mode/status
+
+#212
+  -> typed/digested transformed-output custody
+```
+
+This preserves the useful requirement without shipping a second overlapping provenance schema.
+
+## Non-claims
+
+V0.1 does not claim:
+
+- output digest proves semantic truth;
+- output type is certification;
+- content-addressed custody grants authority;
+- digested output becomes durable memory automatically;
+- one digest format solves all artifact provenance problems;
+- production custody or external certification.
+
+## Stop line
+
+Keep custody metadata as evidence. If the transformed artifact is proposed for durable Agent Memory state, the normal admission, source-currentness, scope, and PAMA boundaries still apply.

--- a/reference/agentmem_ref/derivation_evidence.py
+++ b/reference/agentmem_ref/derivation_evidence.py
@@ -1,4 +1,4 @@
-"""Non-authoritative derivation/provenance envelope for issues #204 and #210.
+"""Non-authoritative derivation/provenance envelope for issues #204, #210, and #212.
 
 A summary, restatement, compression, or other transformation may create useful
 new evidence. It may not create a new origin, independent corroboration, or
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from copy import deepcopy
 from typing import Any
 
@@ -23,6 +24,7 @@ TRUST_STATES = {"untrusted", "unknown", "bounded_trusted", "trusted"}
 SCOPE_RELATIONS = {"preserved", "narrowed"}
 TRANSFORMATION_MODES = {"deterministic", "probabilistic"}
 TRANSFORMATION_STATUSES = {"complete", "partial", "failed"}
+OUTPUT_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def _refs(values: Any, field: str, *, required: bool = False) -> list[str]:
@@ -58,6 +60,32 @@ def _optional_enum(value: Any, field: str, allowed: set[str]) -> str | None:
     if normalized not in allowed:
         raise ValueError(f"unsupported {field}: {normalized!r}")
     return normalized
+
+
+def _output_custody(transform: dict[str, Any]) -> dict[str, str]:
+    """Normalize optional typed/digested output custody without raw payloads.
+
+    ``output_ref`` remains the legacy minimum. If either type or digest is
+    supplied, both are required so the record never presents a partial custody
+    claim. Digest integrity is evidence about referenced bytes only; it does not
+    establish semantic correctness or authority.
+    """
+    output_type = transform.get("output_type")
+    output_digest = transform.get("output_digest")
+    if output_type is None and output_digest is None:
+        return {}
+    if output_type is None or output_digest is None:
+        raise ValueError(
+            "transformation.output_type and transformation.output_digest must be supplied together"
+        )
+    normalized_type = _required_string(output_type, "transformation.output_type")
+    normalized_digest = _required_string(output_digest, "transformation.output_digest")
+    if OUTPUT_DIGEST_RE.fullmatch(normalized_digest) is None:
+        raise ValueError("transformation.output_digest must be sha256:<64 lowercase hex>")
+    return {
+        "output_type": normalized_type,
+        "output_digest": normalized_digest,
+    }
 
 
 def _confidence(value: Any) -> dict[str, Any] | None:
@@ -132,8 +160,8 @@ def normalize_derivation(value: dict[str, Any], expected_scope: dict[str, Any] |
     """Normalize a first-order transformation while discarding authority-shaped input.
 
     Only the bounded fields below are consumed. Caller-supplied PAMA outcomes,
-    permissions, certification, lifecycle state, prompts, raw content, and
-    similar fields have no output path.
+    permissions, certification, lifecycle state, prompts, raw output content,
+    and similar fields have no output path.
     """
     if not isinstance(value, dict):
         raise ValueError("derivation input must be an object")
@@ -161,6 +189,7 @@ def normalize_derivation(value: dict[str, Any], expected_scope: dict[str, Any] |
         transformation["mode"] = mode
     if status is not None:
         transformation["status"] = status
+    transformation.update(_output_custody(transform))
 
     confidence = _confidence(value.get("confidence"))
     created_at = _required_string(value.get("created_at"), "created_at")
@@ -255,17 +284,16 @@ def derive_from(
 
     evidence_refs = _refs(transformation.get("evidence_refs"), "evidence_refs", required=True)
     child_scope = _governed_scope_for_child(source_derivation["scope"], narrowed_scope, scope_basis_refs)
-    child_transformation = {
+    child_transformation: dict[str, Any] = {
         "method": transformation.get("method"),
         "transformer_ref": transformation.get("transformer_ref"),
         "transformer_version": transformation.get("transformer_version"),
         "transformer_trust": transformation.get("transformer_trust"),
         "output_ref": transformation.get("output_ref"),
     }
-    if transformation.get("mode") is not None:
-        child_transformation["mode"] = transformation.get("mode")
-    if transformation.get("status") is not None:
-        child_transformation["status"] = transformation.get("status")
+    for field in ("mode", "status", "output_type", "output_digest"):
+        if transformation.get(field) is not None:
+            child_transformation[field] = transformation.get(field)
 
     value = {
         "root_origin_refs": deepcopy(source_derivation["root_origin_refs"]),

--- a/reference/tests/test_derivation_output_custody.py
+++ b/reference/tests/test_derivation_output_custody.py
@@ -1,0 +1,162 @@
+"""Typed/digested derivation output custody tests for issue #212."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.derivation_currentness import evaluate_derivation_currentness
+from agentmem_ref.derivation_evidence import derive_from, normalize_derivation
+
+SCOPE = {
+    "scope_ref": "scope:tenant-a/project-a",
+    "tenant_ref": "tenant-a",
+    "project_ref": "project-a",
+}
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+
+
+def _input(*, digest=DIGEST_A, include_type=True, include_digest=True):
+    transformation = {
+        "method": "summary",
+        "mode": "probabilistic",
+        "status": "complete",
+        "transformer_ref": "transformer:summary",
+        "transformer_version": "v1",
+        "transformer_trust": "trusted",
+        "output_ref": "artifact:summary:1",
+        "raw_output": "sensitive derived content must not enter custody evidence",
+        "output_payload": {"content": "also must not survive"},
+    }
+    if include_type:
+        transformation["output_type"] = "text/summary"
+    if include_digest:
+        transformation["output_digest"] = digest
+    return {
+        "root_origin_refs": ["origin:a"],
+        "immediate_source_refs": ["origin:a"],
+        "source_trust": "bounded_trusted",
+        "transformation": transformation,
+        "scope": SCOPE,
+        "evidence_refs": ["evidence:a"],
+        "created_at": "2026-08-13T03:25:00Z",
+    }
+
+
+def _currentness(derivation):
+    return evaluate_derivation_currentness(
+        derivation,
+        source_observations=[
+            {
+                "origin_ref": "origin:a",
+                "state": "current",
+                "evidence_class": "ordinary",
+                "evidence_refs": ["evidence:a:current"],
+            }
+        ],
+        scope_observation={
+            "status": "unchanged",
+            "current_scope_ref": SCOPE["scope_ref"],
+            "tenant_ref": SCOPE["tenant_ref"],
+            "project_ref": SCOPE["project_ref"],
+            "evidence_refs": ["evidence:scope:current"],
+        },
+        evaluated_at="2026-08-13T03:25:01Z",
+    )
+
+
+class DerivationOutputCustodyTests(unittest.TestCase):
+    def test_typed_digested_output_is_preserved_without_raw_payload(self):
+        result = normalize_derivation(_input(), expected_scope=SCOPE)
+        transform = result["transformation"]
+        self.assertEqual(transform["output_ref"], "artifact:summary:1")
+        self.assertEqual(transform["output_type"], "text/summary")
+        self.assertEqual(transform["output_digest"], DIGEST_A)
+        self.assertNotIn("raw_output", transform)
+        self.assertNotIn("output_payload", transform)
+        rendered = str(result)
+        self.assertNotIn("sensitive derived content", rendered)
+        self.assertNotIn("also must not survive", rendered)
+
+    def test_output_type_without_digest_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "must be supplied together"):
+            normalize_derivation(_input(include_digest=False))
+
+    def test_output_digest_without_type_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "must be supplied together"):
+            normalize_derivation(_input(include_type=False))
+
+    def test_malformed_output_digest_is_rejected(self):
+        for malformed in (
+            "sha256:abc",
+            "sha256:" + "A" * 64,
+            "sha512:" + "a" * 64,
+            "a" * 64,
+        ):
+            with self.subTest(malformed=malformed):
+                with self.assertRaisesRegex(ValueError, "sha256:<64 lowercase hex>"):
+                    normalize_derivation(_input(digest=malformed))
+
+    def test_same_typed_digested_transformation_replays_identity_stably(self):
+        first = normalize_derivation(_input())
+        second = normalize_derivation(_input())
+        self.assertEqual(first["derivation_id"], second["derivation_id"])
+        self.assertEqual(first["transformation"], second["transformation"])
+        self.assertFalse(first["interpretation"]["repetition_creates_independent_origin"])
+
+    def test_changed_digest_changes_identity_but_not_authority_interpretation(self):
+        first = normalize_derivation(_input(digest=DIGEST_A))
+        second = normalize_derivation(_input(digest=DIGEST_B))
+        self.assertNotEqual(first["derivation_id"], second["derivation_id"])
+        self.assertEqual(first["interpretation"], second["interpretation"])
+        self.assertEqual(first["interpretation"]["authority_effect"], "none")
+        self.assertEqual(first["interpretation"]["independent_corroboration"], "not_established")
+
+    def test_child_derivation_preserves_typed_digested_custody(self):
+        parent = normalize_derivation(_input())
+        child = derive_from(
+            parent,
+            {
+                "method": "compression",
+                "mode": "deterministic",
+                "status": "complete",
+                "transformer_ref": "transformer:compression",
+                "transformer_version": "v2",
+                "transformer_trust": "trusted",
+                "output_ref": "artifact:summary:2",
+                "output_type": "application/summary+json",
+                "output_digest": DIGEST_B,
+                "evidence_refs": ["evidence:compression"],
+                "created_at": "2026-08-13T03:25:02Z",
+                "raw_output": "must still be ignored",
+            },
+            expected_scope=SCOPE,
+        )
+        transform = child["transformation"]
+        self.assertEqual(transform["output_type"], "application/summary+json")
+        self.assertEqual(transform["output_digest"], DIGEST_B)
+        self.assertNotIn("raw_output", transform)
+        self.assertEqual(child["root_origin_refs"], parent["root_origin_refs"])
+
+    def test_legacy_output_ref_only_record_remains_valid(self):
+        legacy = _input(include_type=False, include_digest=False)
+        result = normalize_derivation(legacy, expected_scope=SCOPE)
+        self.assertEqual(result["transformation"]["output_ref"], "artifact:summary:1")
+        self.assertNotIn("output_type", result["transformation"])
+        self.assertNotIn("output_digest", result["transformation"])
+        self.assertEqual(_currentness(result)["applicability"]["status"], "current")
+
+    def test_digest_custody_does_not_change_currentness_or_create_authority(self):
+        typed = normalize_derivation(_input(digest=DIGEST_A), expected_scope=SCOPE)
+        other_digest = normalize_derivation(_input(digest=DIGEST_B), expected_scope=SCOPE)
+        typed_currentness = _currentness(typed)
+        other_currentness = _currentness(other_digest)
+        self.assertEqual(typed_currentness["applicability"], other_currentness["applicability"])
+        self.assertEqual(typed_currentness["interpretation"]["authority_effect"], "none")
+        self.assertEqual(other_currentness["interpretation"]["authority_effect"], "none")
+        self.assertEqual(typed["interpretation"]["certification_claim"], "none")
+        self.assertEqual(other_digest["interpretation"]["memory_admission"], "not_established")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/derivation-evidence.schema.json
+++ b/schemas/derivation-evidence.schema.json
@@ -53,8 +53,20 @@
           "type": "string",
           "enum": ["untrusted", "unknown", "bounded_trusted", "trusted"]
         },
-        "output_ref": { "type": "string", "minLength": 1 }
-      }
+        "output_ref": { "type": "string", "minLength": 1 },
+        "output_type": { "type": "string", "minLength": 1 },
+        "output_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+      },
+      "allOf": [
+        {
+          "if": { "required": ["output_type"] },
+          "then": { "required": ["output_digest"] }
+        },
+        {
+          "if": { "required": ["output_digest"] },
+          "then": { "required": ["output_type"] }
+        }
+      ]
     },
     "prior_derivation_refs": {
       "type": "array",


### PR DESCRIPTION
## Summary

Implements the final bounded requirement from #212 and completes the canonical supersession path for #202 / draft PR #203.

The existing `derivation-evidence` transformation block now supports optional typed/digested output custody without storing raw transformed payloads.

## Canonical custody fields

```text
output_ref
output_type
output_digest
```

`output_ref` remains backward-compatible and sufficient for legacy derivations.

When typed/digested custody is supplied:

```text
output_type + output_digest
```

must be supplied together.

V0.1 digest format:

```text
sha256:<64 lowercase hex>
```

## Evidence boundary

```text
digest integrity != semantic correctness
digest integrity != truth
digest integrity != authority
digest integrity != certification
digest integrity != memory admission
```

The type/ref/digest participate in deterministic derivation identity because they identify the exact transformed artifact under custody. Changing only the digest changes `derivation_id`, but does not change authority/currentness interpretation.

## Privacy / minimization

Raw fields such as `raw_output` and `output_payload` remain outside the bounded normalizer and have no output path.

The provenance envelope therefore reconstructs transformed-artifact custody without copying transformed content.

## Child derivations

`derive_from(...)` carries `output_type` and `output_digest` for each new transformation while preserving the original root-source lineage and existing non-authority semantics.

## Backward compatibility

Legacy records containing only `transformation.output_ref` remain schema-valid and retain the same currentness behavior.

## Negative paths

Focused tests prove:

- output type without digest is rejected;
- output digest without type is rejected;
- malformed/non-lowercase/non-SHA-256 digest is rejected;
- raw transformed payloads are discarded;
- identical typed/digested transformation replay is identity-stable;
- changed digest changes derivation identity but not authority interpretation;
- child derivations preserve typed/digested custody;
- digest custody does not alter derivation currentness or create authority/certification/admission.

## Added/modified surfaces

- additive update to `schemas/derivation-evidence.schema.json`
- additive update to `reference/agentmem_ref/derivation_evidence.py`
- `reference/tests/test_derivation_output_custody.py`
- `docs/profiles/derivation-output-custody-profile.md`
- `.github/workflows/derivation-output-custody.yml`

## Supersession result

This is the last substantive #202 requirement not already absorbed by:

- #204 / PR #205: canonical derivation provenance + authority-laundering containment
- #210 / PR #211: append-only source currentness + scope propagation + transformation mode/status

After this PR merges and exact-head validation passes, #202 and draft PR #203 can be closed as fully superseded without shipping the parallel `transformation-evidence` ontology.

## Stop line

Do not treat output digests as semantic validation, authority, automatic durable admission, or certification. Do not add raw transformed content to the custody envelope.

This PR remains draft until the focused custody gate and all repository-wide regressions pass at the exact final head.

Closes #212