### PR TITLE
Add PAMA 1.2 domain schema mutation compatibility

### DIFF
--- a/.github/workflows/domain-schema-mutation-contract.yml
+++ b/.github/workflows/domain-schema-mutation-contract.yml
@@ -1,0 +1,34 @@
+name: Domain Schema Mutation Contract
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  domain-schema-mutation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Validate schema inventory
+        run: python scripts/validate_schemas.py
+
+      - name: Run PAMA 1.2 domain-schema mutation tests
+        env:
+          PYTHONPATH: reference
+        run: >-
+          python -m unittest
+          tests.test_domain_schema_mutation_policy
+          tests.test_domain_schema_mutation_compatibility

--- a/docs/profiles/pama-1-2-domain-schema-compatibility.md
+++ b/docs/profiles/pama-1-2-domain-schema-compatibility.md
@@ -1,0 +1,37 @@
+# PAMA 1.2 Domain-Schema Compatibility
+
+PAMA decision `1.2.0` adds the closed operation `domain_schema_mutation`.
+
+Compatibility remains cumulative:
+
+```text
+1.0.0  historical operation set
+1.1.0  adds decision_overwrite
+1.2.0  adds domain_schema_mutation
+```
+
+Older records remain valid and are not rewritten. A `domain_schema_mutation` record claiming an older PAMA decision version is invalid. A consequential consumer that does not understand 1.2.0 must report a compatibility failure rather than reinterpret the operation as `other`.
+
+The operation identifies durable application/domain model changes that can alter future extraction, typing, relation meaning, migration, or recall. It does not represent ordinary fact insertion, Agent Memory core-schema changes, unchanged-semantic index rebuilds, or policy changes.
+
+Reference minimum outcomes are:
+
+| Risk | Outcome |
+|---|---|
+| low | `require_review` |
+| medium | `require_review` |
+| high | `require_external_verification` |
+| critical | `require_external_verification` |
+
+Existing PAMA dimensions remain controlling. If the same request also widens scope, the existing `scope_expansion` posture still applies. M5 and A5 floors remain unchanged. Estimator confidence does not lower the operation's required outcome.
+
+Executable evidence:
+
+- `schemas/pama-decision.schema.json`
+- `reference/agentmem_ref/policy.py`
+- `reference/agentmem_ref/domain_schema_mutation.py`
+- `reference/tests/test_domain_schema_mutation_policy.py`
+- `reference/tests/test_domain_schema_mutation_compatibility.py`
+- `.github/workflows/domain-schema-mutation-contract.yml`
+
+Research source: #226. Implementation: #236.

--- a/reference/agentmem_ref/domain_schema_mutation.py
+++ b/reference/agentmem_ref/domain_schema_mutation.py
@@ -8,6 +8,7 @@ any durable authority.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import replace
 
 from . import policy, receipts
 
@@ -63,36 +64,31 @@ def _strictest_decision(
 
 
 def _scope_expansion_floor(proposal: policy.Proposal) -> policy.Decision:
-    scope_proposal = policy.Proposal(
-        proposal_id=proposal.proposal_id,
-        actor_id=proposal.actor_id,
-        charter_version=proposal.charter_version,
-        target_reference=proposal.target_reference,
-        target_class=proposal.target_class,
-        scope=proposal.scope,
-        operation="scope_expansion",
-        current_strength=proposal.current_strength,
-        proposed_strength=proposal.proposed_strength,
-        downstream_authority=proposal.downstream_authority,
-        reversibility=proposal.reversibility,
-        risk_class=proposal.risk_class,
-        evidence_refs=proposal.evidence_refs,
-        estimator_refs=proposal.estimator_refs,
-        estimator_versions=proposal.estimator_versions,
-        confidence=proposal.confidence,
-        actor_authority_resolved=proposal.actor_authority_resolved,
-        approves_own_authority=proposal.approves_own_authority,
-        approval_refs=proposal.approval_refs,
-        review_satisfied=proposal.review_satisfied,
-        state_snapshot=proposal.state_snapshot,
-        tenant_ref=proposal.tenant_ref,
-        purpose=proposal.purpose,
-        isolation_domain_refs=proposal.isolation_domain_refs,
-        required_isolation_domain_refs=proposal.required_isolation_domain_refs,
-        project_ref=proposal.project_ref,
-        task_ref=proposal.task_ref,
-    )
+    scope_proposal = replace(proposal, operation="scope_expansion", review_satisfied=False)
     return policy.evaluate(scope_proposal)
+
+
+def _discharge_review(decision: policy.Decision, proposal: policy.Proposal) -> policy.Decision:
+    if decision.outcome not in (policy.REQUIRE_REVIEW, policy.REQUIRE_EXTERNAL_VERIFICATION):
+        return decision
+    if not proposal.review_satisfied:
+        return decision
+    if not proposal.approval_refs or proposal.approves_own_authority:
+        return policy.Decision(
+            outcome=decision.outcome,
+            permitted_actions=decision.permitted_actions,
+            prohibited_actions=decision.prohibited_actions,
+            reasons=decision.reasons + ("review claimed without an external approval record",),
+            policy_version=decision.policy_version,
+        )
+    permitted, prohibited = _envelope(policy.ALLOW_WITH_LEDGER, proposal.operation)
+    return policy.Decision(
+        outcome=policy.ALLOW_WITH_LEDGER,
+        permitted_actions=permitted,
+        prohibited_actions=prohibited,
+        reasons=decision.reasons + (f"review discharged by {list(proposal.approval_refs)}",),
+        policy_version=decision.policy_version,
+    )
 
 
 def evaluate(
@@ -102,15 +98,17 @@ def evaluate(
 ) -> policy.Decision:
     """Evaluate a domain-schema mutation while preserving stricter PAMA floors.
 
-    The generic PAMA evaluator still applies actor, target-class, downstream-
-    authority, isolation-domain, reversibility, evidence, and review rules.
-    This extension then adds the explicit domain-schema operation minimum and,
-    when the proposal also widens scope, the existing scope-expansion floor.
+    The generic evaluator first runs with review discharge disabled, preserving
+    actor, target-class, downstream-authority, isolation, reversibility, and
+    evidence constraints. The explicit operation and any scope-expansion floor
+    are then applied. Only after those floors exist may a valid external review
+    discharge the resulting review/verification requirement.
     """
     if proposal.operation != DOMAIN_SCHEMA_MUTATION:
         raise ValueError("domain-schema evaluator requires domain_schema_mutation")
 
-    decision = policy.evaluate(proposal)
+    undecided_review = replace(proposal, review_satisfied=False)
+    decision = policy.evaluate(undecided_review)
     decision = _strictest_decision(
         decision,
         required_outcome_for_risk(proposal.risk_class),
@@ -119,7 +117,7 @@ def evaluate(
     )
 
     if requested_scope_change:
-        scope_decision = _scope_expansion_floor(proposal)
+        scope_decision = _scope_expansion_floor(undecided_review)
         decision = _strictest_decision(
             decision,
             scope_decision.outcome,
@@ -127,7 +125,7 @@ def evaluate(
             "scope-expansion floor preserved",
         )
 
-    return decision
+    return _discharge_review(decision, proposal)
 
 
 def build_pama_decision(
@@ -199,9 +197,8 @@ def enforce_consumer_compatibility(
 ) -> None:
     """Fail explicitly when a consequential consumer cannot interpret the record."""
     receipts.validate("pama-decision.schema.json", pama_decision)
-    supported_versions = set(supported_schema_versions)
     version = pama_decision.get("schema_version")
-    if version not in supported_versions:
+    if version not in set(supported_schema_versions):
         raise ValueError(f"unsupported PAMA schema version {version!r}")
 
     if supported_operations is not None:

--- a/reference/agentmem_ref/domain_schema_mutation.py
+++ b/reference/agentmem_ref/domain_schema_mutation.py
@@ -1,15 +1,30 @@
-"""Version and compatibility helpers for governed domain-schema mutation."""
+"""Versioned PAMA support for governed application/domain ontology changes.
+
+This module is intentionally narrow. It adds one known consequential operation
+without introducing a canonical domain ontology or giving discovery estimators
+any durable authority.
+"""
 
 from __future__ import annotations
+
+from collections.abc import Iterable
 
 from . import policy, receipts
 
 DOMAIN_SCHEMA_MUTATION = "domain_schema_mutation"
 PAMA_SCHEMA_VERSION = "1.2.0"
 
+_OUTCOME_ORDER = {
+    policy.ALLOW: 0,
+    policy.ALLOW_WITH_LEDGER: 1,
+    policy.REQUIRE_REVIEW: 2,
+    policy.REQUIRE_EXTERNAL_VERIFICATION: 3,
+    policy.BLOCK: 4,
+}
+
 
 def required_outcome_for_risk(risk_class: str) -> str:
-    """Return the explicit minimum PAMA posture for a domain-schema mutation."""
+    """Return the minimum PAMA posture for domain-schema mutation."""
     if risk_class in ("low", "medium"):
         return policy.REQUIRE_REVIEW
     if risk_class in ("high", "critical"):
@@ -17,10 +32,37 @@ def required_outcome_for_risk(risk_class: str) -> str:
     raise ValueError(f"unsupported risk class {risk_class!r}")
 
 
-def enforce_scope_floor(decision: policy.Decision, proposal: policy.Proposal) -> policy.Decision:
-    """Preserve the existing scope-expansion floor when ontology change widens scope."""
-    if not proposal.requested_scope_change:
-        return decision
+def _envelope(outcome: str, operation: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    if outcome == policy.REQUIRE_REVIEW:
+        return ("enter_pending_verification", "collect_more_evidence", "defer"), (operation,)
+    if outcome == policy.REQUIRE_EXTERNAL_VERIFICATION:
+        return ("request_external_verification", "collect_more_evidence", "defer"), (operation,)
+    if outcome == policy.BLOCK:
+        return (), (operation, "enter_pending_verification", "request_external_verification")
+    if outcome in (policy.ALLOW, policy.ALLOW_WITH_LEDGER):
+        return (operation, "collect_more_evidence", "defer"), ()
+    raise ValueError(f"unsupported outcome {outcome!r}")
+
+
+def _strictest_decision(
+    current: policy.Decision,
+    minimum_outcome: str,
+    operation: str,
+    reason: str,
+) -> policy.Decision:
+    if _OUTCOME_ORDER[current.outcome] >= _OUTCOME_ORDER[minimum_outcome]:
+        return current
+    permitted, prohibited = _envelope(minimum_outcome, operation)
+    return policy.Decision(
+        outcome=minimum_outcome,
+        permitted_actions=permitted,
+        prohibited_actions=prohibited,
+        reasons=current.reasons + (reason,),
+        policy_version=current.policy_version,
+    )
+
+
+def _scope_expansion_floor(proposal: policy.Proposal) -> policy.Decision:
     scope_proposal = policy.Proposal(
         proposal_id=proposal.proposal_id,
         actor_id=proposal.actor_id,
@@ -50,61 +92,42 @@ def enforce_scope_floor(decision: policy.Decision, proposal: policy.Proposal) ->
         project_ref=proposal.project_ref,
         task_ref=proposal.task_ref,
     )
-    scope_decision = policy.evaluate(scope_proposal)
-    order = {
-        policy.ALLOW: 0,
-        policy.ALLOW_WITH_LEDGER: 1,
-        policy.REQUIRE_REVIEW: 2,
-        policy.REQUIRE_EXTERNAL_VERIFICATION: 3,
-        policy.BLOCK: 4,
-    }
-    if order[scope_decision.outcome] <= order[decision.outcome]:
-        return decision
-    permitted, prohibited = _envelope(scope_decision.outcome, proposal.operation)
-    return policy.Decision(
-        outcome=scope_decision.outcome,
-        permitted_actions=permitted,
-        prohibited_actions=prohibited,
-        reasons=decision.reasons + ("scope-expansion floor preserved",),
-        policy_version=decision.policy_version,
-    )
+    return policy.evaluate(scope_proposal)
 
 
-def evaluate(proposal: policy.Proposal) -> policy.Decision:
-    """Evaluate the new operation without letting estimator output weaken its floor."""
+def evaluate(
+    proposal: policy.Proposal,
+    *,
+    requested_scope_change: str = "",
+) -> policy.Decision:
+    """Evaluate a domain-schema mutation while preserving stricter PAMA floors.
+
+    The generic PAMA evaluator still applies actor, target-class, downstream-
+    authority, isolation-domain, reversibility, evidence, and review rules.
+    This extension then adds the explicit domain-schema operation minimum and,
+    when the proposal also widens scope, the existing scope-expansion floor.
+    """
     if proposal.operation != DOMAIN_SCHEMA_MUTATION:
         raise ValueError("domain-schema evaluator requires domain_schema_mutation")
+
     decision = policy.evaluate(proposal)
-    minimum = required_outcome_for_risk(proposal.risk_class)
-    order = {
-        policy.ALLOW: 0,
-        policy.ALLOW_WITH_LEDGER: 1,
-        policy.REQUIRE_REVIEW: 2,
-        policy.REQUIRE_EXTERNAL_VERIFICATION: 3,
-        policy.BLOCK: 4,
-    }
-    if order[decision.outcome] < order[minimum]:
-        permitted, prohibited = _envelope(minimum, proposal.operation)
-        decision = policy.Decision(
-            outcome=minimum,
-            permitted_actions=permitted,
-            prohibited_actions=prohibited,
-            reasons=decision.reasons + ("domain-schema mutation minimum",),
-            policy_version=decision.policy_version,
+    decision = _strictest_decision(
+        decision,
+        required_outcome_for_risk(proposal.risk_class),
+        proposal.operation,
+        "domain-schema mutation minimum",
+    )
+
+    if requested_scope_change:
+        scope_decision = _scope_expansion_floor(proposal)
+        decision = _strictest_decision(
+            decision,
+            scope_decision.outcome,
+            proposal.operation,
+            "scope-expansion floor preserved",
         )
-    return enforce_scope_floor(decision, proposal)
 
-
-def _envelope(outcome: str, operation: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    if outcome == policy.REQUIRE_REVIEW:
-        return ("enter_pending_verification", "collect_more_evidence", "defer"), (operation,)
-    if outcome == policy.REQUIRE_EXTERNAL_VERIFICATION:
-        return ("request_external_verification", "collect_more_evidence", "defer"), (operation,)
-    if outcome == policy.BLOCK:
-        return (), (operation, "enter_pending_verification", "request_external_verification")
-    if outcome in (policy.ALLOW, policy.ALLOW_WITH_LEDGER):
-        return (operation, "collect_more_evidence", "defer"), ()
-    raise ValueError(f"unsupported outcome {outcome!r}")
+    return decision
 
 
 def build_pama_decision(
@@ -114,15 +137,74 @@ def build_pama_decision(
     selected_action: str,
     selection_mode: str | None,
     receipt_ref: str,
+    requested_scope_change: str = "",
 ) -> dict:
-    """Build a canonical 1.2.0 PAMA decision for domain-schema mutation."""
-    document = receipts.build_pama_decision(
-        proposal,
-        decision,
-        selected_action=selected_action,
-        selection_mode=selection_mode,
-        receipt_ref=receipt_ref,
-    )
-    document["schema_version"] = PAMA_SCHEMA_VERSION
+    """Build and validate a canonical PAMA 1.2.0 decision artifact."""
+    if proposal.operation != DOMAIN_SCHEMA_MUTATION:
+        raise ValueError("1.2.0 builder requires domain_schema_mutation")
+
+    document = {
+        "schema_version": PAMA_SCHEMA_VERSION,
+        "proposal_id": proposal.proposal_id,
+        "proposing_actor": {
+            "id": proposal.actor_id,
+            "charter_version": proposal.charter_version,
+        },
+        "target": {
+            "reference": proposal.target_reference,
+            "class": proposal.target_class,
+            "scope": proposal.scope,
+        },
+        "mutation": {
+            "operation": proposal.operation,
+            "current_strength": proposal.current_strength,
+            "proposed_strength": proposal.proposed_strength,
+            "downstream_authority": proposal.downstream_authority,
+            "reversibility": proposal.reversibility,
+            "risk_class": proposal.risk_class,
+        },
+        "basis": {"evidence_refs": list(proposal.evidence_refs)},
+        "policy": {"policy_version": decision.policy_version},
+        "decision": {
+            "outcome": decision.outcome,
+            "permitted_actions": list(decision.permitted_actions),
+            "prohibited_actions": list(decision.prohibited_actions),
+            "selected_action": None if selected_action == receipts.NO_ACTION else selected_action,
+            "selection_mode": selection_mode,
+            "decision_receipt_ref": receipt_ref,
+        },
+    }
+    if requested_scope_change:
+        document["mutation"]["requested_scope_change"] = requested_scope_change
+    if proposal.tenant_ref:
+        document["target"]["tenant_ref"] = proposal.tenant_ref
+    if proposal.purpose:
+        document["target"]["purpose"] = proposal.purpose
+    if proposal.estimator_refs:
+        document["basis"]["estimator_refs"] = list(proposal.estimator_refs)
+    if proposal.estimator_versions:
+        document["basis"]["estimator_versions"] = list(proposal.estimator_versions)
+    if proposal.confidence is not None:
+        document["basis"]["confidence"] = proposal.confidence
+
     receipts.validate("pama-decision.schema.json", document)
     return document
+
+
+def enforce_consumer_compatibility(
+    pama_decision: dict,
+    *,
+    supported_schema_versions: Iterable[str],
+    supported_operations: Iterable[str] | None = None,
+) -> None:
+    """Fail explicitly when a consequential consumer cannot interpret the record."""
+    receipts.validate("pama-decision.schema.json", pama_decision)
+    supported_versions = set(supported_schema_versions)
+    version = pama_decision.get("schema_version")
+    if version not in supported_versions:
+        raise ValueError(f"unsupported PAMA schema version {version!r}")
+
+    if supported_operations is not None:
+        operation = pama_decision["mutation"]["operation"]
+        if operation not in set(supported_operations):
+            raise ValueError(f"unsupported PAMA operation {operation!r}")

--- a/reference/agentmem_ref/domain_schema_mutation.py
+++ b/reference/agentmem_ref/domain_schema_mutation.py
@@ -1,0 +1,128 @@
+"""Version and compatibility helpers for governed domain-schema mutation."""
+
+from __future__ import annotations
+
+from . import policy, receipts
+
+DOMAIN_SCHEMA_MUTATION = "domain_schema_mutation"
+PAMA_SCHEMA_VERSION = "1.2.0"
+
+
+def required_outcome_for_risk(risk_class: str) -> str:
+    """Return the explicit minimum PAMA posture for a domain-schema mutation."""
+    if risk_class in ("low", "medium"):
+        return policy.REQUIRE_REVIEW
+    if risk_class in ("high", "critical"):
+        return policy.REQUIRE_EXTERNAL_VERIFICATION
+    raise ValueError(f"unsupported risk class {risk_class!r}")
+
+
+def enforce_scope_floor(decision: policy.Decision, proposal: policy.Proposal) -> policy.Decision:
+    """Preserve the existing scope-expansion floor when ontology change widens scope."""
+    if not proposal.requested_scope_change:
+        return decision
+    scope_proposal = policy.Proposal(
+        proposal_id=proposal.proposal_id,
+        actor_id=proposal.actor_id,
+        charter_version=proposal.charter_version,
+        target_reference=proposal.target_reference,
+        target_class=proposal.target_class,
+        scope=proposal.scope,
+        operation="scope_expansion",
+        current_strength=proposal.current_strength,
+        proposed_strength=proposal.proposed_strength,
+        downstream_authority=proposal.downstream_authority,
+        reversibility=proposal.reversibility,
+        risk_class=proposal.risk_class,
+        evidence_refs=proposal.evidence_refs,
+        estimator_refs=proposal.estimator_refs,
+        estimator_versions=proposal.estimator_versions,
+        confidence=proposal.confidence,
+        actor_authority_resolved=proposal.actor_authority_resolved,
+        approves_own_authority=proposal.approves_own_authority,
+        approval_refs=proposal.approval_refs,
+        review_satisfied=proposal.review_satisfied,
+        state_snapshot=proposal.state_snapshot,
+        tenant_ref=proposal.tenant_ref,
+        purpose=proposal.purpose,
+        isolation_domain_refs=proposal.isolation_domain_refs,
+        required_isolation_domain_refs=proposal.required_isolation_domain_refs,
+        project_ref=proposal.project_ref,
+        task_ref=proposal.task_ref,
+    )
+    scope_decision = policy.evaluate(scope_proposal)
+    order = {
+        policy.ALLOW: 0,
+        policy.ALLOW_WITH_LEDGER: 1,
+        policy.REQUIRE_REVIEW: 2,
+        policy.REQUIRE_EXTERNAL_VERIFICATION: 3,
+        policy.BLOCK: 4,
+    }
+    if order[scope_decision.outcome] <= order[decision.outcome]:
+        return decision
+    permitted, prohibited = _envelope(scope_decision.outcome, proposal.operation)
+    return policy.Decision(
+        outcome=scope_decision.outcome,
+        permitted_actions=permitted,
+        prohibited_actions=prohibited,
+        reasons=decision.reasons + ("scope-expansion floor preserved",),
+        policy_version=decision.policy_version,
+    )
+
+
+def evaluate(proposal: policy.Proposal) -> policy.Decision:
+    """Evaluate the new operation without letting estimator output weaken its floor."""
+    if proposal.operation != DOMAIN_SCHEMA_MUTATION:
+        raise ValueError("domain-schema evaluator requires domain_schema_mutation")
+    decision = policy.evaluate(proposal)
+    minimum = required_outcome_for_risk(proposal.risk_class)
+    order = {
+        policy.ALLOW: 0,
+        policy.ALLOW_WITH_LEDGER: 1,
+        policy.REQUIRE_REVIEW: 2,
+        policy.REQUIRE_EXTERNAL_VERIFICATION: 3,
+        policy.BLOCK: 4,
+    }
+    if order[decision.outcome] < order[minimum]:
+        permitted, prohibited = _envelope(minimum, proposal.operation)
+        decision = policy.Decision(
+            outcome=minimum,
+            permitted_actions=permitted,
+            prohibited_actions=prohibited,
+            reasons=decision.reasons + ("domain-schema mutation minimum",),
+            policy_version=decision.policy_version,
+        )
+    return enforce_scope_floor(decision, proposal)
+
+
+def _envelope(outcome: str, operation: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    if outcome == policy.REQUIRE_REVIEW:
+        return ("enter_pending_verification", "collect_more_evidence", "defer"), (operation,)
+    if outcome == policy.REQUIRE_EXTERNAL_VERIFICATION:
+        return ("request_external_verification", "collect_more_evidence", "defer"), (operation,)
+    if outcome == policy.BLOCK:
+        return (), (operation, "enter_pending_verification", "request_external_verification")
+    if outcome in (policy.ALLOW, policy.ALLOW_WITH_LEDGER):
+        return (operation, "collect_more_evidence", "defer"), ()
+    raise ValueError(f"unsupported outcome {outcome!r}")
+
+
+def build_pama_decision(
+    proposal: policy.Proposal,
+    decision: policy.Decision,
+    *,
+    selected_action: str,
+    selection_mode: str | None,
+    receipt_ref: str,
+) -> dict:
+    """Build a canonical 1.2.0 PAMA decision for domain-schema mutation."""
+    document = receipts.build_pama_decision(
+        proposal,
+        decision,
+        selected_action=selected_action,
+        selection_mode=selection_mode,
+        receipt_ref=receipt_ref,
+    )
+    document["schema_version"] = PAMA_SCHEMA_VERSION
+    receipts.validate("pama-decision.schema.json", document)
+    return document

--- a/reference/agentmem_ref/policy.py
+++ b/reference/agentmem_ref/policy.py
@@ -63,6 +63,10 @@ _BASE_TABLE: dict[tuple[str, str], str] = {
     ("decision_overwrite", "medium"): REQUIRE_REVIEW,
     ("decision_overwrite", "high"): REQUIRE_EXTERNAL_VERIFICATION,
     ("decision_overwrite", "critical"): REQUIRE_EXTERNAL_VERIFICATION,
+    ("domain_schema_mutation", "low"): REQUIRE_REVIEW,
+    ("domain_schema_mutation", "medium"): REQUIRE_REVIEW,
+    ("domain_schema_mutation", "high"): REQUIRE_EXTERNAL_VERIFICATION,
+    ("domain_schema_mutation", "critical"): REQUIRE_EXTERNAL_VERIFICATION,
     ("promotion", "low"): ALLOW_WITH_LEDGER,
     ("promotion", "medium"): REQUIRE_REVIEW,
     ("promotion", "high"): REQUIRE_REVIEW,
@@ -120,6 +124,7 @@ class Proposal:
     approves_own_authority: bool = False
     approval_refs: tuple[str, ...] = ()
     review_satisfied: bool = False
+    requested_scope_change: str = ""
     state_snapshot: str = ""
     tenant_ref: str = ""
     purpose: str = ""
@@ -169,6 +174,12 @@ def _apply_modifiers(outcome: str, proposal: Proposal) -> tuple[str, list[str]]:
     bound_domains = set(proposal.isolation_domain_refs)
     if required_domains and not required_domains.issubset(bound_domains):
         return BLOCK, ["required isolation domains must be bound to the memory scope"]
+    if proposal.operation == "domain_schema_mutation" and proposal.requested_scope_change:
+        scope_floor = _BASE_TABLE[("scope_expansion", proposal.risk_class)]
+        escalated = _strictest(outcome, scope_floor)
+        if escalated != outcome:
+            reasons.append("M-SCOPE: domain-schema mutation also requests scope expansion")
+        outcome = escalated
     if proposal.reversibility == "irreversible":
         escalated = _strictest(outcome, REQUIRE_REVIEW)
         if proposal.risk_class in ("high", "critical"):

--- a/reference/tests/test_domain_schema_mutation_compatibility.py
+++ b/reference/tests/test_domain_schema_mutation_compatibility.py
@@ -30,6 +30,21 @@ def selected(decision, operation):
 
 
 class DomainSchemaMutationCompatibilityTests(unittest.TestCase):
+    def test_historical_1_0_and_1_1_decisions_remain_valid(self):
+        for operation, risk, expected_version in (
+            ("promotion", "medium", "1.0.0"),
+            ("decision_overwrite", "high", "1.1.0"),
+        ):
+            with self.subTest(operation=operation):
+                item = proposal(operation=operation, risk=risk)
+                decision = policy.evaluate(item)
+                document = receipts.build_pama_decision(
+                    item, decision, selected_action=selected(decision, item.operation),
+                    selection_mode="deterministic", receipt_ref=f"receipt:{operation}",
+                )
+                self.assertEqual(document["schema_version"], expected_version)
+                receipts.validate("pama-decision.schema.json", document)
+
     def test_1_2_document_validates_and_binds_scope_change(self):
         item = proposal(scope_change="project-local -> tenant-shared")
         decision = dsm.evaluate(item, requested_scope_change=item.requested_scope_change)

--- a/reference/tests/test_domain_schema_mutation_compatibility.py
+++ b/reference/tests/test_domain_schema_mutation_compatibility.py
@@ -1,0 +1,86 @@
+"""PAMA 1.2 serialization and compatibility cases."""
+
+import unittest
+
+from agentmem_ref import domain_schema_mutation as dsm
+from agentmem_ref import policy, receipts
+
+
+def proposal(operation=dsm.DOMAIN_SCHEMA_MUTATION, risk="high", scope_change=""):
+    return policy.Proposal(
+        proposal_id=f"proposal:{operation}:{risk}", actor_id="agent:schema", charter_version="charter:1",
+        target_reference="domain-model:project-a", target_class=policy.M3, scope="tenant-a/project-a",
+        operation=operation, current_strength="promoted", proposed_strength="canonical",
+        downstream_authority=policy.A3, reversibility="versioned_revocable", risk_class=risk,
+        evidence_refs=("evidence:schema",), state_snapshot="snapshot:model:v4", tenant_ref="tenant-a",
+        purpose="ontology evolution", isolation_domain_refs=("tenant-a/project-a",),
+        required_isolation_domain_refs=("tenant-a/project-a",), project_ref="project-a",
+        requested_scope_change=scope_change,
+    )
+
+
+def selected(decision, operation):
+    if decision.outcome == policy.REQUIRE_REVIEW:
+        return "enter_pending_verification"
+    if decision.outcome == policy.REQUIRE_EXTERNAL_VERIFICATION:
+        return "request_external_verification"
+    if decision.outcome == policy.BLOCK:
+        return receipts.NO_ACTION
+    return operation
+
+
+class DomainSchemaMutationCompatibilityTests(unittest.TestCase):
+    def test_1_2_document_validates_and_binds_scope_change(self):
+        item = proposal(scope_change="project-local -> tenant-shared")
+        decision = dsm.evaluate(item, requested_scope_change=item.requested_scope_change)
+        document = dsm.build_pama_decision(
+            item, decision, selected_action=selected(decision, item.operation),
+            selection_mode="deterministic", receipt_ref="receipt:schema:1",
+            requested_scope_change=item.requested_scope_change,
+        )
+        self.assertEqual(document["schema_version"], "1.2.0")
+        self.assertEqual(document["mutation"]["operation"], dsm.DOMAIN_SCHEMA_MUTATION)
+        self.assertEqual(document["mutation"]["requested_scope_change"], item.requested_scope_change)
+        receipts.validate("pama-decision.schema.json", document)
+
+    def test_domain_schema_mutation_claiming_1_1_is_rejected(self):
+        item = proposal()
+        decision = dsm.evaluate(item)
+        document = dsm.build_pama_decision(
+            item, decision, selected_action=selected(decision, item.operation),
+            selection_mode="deterministic", receipt_ref="receipt:schema:2",
+        )
+        document["schema_version"] = "1.1.0"
+        with self.assertRaisesRegex(ValueError, "1.2.0"):
+            receipts.validate("pama-decision.schema.json", document)
+
+    def test_legacy_consumer_rejects_1_2_explicitly(self):
+        item = proposal()
+        decision = dsm.evaluate(item)
+        document = dsm.build_pama_decision(
+            item, decision, selected_action=selected(decision, item.operation),
+            selection_mode="deterministic", receipt_ref="receipt:schema:3",
+        )
+        with self.assertRaisesRegex(ValueError, "unsupported PAMA schema version"):
+            dsm.enforce_consumer_compatibility(document, supported_schema_versions=("1.0.0", "1.1.0"))
+
+    def test_receipt_pair_preserves_exact_operation_and_version(self):
+        item = proposal()
+        decision = dsm.evaluate(item)
+        chosen = selected(decision, item.operation)
+        receipt = receipts.build_receipt(
+            receipt_id="receipt:schema:pair", proposal=item, decision=decision, selected_action=chosen,
+            selection_mode="deterministic", timestamp="2026-08-13T12:30:00Z",
+            before_state="domain-model:v4", after_state="pending_verification",
+        )
+        pama = dsm.build_pama_decision(
+            item, decision, selected_action=chosen, selection_mode="deterministic", receipt_ref=receipt["receipt_id"],
+        )
+        receipts.verify_receipt_decision_pair(receipt, pama)
+        self.assertEqual(receipt["requested_action"], dsm.DOMAIN_SCHEMA_MUTATION)
+        self.assertEqual(pama["mutation"]["operation"], dsm.DOMAIN_SCHEMA_MUTATION)
+        self.assertEqual(pama["schema_version"], "1.2.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_domain_schema_mutation_policy.py
+++ b/reference/tests/test_domain_schema_mutation_policy.py
@@ -1,0 +1,54 @@
+"""Focused policy cases for PAMA 1.2 domain-schema mutation."""
+
+import unittest
+
+from agentmem_ref import domain_schema_mutation as dsm
+from agentmem_ref import policy
+
+
+def make_proposal(risk="medium", target=policy.M3, authority=policy.A3, evidence=("evidence:schema",), confidence=None, self_approve=False, reviewed=False, approvals=()):
+    return policy.Proposal(
+        proposal_id=f"schema:{risk}", actor_id="agent:schema-observer", charter_version="charter:1",
+        target_reference="domain-model:project-a", target_class=target, scope="tenant-a/project-a",
+        operation=dsm.DOMAIN_SCHEMA_MUTATION, current_strength="promoted", proposed_strength="canonical",
+        downstream_authority=authority, reversibility="versioned_revocable", risk_class=risk,
+        evidence_refs=evidence, estimator_refs=("estimator:schema",) if confidence is not None else (),
+        estimator_versions=("schema:1",) if confidence is not None else (), confidence=confidence,
+        approves_own_authority=self_approve, review_satisfied=reviewed, approval_refs=approvals,
+        state_snapshot="snapshot:model:v4", tenant_ref="tenant-a", purpose="ontology evolution",
+        isolation_domain_refs=("tenant-a/project-a",), required_isolation_domain_refs=("tenant-a/project-a",),
+        project_ref="project-a",
+    )
+
+
+class DomainSchemaMutationPolicyTests(unittest.TestCase):
+    def test_explicit_risk_table(self):
+        expected = {"low": policy.REQUIRE_REVIEW, "medium": policy.REQUIRE_REVIEW, "high": policy.REQUIRE_EXTERNAL_VERIFICATION, "critical": policy.REQUIRE_EXTERNAL_VERIFICATION}
+        for risk, outcome in expected.items():
+            with self.subTest(risk=risk):
+                self.assertEqual(dsm.evaluate(make_proposal(risk=risk)).outcome, outcome)
+
+    def test_estimator_confidence_and_missing_evidence_do_not_weaken(self):
+        self.assertEqual(dsm.evaluate(make_proposal(risk="high", confidence=0.999999)).outcome, policy.REQUIRE_EXTERNAL_VERIFICATION)
+        low = dsm.evaluate(make_proposal(risk="low", evidence=()))
+        self.assertEqual(low.outcome, policy.REQUIRE_REVIEW)
+        self.assertTrue(any("M-EVID" in reason for reason in low.reasons))
+
+    def test_self_approval_blocks(self):
+        result = dsm.evaluate(make_proposal(risk="low", self_approve=True, reviewed=True, approvals=("approval:self",)))
+        self.assertEqual(result.outcome, policy.BLOCK)
+
+    def test_scope_and_governance_floors_remain_strict(self):
+        scoped = dsm.evaluate(make_proposal(risk="critical"), requested_scope_change="project -> tenant")
+        self.assertEqual(scoped.outcome, policy.BLOCK)
+        governance = dsm.evaluate(make_proposal(risk="low", target=policy.M5, authority=policy.A5))
+        self.assertEqual(governance.outcome, policy.REQUIRE_EXTERNAL_VERIFICATION)
+
+    def test_review_discharges_only_after_floors(self):
+        result = dsm.evaluate(make_proposal(risk="high", reviewed=True, approvals=("approval:independent",)))
+        self.assertEqual(result.outcome, policy.ALLOW_WITH_LEDGER)
+        self.assertIn(dsm.DOMAIN_SCHEMA_MUTATION, result.permitted_actions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/pama-decision.schema.json
+++ b/schemas/pama-decision.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/pama-decision.schema.json",
   "title": "Proportional Adaptive Mutation Authority Decision",
-  "description": "Doctrine-level compatibility contract for PAMA authority evaluations. PAMA is native Agent Memory doctrine authored by Kevin R. Knapp. PAMA decision 1.1.0 adds the decision_overwrite operation; historical 1.0.0 decisions remain valid.",
+  "description": "Doctrine-level compatibility contract for PAMA authority evaluations. PAMA is native Agent Memory doctrine authored by Kevin R. Knapp. PAMA decision 1.1.0 adds the decision_overwrite operation; 1.2.0 adds domain_schema_mutation; historical 1.0.0 and 1.1.0 decisions remain valid.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -82,6 +82,7 @@
             "link_deletion",
             "correction",
             "decision_overwrite",
+            "domain_schema_mutation",
             "promotion",
             "crystallization",
             "pruning",
@@ -303,6 +304,24 @@
         "required": ["schema_version"],
         "properties": {
           "schema_version": {"const": "1.1.0"}
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "mutation": {
+            "properties": {
+              "operation": {"const": "domain_schema_mutation"}
+            },
+            "required": ["operation"]
+          }
+        }
+      },
+      "then": {
+        "required": ["schema_version"],
+        "properties": {
+          "schema_version": {"const": "1.2.0"}
         }
       }
     }


### PR DESCRIPTION
Implements #236.

This change adds `domain_schema_mutation` to PAMA decision version 1.2.0 while preserving historical 1.0.0 and 1.1.0 records.

The reference posture is review for low/medium risk and external verification for high/critical risk. Existing scope, M5, and A5 floors remain stricter where applicable. Estimator confidence does not reduce the required outcome.

The slice includes schema compatibility, reference behavior, explicit older-consumer failure, exact decision/receipt binding tests, a focused CI workflow, and a concise PAMA 1.2 compatibility profile.

The PR remains draft until the final exact head passes the complete repository validation matrix.

Closes #236