### PR TITLE
Run post-closeout branch maintenance

### DIFF
--- a/.github/workflows/post-closeout-maintenance.yml
+++ b/.github/workflows/post-closeout-maintenance.yml
@@ -1,0 +1,35 @@
+name: Post Closeout Maintenance
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  maintenance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prune reconciled historical refs
+        shell: bash
+        run: |
+          set -euo pipefail
+          refs=(
+            "agent/255-policy-projection"
+            "agent/256-compatibility"
+            "agent/262-temporal-commitment"
+            "agent/265-mainline"
+            "integration/258-259-temporal-commitments"
+          )
+          for ref in "${refs[@]}"; do
+            if git ls-remote --heads origin "refs/heads/$ref" | grep -q .; then
+              git push origin ":refs/heads/$ref"
+            fi
+          done


### PR DESCRIPTION
One-shot repository maintenance after the issue/PR closeout. The workflow targets only five branches whose unique-work disposition has already been verified as merged, superseded, or ancestor-only. After the branch cleanup runs on `main`, this workflow will be removed in a second PR.