### PR TITLE
Clean up audited historical branches for #72

### DIFF
--- a/.github/workflows/historical-branch-cleanup.yml
+++ b/.github/workflows/historical-branch-cleanup.yml
@@ -1,0 +1,172 @@
+name: Historical Branch Cleanup
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  delete-audited-historical-refs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Delete only audited historical branch refs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          branches=(
+            "Knapp-Kevin-patch-1"
+            "agent/adr-portable-memory-governance-evidence"
+            "agent/aligned-projects-intellectual-lineage"
+            "agent/brand-assets-readme-wiki"
+            "agent/evidence-falsification-readmission"
+            "agent/fix-brand-image-quality"
+            "agent/fix-brand-image-quality-final"
+            "agent/governance-projection-v0-1"
+            "agent/memory-isolation-domains-adr"
+            "agent/143-shared-write-claims"
+            "agent/144-durable-decision-overwrite-authority"
+            "agent/146-source-neutral-claim-record"
+            "agent/147-governed-semantic-readmission"
+            "agent/148-forbidden-hit-conformance"
+            "agent/149-epistemic-promotion-conformance"
+            "agent/152-enforcement-evidence-v01"
+            "agent/152-policy-enforcement-boundary"
+            "agent/156-reproducible-reference-deps-doc-sync"
+            "agent/157-receipt-decision-backlink"
+            "agent/159-readme-status-alignment"
+            "agent/180-external-evidence-normalization"
+            "agent/181-precedent-applicability"
+            "agent/185-otel-correlation-v01"
+            "agent/187-approval-evidence"
+            "agent/189-maf-lifecycle-v01"
+            "agent/190-governed-mcp-interaction-v01"
+            "agent/194-governed-a2a-evidence-v01"
+            "agent/196-security-evidence-depth-v01"
+            "agent/198-security-finding-evidence-v01"
+            "agent/200-contextual-recall-sleeper-v01"
+            "agent/202-transformation-authority-laundering-v01"
+            "agent/204-authority-laundering-v01"
+            "agent/206-unsafe-composition-evidence"
+            "agent/208-langgraph-lifecycle-v01"
+            "agent/210-derivation-currentness-v01"
+            "agent/212-derivation-output-custody"
+            "agent/214-opa-policy-comparator"
+            "agent/216-cedar-policy-comparator"
+            "agent/221-cmcp-inbound-evidence"
+            "agent/223-agent-manifest-evidence"
+            "brand/replace-broken-webp-with-svg"
+            "claude/p4-canonical-derived-state"
+            "claude/repo-cleanup-issues-n711x7"
+            "dev/attribution-remediation"
+            "docs/issues-137-138-architecture-plan"
+            "docs/quality-peer-ecosystem-cedar"
+            "docs/swap-governed-memory-flow-png"
+            "docs/wiki-home-refinement"
+            "docs/wiki-home-visual-discoverability"
+            "docs/46-accept-adr020"
+            "docs/46-adr020-acceptance-audit"
+            "docs/46-runtime-program-closeout"
+            "docs/68-accept-adr-022"
+            "docs/68-isolation-completion-audit"
+            "docs/68-isolation-domain-contract"
+            "docs/68-isolation-gap-audit"
+            "docs/68-shared-memory-isolation-reconciliation"
+            "docs/68-sync-canonical-isolation-contract"
+            "docs/73-final-visual-guide-sync"
+            "docs/73-v1-governed-recall"
+            "docs/73-v1-lifecycle-map"
+            "docs/73-v1-lifecycle-map-current"
+            "docs/73-v1-pama-decision-flow"
+            "docs/73-v1-strength-stability"
+            "docs/73-v1-visual-guide"
+            "docs/73-v2-deletion-propagation"
+            "docs/73-v2-scenario-walkthroughs"
+            "docs/73-v2-scenario-walkthroughs-current"
+            "docs/73-v2-temporal-correction"
+            "docs/73-v3-isolation-domain-visual"
+            "docs/73-v3-portable-evidence-chain"
+            "docs/73-wiki-home-ux-completion"
+            "docs/147-semantic-readmission-sync"
+            "docs/01010001-agent-memory-brand"
+            "governance/ai-contribution-policy-current"
+            "governance/human-accountable-ai-contributions"
+            "impl232-uor-a"
+            "impl232-uor-b"
+            "impl-232-uor"
+            "impl-250-reusable-grants"
+            "implementation/223-agent-manifest-evidence"
+            "implementation/233-precedent-estimator-retrieval"
+            "implementation/236-domain-schema-mutation-v12"
+            "implementation/238-maintenance-run-evidence"
+            "implementation/240-conditional-memory-influence-gate"
+            "maintenance/remove-failsafe-artifacts"
+            "p5-security-scorecard"
+            "p6-mem0-comparator"
+            "p6-mem0-comparator-pre-rebase"
+            "p45-acceptance-closeout"
+            "p45-domain-authority-continuity"
+            "p45-lifecycle-composition"
+            "p45a-portable-evidence-core"
+            "p45b-agent-manifest-correlation"
+            "p45c-trace-action-evidence"
+            "reference/68-boundary-crossing-receipts"
+            "reference/68-derived-scope-governance"
+            "reference/68-recall-isolation-domains"
+            "reference/68-shared-domain-membership"
+            "research/137-latent-predictive-state"
+            "research/138-field-claim-registry"
+            "research/224-memory-architecture-baseline"
+            "research/226-progressive-domain-schema"
+            "research/226-progressive-domain-schema-discovery"
+            "research/227-autonomous-maintenance"
+            "research/228-model-internal-conditional-memory"
+            "research/230-operational-memory-benchmark"
+            "research/246-long-horizon-memory-benchmark"
+            "research-161-matrix"
+            "research-161-matrix-v2"
+            "runtime/46-p7-governed-interchange"
+            "runtime/46-p7-lifecycle-continuity"
+            "runtime/46-p7-two-store-propagation"
+            "runtime/46-p8-telemetry-minimization"
+            "runtime/46-p8-telemetry-retention"
+            "runtime/46-p9-systems-characterization"
+            "runtime/68-authorized-redacted-export"
+            "runtime/68-composition-gate"
+            "runtime/68-required-compartment-semantics"
+            "runtime/68-scope-reduction-propagation"
+            "runtime/68-shared-revocation-propagation"
+            "runtime-concurrency-evidence"
+            "schema/68-isolation-domain-representation"
+          )
+
+          deleted=0
+          already_absent=0
+
+          for branch in "${branches[@]}"; do
+            if git ls-remote --exit-code --heads origin "refs/heads/$branch" >/dev/null 2>&1; then
+              echo "Deleting audited branch: $branch"
+              git push origin --delete "$branch"
+              deleted=$((deleted + 1))
+            else
+              echo "Already absent: $branch"
+              already_absent=$((already_absent + 1))
+            fi
+          done
+
+          echo "Deleted: $deleted"
+          echo "Already absent: $already_absent"
+          echo "Audited list size: ${#branches[@]}"
+
+          if [[ $((deleted + already_absent)) -ne ${#branches[@]} ]]; then
+            echo "Cleanup accounting mismatch" >&2
+            exit 1
+          fi


### PR DESCRIPTION
Adds a temporary one-shot GitHub Actions workflow containing only the 123 historical branch refs already reconciled under #72. On merge to `main`, it requests `contents: write`, deletes only those frozen audited refs, treats already-absent refs idempotently, and emits deletion accounting. No dynamically discovered or future branch is in scope. The workflow will be removed immediately after successful cleanup verification.