### PR TITLE
Prove generic external policy composition against pinned Cedar

### DIFF
--- a/.github/workflows/cedar-policy-comparator.yml
+++ b/.github/workflows/cedar-policy-comparator.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build pinned Cedar CLI from exact source commit
         env:
-          CEDAR_SOURCE_COMMIT: fdcbaed9bba4f67b498f60733cb9253d2ffc968e
+          CEDAR_SOURCE_COMMIT: fdcbaed32bdb8c8d13e4eaf2b58db5555e9fb8c5
           CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         run: >-
           cargo install

--- a/.github/workflows/cedar-policy-comparator.yml
+++ b/.github/workflows/cedar-policy-comparator.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Build pinned Cedar CLI from exact source commit
         env:
           CEDAR_SOURCE_COMMIT: fdcbaed9bba4f67b498f60733cb9253d2ffc968e
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         run: >-
           cargo install
           --locked

--- a/.github/workflows/cedar-policy-comparator.yml
+++ b/.github/workflows/cedar-policy-comparator.yml
@@ -1,0 +1,71 @@
+name: Cedar Policy Comparator
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  cedar-policy-comparator:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Install exact Rust toolchain
+        run: |
+          rustup toolchain install 1.89.0 --profile minimal
+          rustup default 1.89.0
+          rustc --version
+          cargo --version
+
+      - name: Build pinned Cedar CLI from exact source commit
+        env:
+          CEDAR_SOURCE_COMMIT: fdcbaed9bba4f67b498f60733cb9253d2ffc968e
+        run: >-
+          cargo install
+          --locked
+          --root /tmp/cedar-install
+          --git https://github.com/cedar-policy/cedar
+          --rev "$CEDAR_SOURCE_COMMIT"
+          cedar-policy-cli
+
+      - name: Verify pinned Cedar version and policy artifact
+        env:
+          CEDAR_POLICY_SHA256: a369c1423d48b6656e5e19f2589cc4660e00695e3b084c0a732b3f7f7ba6e18f
+        run: |
+          /tmp/cedar-install/bin/cedar --version
+          /tmp/cedar-install/bin/cedar --version | grep -F "4.12.0"
+          echo "$CEDAR_POLICY_SHA256  reference/policies/cedar_agent_memory_v01.cedar" | sha256sum --check --strict
+
+      - name: Execute Cedar adapter parser regressions
+        env:
+          PYTHONPATH: reference
+        run: python -m unittest tests.test_cedar_policy_comparator
+
+      - name: Execute real Cedar external-policy comparator
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          PYTHONPATH=reference
+          python reference/run_cedar_policy_comparator.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --cedar-binary /tmp/cedar-install/bin/cedar
+          --output cedar-policy-comparator.json
+
+      - name: Upload Cedar policy composition evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: cedar-policy-comparator-evidence
+          path: cedar-policy-comparator.json
+          if-no-files-found: error

--- a/docs/profiles/external-enforcement-decision-profile.md
+++ b/docs/profiles/external-enforcement-decision-profile.md
@@ -4,7 +4,7 @@
 
 This profile defines the smallest vendor-neutral boundary needed to carry an Agent Memory governed mutation decision to an optional external policy or enforcement host without surrendering memory-specific semantics.
 
-It implements the Phase 1 contract work of issue #152 and is now behaviorally proven against a first real deterministic policy host, Open Policy Agent (OPA). OPA remains an optional reference peer, not a required Agent Memory dependency.
+It implements the Phase 1 contract work of issue #152 and is now behaviorally proven against two materially different real deterministic policy hosts: Open Policy Agent (OPA) and Cedar. Both remain optional reference peers, not required Agent Memory dependencies.
 
 The responsibility split is:
 
@@ -162,7 +162,7 @@ issued_at
 
 `reason` and provider evidence are provenance for the external decision. They do not become Agent Memory truth merely because the provider is trusted to make policy decisions.
 
-Provider-specific revision, package, rule, bundle, or source identity may travel inside the bounded `evidence` object when needed for reconstructability. Such metadata does not become a new canonical Agent Memory authority field merely because one provider exposes it.
+Provider-specific revision, package, rule, bundle, source identity, policy artifact digest, determining policy ID, or equivalent reconstructability metadata may travel inside the bounded `evidence` object. Such metadata does not become a new canonical Agent Memory authority field merely because one provider exposes it.
 
 ## Provider posture
 
@@ -401,6 +401,125 @@ real OPA decision mechanics
 
 That is the result the first real peer was intended to test.
 
+## Second real policy-host proof: Cedar
+
+The same generic seam is now behaviorally proven against Cedar `v4.12.0`, exact tag commit `fdcbaed32bdb8c8d13e4eaf2b58db5555e9fb8c5`.
+
+The dedicated workflow builds `cedar-policy-cli` from that exact Git source under the release's Rust 1.89 minimum toolchain, verifies the installed Cedar 4.12.0 binary, verifies the checked-in policy artifact SHA-256, and executes the comparator against the real engine.
+
+### Why Cedar is a meaningful second host
+
+Cedar's result shape is materially different from the OPA comparator.
+
+OPA can return an arbitrary structured value that echoes Agent Memory metadata. Cedar `authorize` instead evaluates an explicit principal/action/resource/context request and returns `ALLOW` or `DENY` plus diagnostics such as determining policy IDs.
+
+The Cedar adapter therefore owns request/result binding:
+
+```text
+Agent Memory input_identity
++ principal / action / resource / minimized context
++ exact policy artifact SHA-256
+-> real Cedar authorize
+-> ALLOW / DENY + determining policy IDs
+-> adapter binds result to the exact request it executed
+-> existing generic external decision
+-> existing generic composition
+```
+
+No Cedar-specific field was added to the canonical composition schemas.
+
+### Minimized Cedar request
+
+The reference comparator maps only the bounded request identity and action context:
+
+```text
+principal <- actor_id
+action    <- operation
+resource  <- memory_id
+context   <- input_identity
+             purpose
+             risk_class
+             scope
+             tenant_ref
+             pama_outcome
+             policy_version
+```
+
+Raw memory content, prompts, hidden reasoning, arbitrary evidence payloads, and retrieved context are not required.
+
+### Real Cedar monotonic matrix
+
+The pinned real Cedar engine proves:
+
+```text
+native allow + Cedar allow              -> allow
+native allow + Cedar deny               -> deny
+native require_approval + Cedar allow   -> require_approval
+native deny + Cedar allow               -> deny
+```
+
+Cedar can therefore tighten a native Agent Memory consequence without gaining a path to loosen PAMA.
+
+### Policy artifact identity versus provider revision
+
+Cedar CLI does not return an arbitrary policy-revision field. The adapter instead binds decision evidence to the exact policy artifact under evaluation:
+
+```text
+policy_ref
+policy_sha256
+cedar_release
+cedar_source_commit
+determining_policy_ids
+request_digest
+```
+
+A mismatched expected policy digest is rejected at the adapter edge before any valid external decision reaches generic composition. Advisory versus authoritative failure posture is then handled by the existing generic rules.
+
+This demonstrates a useful cross-provider result: reconstructable provider policy identity belongs in bounded external evidence, while the generic composition contract needs only stable decision and Agent Memory input identity semantics.
+
+### Cedar DENY is not provider failure
+
+The pinned Cedar CLI uses exit code `2` for a completed authorization request whose decision is `DENY`. The adapter therefore treats that documented return code as a valid policy result and distinguishes it from actual CLI/provider failure.
+
+The distinction matters:
+
+```text
+policy evaluated and denied
+!=
+policy engine failed to evaluate
+```
+
+### Stale Agent Memory input identity remains generic
+
+A valid Cedar decision is rebound to the Agent Memory `input_identity` of the exact request the adapter executed. Replaying that normalized decision against another projection is rejected by the same generic stale-identity gate used for OPA.
+
+No Cedar-specific replay exception is needed.
+
+### Decision remains distinct from enforcement
+
+Successful Cedar authorization still produces:
+
+```text
+execution_status = unknown
+```
+
+Cedar ALLOW or DENY is policy-decision evidence. It is not approval, an enforcement witness, execution evidence, lifecycle satisfaction, or canonical Agent Memory state.
+
+## Generic finding after two materially different hosts
+
+OPA and Cedar differ significantly in policy language, request/result shape, and how reconstructable policy identity is surfaced. Both nevertheless fit the same core contract:
+
+```text
+Agent Memory semantics / PAMA
+-> minimized current-action projection
+-> provider-specific adapter
+-> external policy decision bound to exact input_identity
+-> monotonic composition
+-> separate approval / enforcement / execution evidence
+```
+
+The two-host proof therefore strengthens the claim that the generic seam is provider-neutral at this boundary. It does **not** imply that every authorization system will fit without further research, or that a third engine should be added merely to accumulate logos.
+
 ## Relationship to existing Agent Memory contracts
 
 This profile composes with existing artifacts rather than replacing them:
@@ -410,7 +529,7 @@ This profile composes with existing artifacts rather than replacing them:
 - portable governance evidence may correlate a completed Agent Memory decision with external trust systems;
 - Governance Context Projection carries remembered context/precedent outward and does not become this action-decision projection;
 - execution evidence remains a separate surface;
-- real OPA policy evaluation remains external decision evidence and does not become memory state merely because it is deterministic.
+- real OPA and Cedar policy evaluations remain external decision evidence and do not become memory state merely because they are deterministic.
 
 The outbound directions are therefore distinct:
 
@@ -430,31 +549,23 @@ Portable governance evidence
 
 ## Follow-on gate
 
-The #166 research order requires a second materially different deterministic policy peer before this abstraction is treated as broadly proven.
+The #166 two-host policy-abstraction gate is now satisfied by OPA and Cedar.
 
-The recommended second host is Cedar.
+A third policy peer should be added only when it tests a **materially different responsibility or failure mode**, not merely another allow/deny API. Examples may include relationship-based authorization state, embedded authorization libraries, identity-rich local PDP deployment, or a standards-shaped access-evaluation surface.
 
-```text
-OPA first
--> generic seam survives one real host
-
-Cedar second
--> test whether the same projection/result/composition contract survives a different policy model
-```
-
-Do not add a third policy peer until OPA and Cedar have both been evaluated through the same generic boundary, or a real incompatibility has been returned to research.
+Cedarling research is tracked separately because its potential value is primarily deployment, identity/token handling, policy-store evidence, local PDP operation, OPA bridging, and AuthZen exposure rather than proving Cedar's policy semantics a second time.
 
 ## Non-goals
 
 - making Agent Memory a universal PDP;
-- adopting Microsoft AGT, DashClaw, OPA, Cedar, or another provider as a required dependency;
+- adopting Microsoft AGT, DashClaw, OPA, Cedar, Cedarling, or another provider as a required dependency;
 - importing a vendor policy language into memory doctrine;
 - allowing external `allow` to weaken PAMA;
 - treating a decision receipt as execution proof;
 - exporting raw memory content when stable references and characteristics suffice;
 - supporting transform-style provider verdicts in V0.1;
-- using OPA policy revision as standing Agent Memory authority;
-- treating OPA policy evaluation as approval or enforcement evidence.
+- using provider policy revision, policy digest, or determining policy ID as standing Agent Memory authority;
+- treating OPA or Cedar policy evaluation as approval or enforcement evidence.
 
 ## Doctrine boundary
 

--- a/reference/agentmem_ref/cedar_policy_comparator.py
+++ b/reference/agentmem_ref/cedar_policy_comparator.py
@@ -35,7 +35,7 @@ from .substrate import InMemoryTemporalGraph
 
 CEDAR_VERSION = "4.12.0"
 CEDAR_TAG = "v4.12.0"
-CEDAR_SOURCE_COMMIT = "fdcbaed9bba4f67b498f60733cb9253d2ffc968e"
+CEDAR_SOURCE_COMMIT = "fdcbaed32bdb8c8d13e4eaf2b58db5555e9fb8c5"
 CEDAR_PROVIDER_ID = "cedar-policy/cedar"
 CEDAR_POLICY_PATH = Path(__file__).resolve().parents[1] / "policies" / "cedar_agent_memory_v01.cedar"
 CEDAR_POLICY_SHA256 = "sha256:a369c1423d48b6656e5e19f2589cc4660e00695e3b084c0a732b3f7f7ba6e18f"

--- a/reference/agentmem_ref/cedar_policy_comparator.py
+++ b/reference/agentmem_ref/cedar_policy_comparator.py
@@ -1,0 +1,625 @@
+"""Pinned real-Cedar comparator for Agent Memory external policy composition.
+
+Issue #216 proves the existing vendor-neutral external policy seam against the
+real Cedar CLI. Cedar-specific request binding, policy-artifact custody, and
+diagnostic parsing remain at this adapter edge. Valid results are normalized
+through the existing external-policy-decision builder and composed by the
+existing monotonic composition implementation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import policy
+from .enforcement_composition import (
+    ALLOW,
+    DENY,
+    PROVIDER_ADVISORY,
+    PROVIDER_AUTHORITATIVE,
+    REQUIRE_APPROVAL,
+    STATUS_AVAILABLE,
+    STATUS_STALE_IDENTITY,
+    STATUS_UNAVAILABLE,
+    build_external_decision,
+    build_projection,
+    compose,
+)
+from .substrate import InMemoryTemporalGraph
+
+CEDAR_VERSION = "4.12.0"
+CEDAR_TAG = "v4.12.0"
+CEDAR_SOURCE_COMMIT = "fdcbaed9bba4f67b498f60733cb9253d2ffc968e"
+CEDAR_PROVIDER_ID = "cedar-policy/cedar"
+CEDAR_POLICY_PATH = Path(__file__).resolve().parents[1] / "policies" / "cedar_agent_memory_v01.cedar"
+CEDAR_POLICY_SHA256 = "sha256:a369c1423d48b6656e5e19f2589cc4660e00695e3b084c0a732b3f7f7ba6e18f"
+
+
+@dataclass(frozen=True)
+class CedarAdapterObservation:
+    status: str
+    external_decision: dict[str, Any] | None = None
+    policy_sha256: str | None = None
+    determining_policy_ids: tuple[str, ...] = ()
+    request_digest: str | None = None
+    error: str | None = None
+
+
+def _proposal(
+    *,
+    proposal_id: str,
+    purpose: str,
+    operation: str = "promotion",
+    risk_class: str = "low",
+    target_class: str = policy.M2,
+    downstream_authority: str = policy.A1,
+    reversibility: str = "reversible",
+) -> policy.Proposal:
+    return policy.Proposal(
+        proposal_id=proposal_id,
+        actor_id="actor:cedar-comparator",
+        charter_version="charter:cedar-comparator-v1",
+        target_reference=f"mem:{proposal_id}",
+        target_class=target_class,
+        scope="scope:tenant-a/project-a",
+        operation=operation,
+        current_strength="promoted" if operation == "scope_expansion" else "reinforced",
+        proposed_strength="canonical" if operation == "scope_expansion" else "promoted",
+        downstream_authority=downstream_authority,
+        reversibility=reversibility,
+        risk_class=risk_class,
+        evidence_refs=(f"evidence:{proposal_id}",),
+        state_snapshot="v0",
+        tenant_ref="tenant-a",
+        purpose=purpose,
+        isolation_domain_refs=("scope:tenant-a/project-a",),
+        project_ref="project-a",
+    )
+
+
+def _projection(
+    *,
+    proposal_id: str,
+    purpose: str,
+    operation: str = "promotion",
+    risk_class: str = "low",
+    target_class: str = policy.M2,
+    downstream_authority: str = policy.A1,
+    reversibility: str = "reversible",
+) -> tuple[policy.Proposal, policy.Decision, dict[str, Any]]:
+    proposal = _proposal(
+        proposal_id=proposal_id,
+        purpose=purpose,
+        operation=operation,
+        risk_class=risk_class,
+        target_class=target_class,
+        downstream_authority=downstream_authority,
+        reversibility=reversibility,
+    )
+    decision = policy.evaluate(proposal)
+    return proposal, decision, build_projection(proposal, decision)
+
+
+def minimized_cedar_context(projection: dict[str, Any]) -> dict[str, Any]:
+    """Return the bounded Cedar request context, excluding raw memory payloads."""
+    allowed = (
+        "input_identity",
+        "purpose",
+        "risk_class",
+        "scope",
+        "tenant_ref",
+        "pama_outcome",
+        "policy_version",
+    )
+    return {field: projection[field] for field in allowed if field in projection}
+
+
+def _uid(kind: str, value: str) -> str:
+    return f"{kind}::{json.dumps(value, ensure_ascii=False)}"
+
+
+def build_cedar_request(projection: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "principal": _uid("Agent", projection["actor_id"]),
+        "action": _uid("Action", projection["operation"]),
+        "resource": _uid("Memory", projection["memory_id"]),
+        "context": minimized_cedar_context(projection),
+    }
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def policy_sha256(policy_path: Path = CEDAR_POLICY_PATH) -> str:
+    return _sha256_bytes(policy_path.read_bytes())
+
+
+def request_digest(request: dict[str, Any]) -> str:
+    raw = json.dumps(request, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return _sha256_bytes(raw)
+
+
+def parse_cedar_authorize_output(stdout: str, returncode: int) -> dict[str, Any]:
+    """Parse Cedar v4.12.0 human output without treating DENY exit 2 as failure."""
+    lines = [line.rstrip() for line in stdout.splitlines()]
+    decision_lines = [line.strip() for line in lines if line.strip() in {"ALLOW", "DENY"}]
+    if len(decision_lines) != 1:
+        raise ValueError("Cedar authorize output must contain exactly one ALLOW or DENY decision")
+    decision = decision_lines[0]
+    expected_returncode = 0 if decision == "ALLOW" else 2
+    if returncode != expected_returncode:
+        raise ValueError(
+            f"Cedar decision/exit mismatch: decision={decision}, returncode={returncode}, "
+            f"expected={expected_returncode}"
+        )
+
+    policy_ids: list[str] = []
+    marker = "note: this decision was due to the following policies:"
+    for index, line in enumerate(lines):
+        if line.strip() != marker:
+            continue
+        for candidate in lines[index + 1 :]:
+            stripped = candidate.strip()
+            if not stripped:
+                break
+            if stripped.startswith("note:"):
+                break
+            policy_ids.append(stripped)
+        break
+
+    return {
+        "decision": decision.lower(),
+        "determining_policy_ids": tuple(policy_ids),
+    }
+
+
+def detect_cedar_version(cedar_binary: str) -> str:
+    try:
+        completed = subprocess.run(
+            [cedar_binary, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        raise RuntimeError(f"Cedar binary unavailable: {exc}") from exc
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Cedar version command failed: {completed.stderr.strip() or completed.stdout.strip()}"
+        )
+    text = completed.stdout.strip() or completed.stderr.strip()
+    tokens = text.split()
+    for token in reversed(tokens):
+        if token == CEDAR_VERSION:
+            return token
+    raise RuntimeError(f"Cedar version output did not contain {CEDAR_VERSION!r}: {text!r}")
+
+
+def evaluate_cedar(
+    projection: dict[str, Any],
+    *,
+    cedar_binary: str,
+    expected_policy_sha256: str = CEDAR_POLICY_SHA256,
+    issued_at: str = "2026-08-13T04:50:00Z",
+    policy_path: Path = CEDAR_POLICY_PATH,
+) -> CedarAdapterObservation:
+    """Run real Cedar and normalize only an exact-policy, exact-request result."""
+    observed_policy_sha256 = policy_sha256(policy_path)
+    if observed_policy_sha256 != expected_policy_sha256:
+        return CedarAdapterObservation(
+            status="stale_policy_artifact",
+            policy_sha256=observed_policy_sha256,
+            error=(
+                f"Cedar policy digest mismatch: expected {expected_policy_sha256!r}, "
+                f"observed {observed_policy_sha256!r}"
+            ),
+        )
+
+    request = build_cedar_request(projection)
+    req_digest = request_digest(request)
+    with tempfile.TemporaryDirectory(prefix="agent-memory-cedar-") as tmpdir:
+        tmp = Path(tmpdir)
+        context_path = tmp / "context.json"
+        entities_path = tmp / "entities.json"
+        context_path.write_text(
+            json.dumps(request["context"], sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        entities_path.write_text("[]\n", encoding="utf-8")
+        command = [
+            cedar_binary,
+            "authorize",
+            "--principal",
+            request["principal"],
+            "--action",
+            request["action"],
+            "--resource",
+            request["resource"],
+            "--context",
+            str(context_path),
+            "--policies",
+            str(policy_path),
+            "--entities",
+            str(entities_path),
+            "--verbose",
+        ]
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (FileNotFoundError, OSError) as exc:
+            return CedarAdapterObservation(
+                status="unavailable",
+                policy_sha256=observed_policy_sha256,
+                request_digest=req_digest,
+                error=str(exc),
+            )
+        except subprocess.TimeoutExpired as exc:
+            return CedarAdapterObservation(
+                status="error",
+                policy_sha256=observed_policy_sha256,
+                request_digest=req_digest,
+                error=f"Cedar evaluation timeout: {exc}",
+            )
+
+    if completed.returncode not in {0, 2}:
+        return CedarAdapterObservation(
+            status="error",
+            policy_sha256=observed_policy_sha256,
+            request_digest=req_digest,
+            error=completed.stderr.strip() or completed.stdout.strip() or f"Cedar exited {completed.returncode}",
+        )
+
+    try:
+        parsed = parse_cedar_authorize_output(completed.stdout, completed.returncode)
+    except ValueError as exc:
+        return CedarAdapterObservation(
+            status="invalid",
+            policy_sha256=observed_policy_sha256,
+            request_digest=req_digest,
+            error=str(exc),
+        )
+
+    reason = f"Cedar authorization {parsed['decision'].upper()}"
+    if parsed["determining_policy_ids"]:
+        reason += " via " + ",".join(parsed["determining_policy_ids"])
+
+    try:
+        external_decision = build_external_decision(
+            provider_id=CEDAR_PROVIDER_ID,
+            provider_version=CEDAR_VERSION,
+            input_identity=projection["input_identity"],
+            decision=parsed["decision"],
+            reason=reason,
+            issued_at=issued_at,
+            evidence={
+                "policy_engine": "cedar",
+                "cedar_release": CEDAR_TAG,
+                "cedar_source_commit": CEDAR_SOURCE_COMMIT,
+                "policy_ref": str(policy_path.relative_to(Path(__file__).resolve().parents[2])),
+                "policy_sha256": observed_policy_sha256,
+                "determining_policy_ids": list(parsed["determining_policy_ids"]),
+                "request_digest": req_digest,
+            },
+        )
+    except ValueError as exc:
+        return CedarAdapterObservation(
+            status="invalid",
+            policy_sha256=observed_policy_sha256,
+            determining_policy_ids=parsed["determining_policy_ids"],
+            request_digest=req_digest,
+            error=str(exc),
+        )
+
+    return CedarAdapterObservation(
+        status="available",
+        external_decision=external_decision,
+        policy_sha256=observed_policy_sha256,
+        determining_policy_ids=parsed["determining_policy_ids"],
+        request_digest=req_digest,
+    )
+
+
+def _compose_observation(
+    projection: dict[str, Any],
+    observation: CedarAdapterObservation,
+    provider_mode: str,
+) -> dict[str, Any]:
+    return compose(
+        projection,
+        provider_mode=provider_mode,
+        external_decision=observation.external_decision if observation.status == "available" else None,
+    )
+
+
+def _matrix_case(
+    *,
+    case_id: str,
+    proposal_id: str,
+    purpose: str,
+    expected_local: str,
+    expected_cedar: str,
+    expected_effective: str,
+    cedar_binary: str,
+    operation: str = "promotion",
+    risk_class: str = "low",
+    target_class: str = policy.M2,
+    downstream_authority: str = policy.A1,
+    reversibility: str = "reversible",
+) -> dict[str, Any]:
+    _, native, projection = _projection(
+        proposal_id=proposal_id,
+        purpose=purpose,
+        operation=operation,
+        risk_class=risk_class,
+        target_class=target_class,
+        downstream_authority=downstream_authority,
+        reversibility=reversibility,
+    )
+    observation = evaluate_cedar(projection, cedar_binary=cedar_binary)
+    if observation.status != "available" or observation.external_decision is None:
+        raise AssertionError(f"{case_id}: real Cedar decision unavailable: {observation}")
+    receipt = compose(
+        projection,
+        provider_mode=PROVIDER_AUTHORITATIVE,
+        external_decision=observation.external_decision,
+    )
+    checks = {
+        "local_expected": receipt["local_normalized_decision"] == expected_local,
+        "cedar_expected": receipt.get("external_normalized_decision") == expected_cedar,
+        "effective_expected": receipt["effective_decision"] == expected_effective,
+        "provider_available": receipt["external_provider_status"] == STATUS_AVAILABLE,
+        "execution_not_established": receipt["execution_status"] == "unknown",
+        "projection_identity_preserved": observation.external_decision["input_identity"] == projection["input_identity"],
+        "policy_digest_preserved": (
+            observation.external_decision.get("evidence", {}).get("policy_sha256") == CEDAR_POLICY_SHA256
+        ),
+        "request_digest_preserved": (
+            observation.external_decision.get("evidence", {}).get("request_digest") == observation.request_digest
+        ),
+        "pama_envelope_unchanged": (
+            projection["permitted_actions"] == sorted(set(native.permitted_actions))
+            and projection["prohibited_actions"] == sorted(set(native.prohibited_actions))
+        ),
+    }
+    return {
+        "case_id": case_id,
+        "native_outcome": native.outcome,
+        "projection": projection,
+        "cedar_observation": observation,
+        "composition": receipt,
+        "checks": checks,
+        "passed": all(checks.values()),
+    }
+
+
+def run_comparator(agent_memory_commit: str, *, cedar_binary: str = "cedar") -> dict[str, Any]:
+    if len(agent_memory_commit) != 40 or any(ch not in "0123456789abcdef" for ch in agent_memory_commit):
+        raise ValueError("agent_memory_commit must be an exact lowercase 40-hex commit")
+    installed_version = detect_cedar_version(cedar_binary)
+    if installed_version != CEDAR_VERSION:
+        raise RuntimeError(f"expected Cedar {CEDAR_VERSION}, found {installed_version}")
+    observed_policy_sha256 = policy_sha256()
+    if observed_policy_sha256 != CEDAR_POLICY_SHA256:
+        raise RuntimeError(
+            f"checked-in Cedar policy digest mismatch: expected {CEDAR_POLICY_SHA256}, "
+            f"observed {observed_policy_sha256}"
+        )
+
+    substrate = InMemoryTemporalGraph()
+    initial_writes = len(substrate.write_log)
+
+    matrix = [
+        _matrix_case(
+            case_id="native-allow-cedar-allow",
+            proposal_id="cedar:allow-allow",
+            purpose="cedar-allow",
+            expected_local=ALLOW,
+            expected_cedar=ALLOW,
+            expected_effective=ALLOW,
+            cedar_binary=cedar_binary,
+        ),
+        _matrix_case(
+            case_id="native-allow-cedar-deny",
+            proposal_id="cedar:allow-deny",
+            purpose="cedar-deny",
+            expected_local=ALLOW,
+            expected_cedar=DENY,
+            expected_effective=DENY,
+            cedar_binary=cedar_binary,
+        ),
+        _matrix_case(
+            case_id="native-require-approval-cedar-allow",
+            proposal_id="cedar:review-allow",
+            purpose="cedar-allow",
+            risk_class="medium",
+            expected_local=REQUIRE_APPROVAL,
+            expected_cedar=ALLOW,
+            expected_effective=REQUIRE_APPROVAL,
+            cedar_binary=cedar_binary,
+        ),
+        _matrix_case(
+            case_id="native-deny-cedar-allow",
+            proposal_id="cedar:deny-allow",
+            purpose="cedar-allow",
+            operation="scope_expansion",
+            risk_class="critical",
+            target_class=policy.M5,
+            downstream_authority=policy.A5,
+            reversibility="irreversible",
+            expected_local=DENY,
+            expected_cedar=ALLOW,
+            expected_effective=DENY,
+            cedar_binary=cedar_binary,
+        ),
+    ]
+
+    _, _, failure_projection = _projection(
+        proposal_id="cedar:provider-failure",
+        purpose="cedar-allow",
+    )
+    unavailable_observation = evaluate_cedar(
+        failure_projection,
+        cedar_binary="/definitely/missing/cedar",
+    )
+    advisory_unavailable = _compose_observation(
+        failure_projection,
+        unavailable_observation,
+        PROVIDER_ADVISORY,
+    )
+    authoritative_unavailable = _compose_observation(
+        failure_projection,
+        unavailable_observation,
+        PROVIDER_AUTHORITATIVE,
+    )
+
+    stale_policy_observation = evaluate_cedar(
+        failure_projection,
+        cedar_binary=cedar_binary,
+        expected_policy_sha256="sha256:" + "0" * 64,
+    )
+    advisory_stale_policy = _compose_observation(
+        failure_projection,
+        stale_policy_observation,
+        PROVIDER_ADVISORY,
+    )
+    authoritative_stale_policy = _compose_observation(
+        failure_projection,
+        stale_policy_observation,
+        PROVIDER_AUTHORITATIVE,
+    )
+
+    _, _, projection_a = _projection(
+        proposal_id="cedar:identity-a",
+        purpose="cedar-allow",
+    )
+    _, _, projection_b = _projection(
+        proposal_id="cedar:identity-b",
+        purpose="cedar-allow",
+    )
+    identity_observation = evaluate_cedar(projection_a, cedar_binary=cedar_binary)
+    if identity_observation.status != "available" or identity_observation.external_decision is None:
+        raise AssertionError(f"identity Cedar evaluation unavailable: {identity_observation}")
+    authoritative_stale_identity = compose(
+        projection_b,
+        provider_mode=PROVIDER_AUTHORITATIVE,
+        external_decision=identity_observation.external_decision,
+    )
+    advisory_stale_identity = compose(
+        projection_b,
+        provider_mode=PROVIDER_ADVISORY,
+        external_decision=identity_observation.external_decision,
+    )
+
+    final_writes = len(substrate.write_log)
+    checks = {
+        "real_cedar_version_exact": installed_version == CEDAR_VERSION,
+        "policy_artifact_digest_exact": observed_policy_sha256 == CEDAR_POLICY_SHA256,
+        "real_cedar_matrix_passed": all(case["passed"] for case in matrix),
+        "cedar_can_tighten_native_allow": matrix[1]["composition"]["effective_decision"] == DENY,
+        "cedar_allow_cannot_loosen_native_review": matrix[2]["composition"]["effective_decision"] == REQUIRE_APPROVAL,
+        "cedar_allow_cannot_loosen_native_deny": matrix[3]["composition"]["effective_decision"] == DENY,
+        "advisory_unavailable_preserves_native": (
+            unavailable_observation.status == "unavailable"
+            and advisory_unavailable["external_provider_status"] == STATUS_UNAVAILABLE
+            and advisory_unavailable["effective_decision"] == ALLOW
+        ),
+        "authoritative_unavailable_fails_closed": (
+            authoritative_unavailable["external_provider_status"] == STATUS_UNAVAILABLE
+            and authoritative_unavailable["effective_decision"] == DENY
+        ),
+        "stale_policy_artifact_detected_at_adapter": stale_policy_observation.status == "stale_policy_artifact",
+        "advisory_stale_policy_preserves_native": advisory_stale_policy["effective_decision"] == ALLOW,
+        "authoritative_stale_policy_fails_closed": authoritative_stale_policy["effective_decision"] == DENY,
+        "stale_input_identity_detected_by_generic_layer": (
+            authoritative_stale_identity["external_provider_status"] == STATUS_STALE_IDENTITY
+            and advisory_stale_identity["external_provider_status"] == STATUS_STALE_IDENTITY
+        ),
+        "authoritative_stale_identity_fails_closed": authoritative_stale_identity["effective_decision"] == DENY,
+        "advisory_stale_identity_preserves_native": advisory_stale_identity["effective_decision"] == ALLOW,
+        "cedar_success_not_execution_evidence": all(
+            case["composition"]["execution_status"] == "unknown" for case in matrix
+        ),
+        "cedar_decision_did_not_create_memory_fact": final_writes == initial_writes == 0,
+        "generic_composition_receipt_has_no_cedar_specific_core_fields": all(
+            not any(key.startswith("cedar_") for key in case["composition"]) for case in matrix
+        ),
+        "minimized_policy_input_excludes_raw_payloads": all(
+            "raw" not in key and "content" not in key and "prompt" not in key
+            for key in minimized_cedar_context(matrix[0]["projection"])
+        ),
+    }
+    passed = all(checks.values())
+    result = {
+        "schema_version": "1.0.0",
+        "comparator": "cedar-external-policy-composition-v0.1",
+        "agent_memory_commit": agent_memory_commit,
+        "pinned_cedar": {
+            "release": CEDAR_TAG,
+            "source_commit": CEDAR_SOURCE_COMMIT,
+            "installed_version": installed_version,
+            "policy_ref": str(CEDAR_POLICY_PATH.relative_to(Path(__file__).resolve().parents[2])),
+            "policy_sha256": observed_policy_sha256,
+        },
+        "matrix": [
+            {
+                "case_id": case["case_id"],
+                "native_outcome": case["native_outcome"],
+                "input_identity": case["projection"]["input_identity"],
+                "cedar_status": case["cedar_observation"].status,
+                "cedar_decision": case["cedar_observation"].external_decision,
+                "determining_policy_ids": list(case["cedar_observation"].determining_policy_ids),
+                "request_digest": case["cedar_observation"].request_digest,
+                "composition": case["composition"],
+                "checks": case["checks"],
+                "passed": case["passed"],
+            }
+            for case in matrix
+        ],
+        "failure_modes": {
+            "unavailable": {
+                "adapter_status": unavailable_observation.status,
+                "advisory": advisory_unavailable,
+                "authoritative": authoritative_unavailable,
+            },
+            "stale_policy_artifact": {
+                "adapter_status": stale_policy_observation.status,
+                "observed_policy_sha256": stale_policy_observation.policy_sha256,
+                "advisory": advisory_stale_policy,
+                "authoritative": authoritative_stale_policy,
+            },
+            "stale_input_identity": {
+                "source_identity": projection_a["input_identity"],
+                "current_identity": projection_b["input_identity"],
+                "advisory": advisory_stale_identity,
+                "authoritative": authoritative_stale_identity,
+            },
+        },
+        "memory_write_count": final_writes,
+        "checks": checks,
+        "passed": passed,
+        "non_claims": [
+            "cedar_decision_is_not_agent_memory_authority",
+            "cedar_allow_is_not_approval_or_standing_permission",
+            "cedar_decision_is_not_enforcement_evidence",
+            "cedar_authorization_success_is_not_execution_evidence",
+            "cedar_policy_artifact_identity_is_adapter_evidence_not_canonical_memory_state",
+            "cedar_policy_is_not_agent_memory_canonical_policy_storage",
+        ],
+    }
+    if not passed:
+        failed = [name for name, ok in checks.items() if not ok]
+        raise AssertionError(f"Cedar external-policy comparator failed: {failed}; result={result}")
+    return result

--- a/reference/policies/cedar_agent_memory_v01.cedar
+++ b/reference/policies/cedar_agent_memory_v01.cedar
@@ -1,0 +1,16 @@
+@id("agent_memory_permit")
+permit (
+    principal,
+    action,
+    resource
+);
+
+@id("agent_memory_deny_purpose")
+forbid (
+    principal,
+    action,
+    resource
+)
+when {
+    context.purpose == "cedar-deny"
+};

--- a/reference/run_cedar_policy_comparator.py
+++ b/reference/run_cedar_policy_comparator.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Run the pinned Cedar external-policy composition comparator."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref.cedar_policy_comparator import run_comparator
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--cedar-binary", default="cedar")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    result = run_comparator(args.agent_memory_commit, cedar_binary=args.cedar_binary)
+    Path(args.output).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/reference/tests/test_cedar_policy_comparator.py
+++ b/reference/tests/test_cedar_policy_comparator.py
@@ -1,0 +1,128 @@
+"""Cedar adapter-edge tests that do not require an installed Cedar binary."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref import policy
+from agentmem_ref.cedar_policy_comparator import (
+    CEDAR_POLICY_SHA256,
+    build_cedar_request,
+    minimized_cedar_context,
+    parse_cedar_authorize_output,
+    policy_sha256,
+    request_digest,
+)
+from agentmem_ref.enforcement_composition import build_projection
+
+
+class CedarPolicyComparatorTests(unittest.TestCase):
+    def _projection(self):
+        proposal = policy.Proposal(
+            proposal_id="proposal:cedar:minimize",
+            actor_id="actor:test",
+            charter_version="charter:v1",
+            target_reference="mem:cedar:minimize",
+            target_class=policy.M2,
+            scope="scope:tenant-a/project-a",
+            operation="promotion",
+            current_strength="reinforced",
+            proposed_strength="promoted",
+            downstream_authority=policy.A1,
+            reversibility="reversible",
+            risk_class="low",
+            evidence_refs=("evidence:cedar",),
+            state_snapshot="v0",
+            tenant_ref="tenant-a",
+            purpose="cedar-allow",
+            isolation_domain_refs=("scope:tenant-a/project-a",),
+            project_ref="project-a",
+        )
+        return build_projection(proposal, policy.evaluate(proposal))
+
+    def test_parse_allow_with_verbose_policy_id(self):
+        parsed = parse_cedar_authorize_output(
+            "\nALLOW\n\nnote: this decision was due to the following policies:\n  agent_memory_permit\n\n",
+            0,
+        )
+        self.assertEqual(parsed["decision"], "allow")
+        self.assertEqual(parsed["determining_policy_ids"], ("agent_memory_permit",))
+
+    def test_parse_deny_exit_two_is_valid_policy_decision(self):
+        parsed = parse_cedar_authorize_output(
+            "\nDENY\n\nnote: this decision was due to the following policies:\n  agent_memory_deny_purpose\n\n",
+            2,
+        )
+        self.assertEqual(parsed["decision"], "deny")
+        self.assertEqual(parsed["determining_policy_ids"], ("agent_memory_deny_purpose",))
+
+    def test_parse_rejects_missing_decision(self):
+        with self.assertRaisesRegex(ValueError, "exactly one ALLOW or DENY"):
+            parse_cedar_authorize_output("note: no policies applied\n", 0)
+
+    def test_parse_rejects_ambiguous_decision(self):
+        with self.assertRaisesRegex(ValueError, "exactly one ALLOW or DENY"):
+            parse_cedar_authorize_output("ALLOW\nDENY\n", 0)
+
+    def test_parse_rejects_decision_exit_mismatch(self):
+        with self.assertRaisesRegex(ValueError, "decision/exit mismatch"):
+            parse_cedar_authorize_output("DENY\n", 0)
+
+    def test_policy_digest_is_pinned(self):
+        self.assertEqual(policy_sha256(), CEDAR_POLICY_SHA256)
+
+    def test_minimized_context_has_no_raw_payload_surface(self):
+        projection = self._projection()
+        minimized = minimized_cedar_context(projection)
+        self.assertEqual(minimized["input_identity"], projection["input_identity"])
+        self.assertEqual(minimized["purpose"], "cedar-allow")
+        for forbidden in (
+            "evidence_refs",
+            "authority_refs",
+            "raw_memory",
+            "memory_content",
+            "prompt",
+            "hidden_reasoning",
+        ):
+            self.assertNotIn(forbidden, minimized)
+
+    def test_request_binds_exact_projection_identity(self):
+        projection = self._projection()
+        request = build_cedar_request(projection)
+        self.assertEqual(request["context"]["input_identity"], projection["input_identity"])
+        self.assertEqual(request["principal"], 'Agent::"actor:test"')
+        self.assertEqual(request["action"], 'Action::"promotion"')
+        self.assertEqual(request["resource"], 'Memory::"mem:cedar:minimize"')
+        self.assertTrue(request_digest(request).startswith("sha256:"))
+
+    def test_request_digest_changes_with_bound_identity(self):
+        first = self._projection()
+        second = dict(first)
+        second["input_identity"] = "sha256:" + "f" * 64
+        self.assertNotEqual(
+            request_digest(build_cedar_request(first)),
+            request_digest(build_cedar_request(second)),
+        )
+
+    def test_minimized_request_does_not_adopt_authority_shaped_fields(self):
+        projection = self._projection()
+        projection.update(
+            {
+                "standing_authority": True,
+                "approval": "granted",
+                "execution_status": "executed",
+                "enforcement_status": "enforced",
+                "raw_memory": "secret",
+            }
+        )
+        request = build_cedar_request(projection)
+        context = request["context"]
+        self.assertNotIn("standing_authority", context)
+        self.assertNotIn("approval", context)
+        self.assertNotIn("execution_status", context)
+        self.assertNotIn("enforcement_status", context)
+        self.assertNotIn("raw_memory", context)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #216: prove the existing vendor-neutral external policy composition seam against **real Cedar v4.12.0** as the second deterministic policy host after OPA.

Pinned host:

- repository: `cedar-policy/cedar`
- release: `v4.12.0`
- exact source commit: `fdcbaed32bdb8c8d13e4eaf2b58db5555e9fb8c5`
- CLI crate/binary: `cedar-policy-cli` / `cedar`
- Rust MSRV used by the pinned release: 1.89

The exact source commit was resolved directly from the Git tag ref rather than inferred from a search result.

## Material difference from OPA

Cedar does not return an arbitrary decision object containing Agent Memory metadata. The adapter therefore binds Cedar's ALLOW/DENY result to the exact request it executed and preserves policy identity separately:

```text
Agent Memory minimized projection
 -> principal / action / resource / context
 -> real Cedar authorize
 -> ALLOW / DENY + determining policy IDs
 -> exact request digest + policy SHA-256
 -> existing external-policy-decision builder
 -> existing monotonic compose(...)
```

No Cedar-specific canonical composition fields are introduced.

## Native Cedar policy

`reference/policies/cedar_agent_memory_v01.cedar` contains:

- a general permit policy;
- a `forbid` policy when `context.purpose == "cedar-deny"`;
- explicit `@id(...)` annotations so determining policy IDs are reconstructable.

The policy artifact itself is pinned by SHA-256:

`a369c1423d48b6656e5e19f2589cc4660e00695e3b084c0a732b3f7f7ba6e18f`

## Required monotonic matrix

```text
native allow + Cedar allow            -> allow
native allow + Cedar deny             -> deny
native require_approval + Cedar allow -> require_approval
native deny + Cedar allow             -> deny
```

Cedar may tighten PAMA but cannot loosen it.

## Adapter evidence

Cedar-specific evidence stays at the adapter edge:

- Cedar release and source commit;
- exact checked-in policy ref and SHA-256;
- determining policy IDs;
- digest of the exact principal/action/resource/context request executed.

Cedar ALLOW remains neither approval nor standing authority. Cedar execution success remains policy-decision evidence only; composition receipts keep `execution_status = unknown`.

## Failure / stale behavior

The comparator proves:

- wrong policy digest is rejected before a Cedar result reaches generic composition;
- valid Cedar decision replayed against another Agent Memory `input_identity` is rejected by the existing generic stale-identity gate;
- advisory peer unavailable/stale preserves native PAMA while recording the gap;
- authoritative peer unavailable/stale fails closed to deny;
- Cedar DENY's documented exit code 2 is treated as a valid authorization result, not provider failure;
- malformed or ambiguous CLI output is invalid evidence.

## Privacy / minimization

The Cedar request contains only bounded action/governance context. Raw memory content, prompts, hidden reasoning, and arbitrary evidence payloads are excluded.

## Exact-source CI

`Cedar Policy Comparator`:

1. installs Rust 1.89.0;
2. builds `cedar-policy-cli` from exact Git commit `fdcbaed32bdb...`;
3. verifies Cedar 4.12.0;
4. verifies the checked-in policy SHA-256;
5. runs parser/minimization regressions;
6. runs the real Cedar comparator;
7. uploads a machine-readable exact-head evidence artifact.

## Stop line

Do not expand this PR into Cedar deployment/service management, Cedar as canonical Agent Memory policy storage, Cedarling, third policy engines, or execution/enforcement claims.

This PR remains draft until the real Cedar comparator and repository-wide exact-head CI pass. Only after the real host survives will the generic external-enforcement profile be updated with second-host findings.

Closes #216