### PR TITLE
Prove monotonic external policy composition against pinned OPA

### DIFF
--- a/.github/workflows/opa-policy-comparator.yml
+++ b/.github/workflows/opa-policy-comparator.yml
@@ -1,0 +1,60 @@
+name: OPA Policy Comparator
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  opa-policy-comparator:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Download and verify pinned OPA binary
+        env:
+          OPA_URL: https://github.com/open-policy-agent/opa/releases/download/v1.19.0/opa_linux_amd64
+          OPA_SHA256: 4ae5eeec241c9f5df7c5f566fe96e26336ce186f8c773c46ffdf10b48189a520
+        run: |
+          curl --fail --location --silent --show-error "$OPA_URL" --output /tmp/opa
+          echo "$OPA_SHA256  /tmp/opa" | sha256sum --check --strict
+          chmod +x /tmp/opa
+
+      - name: Verify pinned OPA version and policy syntax
+        run: |
+          /tmp/opa version
+          /tmp/opa version | grep -F "Version: 1.19.0"
+          /tmp/opa check reference/policies/opa_agent_memory_v01.rego
+
+      - name: Execute OPA adapter parser regressions
+        env:
+          PYTHONPATH: reference
+        run: python -m unittest tests.test_opa_policy_comparator
+
+      - name: Execute real OPA external-policy comparator
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          PYTHONPATH=reference
+          python reference/run_opa_policy_comparator.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --opa-binary /tmp/opa
+          --output opa-policy-comparator.json
+
+      - name: Upload OPA policy composition evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: opa-policy-comparator-evidence
+          path: opa-policy-comparator.json
+          if-no-files-found: error

--- a/docs/profiles/external-enforcement-decision-profile.md
+++ b/docs/profiles/external-enforcement-decision-profile.md
@@ -4,7 +4,7 @@
 
 This profile defines the smallest vendor-neutral boundary needed to carry an Agent Memory governed mutation decision to an optional external policy or enforcement host without surrendering memory-specific semantics.
 
-It implements the Phase 1 contract work of issue #152. It does not make any external governance system a dependency and does not define a general agent-wide policy engine.
+It implements the Phase 1 contract work of issue #152 and is now behaviorally proven against a first real deterministic policy host, Open Policy Agent (OPA). OPA remains an optional reference peer, not a required Agent Memory dependency.
 
 The responsibility split is:
 
@@ -101,7 +101,7 @@ receipt_ref, when available
 
 The projection does not require raw memory content, prompts, rationale prose, or retrieved context.
 
-`input_identity` is a deterministic SHA-256 identity over the canonical projection inputs that define the requested action and its authority state. The reference profile will define the exact canonicalization before claiming cross-runtime interoperability.
+`input_identity` is a deterministic SHA-256 identity over the canonical projection inputs that define the requested action and its authority state. The reference implementation uses deterministic canonicalization before cross-provider composition.
 
 ## Normalized composition lattice
 
@@ -114,14 +114,14 @@ allow < warn < require_approval < deny
 Agent Memory PAMA maps conservatively:
 
 ```text
-allow                       -> allow
-allow_with_ledger           -> allow
-require_review              -> require_approval
+allow                         -> allow
+allow_with_ledger             -> allow
+require_review                -> require_approval
 require_external_verification -> require_approval
-abstain                     -> require_approval
-collect_more_evidence       -> require_approval
-quarantine                  -> deny
-block                       -> deny
+abstain                       -> require_approval
+collect_more_evidence         -> require_approval
+quarantine                    -> deny
+block                         -> deny
 ```
 
 An optional external provider V0.1 may return:
@@ -130,7 +130,7 @@ An optional external provider V0.1 may return:
 allow
 warn
 escalate
- deny
+deny
 ```
 
 with the adapter mapping:
@@ -161,6 +161,8 @@ issued_at
 ```
 
 `reason` and provider evidence are provenance for the external decision. They do not become Agent Memory truth merely because the provider is trusted to make policy decisions.
+
+Provider-specific revision, package, rule, bundle, or source identity may travel inside the bounded `evidence` object when needed for reconstructability. Such metadata does not become a new canonical Agent Memory authority field merely because one provider exposes it.
 
 ## Provider posture
 
@@ -200,6 +202,8 @@ When `require_approval` is the effective result:
 - approval cannot broaden scope or change the memory operation silently;
 - the approval principal and authority evidence remain separate from the memory proposal itself;
 - approval satisfaction still does not prove execution.
+
+An external provider returning `allow` is not an approval record and cannot discharge an Agent Memory `require_approval` consequence.
 
 The existing durable-decision overwrite and shared-write coordination evidence demonstrate the same general rule inside Agent Memory: a valid coordination or approval artifact is not a bypass token for PAMA.
 
@@ -276,7 +280,7 @@ Under authoritative provider mode the effective result is deny. Under advisory m
 ### Provider unavailable
 
 ```text
-advisory provider unavailable     -> local decision + unavailable evidence
+advisory provider unavailable      -> local decision + unavailable evidence
 authoritative provider unavailable -> deny
 ```
 
@@ -290,6 +294,113 @@ expected execution_status = unknown
 
 No conformance report may upgrade that state to enforced, prevented, or executed by inference.
 
+## First real policy-host proof: Open Policy Agent
+
+The generic seam is behaviorally proven against OPA `v1.19.0`, exact source commit `1e32c796e8979b1bda2f768138500b1deb95ff24`.
+
+The dedicated comparator verifies the official Linux amd64 release artifact against SHA-256:
+
+```text
+4ae5eeec241c9f5df7c5f566fe96e26336ce186f8c773c46ffdf10b48189a520
+```
+
+It then validates a Rego v1 comparator policy and evaluates real projections with the real OPA CLI.
+
+### Minimized OPA input
+
+OPA receives an explicit subset of the already-minimized projection:
+
+```text
+input_identity
+proposal_id
+memory_id
+operation
+actor_id
+scope
+tenant_ref
+purpose
+state_snapshot
+risk_class
+reversibility
+pama_decision_ref
+pama_outcome
+permitted_actions
+prohibited_actions
+policy_version
+```
+
+It does not require raw memory content, evidence payloads, prompts, hidden reasoning, or retrieved context.
+
+### Real monotonic matrix
+
+The pinned real OPA engine proves:
+
+```text
+native allow + OPA allow              -> allow
+native allow + OPA deny               -> deny
+native require_approval + OPA allow   -> require_approval
+native deny + OPA allow               -> deny
+```
+
+This confirms the first external policy host can tighten Agent Memory consequence but cannot loosen PAMA.
+
+### OPA policy revision
+
+The comparator policy returns an explicit policy revision. The OPA adapter compares it with the expected pinned revision **before** building a valid generic external decision.
+
+```text
+expected revision == observed revision
+-> normalize external decision
+-> generic composition
+
+expected revision != observed revision
+-> adapter marks stale policy revision
+-> no valid external decision reaches generic composition
+-> configured advisory/authoritative provider-failure posture applies
+```
+
+OPA revision is therefore adapter evidence, not a new canonical composition field.
+
+The real-host proof did not require a generic schema change for OPA revision semantics.
+
+### Stale Agent Memory input identity
+
+The comparator also reuses one valid real OPA decision against a different current Agent Memory projection.
+
+The existing generic composition layer detects the mismatched `input_identity` and records stale identity. No OPA-specific identity exception is needed.
+
+### Decision remains distinct from enforcement
+
+A successful real OPA evaluation still produces a composition receipt with:
+
+```text
+execution_status = unknown
+```
+
+OPA's policy decision does not prove:
+
+- the action executed;
+- an enforcement point was reached;
+- the action was prevented;
+- a human approved the action;
+- durable Agent Memory state changed.
+
+The comparator creates no canonical memory write merely because OPA returned a decision.
+
+### Generic finding from the first host
+
+OPA required no provider-specific canonical composition semantics.
+
+Its package, rule, policy revision, release, and source pin fit inside external decision evidence. Its `allow`/`deny` result fits the existing normalized consequence lattice. Its input binding uses the existing Agent Memory `input_identity`.
+
+```text
+real OPA decision mechanics
+-> existing external decision builder
+-> existing monotonic composition receipt
+```
+
+That is the result the first real peer was intended to test.
+
 ## Relationship to existing Agent Memory contracts
 
 This profile composes with existing artifacts rather than replacing them:
@@ -298,7 +409,8 @@ This profile composes with existing artifacts rather than replacing them:
 - decision receipt records the selected Agent Memory consequence;
 - portable governance evidence may correlate a completed Agent Memory decision with external trust systems;
 - Governance Context Projection carries remembered context/precedent outward and does not become this action-decision projection;
-- execution evidence remains a separate future surface.
+- execution evidence remains a separate surface;
+- real OPA policy evaluation remains external decision evidence and does not become memory state merely because it is deterministic.
 
 The outbound directions are therefore distinct:
 
@@ -316,15 +428,33 @@ Portable governance evidence
   -> verifier / attestation consumer
 ```
 
+## Follow-on gate
+
+The #166 research order requires a second materially different deterministic policy peer before this abstraction is treated as broadly proven.
+
+The recommended second host is Cedar.
+
+```text
+OPA first
+-> generic seam survives one real host
+
+Cedar second
+-> test whether the same projection/result/composition contract survives a different policy model
+```
+
+Do not add a third policy peer until OPA and Cedar have both been evaluated through the same generic boundary, or a real incompatibility has been returned to research.
+
 ## Non-goals
 
 - making Agent Memory a universal PDP;
-- adopting Microsoft AGT, DashClaw, OPA, Cedar, or another provider as a dependency;
+- adopting Microsoft AGT, DashClaw, OPA, Cedar, or another provider as a required dependency;
 - importing a vendor policy language into memory doctrine;
 - allowing external `allow` to weaken PAMA;
 - treating a decision receipt as execution proof;
 - exporting raw memory content when stable references and characteristics suffice;
-- supporting transform-style provider verdicts in V0.1.
+- supporting transform-style provider verdicts in V0.1;
+- using OPA policy revision as standing Agent Memory authority;
+- treating OPA policy evaluation as approval or enforcement evidence.
 
 ## Doctrine boundary
 

--- a/reference/agentmem_ref/opa_policy_comparator.py
+++ b/reference/agentmem_ref/opa_policy_comparator.py
@@ -1,0 +1,545 @@
+"""Pinned real-OPA comparator for Agent Memory external policy composition.
+
+Issue #214 proves the existing vendor-neutral external policy seam against the
+real OPA CLI. OPA-specific parsing and policy-revision handling remain at this
+adapter edge. Valid results are normalized through the existing
+``external-policy-decision`` builder and composed by the existing monotonic
+composition implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import policy
+from .enforcement_composition import (
+    ALLOW,
+    DENY,
+    PROVIDER_ADVISORY,
+    PROVIDER_AUTHORITATIVE,
+    REQUIRE_APPROVAL,
+    STATUS_AVAILABLE,
+    STATUS_STALE_IDENTITY,
+    STATUS_UNAVAILABLE,
+    build_external_decision,
+    build_projection,
+    compose,
+)
+from .substrate import InMemoryTemporalGraph
+
+OPA_VERSION = "1.19.0"
+OPA_TAG = "v1.19.0"
+OPA_SOURCE_COMMIT = "1e32c796e8979b1bda2f768138500b1deb95ff24"
+OPA_PROVIDER_ID = "open-policy-agent/opa"
+OPA_POLICY_PACKAGE = "agentmemory"
+OPA_POLICY_RULE = "decision"
+OPA_POLICY_QUERY = f"data.{OPA_POLICY_PACKAGE}.{OPA_POLICY_RULE}"
+OPA_POLICY_REVISION = "agent-memory-opa-policy-v0.1.0"
+OPA_POLICY_PATH = Path(__file__).resolve().parents[1] / "policies" / "opa_agent_memory_v01.rego"
+
+
+@dataclass(frozen=True)
+class OpaAdapterObservation:
+    status: str
+    external_decision: dict[str, Any] | None = None
+    observed_policy_revision: str | None = None
+    error: str | None = None
+
+
+def _proposal(
+    *,
+    proposal_id: str,
+    purpose: str,
+    operation: str = "promotion",
+    risk_class: str = "low",
+    target_class: str = policy.M2,
+    downstream_authority: str = policy.A1,
+    reversibility: str = "reversible",
+) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=proposal_id,
+        actor_id="actor:opa-comparator",
+        charter_version="charter:opa-comparator-v1",
+        target_reference=f"mem:{proposal_id}",
+        target_class=target_class,
+        scope="scope:tenant-a/project-a",
+        operation=operation,
+        current_strength="promoted" if operation == "scope_expansion" else "reinforced",
+        proposed_strength="canonical" if operation == "scope_expansion" else "promoted",
+        downstream_authority=downstream_authority,
+        reversibility=reversibility,
+        risk_class=risk_class,
+        evidence_refs=(f"evidence:{proposal_id}",),
+        state_snapshot="v0",
+        tenant_ref="tenant-a",
+        purpose=purpose,
+        isolation_domain_refs=("scope:tenant-a/project-a",),
+        project_ref="project-a",
+    )
+
+
+def _projection(
+    *,
+    proposal_id: str,
+    purpose: str,
+    operation: str = "promotion",
+    risk_class: str = "low",
+    target_class: str = policy.M2,
+    downstream_authority: str = policy.A1,
+    reversibility: str = "reversible",
+) -> tuple[policy.Proposal, policy.Decision, dict[str, Any]]:
+    proposal = _proposal(
+        proposal_id=proposal_id,
+        purpose=purpose,
+        operation=operation,
+        risk_class=risk_class,
+        target_class=target_class,
+        downstream_authority=downstream_authority,
+        reversibility=reversibility,
+    )
+    decision = policy.evaluate(proposal)
+    return proposal, decision, build_projection(proposal, decision)
+
+
+def minimized_opa_input(projection: dict[str, Any]) -> dict[str, Any]:
+    """Return the explicit subset the OPA comparator is allowed to inspect."""
+    allowed = (
+        "input_identity",
+        "proposal_id",
+        "memory_id",
+        "operation",
+        "actor_id",
+        "scope",
+        "tenant_ref",
+        "purpose",
+        "state_snapshot",
+        "risk_class",
+        "reversibility",
+        "pama_decision_ref",
+        "pama_outcome",
+        "permitted_actions",
+        "prohibited_actions",
+        "policy_version",
+    )
+    return {field: projection[field] for field in allowed if field in projection}
+
+
+def parse_opa_eval_document(document: Any) -> dict[str, Any]:
+    """Extract the value of one ``opa eval --format=json`` expression."""
+    if not isinstance(document, dict):
+        raise ValueError("OPA eval output must be a JSON object")
+    results = document.get("result")
+    if not isinstance(results, list) or len(results) != 1:
+        raise ValueError("OPA eval output must contain exactly one result")
+    expressions = results[0].get("expressions") if isinstance(results[0], dict) else None
+    if not isinstance(expressions, list) or len(expressions) != 1:
+        raise ValueError("OPA eval output must contain exactly one expression")
+    expression = expressions[0]
+    if not isinstance(expression, dict) or not isinstance(expression.get("value"), dict):
+        raise ValueError("OPA eval expression must contain an object value")
+    value = expression["value"]
+    required = ("decision", "reason", "input_identity", "policy_revision")
+    missing = [field for field in required if not isinstance(value.get(field), str) or not value.get(field)]
+    if missing:
+        raise ValueError(f"OPA decision missing required fields: {missing}")
+    if value["decision"] not in {"allow", "warn", "escalate", "deny"}:
+        raise ValueError(f"unsupported OPA decision {value['decision']!r}")
+    return {
+        "decision": value["decision"],
+        "reason": value["reason"],
+        "input_identity": value["input_identity"],
+        "policy_revision": value["policy_revision"],
+    }
+
+
+def detect_opa_version(opa_binary: str) -> str:
+    try:
+        completed = subprocess.run(
+            [opa_binary, "version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        raise RuntimeError(f"OPA binary unavailable: {exc}") from exc
+    if completed.returncode != 0:
+        raise RuntimeError(f"OPA version command failed: {completed.stderr.strip() or completed.stdout.strip()}")
+    for line in completed.stdout.splitlines():
+        if line.startswith("Version:"):
+            return line.split(":", 1)[1].strip()
+    raise RuntimeError("OPA version output did not contain Version:")
+
+
+def evaluate_opa(
+    projection: dict[str, Any],
+    *,
+    opa_binary: str,
+    expected_policy_revision: str = OPA_POLICY_REVISION,
+    issued_at: str = "2026-08-13T03:35:00Z",
+    policy_path: Path = OPA_POLICY_PATH,
+) -> OpaAdapterObservation:
+    """Evaluate the pinned OPA policy and normalize only a compatible result."""
+    input_document = minimized_opa_input(projection)
+    with tempfile.NamedTemporaryFile("w", suffix=".json", encoding="utf-8", delete=False) as handle:
+        json.dump(input_document, handle, sort_keys=True, separators=(",", ":"))
+        input_path = Path(handle.name)
+    try:
+        try:
+            completed = subprocess.run(
+                [
+                    opa_binary,
+                    "eval",
+                    "--format=json",
+                    "--data",
+                    str(policy_path),
+                    "--input",
+                    str(input_path),
+                    OPA_POLICY_QUERY,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (FileNotFoundError, OSError) as exc:
+            return OpaAdapterObservation(status="unavailable", error=str(exc))
+        except subprocess.TimeoutExpired as exc:
+            return OpaAdapterObservation(status="error", error=f"OPA evaluation timeout: {exc}")
+    finally:
+        input_path.unlink(missing_ok=True)
+
+    if completed.returncode != 0:
+        return OpaAdapterObservation(
+            status="error",
+            error=completed.stderr.strip() or completed.stdout.strip() or f"OPA exited {completed.returncode}",
+        )
+    try:
+        document = json.loads(completed.stdout)
+        value = parse_opa_eval_document(document)
+    except (json.JSONDecodeError, ValueError) as exc:
+        return OpaAdapterObservation(status="invalid", error=str(exc))
+
+    observed_revision = value["policy_revision"]
+    if observed_revision != expected_policy_revision:
+        return OpaAdapterObservation(
+            status="stale_policy_revision",
+            observed_policy_revision=observed_revision,
+            error=(
+                f"OPA policy revision mismatch: expected {expected_policy_revision!r}, "
+                f"observed {observed_revision!r}"
+            ),
+        )
+
+    try:
+        decision = build_external_decision(
+            provider_id=OPA_PROVIDER_ID,
+            provider_version=OPA_VERSION,
+            input_identity=value["input_identity"],
+            decision=value["decision"],
+            reason=value["reason"],
+            issued_at=issued_at,
+            evidence={
+                "policy_engine": "opa",
+                "policy_package": OPA_POLICY_PACKAGE,
+                "policy_rule": OPA_POLICY_RULE,
+                "policy_revision": observed_revision,
+                "policy_ref": str(policy_path.relative_to(Path(__file__).resolve().parents[2])),
+                "opa_release": OPA_TAG,
+                "opa_source_commit": OPA_SOURCE_COMMIT,
+            },
+        )
+    except ValueError as exc:
+        return OpaAdapterObservation(status="invalid", observed_policy_revision=observed_revision, error=str(exc))
+    return OpaAdapterObservation(
+        status="available",
+        external_decision=decision,
+        observed_policy_revision=observed_revision,
+    )
+
+
+def _compose_observation(projection: dict[str, Any], observation: OpaAdapterObservation, provider_mode: str) -> dict[str, Any]:
+    return compose(
+        projection,
+        provider_mode=provider_mode,
+        external_decision=observation.external_decision if observation.status == "available" else None,
+    )
+
+
+def _matrix_case(
+    *,
+    case_id: str,
+    proposal_id: str,
+    purpose: str,
+    expected_local: str,
+    expected_opa: str,
+    expected_effective: str,
+    opa_binary: str,
+    operation: str = "promotion",
+    risk_class: str = "low",
+    target_class: str = policy.M2,
+    downstream_authority: str = policy.A1,
+    reversibility: str = "reversible",
+) -> dict[str, Any]:
+    proposal, native, projection = _projection(
+        proposal_id=proposal_id,
+        purpose=purpose,
+        operation=operation,
+        risk_class=risk_class,
+        target_class=target_class,
+        downstream_authority=downstream_authority,
+        reversibility=reversibility,
+    )
+    observation = evaluate_opa(projection, opa_binary=opa_binary)
+    if observation.status != "available" or observation.external_decision is None:
+        raise AssertionError(f"{case_id}: real OPA decision unavailable: {observation}")
+    receipt = compose(
+        projection,
+        provider_mode=PROVIDER_AUTHORITATIVE,
+        external_decision=observation.external_decision,
+    )
+    checks = {
+        "local_expected": receipt["local_normalized_decision"] == expected_local,
+        "opa_expected": receipt.get("external_normalized_decision") == expected_opa,
+        "effective_expected": receipt["effective_decision"] == expected_effective,
+        "provider_available": receipt["external_provider_status"] == STATUS_AVAILABLE,
+        "execution_not_established": receipt["execution_status"] == "unknown",
+        "projection_identity_preserved": observation.external_decision["input_identity"] == projection["input_identity"],
+        "policy_revision_preserved": (
+            observation.external_decision.get("evidence", {}).get("policy_revision") == OPA_POLICY_REVISION
+        ),
+        "pama_envelope_unchanged": (
+            projection["permitted_actions"] == sorted(set(native.permitted_actions))
+            and projection["prohibited_actions"] == sorted(set(native.prohibited_actions))
+        ),
+    }
+    return {
+        "case_id": case_id,
+        "proposal": proposal,
+        "native_outcome": native.outcome,
+        "projection": projection,
+        "opa_observation": observation,
+        "composition": receipt,
+        "checks": checks,
+        "passed": all(checks.values()),
+    }
+
+
+def run_comparator(agent_memory_commit: str, *, opa_binary: str = "opa") -> dict[str, Any]:
+    if len(agent_memory_commit) != 40 or any(ch not in "0123456789abcdef" for ch in agent_memory_commit):
+        raise ValueError("agent_memory_commit must be an exact lowercase 40-hex commit")
+    installed_version = detect_opa_version(opa_binary)
+    if installed_version != OPA_VERSION:
+        raise RuntimeError(f"expected OPA {OPA_VERSION}, found {installed_version}")
+
+    substrate = InMemoryTemporalGraph()
+    initial_writes = len(substrate.write_log)
+
+    matrix = [
+        _matrix_case(
+            case_id="native-allow-opa-allow",
+            proposal_id="opa:allow-allow",
+            purpose="opa-allow",
+            expected_local=ALLOW,
+            expected_opa=ALLOW,
+            expected_effective=ALLOW,
+            opa_binary=opa_binary,
+        ),
+        _matrix_case(
+            case_id="native-allow-opa-deny",
+            proposal_id="opa:allow-deny",
+            purpose="opa-deny",
+            expected_local=ALLOW,
+            expected_opa=DENY,
+            expected_effective=DENY,
+            opa_binary=opa_binary,
+        ),
+        _matrix_case(
+            case_id="native-require-approval-opa-allow",
+            proposal_id="opa:review-allow",
+            purpose="opa-allow",
+            risk_class="medium",
+            expected_local=REQUIRE_APPROVAL,
+            expected_opa=ALLOW,
+            expected_effective=REQUIRE_APPROVAL,
+            opa_binary=opa_binary,
+        ),
+        _matrix_case(
+            case_id="native-deny-opa-allow",
+            proposal_id="opa:deny-allow",
+            purpose="opa-allow",
+            operation="scope_expansion",
+            risk_class="critical",
+            target_class=policy.M5,
+            downstream_authority=policy.A5,
+            reversibility="irreversible",
+            expected_local=DENY,
+            expected_opa=ALLOW,
+            expected_effective=DENY,
+            opa_binary=opa_binary,
+        ),
+    ]
+
+    # Provider-unavailable semantics are generic and must remain mode-specific.
+    _, _, failure_projection = _projection(
+        proposal_id="opa:provider-failure",
+        purpose="opa-allow",
+    )
+    unavailable_observation = evaluate_opa(
+        failure_projection,
+        opa_binary="/definitely/missing/opa",
+    )
+    advisory_unavailable = _compose_observation(failure_projection, unavailable_observation, PROVIDER_ADVISORY)
+    authoritative_unavailable = _compose_observation(
+        failure_projection,
+        unavailable_observation,
+        PROVIDER_AUTHORITATIVE,
+    )
+
+    # Adapter-specific policy revision staleness is rejected before generic
+    # composition. The generic layer then applies configured peer-failure mode.
+    stale_revision_observation = evaluate_opa(
+        failure_projection,
+        opa_binary=opa_binary,
+        expected_policy_revision="agent-memory-opa-policy-stale-test",
+    )
+    advisory_stale_revision = _compose_observation(
+        failure_projection,
+        stale_revision_observation,
+        PROVIDER_ADVISORY,
+    )
+    authoritative_stale_revision = _compose_observation(
+        failure_projection,
+        stale_revision_observation,
+        PROVIDER_AUTHORITATIVE,
+    )
+
+    # A valid real OPA decision for one exact projection cannot be replayed
+    # against another Agent Memory input identity.
+    _, _, projection_a = _projection(
+        proposal_id="opa:identity-a",
+        purpose="opa-allow",
+    )
+    _, _, projection_b = _projection(
+        proposal_id="opa:identity-b",
+        purpose="opa-allow",
+    )
+    identity_observation = evaluate_opa(projection_a, opa_binary=opa_binary)
+    if identity_observation.status != "available" or identity_observation.external_decision is None:
+        raise AssertionError(f"identity OPA evaluation unavailable: {identity_observation}")
+    authoritative_stale_identity = compose(
+        projection_b,
+        provider_mode=PROVIDER_AUTHORITATIVE,
+        external_decision=identity_observation.external_decision,
+    )
+    advisory_stale_identity = compose(
+        projection_b,
+        provider_mode=PROVIDER_ADVISORY,
+        external_decision=identity_observation.external_decision,
+    )
+
+    final_writes = len(substrate.write_log)
+    matrix_passed = all(case["passed"] for case in matrix)
+    checks = {
+        "real_opa_version_exact": installed_version == OPA_VERSION,
+        "real_opa_matrix_passed": matrix_passed,
+        "opa_can_tighten_native_allow": matrix[1]["composition"]["effective_decision"] == DENY,
+        "opa_allow_cannot_loosen_native_review": matrix[2]["composition"]["effective_decision"] == REQUIRE_APPROVAL,
+        "opa_allow_cannot_loosen_native_deny": matrix[3]["composition"]["effective_decision"] == DENY,
+        "advisory_unavailable_preserves_native": (
+            unavailable_observation.status == "unavailable"
+            and advisory_unavailable["external_provider_status"] == STATUS_UNAVAILABLE
+            and advisory_unavailable["effective_decision"] == ALLOW
+        ),
+        "authoritative_unavailable_fails_closed": (
+            authoritative_unavailable["external_provider_status"] == STATUS_UNAVAILABLE
+            and authoritative_unavailable["effective_decision"] == DENY
+        ),
+        "stale_policy_revision_detected_at_adapter": stale_revision_observation.status == "stale_policy_revision",
+        "advisory_stale_revision_preserves_native": advisory_stale_revision["effective_decision"] == ALLOW,
+        "authoritative_stale_revision_fails_closed": authoritative_stale_revision["effective_decision"] == DENY,
+        "stale_input_identity_detected_by_generic_layer": (
+            authoritative_stale_identity["external_provider_status"] == STATUS_STALE_IDENTITY
+            and advisory_stale_identity["external_provider_status"] == STATUS_STALE_IDENTITY
+        ),
+        "authoritative_stale_identity_fails_closed": authoritative_stale_identity["effective_decision"] == DENY,
+        "advisory_stale_identity_preserves_native": advisory_stale_identity["effective_decision"] == ALLOW,
+        "opa_success_not_execution_evidence": all(
+            case["composition"]["execution_status"] == "unknown" for case in matrix
+        ),
+        "opa_decision_did_not_create_memory_fact": final_writes == initial_writes == 0,
+        "generic_composition_receipt_has_no_opa_specific_core_fields": all(
+            not any(key.startswith("opa_") for key in case["composition"]) for case in matrix
+        ),
+        "minimized_policy_input_excludes_raw_payloads": all(
+            "raw" not in key and "content" not in key and "prompt" not in key
+            for key in minimized_opa_input(matrix[0]["projection"])
+        ),
+    }
+    passed = all(checks.values())
+    result = {
+        "schema_version": "1.0.0",
+        "comparator": "opa-external-policy-composition-v0.1",
+        "agent_memory_commit": agent_memory_commit,
+        "pinned_opa": {
+            "release": OPA_TAG,
+            "source_commit": OPA_SOURCE_COMMIT,
+            "installed_version": installed_version,
+            "policy_ref": str(OPA_POLICY_PATH.relative_to(Path(__file__).resolve().parents[2])),
+            "policy_package": OPA_POLICY_PACKAGE,
+            "policy_rule": OPA_POLICY_RULE,
+            "expected_policy_revision": OPA_POLICY_REVISION,
+        },
+        "matrix": [
+            {
+                "case_id": case["case_id"],
+                "native_outcome": case["native_outcome"],
+                "input_identity": case["projection"]["input_identity"],
+                "opa_status": case["opa_observation"].status,
+                "opa_decision": case["opa_observation"].external_decision,
+                "composition": case["composition"],
+                "checks": case["checks"],
+                "passed": case["passed"],
+            }
+            for case in matrix
+        ],
+        "failure_modes": {
+            "unavailable": {
+                "adapter_status": unavailable_observation.status,
+                "advisory": advisory_unavailable,
+                "authoritative": authoritative_unavailable,
+            },
+            "stale_policy_revision": {
+                "adapter_status": stale_revision_observation.status,
+                "observed_policy_revision": stale_revision_observation.observed_policy_revision,
+                "advisory": advisory_stale_revision,
+                "authoritative": authoritative_stale_revision,
+            },
+            "stale_input_identity": {
+                "source_identity": projection_a["input_identity"],
+                "current_identity": projection_b["input_identity"],
+                "advisory": advisory_stale_identity,
+                "authoritative": authoritative_stale_identity,
+            },
+        },
+        "memory_write_count": final_writes,
+        "checks": checks,
+        "passed": passed,
+        "non_claims": [
+            "opa_decision_is_not_agent_memory_authority",
+            "opa_allow_is_not_approval_or_standing_permission",
+            "opa_decision_is_not_enforcement_evidence",
+            "opa_evaluation_success_is_not_execution_evidence",
+            "opa_policy_revision_is_adapter_evidence_not_canonical_memory_state",
+            "opa_policy_is_not_agent_memory_canonical_policy_storage",
+        ],
+    }
+    if not passed:
+        failed = [name for name, ok in checks.items() if not ok]
+        raise AssertionError(f"OPA external-policy comparator failed: {failed}; result={result}")
+    return result

--- a/reference/policies/opa_agent_memory_v01.rego
+++ b/reference/policies/opa_agent_memory_v01.rego
@@ -1,0 +1,23 @@
+package agentmemory
+
+import rego.v1
+
+policy_revision := "agent-memory-opa-policy-v0.1.0"
+
+# This policy is a comparator fixture, not canonical Agent Memory policy.
+# It consumes only the minimized external-enforcement projection. A purpose
+# marker chooses a deliberately stricter peer decision for the monotonic matrix;
+# all other bounded cases return allow so native PAMA strictness remains visible.
+decision := {
+    "decision": "deny",
+    "reason": "OPA comparator fixture denies the explicitly marked peer-deny case",
+    "input_identity": input.input_identity,
+    "policy_revision": policy_revision,
+} if {
+    input.purpose == "opa-deny"
+} else := {
+    "decision": "allow",
+    "reason": "OPA comparator fixture allows this bounded projection",
+    "input_identity": input.input_identity,
+    "policy_revision": policy_revision,
+}

--- a/reference/run_opa_policy_comparator.py
+++ b/reference/run_opa_policy_comparator.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Run the pinned OPA external-policy composition comparator."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref.opa_policy_comparator import run_comparator
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--opa-binary", default="opa")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    result = run_comparator(args.agent_memory_commit, opa_binary=args.opa_binary)
+    Path(args.output).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/reference/tests/test_opa_policy_comparator.py
+++ b/reference/tests/test_opa_policy_comparator.py
@@ -1,0 +1,110 @@
+"""OPA adapter-edge tests that do not require an installed OPA binary."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.opa_policy_comparator import (
+    OPA_POLICY_REVISION,
+    minimized_opa_input,
+    parse_opa_eval_document,
+)
+from agentmem_ref import policy
+from agentmem_ref.enforcement_composition import build_projection
+
+
+class OpaPolicyComparatorTests(unittest.TestCase):
+    def _document(self, **overrides):
+        value = {
+            "decision": "allow",
+            "reason": "fixture",
+            "input_identity": "sha256:" + "a" * 64,
+            "policy_revision": OPA_POLICY_REVISION,
+        }
+        value.update(overrides)
+        return {
+            "result": [
+                {
+                    "expressions": [
+                        {
+                            "value": value,
+                            "text": "data.agentmemory.decision",
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def test_parse_valid_opa_eval_document(self):
+        value = parse_opa_eval_document(self._document())
+        self.assertEqual(value["decision"], "allow")
+        self.assertEqual(value["policy_revision"], OPA_POLICY_REVISION)
+
+    def test_parse_rejects_missing_result(self):
+        with self.assertRaisesRegex(ValueError, "exactly one result"):
+            parse_opa_eval_document({})
+
+    def test_parse_rejects_missing_required_fields(self):
+        with self.assertRaisesRegex(ValueError, "missing required fields"):
+            parse_opa_eval_document(self._document(reason=""))
+
+    def test_parse_rejects_unknown_decision(self):
+        with self.assertRaisesRegex(ValueError, "unsupported OPA decision"):
+            parse_opa_eval_document(self._document(decision="permit_forever"))
+
+    def test_minimized_input_has_no_raw_payload_surface(self):
+        proposal = policy.Proposal(
+            proposal_id="proposal:opa:minimize",
+            actor_id="actor:test",
+            charter_version="charter:v1",
+            target_reference="mem:opa:minimize",
+            target_class=policy.M2,
+            scope="scope:tenant-a/project-a",
+            operation="promotion",
+            current_strength="reinforced",
+            proposed_strength="promoted",
+            downstream_authority=policy.A1,
+            reversibility="reversible",
+            risk_class="low",
+            evidence_refs=("evidence:opa",),
+            state_snapshot="v0",
+            tenant_ref="tenant-a",
+            purpose="opa-allow",
+            isolation_domain_refs=("scope:tenant-a/project-a",),
+            project_ref="project-a",
+        )
+        projection = build_projection(proposal, policy.evaluate(proposal))
+        minimized = minimized_opa_input(projection)
+        self.assertEqual(minimized["input_identity"], projection["input_identity"])
+        self.assertEqual(minimized["operation"], "promotion")
+        self.assertEqual(minimized["purpose"], "opa-allow")
+        for forbidden in (
+            "evidence_refs",
+            "authority_refs",
+            "raw_memory",
+            "memory_content",
+            "prompt",
+            "hidden_reasoning",
+        ):
+            self.assertNotIn(forbidden, minimized)
+
+    def test_parse_does_not_adopt_extra_opa_authority_fields(self):
+        document = self._document()
+        value = document["result"][0]["expressions"][0]["value"]
+        value.update(
+            {
+                "approval": "granted",
+                "standing_authority": True,
+                "execution_status": "executed",
+                "enforcement_status": "enforced",
+            }
+        )
+        parsed = parse_opa_eval_document(document)
+        self.assertEqual(
+            set(parsed),
+            {"decision", "reason", "input_identity", "policy_revision"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #214: prove the existing vendor-neutral external policy composition seam against a **real pinned OPA engine** rather than the in-repo fake provider.

Pinned host:

- OPA `v1.19.0`
- exact source commit `1e32c796e8979b1bda2f768138500b1deb95ff24`
- official Linux amd64 release asset SHA-256 `4ae5eeec241c9f5df7c5f566fe96e26336ce186f8c773c46ffdf10b48189a520`

## Real policy path

A small Rego v1 comparator policy consumes only the existing content-minimized `external-enforcement-decision-projection` subset and returns:

```text
decision
reason
input_identity
policy_revision
```

OPA-specific policy revision stays adapter evidence. An unexpected revision is rejected before generic composition rather than becoming a new canonical composition field.

Valid OPA results are normalized through the existing `build_external_decision(...)` and composed only through the existing `compose(...)` implementation.

## Monotonic real-host matrix

The real OPA CLI must prove:

```text
native allow + OPA allow -> allow
native allow + OPA deny -> deny
native require_approval + OPA allow -> require_approval
native deny + OPA allow -> deny
```

OPA may tighten native PAMA consequence but cannot loosen it.

## Failure semantics

The comparator also proves:

- advisory provider unavailable -> native PAMA remains effective;
- authoritative provider unavailable -> fail closed to deny;
- unexpected OPA policy revision -> adapter rejects the decision, then advisory/authoritative generic failure semantics apply;
- a valid real OPA decision replayed against a different Agent Memory `input_identity` is detected by the existing generic stale-identity gate;
- advisory stale identity preserves native decision;
- authoritative stale identity denies.

## Decision != enforcement

Every successful composition receipt retains:

```text
execution_status = unknown
```

The comparator never claims that OPA evaluation means the action executed or that an enforcement point was reached.

OPA `allow` is also not approval, standing permission, memory authority, or canonical memory state.

## No OPA-specific core semantics

The generic projection/decision/composition schemas are unchanged.

OPA-specific package/rule/revision/source-pin information is carried only inside the existing external decision `evidence` object.

## Privacy / minimization

OPA input is an explicit allowlist from the already-minimized projection. It excludes evidence payloads, raw memory content, prompts, hidden reasoning, and arbitrary application state.

## Dedicated exact-head gate

`OPA Policy Comparator`:

1. downloads the official OPA v1.19.0 Linux binary;
2. verifies its official release SHA-256;
3. verifies `Version: 1.19.0`;
4. validates the Rego policy with `opa check`;
5. runs adapter parser regressions;
6. executes the real OPA monotonic/failure comparator;
7. uploads the exact-head machine-readable comparator artifact.

## Added surfaces

- `reference/policies/opa_agent_memory_v01.rego`
- `reference/agentmem_ref/opa_policy_comparator.py`
- `reference/run_opa_policy_comparator.py`
- `reference/tests/test_opa_policy_comparator.py`
- `.github/workflows/opa-policy-comparator.yml`

## Stop line

Do not expand this PR into OPA server/bundle operations, OPA as canonical policy storage, an enforcement claim, Cedar support, or new PAMA semantics.

This PR remains draft until the real OPA comparator passes at the exact final head, the generic external-enforcement profile is updated only with surviving findings, all repository-wide regressions pass, and #214 acceptance criteria are reviewed.

Closes #214