### PR TITLE
Implement governed procedural memory and capability routing

### DIFF
--- a/.github/workflows/procedural-memory-evidence.yml
+++ b/.github/workflows/procedural-memory-evidence.yml
@@ -1,0 +1,50 @@
+name: Procedural Memory Evidence
+
+on:
+  pull_request:
+    paths:
+      - "reference/agentmem_ref/capabilities.py"
+      - "reference/agentmem_ref/procedural_memory.py"
+      - "reference/tests/test_component_capabilities.py"
+      - "reference/tests/test_procedural_memory.py"
+      - "reference/run_procedural_memory.py"
+      - "reference/fixtures/component-capabilities/**"
+      - "schemas/component-capability-profile.schema.json"
+      - ".github/workflows/procedural-memory-evidence.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  procedural-memory-evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install reference dependencies
+        run: python -m pip install -r reference/requirements.txt
+
+      - name: Validate component capability schema
+        run: python scripts/validate_schemas.py
+
+      - name: Test capability declarations and routing
+        run: python -m unittest discover -s reference/tests -p 'test_component_capabilities.py' -t reference
+
+      - name: Test governed procedural memory
+        run: python -m unittest discover -s reference/tests -p 'test_procedural_memory.py' -t reference
+
+      - name: Emit governed procedural-memory evidence
+        run: python reference/run_procedural_memory.py --output artifacts/procedural-memory-evidence.json
+
+      - name: Upload governed procedural-memory evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: procedural-memory-evidence
+          path: artifacts/procedural-memory-evidence.json

--- a/.github/workflows/procedural-memory-evidence.yml
+++ b/.github/workflows/procedural-memory-evidence.yml
@@ -10,6 +10,11 @@ on:
       - "reference/run_procedural_memory.py"
       - "reference/fixtures/component-capabilities/**"
       - "schemas/component-capability-profile.schema.json"
+      - "docs/adr/ADR-034-procedural-memory-is-not-execution-authority.md"
+      - "docs/adr/README.md"
+      - "docs/programs/memory-modules/README.md"
+      - "docs/programs/runtime-evidence/procedural-memory.md"
+      - "wiki-src/Architecture-Decisions.md"
       - ".github/workflows/procedural-memory-evidence.yml"
   workflow_dispatch:
 

--- a/docs/adr/ADR-034-procedural-memory-is-not-execution-authority.md
+++ b/docs/adr/ADR-034-procedural-memory-is-not-execution-authority.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -14,178 +14,141 @@ procedure is not permission
 permission is not governance
 ```
 
-The external memory frontier now makes this boundary operationally urgent.
+The external memory frontier makes this boundary operationally important. Agent systems increasingly retain reusable procedures, playbooks, tool-use routines, skills, scripts, resources, condensed experience, or learned strategies that can materially change later behavior. The representation is not the stable architectural question.
 
-Modern agent-memory systems increasingly retain reusable procedures, strategies, playbooks, tool-use routines, and “skills” as memory. MemOS, MIRIX, Letta, Acontext, and research on execution-oriented/procedural memory all expose forms of retained know-how that can materially change later agent behavior.
-
-Some skill formats are human-readable Markdown. Others include scripts/resources, learned policies, condensed experience, or routing triggers. The substrate is not the stable architectural question.
-
-The stable question is whether storing or recalling a procedure silently grants the agent authority to activate or execute it.
+The stable question is whether storing or recalling a procedure silently grants authority to apply or execute it.
 
 It must not.
 
-A second frontier has also emerged: systems such as MemSkill and EvolveMem learn **how the memory system itself should remember**, including extraction, consolidation, retrieval, ranking, and forgetting strategies. These “metamemory” procedures are even more consequential because they alter future memory formation and recall.
+A related frontier is **metamemory**: retained or learned procedures about how the memory system itself should extract, consolidate, route, retrieve, rank, prune, archive, or forget memory. Metamemory has a higher consequence surface because applying it changes future memory formation and recall.
 
-Existing doctrine covers pieces of this problem:
+Existing doctrine supplies the controlling boundaries:
 
-- ADR-020 separates uncertain/learned proposals from governed consequences;
+- ADR-020 separates learned/probabilistic proposals from governed consequences;
 - ADR-022 governs cross-scope memory movement;
-- ADR-025 (Proposed) addresses explicit authority for durable decision overwrite;
-- ADR-027 (Proposed) addresses governed re-admission of rejected values;
+- ADR-028 preserves representation and implementation portability;
+- ADR-030 separates current compatible projections from historical/serializable state;
 - ADR-032 governs structural adaptation and forbids probabilistic self-authorization;
 - ADR-033 establishes capability-oriented composition and deterministic routing floors;
-- PAMA separates memory target class, operation, downstream authority, risk, and review requirements.
+- PAMA separates target class, operation, downstream authority, risk, and review requirements.
 
-The missing doctrine is the lifecycle and authority boundary for retained **procedural/skill memory** itself.
+## Decision
 
-## Decision candidate
+Agent Memory treats procedural/skill memory as **governed retained state with separate retrieval, admission/activation, action-authority, and execution boundaries**.
 
-Agent Memory SHOULD treat procedural/skill memory as governed retained state with a separate activation and execution boundary.
-
-> **A remembered procedure may influence a plan. It does not, by being remembered, grant permission to perform the procedure's actions.**
+> **A remembered procedure may influence a plan after governed admission. It does not, by being remembered, grant permission to perform the procedure's actions.**
 
 The architecture separates at least:
 
 ```text
 skill retention
-  store/version/scope/provenance the procedure
-
+  store / version / scope / provenance the procedure
+        |
+        v
 skill retrieval
   produce the procedure as a memory candidate
-
+        |
+        v
 skill admission / activation
-  permit the procedure to influence the current plan/context
-
-skill execution
-  perform tools/actions described by the procedure under Runtime/Governance authority
+  permit the current procedure to influence plan/context
+        |
+        v
+runtime action proposal
+  identify an action the agent wants to perform
+        |
+        v
+action governance where applicable
+  permit / review / block the exact action
+        |
+        v
+execution evidence
 ```
 
-No earlier stage implies the later stage.
+No earlier stage implies a later stage.
 
-## Procedural memory unit
+## Procedural-memory semantic boundary
 
-A procedural-memory implementation MAY use Markdown, structured JSON, files, database records, code bundles, learned policies, or another representation.
+A procedural-memory implementation MAY use Markdown, JSON, files, database records, code bundles, learned policies, or another representation.
 
-At the Agent Memory semantic boundary, a durable procedural memory SHOULD be able to represent or derive at least:
+At the Agent Memory boundary, a durable procedure MUST preserve or make reconstructable enough information to govern at least:
 
-```text
-logical procedure identity
-version / currentness
-scope / isolation domain
-purpose / applicability or trigger conditions
-procedure content/reference
-provenance/source episodes or authored source
-validation/evaluation evidence where available
-known constraints / hazards / prerequisites
-supersession/correction lineage
-sensitivity
-activation posture
-content/reference integrity
-```
+- logical procedure identity;
+- version and currentness;
+- scope and isolation domain;
+- purpose/applicability;
+- exact procedure content or integrity-bound reference;
+- provenance/source evidence;
+- validation evidence where available;
+- constraints, hazards, or prerequisites where applicable;
+- supersession/correction lineage;
+- activation posture.
 
-Exact field names are an implementation/schema question, not fixed by this ADR.
+Exact field names and serialization are implementation/profile choices rather than canonical doctrine.
 
-## Promotion into procedural memory
+## Promotion
 
-A procedure may originate from:
-
-- explicit human instruction;
-- imported project/user documentation;
-- repeated successful agent experience;
-- consolidation/synthesis over episodes;
-- external skill catalogs;
-- another governed memory domain;
-- learned skill-generation systems.
+A procedure may originate from human instruction, documentation, episodic experience, consolidation/synthesis, external skill catalogs, another governed memory domain, or a learned skill-generation system.
 
 Origin establishes provenance, not authority.
 
-Promotion from episodic experience into durable procedural memory is a consequential memory mutation and must pass the normal PAMA/currentness/scope path.
+Promotion into durable procedural memory is a memory mutation and MUST pass the normal PAMA/currentness/scope path. Learned confidence or expected utility cannot authorize the durable consequence.
 
-A model's confidence that a procedure is useful does not authorize durable promotion.
+A proposal MUST NOT mutate durable procedural state merely because it exists.
 
-## Activation/admission
+## Exact payload and approval binding
 
-Procedural recall produces a **candidate skill/procedure**.
+Where a procedural mutation requires review or approval, the authorization MUST bind the exact payload or integrity-bound reference, proposal identity, and current-state snapshot sufficiently to prevent approval substitution.
 
-Before the procedure may influence the active plan/context, Agent Memory must apply governed recall/admission constraints including as applicable:
+```text
+approval for skill X @ state N
+        !=
+approval for modified skill Y @ state N
+        !=
+approval for X after state N has changed
+```
 
-- currentness and supersession;
-- scope/isolation;
-- purpose/applicability;
-- sensitivity;
-- rejection/readmission state;
-- material validation status;
-- required authority ceilings;
-- source/provenance availability;
-- consumer/runtime compatibility.
+A generic `approved=true`, reused approval reference, stale cached approval, or approval for a predecessor version is not sufficient standing authority for a different payload or state.
 
-A high similarity score, trigger match, graph reachability, or learned router choice does not bypass admission.
+## Retrieval and admission
+
+Procedural retrieval produces a **candidate procedure**. Before the procedure may influence the active plan/context, governed admission must apply relevant currentness, supersession, scope/isolation, purpose/applicability, rejection/readmission, provenance, sensitivity, compatibility, and validation constraints.
+
+A high similarity score, graph reachability, trigger match, learned router choice, or component-selection result cannot bypass admission.
+
+Superseded or tombstoned procedures may remain retrievable for reconstruction while being refused as current guidance.
 
 ## Execution remains outside memory authority
 
-Once admitted, a procedural memory may recommend or shape Runtime behavior.
+Once admitted, procedural memory may shape planning and produce candidate runtime actions. Actual tool/action authority remains with Agent Runtime and/or Agent Governance as applicable.
 
-The Runtime and/or Agent Governance system remains responsible for actual action/tool execution authority.
+A stored skill containing a shell command, HTTP request, repository mutation, deployment step, payment action, or destructive operation does not inherit execution authority from its retention, prior validation, prior successful use, or prior approval in another state.
 
-```text
-Agent Memory
-  recalls/admit procedure
-        |
-        v
-Agent Runtime
-  forms plan / proposes action
-        |
-        v
-Agent Governance where applicable
-  permits / reviews / blocks action
-        |
-        v
-execution
-```
-
-A stored skill containing a shell command, HTTP call, repository mutation, payment step, deployment procedure, or destructive operation does not inherit authority merely because the skill was previously approved for another case.
+The identities for memory proposal, PAMA decision, memory commit receipt, recall/admission, action proposal, action-governance decision, and execution evidence SHOULD remain distinguishable and correlatable rather than being collapsed into one reusable "approved skill" token.
 
 ## Correction and supersession
 
-Procedural memories are versioned knowledge, not immortal scripts.
-
-When a procedure changes:
+Procedural memories are versioned retained state.
 
 ```text
 old current procedure
   -> correction/successor proposal
-  -> governance/currentness evaluation
+  -> current-state + authority evaluation
+  -> exact approval when required
   -> new current procedure
   -> old procedure retained as superseded history where required
 ```
 
-Superseded procedures MUST NOT be admitted as current merely because a retrieval component ranks them highly.
-
-Historical procedures may remain queryable for reconstruction, incident analysis, or rollback evidence without being current guidance.
+A superseded procedure MUST NOT regain current influence merely because retrieval ranks it highly. Stale proposals and approvals MUST fail after the governed state advances.
 
 ## Cross-scope transfer
 
-A useful skill in one project, tenant, environment, or toolchain does not automatically transfer to another.
+A useful procedure in one project, tenant, environment, or toolchain does not automatically transfer to another. Cross-scope procedural reuse is governed by ADR-022 and may require rescoping, compatibility validation, renewed authority, or new evidence.
 
-Cross-scope procedural reuse is a governed boundary crossing under ADR-022.
-
-Transfer may require:
-
-- re-scoping;
-- compatibility validation;
-- removal/generalization of environment-specific assumptions;
-- renewed authority/approval;
-- new validation evidence.
-
-The same procedure text in two domains does not imply the same applicability or authority.
+The same text in two domains does not imply the same applicability or authority.
 
 ## Procedure plus executable artifacts
 
-Some skill systems package instructions with executable scripts/resources.
-
-Agent Memory may retain and retrieve such artifacts as `resource_artifact_memory` associated with `procedural_skill_memory`.
-
-However:
+A skill may reference scripts or resources. Retention and integrity do not imply trust or execution permission:
 
 ```text
 artifact retained
@@ -194,156 +157,135 @@ artifact retained
   != execution authorized
 ```
 
-Integrity, provenance, malware/supply-chain checks, runtime sandboxing, and action governance remain separate controls.
+Supply-chain validation, sandboxing, external governance, and execution evidence remain separate concerns.
 
-## Metamemory is a stricter sub-class
+## Metamemory is a stricter profile
 
-A procedure about performing a user task is ordinary procedural memory.
+A procedure for performing a user task is ordinary procedural memory.
 
-A procedure about **how Agent Memory itself should form, consolidate, route, retrieve, rank, prune, archive, or forget memory** is a `metamemory_policy` capability.
-
-Metamemory has a higher consequence surface because recalling/applying it changes future memory-system behavior.
+A procedure that changes how Agent Memory forms, consolidates, routes, retrieves, ranks, prunes, archives, or forgets memory is a metamemory/profile-change proposal.
 
 The safe path is:
 
 ```text
 learned metamemory insight
-  -> versioned proposed memory-management/profile change
-  -> deterministic compatibility + regression analysis
-  -> PAMA / ADR-032 structural or policy classification
-  -> bounded authorized commit OR explicit human decision
+  -> retained/proposed management change
+  -> deterministic compatibility / impact / regression evidence
+  -> PAMA / ADR-032 classification
+  -> bounded authorized commit OR explicit review
 ```
 
-A recalled metamemory skill MUST NOT silently modify the active memory profile.
-
-This ADR does not create a separate metamemory authority system. Existing PAMA, ADR-020, ADR-032, configuration compatibility, and normal human-authority boundaries remain controlling.
+A recalled metamemory artifact MUST NOT silently modify the active memory profile. This ADR creates no parallel metamemory authority system.
 
 ## Learned and self-evolving skills
 
-Systems may learn skills from successful episodes, hard cases, failure logs, or benchmark feedback.
+Learned systems MAY propose new procedures, refinements, applicability triggers, retirement candidates, or metamemory changes. They MAY provide utility estimates or validation evidence.
 
-Agent Memory permits probabilistic/learned systems to:
+They do not self-authorize durable promotion, semantic correction, cross-scope transfer, retirement/deletion, active profile mutation, or action execution.
 
-- propose new procedural memories;
-- propose refinements;
-- estimate expected utility;
-- identify applicability triggers;
-- recommend retirement;
-- propose metamemory/profile changes.
+## Capability composition
 
-They do not self-authorize:
+Procedural memory is a capability under ADR-033 rather than a required dedicated product or repository.
 
-- durable promotion;
-- cross-scope transfer;
-- semantic correction;
-- deletion/retirement;
-- active profile mutation;
-- action execution.
+A component may declare `procedural_skill_memory` alongside other capabilities. Multiple implementations may satisfy the capability. Selection/composition is deterministic and maturity-aware, and provider choice does not become mutation authority or recall permission.
 
-For self-evolving retrieval or metamemory changes, regression evidence and rollback boundaries SHOULD be first-class inputs to the governance decision.
+The first reference profile intentionally uses a simple inspectable artifact and the existing governed adapter instead of creating a specialized skill database.
 
-## Evaluation evidence
+## Acceptance evidence
 
-Procedural memory quality is not adequately measured by retrieval accuracy alone.
+ADR-034 was promoted only after the #295 reference vertical slice exercised the decision end to end and the repository-wide doctrine validator passed at the implementation head.
 
-A capability profile SHOULD be able to bind a skill/procedure to evidence such as:
+The executable evidence surfaces are:
 
-- source episodes;
-- successful/failed applications;
-- environment/tool versions;
-- tests or validation runs;
-- negative cases;
-- last validation time;
-- known constraints;
-- observed outcome metrics.
+- `reference/agentmem_ref/capabilities.py` — independent capability maturity and deterministic provider resolution;
+- `schemas/component-capability-profile.schema.json` — machine-readable capability declaration profile;
+- `reference/agentmem_ref/procedural_memory.py` — procedural retention, exact approval binding, activation, action separation, revocation, and metamemory boundary;
+- `reference/tests/test_component_capabilities.py` — maturity, ambiguity, preference, and no-downgrade tests;
+- `reference/tests/test_procedural_memory.py` — positive and adversarial procedural-memory paths;
+- `reference/run_procedural_memory.py` — deterministic reconstructable evidence harness;
+- `.github/workflows/procedural-memory-evidence.yml` — exact-head focused evidence workflow;
+- `docs/programs/runtime-evidence/procedural-memory.md` — evidence map and claim boundary.
 
-This evidence informs currentness and applicability. It does not become standing execution permission.
+The evidence demonstrates:
 
-## First implementation profile
+1. procedure proposal does not mutate durable state;
+2. governed promotion creates a versioned, scoped, integrity-bound procedure;
+3. later-session governed recall admits the current procedure and changes the plan;
+4. admission does not execute actions;
+5. an action requires a separately bound governance decision before execution evidence can be recorded;
+6. correction requires review under the current PAMA profile and supersedes rather than erases the prior version;
+7. approval is bound to the exact procedure payload, proposal, version, and state, and a substituted payload is refused;
+8. an unbound review flag/reference cannot manufacture approval;
+9. stale proposal replay fails after state advances;
+10. a high-relevance foreign-project candidate is not admitted;
+11. revocation/tombstoning removes active influence while retained recovery content/residue is reported honestly;
+12. retained metamemory cannot apply itself through ordinary skill activation and instead yields a separate M5/A5 `policy_mutation` proposal;
+13. memory, approval, action-governance, and execution identities remain distinct;
+14. capability routing remains non-authoritative.
 
-The reference implementation SHOULD deliberately use a simple, inspectable representation before adopting a specialized skill database.
+## Evidence boundary
 
-A suitable v0 profile is:
+Acceptance is a doctrine-maturity decision, not a universal production-conformance claim.
 
-```text
-human-readable Markdown/structured skill artifact
-  + Agent Memory logical identity/provenance/scope/currentness
-  + governed promotion
-  + governed recall/admission
-  + explicit activation evidence
-  + separate Runtime/Governance execution
-```
+The reference proof is deliberately bounded:
 
-The first proof should not require embeddings, GraphRAG, a learned skill model, or a new first-party repository.
-
-Those capabilities can be composed later without changing the behavioral contract.
-
-## Required acceptance evidence before doctrine promotion
-
-This ADR intentionally remains Proposed until the first vertical slice demonstrates at least:
-
-1. an episodic or human-authored procedure can be proposed without immediate mutation;
-2. governed promotion creates durable procedural memory with provenance/scope;
-3. a later session retrieves and admits the current procedure;
-4. the admitted procedure changes the plan without automatically executing actions;
-5. execution still traverses the normal Runtime/Governance boundary;
-6. correction creates a superseding procedure and the old procedure is no longer admitted as current;
-7. stale procedure/approval replay cannot restore an old procedure as current;
-8. cross-project/tenant procedure admission is blocked without governed crossing;
-9. deletion/revocation makes derived/index/cache copies non-influential or reports incomplete residue honestly;
-10. an attempted metamemory/profile change cannot self-authorize through ordinary skill recall;
-11. decision, activation/admission, and execution evidence remain distinct.
+- it proves cross-session reuse inside one governed reference runtime;
+- it does **not** prove process-restart durability, which remains separate work;
+- it uses a reference in-memory procedural representation rather than selecting a universal skill store;
+- it models a separate action-governance/execution boundary without claiming a specific external governance product or real external tool execution;
+- it does not make Markdown, the reference serialization, EvolveAI, CodeGenome, or any external skill format canonical;
+- it does not grant `reference_qualified` maturity to first-party components merely because example declarations exist.
 
 ## Consequences
 
 ### Positive
 
-- makes a major emerging agent-memory capability first-class without giving memory execution authority;
-- creates a clean bridge between experience and reusable agent competence;
-- supports human-readable, external, learned, or first-party skill stores behind one semantic contract;
-- provides a concrete workload for ADR-033 component/capability composition;
-- gives metamemory evolution a safe home under existing governance rather than inventing a parallel authority model;
-- enables EvolveAI lifecycle and CodeGenome provenance to compose later.
+- reusable competence can persist across sessions without becoming standing authority;
+- procedural state gains scope, currentness, correction, supersession, provenance, and revocation semantics;
+- exact approval binding prevents "approved X, committed Y" substitution;
+- human-readable, external, learned, or first-party skill stores can fit behind one semantic boundary;
+- metamemory evolution has a governed path under existing PAMA/ADR-032 rules;
+- the capability provides a concrete workload for ADR-033 composition.
 
 ### Negative
 
-- a “skill” requires more lifecycle/evidence than a convenient prompt snippet;
-- runtime integrations must preserve an extra activation boundary;
-- existing external skill stores may need adapters to express Agent Memory scope/currentness/provenance;
+- a skill requires more lifecycle/evidence than a convenient prompt snippet;
+- runtime integrations must preserve an explicit activation/action-authority boundary;
+- external skill stores may need adapters for Agent Memory scope/currentness/provenance;
 - self-evolving memory systems cannot directly apply every learned optimization.
 
 ## Alternatives considered
 
 ### Treat skills as ordinary facts
 
-Rejected. Procedures have applicability, activation, validation, and execution consequences that facts do not.
+Rejected. Procedures have applicability, activation, validation, and downstream action consequences that ordinary facts do not.
 
-### Treat a recalled skill as already authorized execution
+### Treat a recalled skill as authorized execution
 
-Rejected. This collapses memory, procedure, permission, and governance into one artifact and creates standing-authority replay risk.
+Rejected. This collapses memory, procedure, permission, and governance into a replayable standing-authority artifact.
 
 ### Make one skill format canonical
 
-Rejected. External systems successfully use Markdown, files, structured records, scripts/resources, and learned policies. The representation should remain a capability/profile decision.
+Rejected. Representation remains a capability/profile concern.
 
 ### Put procedural memory entirely in Agent Runtime
 
-Rejected. Durable cross-session procedure identity, provenance, scope, correction, supersession, deletion, and recall are memory responsibilities even though execution is not.
+Rejected. Durable cross-session identity, provenance, scope, correction, supersession, deletion/revocation, and recall are memory responsibilities even though execution is not.
 
-### Create a new proprietary skill-memory repository immediately
+### Create a proprietary skill-memory repository immediately
 
-Rejected for the first slice. Current evidence shows the semantics can be proven with simple artifacts. A new subsystem should be created only if later conformance evidence demonstrates a substrate/capability gap that EvolveAI, CodeGenome, files, ordinary stores, or external adapters cannot satisfy cleanly.
+Rejected. The semantics are proven without another subsystem. A dedicated implementation should be created only if later conformance evidence establishes a capability/substrate gap that existing first-party components, ordinary stores, or external adapters cannot satisfy cleanly.
 
 ## Relationship to other ADRs
 
 - ADR-020 governs learned/probabilistic skill discovery and proposal.
 - ADR-022 governs skill scope and cross-domain transfer.
-- ADR-023, if accepted, strengthens correction-as-supersession behavior.
-- ADR-025, if accepted, applies when a procedural memory carries durable decision-like authority consequences.
-- ADR-027, if accepted, applies to rejected/unsafe procedures that attempt re-entry.
+- ADR-023, if accepted, further generalizes correction-as-supersession doctrine.
+- ADR-025, if accepted, applies when procedural state carries durable decision-like overwrite consequences.
+- ADR-027, if accepted, applies to rejected/unsafe procedures attempting re-entry.
 - ADR-028 preserves representation/language portability.
-- ADR-030 applies when a derived projection of procedural memory feeds authorization/temporal consumers.
-- ADR-032 governs metamemory/structural mutation.
-- ADR-033 governs capability declaration, maturity, and deterministic component composition.
+- ADR-030 governs compatible/current projections consumed by temporal or authorization systems.
+- ADR-032 governs metamemory and structural/profile mutation.
+- ADR-033 governs capability declaration, maturity, and deterministic composition.
 
 This ADR adds no exception to PAMA or existing authority rules.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,12 +15,12 @@ ADR status describes **doctrine maturity**, not implementation maturity.
 
 An `Accepted` ADR does **not** claim:
 
-- every related repository implements it
-- runtime enforcement is complete
-- all behavioral conformance cases pass in production
-- the decision can never be revised
+- every related repository implements it;
+- runtime enforcement is complete everywhere;
+- every behavioral conformance case passes in production;
+- the decision can never be revised.
 
-Implementation maturity is tracked separately through documentation, fixtures, conformance evidence, implementation maps, quality metrics, and runtime evidence.
+Implementation maturity is tracked separately through schemas, fixtures, implementation maps, runtime evidence, quality metrics, and conformance reports.
 
 ## Current doctrine state
 
@@ -39,97 +39,69 @@ ADR-030: Accepted
 ADR-031: Accepted
 ADR-032: Accepted
 ADR-033: Accepted
-ADR-034: Proposed
+ADR-034: Accepted
 ```
 
-ADRs 001-020, ADR-022, ADR-024, ADR-028, ADR-030, ADR-031, ADR-032, and ADR-033 have satisfied their respective doctrine-maturity gates. ADR-020 is deliberately stronger than documentation-only acceptance: it required executable end-to-end runtime evidence and adversarial negative paths before acceptance. ADR-024 likewise required executable positive and negative shared-write coordination evidence before promotion.
+ADRs 001-020, ADR-022, ADR-024, ADR-028, ADR-030, ADR-031, ADR-032, ADR-033, and ADR-034 have satisfied their doctrine-maturity gates.
 
-ADR-021 proposes the interoperability boundary for **portable memory-governance evidence**. It keeps Agent Memory authoritative for memory semantics, PAMA, lifecycle obligations, and canonical decision receipts while allowing external trust systems such as AgenTrust to verify and correlate evidence without redefining those semantics.
-
-ADR-022 establishes **memory isolation domains and controlled boundary crossing** as first-class architecture. It extends ADR-016 by making same-agent cross-project/task separation, shared-memory domains, derived-scope inheritance, and scope crossing explicitly governable rather than leaving them as implied metadata filters.
-
-ADR-023 proposes that durable correction is **append-only supersession rather than destructive deletion**. ADR-024 establishes **pre-write coordination for shared-memory mutation** as accepted doctrine. ADR-025 proposes **explicit authority for overwriting durable decision state**. The #144 implementation slice now supplies executable proposal/authority/PAMA/supersession evidence for ADR-025, but #144 explicitly excludes automatic maturity promotion, so ADR-025 remains Proposed pending a separate doctrine-governance decision.
-
-ADR-026 proposes a source-neutral epistemic boundary: **claim origin establishes provenance, not evidentiary authority**. ADR-027 proposes **governed re-admission for explicitly rejected values** so a corrected value cannot silently return merely by acquiring a fresh identity. Both remain Proposed while their linked evidence programs run.
-
-ADR-028 establishes a **language-neutral normative core with optional implementation and interoperability profiles**. It permits Python-first reference tooling, Rust high-assurance implementations, and UOR/AGT/MCP integrations without allowing any one language or external ecosystem to become the definition of Agent Memory doctrine.
-
-ADR-029 proposes a three-layer governance-consumer boundary: **canonical Agent Memory core -> vendor-neutral Governance Context Projection -> consumer-specific adapter**. The projection is reconstructable derived context, not canonical memory truth, standing permission, or a final external-governance verdict.
-
-ADR-030 establishes that temporal and authorization consumers require a **versioned compatibility/currentness evaluation** before a memory-derived projection can be treated as current policy input. Serialization success is not semantic compatibility, and historical temporal evidence is not current authority.
-
-ADR-031 establishes a **layered temporal-commitment model**. Material temporal claims that determine historical identity belong inside deterministic content commitments, while signer attestation, signer trust, external witnessed time/transparency evidence, currentness, and PAMA authority remain distinct claims.
-
-ADR-032 establishes **governed structural mutability**. Memory shape may adapt, and probabilistic or learned systems may discover and propose structural changes, but canonical structural consequences are committed only through a versioned deterministic authorized envelope or explicit authorized human decision. Authority escalates with semantic impact, blast radius, migration requirements, scope, authority effect, and irreversibility.
-
-ADR-033 establishes **capability-oriented deterministic composition**. Component identity and capability identity are orthogonal, capability maturity is independently declared/evidenced, overlapping implementations require deterministic selection/composition or explicit ambiguity failure, and routing cannot silently downgrade maturity or become mutation/recall authority.
-
-ADR-034 proposes that **procedural/skill memory is retained state rather than standing execution authority**. It separates retention, retrieval, recall admission/activation, and action execution, and treats learned metamemory as a stricter memory-management/profile-change surface governed by existing PAMA/ADR-032 rules. ADR-034 intentionally requires #295 executable evidence before acceptance.
+Several accepted decisions deliberately required stronger-than-documentation evidence. ADR-020 required executable end-to-end governed-consequence evidence and adversarial negative paths. ADR-024 required executable shared-write coordination evidence. ADR-034 required a real procedural-memory vertical slice proving that retained/recalled skills do not become standing execution or metamemory authority.
 
 ## Current status policy
 
 A decision may move from Proposed to Accepted when:
 
-1. its architectural boundary is sufficiently defined
-2. it is integrated consistently into canonical doctrine
-3. known material contradictions have been resolved or documented
-4. required foundational documentation exists
-5. any repository-level schema/fixture prerequisites named by the ADR are satisfied
-6. acceptance does not depend on runtime evidence the ADR explicitly says is still missing
+1. its architectural boundary is sufficiently defined;
+2. it is integrated consistently into canonical doctrine;
+3. known material contradictions have been resolved or documented;
+4. required foundational documentation exists;
+5. any schema/fixture prerequisites named by the ADR are satisfied;
+6. any stronger runtime/evidence gate named by the ADR is satisfied.
 
-If an ADR explicitly requires stronger evidence before acceptance, that requirement controls. Satisfying an evidence prerequisite does not silently promote a Proposed ADR when the governing issue or decision process reserves maturity review as a separate action.
+Satisfying an implementation prerequisite does not silently promote a Proposed ADR when the ADR or governing issue reserves maturity review as a separate decision.
 
 The evidence policy is source-neutral. Native authorship, maintainer status, external publication, implementation popularity, AI generation, or prior acceptance do not make a claim immune to challenge. See [`../policies/EVIDENCE_PROMOTION.md`](../policies/EVIDENCE_PROMOTION.md).
 
-## Governed uncertainty
+## Decision families
+
+### Governed uncertainty
 
 [`ADR-020`](ADR-020-probabilistic-discovery-deterministic-governance.md) is **Accepted**.
 
-Its acceptance required at least one real implementation mapped and tested end to end across:
+Its central boundary is:
 
 ```text
-estimate / proposal
+estimate / learned proposal
   -> governance envelope
   -> permitted action set
   -> selected action
   -> committed consequence
 ```
 
-The repository now has executable evidence for stochastic containment, cross-scope recall, concurrency conflict handling, deletion residue and transitive deletion behavior, reconstructable receipts, adversarial boundary enforcement, and a pinned real-substrate path. The P10 acceptance audit maps all fourteen ADR-020 gates to current evidence.
+The repository has executable evidence for stochastic containment, cross-scope recall, concurrency conflict handling, deletion residue, transitive deletion behavior, reconstructable receipts, adversarial boundary enforcement, and a pinned real-substrate path. Acceptance does not upgrade the narrow reference adapter to universal production conformance.
 
-Acceptance does not upgrade the narrow reference adapter to a higher cumulative conformance level. Doctrine maturity and implementation conformance remain separate claims.
+ADR-032 strengthens this boundary for canonical structural mutation. ADR-034 applies the same separation to reusable procedures and memory-management skills: learned discovery may propose, but retained procedure does not become action or memory-profile authority.
 
-ADR-032 is a domain-specific strengthening of this boundary for canonical structural mutation: probabilistic systems may propose a structural change, but the authority determination that commits the canonical structural consequence must be deterministic and versioned or explicitly human-authorized.
+### Portable memory-governance evidence
 
-ADR-034 applies the same separation to reusable procedures and memory-management skills: learned skill discovery may propose; remembered procedure does not become execution or memory-profile authority.
-
-## Portable memory-governance evidence
-
-[`ADR-021`](ADR-021-portable-memory-governance-evidence-boundary.md) is intentionally **Proposed**.
-
-Its central boundary is:
+[`ADR-021`](ADR-021-portable-memory-governance-evidence-boundary.md) remains **Proposed**.
 
 ```text
 Agent Memory
-  owns memory semantics, PAMA, lifecycle, and canonical receipts
+  owns memory semantics, PAMA, lifecycle, canonical receipts
         |
         v
 portable evidence projection
         |
         v
 external trust / attestation system
-  verifies binding, integrity, and execution correlation
+  verifies binding, integrity, execution correlation
 ```
 
-The external trust system does not acquire authority to redefine memory-specific permission or infer lifecycle satisfaction from cryptographic integrity alone.
+The external verifier does not acquire authority to redefine memory-specific permission or infer lifecycle satisfaction from cryptographic integrity alone. Acceptance requires the interoperability and deletion-completeness evidence named by ADR-021.
 
-ADR-021 acceptance requires an executable interoperability proof, including negative paths and at least one deletion-completeness scenario that distinguishes a valid memory mutation/checkpoint from successful semantic forgetting.
-
-## Memory isolation domains
+### Memory isolation domains
 
 [`ADR-022`](ADR-022-memory-isolation-domains-and-controlled-boundary-crossing.md) is **Accepted**.
-
-Its central boundary is:
 
 ```text
 same agent / same store
@@ -137,17 +109,21 @@ same agent / same store
 same authorized memory domain
 ```
 
-It treats project, task, workspace, session, purpose, tenant, and shared-memory boundaries as logical authority domains rather than assuming storage layout or agent identity provides sufficient isolation.
+Project, task, workspace, session, purpose, tenant, and shared-memory boundaries are logical authority domains rather than mere storage filters. Sharing, exporting, copying, deriving, or broadening scope is a governed consequence. Derived state must not silently gain broader scope than its sources.
 
-Boundary crossing, including sharing, exporting, copying, deriving, inheriting, or broadening scope, is treated as a governed consequence. Derived state must not silently gain broader scope than its sources.
+ADR-034 uses this boundary directly: a highly relevant procedural skill from another project or tenant remains inadmissible without governed crossing.
 
-Acceptance is backed by the canonical isolation-domain contract, additive schema/receipt representation, governed-recall enforcement, same-agent cross-project/task fixtures, derived-scope propagation, unauthorized scope-promotion tests, shared-space member/non-member recall tests, executable crossing receipts, and reconciliation with the future multi-agent shared-memory protocol. This is a doctrine-maturity statement, not universal production-runtime conformance.
+### Corrections and durable state
 
-## Shared durable-memory write coordination
+[`ADR-023`](ADR-023-corrections-are-supersession-not-deletion.md) remains **Proposed**. It generalizes durable correction as append-only supersession rather than destructive erasure.
+
+[`ADR-025`](ADR-025-durable-decision-overwrites-require-explicit-authority.md) remains **Proposed**. The #144 reference slice exercises exact overwrite-authority validation, PAMA, append-only supersession, stale proposals, agent-collusion refusal, authority-binding failures, and PAMA non-override, but its doctrine maturity remains a separate decision.
+
+[`ADR-027`](ADR-027-rejected-values-require-governed-readmission.md) remains **Proposed**. It requires a corrected/rejected value to pass governed re-admission rather than silently returning under a fresh identity.
+
+### Shared durable-memory writes
 
 [`ADR-024`](ADR-024-shared-memory-writes-require-prewrite-claims.md) is **Accepted**.
-
-Its central boundary is:
 
 ```text
 shared write intent
@@ -157,44 +133,17 @@ shared write intent
   -> durable mutation or refusal
 ```
 
-A claim grants the bounded opportunity to attempt the shared write. It does not grant the durable consequence.
+A claim grants only the bounded opportunity to attempt a shared mutation. It cannot loosen PAMA.
 
-Acceptance is backed by executable valid, conflicting, stale, expired, and unauthorized claim paths, schema-valid audit evidence for successful and failed claim outcomes, a negative test proving a valid claim cannot override PAMA `block`, and conflict-resolution documentation that settles competing shared-writer authority before commit. The reference lease coordinator is evidence for the contract, not a normative requirement that every implementation use the same primitive.
+### Source-neutral evidence
 
-## Durable decision overwrite authority evidence
+[`ADR-026`](ADR-026-origin-is-provenance-not-evidentiary-authority.md) remains **Proposed**.
 
-[`ADR-025`](ADR-025-durable-decision-overwrites-require-explicit-authority.md) remains **Proposed**.
+Its candidate rule is that origin establishes provenance, not evidentiary authority. Human, agent, maintainer, imported, or generated claims remain subject to the same evidence/currentness scrutiny appropriate to their consequence.
 
-The #144 reference slice now exercises:
-
-```text
-agent proposal
-  -> exact overwrite-authority validation
-  -> PAMA
-  -> append-only supersession or refusal
-```
-
-The evidence includes proposal-without-mutation, human-confirmed overwrite, bounded delegated low-risk overwrite, stale proposal, agent-collusion rejection, authority-binding failures, append-only supersession, PAMA non-override, and versioned PAMA `decision_overwrite` representation. This closes implementation questions; it does not itself decide doctrine maturity.
-
-## Candidate durable-mutation and interoperability decisions
-
-The remaining Proposed ADRs intentionally separate several related but non-identical questions:
-
-- [`ADR-021`](ADR-021-portable-memory-governance-evidence-boundary.md): define the portable memory-governance evidence boundary with external trust and attestation systems;
-- [`ADR-023`](ADR-023-corrections-are-supersession-not-deletion.md): preserve correction history while removing superseded state from current truth;
-- [`ADR-025`](ADR-025-durable-decision-overwrites-require-explicit-authority.md): require explicit authority before overwriting durable decision state;
-- [`ADR-026`](ADR-026-origin-is-provenance-not-evidentiary-authority.md): apply the same evidence discipline to claims regardless of origin;
-- [`ADR-027`](ADR-027-rejected-values-require-governed-readmission.md): require governed re-admission when a corrected/rejected value later reappears;
-- [`ADR-029`](ADR-029-governance-projection-is-derived-context-not-authority.md): expose vendor-neutral governance context as reconstructable derived state without turning consumer semantics into core memory doctrine;
-- [`ADR-034`](ADR-034-procedural-memory-is-not-execution-authority.md): make reusable procedural memory current/scoped/correctable without granting it standing action or memory-profile authority.
-
-These ADRs must not be collapsed into a single broad "memory safety" or "governance integration" claim. Each has its own acceptance evidence and may be accepted, narrowed, or rejected independently.
-
-## Implementation portability and ecosystem boundaries
+### Implementation portability
 
 [`ADR-028`](ADR-028-language-neutral-core-and-optional-implementation-profiles.md) is **Accepted**.
-
-Its central boundary is:
 
 ```text
 normative doctrine / schemas / fixtures
@@ -204,15 +153,11 @@ reference implementation language
 optional implementation or interoperability profile
 ```
 
-Python may remain the practical reference/integration language where it maximizes ecosystem reach. Rust is a first-class implementation language for high-assurance or performance-sensitive components. UOR, AGT, MCP, and other external systems may supply reusable primitives or profiles, but none becomes authoritative for Agent Memory semantics merely through adoption.
+Python may remain practical reference/integration tooling. Rust remains first-class for high-assurance or performance-sensitive components. UOR, AGT, MCP, and other ecosystems may supply optional profiles without becoming the definition of Agent Memory.
 
-Acceptance is backed by the #232 UOR-Addr interoperability slice, including exact cross-language/content-reference compatibility evidence and negative paths proving that content identity does not confer memory authority or make UOR a required runtime dependency.
+### Governance Context Projection
 
-## Governance Context Projection
-
-[`ADR-029`](ADR-029-governance-projection-is-derived-context-not-authority.md) is intentionally **Proposed**.
-
-Its central boundary is:
+[`ADR-029`](ADR-029-governance-projection-is-derived-context-not-authority.md) remains **Proposed**.
 
 ```text
 canonical Agent Memory primitives
@@ -223,20 +168,14 @@ Governance Context Projection
         |
         v
 consumer-specific adapter
-  policy vocabulary / risk / approval / enforcement
+  policy vocabulary / approval / enforcement
 ```
 
-The projection does not emit a final consumer verdict or standing permission. It is designed so consumers can use remembered rationale, conditions, negative precedent, validity, and outcomes without requiring Agent Memory core to mirror a DashClaw-, AGT/ACS-, or other vendor-specific data model.
+The projection is reconstructable derived context, not canonical truth, standing permission, or a final consumer verdict. Acceptance requires the reference builder, near-match/adversarial evidence, scope/provenance preservation, privacy/minimization evidence, and a consumer integration named by ADR-029.
 
-ADR-029 complements ADR-028: the normative core remains language-neutral, the governance projection remains vendor-neutral, and concrete consumers stay behind optional adapters.
-
-ADR-029 acceptance requires a reconstructable reference builder, adversarial near-match coverage, provenance/scope preservation, privacy/minimization evidence, and at least one consumer integration that demonstrates value without pushing consumer-specific fields into the canonical memory-unit schema.
-
-## Versioned temporal-policy projections
+### Versioned temporal-policy projections
 
 [`ADR-030`](ADR-030-temporal-policy-consumers-require-versioned-compatible-projections.md) is **Accepted**.
-
-Its central boundary is:
 
 ```text
 canonical Agent Memory state
@@ -251,13 +190,11 @@ compatibility / currentness evaluation
 external temporal or authorization consumer
 ```
 
-A projection is not current merely because it serialized successfully or matched historical policy context. Compatibility binds source schema/currentness, projection identity/version, consumer/policy schema and capabilities, isolation strategy, and evidence. External policy may tighten consequences but cannot silently widen PAMA authority.
+Serialization success is not semantic compatibility. Historical temporal evidence is not current authority. Compatibility binds source schema/currentness, projection identity/version, consumer capabilities, isolation strategy, and evidence.
 
-## Cryptographic temporal commitments
+### Cryptographic temporal commitments
 
 [`ADR-031`](ADR-031-temporal-claims-require-deterministic-content-commitments.md) is **Accepted**.
-
-Its central boundary is:
 
 ```text
 temporal claims + payload/schema/scope/order
@@ -266,19 +203,17 @@ temporal claims + payload/schema/scope/order
 deterministic content commitment
         |
         +--> signer attestation
-        +--> optional external witness / transparency evidence
+        +--> optional external witness evidence
         |
         v
 separate Agent Memory currentness + PAMA evaluation
 ```
 
-The commitment provides exact historical identity for material temporal claims. Signer attestation is not signer trust, witnessed time is not event truth, predecessor chaining is not proof of complete or unique history, and cryptographic validity does not create lifecycle currentness or authority. The accepted evidence includes adversarial fork/gap behavior, supersession/currentness separation, witness-binding failures, optional UOR compatibility, and exact-head repository validation.
+Historical identity, signer trust, witnessed time, lifecycle currentness, and authority remain distinct claims.
 
-## Governed mutable memory structure
+### Governed mutable memory structure
 
 [`ADR-032`](ADR-032-governed-mutable-memory-structure.md) is **Accepted**.
-
-Its central boundary is:
 
 ```text
 learned / probabilistic structural discovery
@@ -296,15 +231,13 @@ deterministic authorized envelope OR explicit human authority
 committed structural consequence
 ```
 
-The doctrine distinguishes canonical semantic shape, application/domain ontology, and derived/physical representation. Rebuild-only derived changes may be autonomous under deterministic maintenance policy. Bounded additive changes may be autonomous only when a versioned deterministic rule proves the authorized envelope. Semantic migrations and destructive/cross-scope/authority-bearing changes require explicit human authority unless a future accepted doctrine narrows an exact delegated class.
+Memory shape may adapt, but authority over canonical structural mutation may not be probabilistic. Derived/rebuild-only changes may be autonomous under deterministic maintenance policy. Bounded additive changes require a deterministic authorized envelope. Semantic migrations and destructive/cross-scope/authority-bearing changes require explicit authority unless future doctrine narrows an exact delegated class.
 
-PAMA 1.2 remains conservatively stricter than the new doctrine because it routes all `domain_schema_mutation` outcomes to review or external verification. Issue #281 owns the implementation evidence needed before any narrower autonomous structural path is introduced.
+PAMA 1.2 remains conservatively stricter for `domain_schema_mutation` until narrower autonomous evidence is earned.
 
-## Capability-oriented composition
+### Capability-oriented composition
 
 [`ADR-033`](ADR-033-capabilities-are-independently-declared-and-deterministically-composed.md) is **Accepted**.
-
-Its central boundary is:
 
 ```text
 component identity != capability identity
@@ -315,28 +248,50 @@ required capability + maturity/posture
   -> normal Agent Memory authority/admission remains controlling
 ```
 
-A component may expose many capabilities and a capability may have many implementations. Maturity is per capability. Overlap must resolve through an explicit deterministic rule/composition or fail as ambiguous. Fallback cannot silently downgrade maturity, scope/isolation, currentness, deletion, failure, or authority posture.
+A component may expose many independently matured capabilities, and several components may expose the same capability. Ambiguous overlap must resolve through an explicit deterministic rule/composition or fail explicitly. Fallback cannot silently downgrade maturity, scope/isolation, currentness, deletion, failure, or authority posture.
 
-ADR-033 is the architectural basis for #287/#290 and the EvolveAI/CodeGenome capability qualification work. It does not itself claim those implementation paths are complete.
+The #287/#290 reference slice supplies machine-readable declarations and deterministic routing evidence. EvolveAI and CodeGenome remain evidence-bounded example declarations rather than automatically qualified providers.
 
-## Procedural / skill memory
+### Procedural / skill memory
 
-[`ADR-034`](ADR-034-procedural-memory-is-not-execution-authority.md) is intentionally **Proposed**.
+[`ADR-034`](ADR-034-procedural-memory-is-not-execution-authority.md) is **Accepted**.
 
 Its central boundary is:
 
 ```text
-procedural memory retention
+skill retention
   != retrieval
   != recall admission / activation
-  != action execution authority
+  != action authority
+  != execution evidence
 ```
 
-A remembered procedure can influence a plan after governed admission, but actual actions remain under Agent Runtime / Agent Governance authority. Procedural correction uses normal currentness/supersession rules, and cross-scope skill reuse is governed by ADR-022.
+A remembered procedure may shape a plan after governed admission. Actual actions remain under Runtime/Agent-Governance authority. Correction uses current-state validation, exact-content approval binding when review is required, and supersession. High-relevance foreign-scope candidates remain inadmissible. Revocation removes current influence without falsely claiming physical erasure. Metamemory cannot apply itself through ordinary skill activation and instead becomes a separate PAMA/ADR-032 profile/policy proposal.
 
-ADR-034 also treats learned metamemory as a stricter sub-class: a procedure that changes how Agent Memory extracts, consolidates, routes, retrieves, ranks, prunes, archives, or forgets memory is a proposed configuration/policy/structural consequence, not an ordinary recalled skill that can silently apply itself.
+Acceptance is backed by the #295 reference vertical slice and the focused exact-head evidence workflow:
 
-Issue #295 owns the executable acceptance evidence required before ADR-034 can be considered for promotion.
+- [`../programs/runtime-evidence/procedural-memory.md`](../programs/runtime-evidence/procedural-memory.md)
+- `reference/agentmem_ref/capabilities.py`
+- `reference/agentmem_ref/procedural_memory.py`
+- `reference/tests/test_component_capabilities.py`
+- `reference/tests/test_procedural_memory.py`
+- `reference/run_procedural_memory.py`
+- `.github/workflows/procedural-memory-evidence.yml`
+
+The adversarial path explicitly proves that approval for one procedure payload cannot commit a substituted payload. Acceptance remains bounded to the reference evidence and does not claim process-restart durability or universal production conformance.
+
+## Remaining Proposed ADRs
+
+The remaining Proposed decisions intentionally stay separate:
+
+- [`ADR-021`](ADR-021-portable-memory-governance-evidence-boundary.md): portable memory-governance evidence with external trust/attestation systems;
+- [`ADR-023`](ADR-023-corrections-are-supersession-not-deletion.md): generalized correction-as-supersession doctrine;
+- [`ADR-025`](ADR-025-durable-decision-overwrites-require-explicit-authority.md): explicit authority for durable decision overwrite;
+- [`ADR-026`](ADR-026-origin-is-provenance-not-evidentiary-authority.md): source-neutral evidence authority;
+- [`ADR-027`](ADR-027-rejected-values-require-governed-readmission.md): governed re-admission of rejected values;
+- [`ADR-029`](ADR-029-governance-projection-is-derived-context-not-authority.md): vendor-neutral governance context projection.
+
+These must not be collapsed into a generic "memory safety" claim. Each has its own evidence and acceptance boundary.
 
 ## Canonical references
 
@@ -360,7 +315,7 @@ Issue #295 owns the executable acceptance evidence required before ADR-034 can b
 - [`../programs/memory-modules/README.md`](../programs/memory-modules/README.md)
 - [`../programs/memory-modules/capability-vocabulary.md`](../programs/memory-modules/capability-vocabulary.md)
 - [`../programs/memory-modules/external-capability-frontier.md`](../programs/memory-modules/external-capability-frontier.md)
-- [`../programs/memory-modules/implementation-lane-selection.md`](../programs/memory-modules/implementation-lane-selection.md)
+- [`../programs/runtime-evidence/procedural-memory.md`](../programs/runtime-evidence/procedural-memory.md)
 - [`../profiles/durable-decision-memory-profile.md`](../profiles/durable-decision-memory-profile.md)
 - [`../profiles/governance-context-projection-profile.md`](../profiles/governance-context-projection-profile.md)
 - [`../profiles/temporal-commitment-evidence-profile.md`](../profiles/temporal-commitment-evidence-profile.md)

--- a/docs/programs/memory-modules/README.md
+++ b/docs/programs/memory-modules/README.md
@@ -18,43 +18,84 @@ Capability roles such as graph, vector, GraphRAG, lifecycle, procedural memory, 
 - [`first-party-capability-inventory.md`](first-party-capability-inventory.md) — evidence-bounded EvolveAI and CodeGenome capability/maturity map.
 - [`capability-vocabulary.md`](capability-vocabulary.md) — representation-neutral vocabulary spanning retained-content, graph/vector/temporal retrieval, procedural/metamemory, lifecycle, latent, multimodal, sharing, and operational capabilities.
 - [`external-capability-frontier.md`](external-capability-frontier.md) — external-system mapping and gap classification across the same capability families.
-- [`implementation-lane-selection.md`](implementation-lane-selection.md) — selected next vertical slice: governed procedural/skill memory.
+- [`implementation-lane-selection.md`](implementation-lane-selection.md) — why governed procedural/skill memory was selected as the first product-shaped fabric proof.
+- [`../runtime-evidence/procedural-memory.md`](../runtime-evidence/procedural-memory.md) — executable #295 evidence for capability routing, governed skill lifecycle, action-authority separation, and metamemory refusal.
 
 ## Current doctrine decisions
 
-- ADR-033: capability identity/maturity is independent from component identity and overlapping implementations are composed or selected deterministically.
-- ADR-034 (Proposed): procedural/skill memory is governed retained state, not standing execution authority; metamemory is a stricter configuration/policy-change surface.
+- **ADR-033 Accepted:** capability identity/maturity is independent from component identity and overlapping implementations are composed or selected deterministically.
+- **ADR-034 Accepted:** procedural/skill memory is governed retained state, not standing execution authority; exact approval binds the exact procedure/state, and metamemory is a stricter configuration/policy-change surface.
+
+## Executable capability fabric
+
+The first reference slice implements the minimum reusable #287/#290 surfaces required by #295:
+
+```text
+machine-readable component capability declaration
+        |
+        v
+minimum maturity + posture requirement
+        |
+        v
+deterministic provider resolution
+        |
+        +-- no eligible provider -> explicit failure
+        +-- ambiguous providers -> explicit failure
+        +-- configured eligible preference -> deterministic selection
+        |
+        v
+selected implementation
+        |
+        v
+normal Agent Memory PAMA / recall authority remains controlling
+```
+
+The capability registry never turns provider selection into memory mutation or recall permission. Fallback cannot silently lower minimum maturity or required scope posture.
+
+The checked-in EvolveAI and CodeGenome declarations are evidence-bounded examples. They preserve known limitations and do not promote either subsystem to `reference_qualified` merely because MythologIQ owns them.
+
+## Governed procedural-memory reference slice
+
+The first concrete workload is:
+
+```text
+procedure proposal
+  -> PAMA-governed promotion
+  -> durable scoped/versioned skill
+  -> later-session retrieval candidate
+  -> governed admission/activation
+  -> plan influence
+  -> separate runtime action proposal
+  -> separate action governance
+  -> separate execution evidence
+```
+
+The slice also proves correction/supersession, exact-content approval binding, stale replay refusal, cross-project admission refusal, revocation/residue honesty, and metamemory self-authorization refusal.
+
+It deliberately uses a simple inspectable reference artifact and the existing `GovernedMemoryAdapter`. A new proprietary skill database/repository was not required to prove the semantics.
 
 ## Work tracking
 
 - #274 — capability-oriented memory component program
-- #275 — adversarial first-party/external capability comparison; remains executable/runtime work
-- #280 — component/capability registry and routing fabric
-- #284 — first-party capability inventory and subsystem-gap analysis
-- #286 — external capability coverage mapping
-- #287 — machine-readable capability maturity declarations
-- #289 — first-party subsystem-boundary decision
-- #290 — capability-based routing and overlap resolution
-- #291 — capability vocabulary
-- #292 — EvolveAI capability qualification
-- #293 — CodeGenome capability qualification
+- #275 — adversarial first-party/external capability comparison; remains executable/runtime comparator work
+- #280 — broader component/capability registry and routing fabric program
+- #284 — first-party capability inventory and subsystem-gap analysis, completed
+- #286 — external capability coverage mapping, completed
+- #287 — machine-readable capability maturity declarations, implemented by the #295 reference slice
+- #289 — first-party subsystem-boundary decision, completed
+- #290 — capability-based routing and overlap resolution, implemented by the #295 reference slice
+- #291 — capability vocabulary, completed
+- #292 — EvolveAI capability qualification, remains open
+- #293 — CodeGenome capability qualification, remains open
+- #295 — governed procedural/skill memory reference vertical slice
 
-## Current research conclusion
+## Current portfolio conclusion
 
 No new proprietary memory subsystem is justified by the current gap analysis.
 
-The strongest genuinely distinct missing generic capability is **procedural/skill memory**, but current external evidence demonstrates that this can be proven with simple human-readable/declarative artifacts rather than a new database or repository.
+EvolveAI and CodeGenome remain broad multi-capability first-party subsystem candidates. Their overlapping graph/vector capabilities should be qualified and composed by capability, not split merely to remove implementation overlap.
 
-The first implementation lane therefore is:
-
-```text
-#287 capability declarations
-  -> #290 deterministic capability resolution
-  -> governed procedural/skill memory vertical slice
-  -> ADR-034 acceptance evidence
-```
-
-EvolveAI and CodeGenome remain broad multi-capability first-party subsystem candidates. Their overlapping graph/vector capabilities should be qualified and composed by capability, not split merely to remove code-level duplication.
+Procedural/skill memory was a genuinely distinct generic gap, but the reference implementation demonstrates that its stable value is semantic and governance-oriented rather than tied to a new storage product.
 
 ## Safeguards
 
@@ -66,6 +107,7 @@ retrieval score != recall permission
 graph reachability != permission
 first-party ownership != conformance
 procedural memory != execution permission
+approval for X != approval for modified Y
 metamemory proposal != configuration authority
 ```
 

--- a/docs/programs/runtime-evidence/procedural-memory.md
+++ b/docs/programs/runtime-evidence/procedural-memory.md
@@ -1,0 +1,263 @@
+# Governed Procedural Memory Evidence
+
+Status: **reference runtime evidence for ADR-034 and #295**
+
+This evidence slice proves that Agent Memory can retain and reuse a procedure across sessions without converting the remembered procedure into standing execution authority.
+
+## Claim boundary
+
+The proved reference flow is:
+
+```text
+component capability resolution
+        |
+        v
+procedural-memory proposal
+        |
+        v
+PAMA / current-state / scope evaluation
+        |
+        v
+governed durable skill commit
+        |
+        v
+later-session retrieval candidate
+        |
+        v
+governed recall admission / activation
+        |
+        v
+plan influence
+        |
+        v
+separate runtime action proposal
+        |
+        v
+separate action-governance decision
+        |
+        v
+separate execution evidence
+```
+
+The evidence does **not** claim:
+
+- process-restart durability;
+- a universal skill serialization or skill database;
+- real external tool execution by the reference harness;
+- universal production conformance;
+- reference qualification for EvolveAI or CodeGenome;
+- that component routing, skill retrieval, prior validation, or prior approval grants action authority.
+
+The procedural reference path uses the existing `GovernedMemoryAdapter` and its PAMA/currentness/isolation/tombstone/receipt behavior. It does not implement a parallel authority system.
+
+## Executable surfaces
+
+- `reference/agentmem_ref/capabilities.py`
+- `schemas/component-capability-profile.schema.json`
+- `reference/fixtures/component-capabilities/evolveai.example.json`
+- `reference/fixtures/component-capabilities/codegenome.example.json`
+- `reference/fixtures/component-capabilities/procedural-reference.json`
+- `reference/agentmem_ref/procedural_memory.py`
+- `reference/tests/test_component_capabilities.py`
+- `reference/tests/test_procedural_memory.py`
+- `reference/run_procedural_memory.py`
+- `.github/workflows/procedural-memory-evidence.yml`
+
+## Capability-resolution evidence
+
+ADR-033's enabling contract is exercised before the procedural-memory workload.
+
+The reference registry proves:
+
+| Case | Expected result |
+|---|---|
+| declared capability below required maturity | explicit failure |
+| one eligible provider | deterministic resolution |
+| several eligible providers without a rule | ambiguity failure |
+| explicit preferred eligible provider | deterministic selection |
+| preferred provider below required maturity | failure, no silent fallback |
+| newer component version with weak capability maturity | still ineligible |
+| one component exposing several capabilities | independently resolvable capability maturity |
+| several components composing different capabilities | deterministic composition |
+| resolved capability | `authority_effect` remains `none` or `proposal_only`, never inferred permission |
+
+The EvolveAI and CodeGenome fixtures deliberately mirror the bounded maturity established by the first-party inventory. They are examples for the declaration contract, not conformance promotions.
+
+## Procedural-memory acceptance matrix
+
+### Proposal without mutation
+
+A `SkillArtifact` is converted into a PAMA proposal without writing the substrate or advancing governed state.
+
+The proposal binds:
+
+- logical skill reference;
+- target class `M3_REUSABLE_PROCEDURE_OR_CAPABILITY`;
+- state snapshot;
+- scope and isolation domains;
+- purpose;
+- exact `content_sha256` through the proposal evidence set.
+
+### Governed promotion
+
+The initial low-risk promotion traverses the ordinary `GovernedMemoryAdapter.commit_proposal()` path and current PAMA policy. The stored procedure round-trips through its integrity-bound serialization.
+
+Capability resolution happens before the operation, but the selected component has no authority to make the promotion durable.
+
+### Cross-session plan influence
+
+A later reference session begins without conversational memory, performs governed recall, admits the current scoped skill, and produces a different release plan than the no-memory control.
+
+The simple control is deliberate:
+
+```text
+no admitted procedural memory
+  -> inspect current state only
+
+governed admitted skill
+  -> inspect current state
+  -> apply the admitted procedure
+  -> produce candidate runtime actions
+```
+
+The value claim is lifecycle/governance continuity, not that Agent Memory invented Markdown or bullet lists.
+
+### Execution-authority separation
+
+An admitted skill may produce `ActionProposal` objects. Each starts with:
+
+```text
+requires_governance = true
+governance_decision_ref = empty
+execution_status = not_executed
+```
+
+The reference harness refuses to record execution until an independently supplied governance decision binds the exact action ID. Execution then receives a separate execution reference.
+
+This proves identity and authority separation. It does not claim a production external-governance integration or real external side effect.
+
+### Correction and exact approval binding
+
+Version 2 of the fixture release skill changes the target branch from `release` to `main`.
+
+Under the current PAMA profile:
+
+1. the correction proposal is `require_review` and does not commit;
+2. `approve_skill_proposal()` binds one approval to the exact proposal ID, skill version, content SHA-256, and current state snapshot;
+3. only the exactly bound v2 payload may commit;
+4. v1 remains reconstructable as historical/superseded state;
+5. later recall admits v2 and refuses v1 as `superseded_not_current`.
+
+The adversarial substitution test approves the exact v2 payload targeting `main`, then substitutes a different v2 payload targeting `develop`. Commit fails with:
+
+```text
+skill_proposal_content_mismatch
+```
+
+A manually forged `review_satisfied=true` plus an approval reference without the exact `SkillApproval` binding also fails.
+
+### Stale replay
+
+After v2 advances the state, replaying the v1 proposal cannot mutate and is refused as:
+
+```text
+stale_authorization
+```
+
+Prior approval or proposal history therefore does not become standing authority after current state changes.
+
+### Cross-scope refusal
+
+A second project can receive a highly relevant candidate from the permissive substrate. Governed recall still refuses admission because the required isolation/project domain is absent.
+
+```text
+candidate presence != admitted influence
+```
+
+### Revocation and residue honesty
+
+The reference revocation path uses governed `pruning` and tombstones the current skill.
+
+The reference substrate deliberately retains physical content for recovery, so the evidence reports:
+
+- active influence removed;
+- physical content retained;
+- undeclared residue list;
+- later activation count zero.
+
+The proof therefore distinguishes semantic non-influence from physical erasure rather than claiming complete forgetting from a tombstone.
+
+### Metamemory refusal
+
+A retained metamemory artifact asks to lower capability maturity requirements and change provider precedence.
+
+Ordinary procedural activation refuses it as:
+
+```text
+metamemory_requires_configuration_governance
+```
+
+The same requested consequence can be projected into a separate PAMA proposal with:
+
+```text
+operation = policy_mutation
+target_class = M5_GOVERNANCE_SECURITY_OR_AUTONOMOUS_AUTHORITY
+downstream_authority = A5_GOVERNANCE_CHANGE
+```
+
+Current PAMA returns `require_external_verification`. The learned/retained instruction cannot apply itself.
+
+## Distinct evidence identities
+
+The deterministic harness keeps these separately visible:
+
+```text
+skill logical/version reference
+skill content digest
+memory proposal ID
+PAMA decision
+exact approval reference when required
+memory receipt
+retrieval/admission evidence
+action proposal ID
+action-governance decision reference
+execution reference
+```
+
+No single `approved skill` identity is accepted as evidence for all stages.
+
+## Deterministic evidence harness
+
+Run:
+
+```bash
+python -m pip install -r reference/requirements.txt
+python -m unittest discover -s reference/tests -p 'test_component_capabilities.py' -t reference
+python -m unittest discover -s reference/tests -p 'test_procedural_memory.py' -t reference
+python reference/run_procedural_memory.py --output artifacts/procedural-memory-evidence.json
+```
+
+The dedicated `Procedural Memory Evidence` GitHub Actions workflow runs those focused gates and uploads the JSON report. Its path filters include the implementation, ADR, runtime-evidence, reference-documentation, and Wiki status surfaces so a doctrine/status change must re-prove the same executable boundary at the new PR head.
+
+Repository-wide `Validate Doctrine Evidence` is also required before merge. It independently executes the complete reference test suite, source/schema/doctrine validation, deletion evidence, comparator paths, real-substrate governed paths, conformance report, documentation links, and Wiki links.
+
+## Falsification conditions exercised
+
+The reference slice is considered failed if any of these become true:
+
+- proposal writes before governance;
+- component selection creates memory authority;
+- a retrieved but inadmissible skill changes the plan;
+- skill retention/activation grants execution permission;
+- approval for X can commit Y;
+- a generic review flag can manufacture exact approval;
+- stale or superseded skill state becomes current through retrieval ranking;
+- stale proposal/approval can mutate after state advancement;
+- a foreign-scope skill is admitted without governed crossing;
+- revocation leaves a derived/current influence while claiming removal;
+- metamemory changes the active profile through ordinary skill activation;
+- decision, admission, action governance, and execution evidence collapse into one identity.
+
+## Result
+
+The #295 reference slice satisfies ADR-034's doctrine-promotion evidence boundary while remaining intentionally narrow. It demonstrates reusable procedural continuity with governed authority separation. It does not establish restart-safe production Agent Memory or choose a universal procedural-memory substrate.

--- a/reference/agentmem_ref/capabilities.py
+++ b/reference/agentmem_ref/capabilities.py
@@ -1,0 +1,275 @@
+"""Capability declarations and deterministic component resolution.
+
+This module is the narrow executable surface for ADR-033 and issues #287/#290.
+It deliberately does not know about PAMA, recall admission, or memory mutation.
+Selecting a component says only which configured implementation may supply a
+capability. It never grants authority to use the resulting memory consequence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping
+
+MATURITY_ORDER = (
+    "declared",
+    "implemented",
+    "runtime_wired",
+    "evidence_proven",
+    "reference_qualified",
+)
+_MATURITY_RANK = {name: index for index, name in enumerate(MATURITY_ORDER)}
+
+
+class CapabilityResolutionError(ValueError):
+    """No configured provider can satisfy the exact requirement."""
+
+
+class AmbiguousCapabilityError(CapabilityResolutionError):
+    """Several providers satisfy a requirement and configuration chooses none."""
+
+
+@dataclass(frozen=True)
+class CapabilityDeclaration:
+    capability_id: str
+    capability_version: str
+    maturity: str
+    state_posture: str
+    scope_posture: str
+    failure_posture: str
+    authority_effect: str = "none"
+    evidence_refs: tuple[str, ...] = ()
+    limitations: tuple[str, ...] = ()
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.capability_id or not self.capability_version:
+            raise ValueError("capability identity and version are required")
+        if self.maturity not in _MATURITY_RANK:
+            raise ValueError(f"unknown capability maturity: {self.maturity}")
+        if self.authority_effect not in {"none", "proposal_only"}:
+            raise ValueError("capability authority_effect must be none or proposal_only")
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "CapabilityDeclaration":
+        return cls(
+            capability_id=str(value["capability_id"]),
+            capability_version=str(value["capability_version"]),
+            maturity=str(value["maturity"]),
+            state_posture=str(value["state_posture"]),
+            scope_posture=str(value["scope_posture"]),
+            failure_posture=str(value["failure_posture"]),
+            authority_effect=str(value.get("authority_effect", "none")),
+            evidence_refs=tuple(str(item) for item in value.get("evidence_refs", ())),
+            limitations=tuple(str(item) for item in value.get("limitations", ())),
+            enabled=bool(value.get("enabled", True)),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "capability_id": self.capability_id,
+            "capability_version": self.capability_version,
+            "maturity": self.maturity,
+            "state_posture": self.state_posture,
+            "scope_posture": self.scope_posture,
+            "failure_posture": self.failure_posture,
+            "authority_effect": self.authority_effect,
+            "evidence_refs": list(self.evidence_refs),
+            "limitations": list(self.limitations),
+            "enabled": self.enabled,
+        }
+
+
+@dataclass(frozen=True)
+class ComponentDeclaration:
+    component_id: str
+    component_version: str
+    profile_version: str
+    failure_posture: str
+    capabilities: tuple[CapabilityDeclaration, ...]
+    enabled: bool = True
+    runtime_ref: str = ""
+    provenance_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.component_id or not self.component_version or not self.profile_version:
+            raise ValueError("component identity, component version, and profile version are required")
+        seen: set[tuple[str, str]] = set()
+        for capability in self.capabilities:
+            identity = (capability.capability_id, capability.capability_version)
+            if identity in seen:
+                raise ValueError(f"duplicate capability declaration: {identity}")
+            seen.add(identity)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "ComponentDeclaration":
+        raw_capabilities = value.get("capabilities", ())
+        if not isinstance(raw_capabilities, (list, tuple)):
+            raise ValueError("component capabilities must be an array")
+        return cls(
+            component_id=str(value["component_id"]),
+            component_version=str(value["component_version"]),
+            profile_version=str(value["profile_version"]),
+            failure_posture=str(value["failure_posture"]),
+            capabilities=tuple(CapabilityDeclaration.from_dict(item) for item in raw_capabilities),
+            enabled=bool(value.get("enabled", True)),
+            runtime_ref=str(value.get("runtime_ref", "")),
+            provenance_refs=tuple(str(item) for item in value.get("provenance_refs", ())),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "component_id": self.component_id,
+            "component_version": self.component_version,
+            "profile_version": self.profile_version,
+            "failure_posture": self.failure_posture,
+            "enabled": self.enabled,
+            "runtime_ref": self.runtime_ref,
+            "provenance_refs": list(self.provenance_refs),
+            "capabilities": [capability.to_dict() for capability in self.capabilities],
+        }
+
+
+@dataclass(frozen=True)
+class CapabilityRequirement:
+    capability_id: str
+    minimum_maturity: str
+    capability_version: str = ""
+    required_state_postures: tuple[str, ...] = ()
+    required_scope_postures: tuple[str, ...] = ()
+    allowed_components: tuple[str, ...] = ()
+    preferred_component: str = ""
+
+    def __post_init__(self) -> None:
+        if self.minimum_maturity not in _MATURITY_RANK:
+            raise ValueError(f"unknown minimum maturity: {self.minimum_maturity}")
+
+
+@dataclass(frozen=True)
+class ResolvedCapability:
+    component_id: str
+    component_version: str
+    profile_version: str
+    capability_id: str
+    capability_version: str
+    maturity: str
+    state_posture: str
+    scope_posture: str
+    failure_posture: str
+    authority_effect: str
+    evidence_refs: tuple[str, ...] = ()
+    limitations: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {
+            "component_id": self.component_id,
+            "component_version": self.component_version,
+            "profile_version": self.profile_version,
+            "capability_id": self.capability_id,
+            "capability_version": self.capability_version,
+            "maturity": self.maturity,
+            "state_posture": self.state_posture,
+            "scope_posture": self.scope_posture,
+            "failure_posture": self.failure_posture,
+            "authority_effect": self.authority_effect,
+            "evidence_refs": list(self.evidence_refs),
+            "limitations": list(self.limitations),
+        }
+
+
+@dataclass
+class ComponentRegistry:
+    """Deterministic registry for independently matured capabilities.
+
+    Registration order is intentionally irrelevant. If several providers remain
+    eligible after all explicit constraints, resolution fails unless a preferred
+    provider is configured. That is safer than first-match folklore.
+    """
+
+    preferences: Mapping[str, str] = field(default_factory=dict)
+    _components: dict[str, ComponentDeclaration] = field(default_factory=dict, init=False)
+
+    def register(self, component: ComponentDeclaration) -> None:
+        existing = self._components.get(component.component_id)
+        if existing is not None and existing.component_version == component.component_version:
+            raise ValueError(
+                f"component already registered at version {component.component_version}: {component.component_id}"
+            )
+        self._components[component.component_id] = component
+
+    def register_many(self, components: Iterable[ComponentDeclaration]) -> None:
+        for component in components:
+            self.register(component)
+
+    def resolve(self, requirement: CapabilityRequirement) -> ResolvedCapability:
+        eligible: list[tuple[ComponentDeclaration, CapabilityDeclaration]] = []
+        allowed = set(requirement.allowed_components)
+        for component in self._components.values():
+            if not component.enabled:
+                continue
+            if allowed and component.component_id not in allowed:
+                continue
+            for capability in component.capabilities:
+                if not capability.enabled or capability.capability_id != requirement.capability_id:
+                    continue
+                if requirement.capability_version and capability.capability_version != requirement.capability_version:
+                    continue
+                if not maturity_satisfies(capability.maturity, requirement.minimum_maturity):
+                    continue
+                if requirement.required_state_postures and capability.state_posture not in requirement.required_state_postures:
+                    continue
+                if requirement.required_scope_postures and capability.scope_posture not in requirement.required_scope_postures:
+                    continue
+                eligible.append((component, capability))
+
+        preferred = requirement.preferred_component or self.preferences.get(requirement.capability_id, "")
+        if preferred:
+            matches = [pair for pair in eligible if pair[0].component_id == preferred]
+            if len(matches) != 1:
+                raise CapabilityResolutionError(
+                    f"preferred provider {preferred!r} is not eligible for {requirement.capability_id!r} "
+                    f"at minimum maturity {requirement.minimum_maturity!r}"
+                )
+            return _resolved(*matches[0])
+
+        if not eligible:
+            raise CapabilityResolutionError(
+                f"no eligible provider for {requirement.capability_id!r} at minimum maturity "
+                f"{requirement.minimum_maturity!r}"
+            )
+        if len(eligible) > 1:
+            providers = sorted(pair[0].component_id for pair in eligible)
+            raise AmbiguousCapabilityError(
+                f"ambiguous providers for {requirement.capability_id!r}: {providers}; configure explicit preference"
+            )
+        return _resolved(*eligible[0])
+
+    def resolve_many(self, requirements: Iterable[CapabilityRequirement]) -> tuple[ResolvedCapability, ...]:
+        return tuple(self.resolve(requirement) for requirement in requirements)
+
+    def component(self, component_id: str) -> ComponentDeclaration | None:
+        return self._components.get(component_id)
+
+
+def maturity_satisfies(actual: str, minimum: str) -> bool:
+    try:
+        return _MATURITY_RANK[actual] >= _MATURITY_RANK[minimum]
+    except KeyError as exc:
+        raise ValueError(f"unknown maturity: {exc.args[0]}") from exc
+
+
+def _resolved(component: ComponentDeclaration, capability: CapabilityDeclaration) -> ResolvedCapability:
+    return ResolvedCapability(
+        component_id=component.component_id,
+        component_version=component.component_version,
+        profile_version=component.profile_version,
+        capability_id=capability.capability_id,
+        capability_version=capability.capability_version,
+        maturity=capability.maturity,
+        state_posture=capability.state_posture,
+        scope_posture=capability.scope_posture,
+        failure_posture=capability.failure_posture,
+        authority_effect=capability.authority_effect,
+        evidence_refs=capability.evidence_refs,
+        limitations=capability.limitations,
+    )

--- a/reference/agentmem_ref/procedural_memory.py
+++ b/reference/agentmem_ref/procedural_memory.py
@@ -259,8 +259,8 @@ class ProceduralMemoryRuntime:
             target_class=policy.M3,
             scope=artifact.scope,
             operation=operation,
-            current_strength="candidate" if current_version == 0 else "durable",
-            proposed_strength="durable",
+            current_strength="reinforced" if current_version == 0 else "promoted",
+            proposed_strength="promoted",
             downstream_authority=policy.A2,
             reversibility="reversible",
             risk_class="low" if operation == "promotion" else "medium",
@@ -278,8 +278,6 @@ class ProceduralMemoryRuntime:
 
     def commit_skill(self, skill_proposal: SkillProposal) -> SkillCommitResult:
         resolution = self.resolve_capability()
-        # Round-trip validation makes the exact committed payload and digest the
-        # thing we subsequently trust, not the in-memory dataclass alone.
         serialized = skill_proposal.artifact.serialize()
         SkillArtifact.from_text(serialized)
         result = self.adapter.commit_proposal(skill_proposal.proposal, serialized)
@@ -392,8 +390,8 @@ class ProceduralMemoryRuntime:
             target_class=policy.M3,
             scope="procedural-memory",
             operation="pruning",
-            current_strength="durable",
-            proposed_strength="pruned",
+            current_strength="promoted",
+            proposed_strength="archived",
             downstream_authority=policy.A1,
             reversibility="reversible",
             risk_class="low",
@@ -428,8 +426,8 @@ class ProceduralMemoryRuntime:
             target_class=policy.M5,
             scope=artifact.scope,
             operation="policy_mutation",
-            current_strength="candidate",
-            proposed_strength="durable",
+            current_strength="reinforced",
+            proposed_strength="promoted",
             downstream_authority=policy.A5,
             reversibility="reversible",
             risk_class="high",

--- a/reference/agentmem_ref/procedural_memory.py
+++ b/reference/agentmem_ref/procedural_memory.py
@@ -1,0 +1,516 @@
+"""Governed procedural/skill memory reference vertical slice.
+
+This module proves the ADR-034 boundary without inventing a specialized skill
+store. A skill is serialized as bounded JSON metadata plus human-readable
+Markdown, committed through the existing GovernedMemoryAdapter, recalled through
+its admission path, and allowed to influence a plan only after skill-specific
+currentness/applicability checks.
+
+Crucially:
+
+    retained skill != activated skill != authorized action != execution
+
+The reference action gate records that separation but performs no real external
+side effect. Runtime/Agent-Governance systems remain authoritative for actions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field, replace
+from typing import Iterable
+
+from . import policy
+from .adapter import CommitResult, GovernedMemoryAdapter, RecallContext
+from .capabilities import (
+    CapabilityDeclaration,
+    CapabilityRequirement,
+    ComponentDeclaration,
+    ComponentRegistry,
+    ResolvedCapability,
+)
+from .substrate import TemporalGraphPort
+
+PROCEDURAL_CAPABILITY = "procedural_skill_memory"
+PROCEDURAL_CAPABILITY_VERSION = "1.0"
+PROCEDURAL_MINIMUM_MATURITY = "runtime_wired"
+SKILL_FORMAT = "agent-memory-skill/v1"
+SKILL_HEADER = f"--- {SKILL_FORMAT}\n"
+SKILL_SEPARATOR = "\n--- procedure\n"
+PLAN_INFLUENCE_ONLY = "plan_influence_only"
+TASK_PROCEDURE = "task_procedure"
+METAMEMORY = "metamemory"
+
+
+@dataclass(frozen=True)
+class SkillArtifact:
+    skill_id: str
+    version: int
+    purpose: str
+    scope: str
+    isolation_domain_refs: tuple[str, ...]
+    required_isolation_domain_refs: tuple[str, ...]
+    procedure_markdown: str
+    provenance_refs: tuple[str, ...]
+    validation_refs: tuple[str, ...] = ()
+    constraints: tuple[str, ...] = ()
+    action_templates: tuple[str, ...] = ()
+    activation_posture: str = PLAN_INFLUENCE_ONLY
+    skill_kind: str = TASK_PROCEDURE
+    management_effects: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.skill_id or self.version < 1:
+            raise ValueError("skill identity and positive version are required")
+        if not self.procedure_markdown.strip():
+            raise ValueError("procedure Markdown is required")
+        if not self.scope or not self.isolation_domain_refs:
+            raise ValueError("procedural memory requires explicit scope and isolation domain")
+        if not set(self.required_isolation_domain_refs).issubset(set(self.isolation_domain_refs)):
+            raise ValueError("required isolation domains must be included in bound isolation domains")
+        if self.skill_kind not in {TASK_PROCEDURE, METAMEMORY}:
+            raise ValueError(f"unsupported skill_kind: {self.skill_kind}")
+        if self.skill_kind == METAMEMORY and not self.management_effects:
+            raise ValueError("metamemory artifacts must declare management_effects")
+
+    @property
+    def memory_reference(self) -> str:
+        return f"skill:{self.skill_id}"
+
+    @property
+    def version_reference(self) -> str:
+        return f"{self.memory_reference}@v{self.version}"
+
+    def _payload(self) -> dict:
+        return {
+            "format": SKILL_FORMAT,
+            "skill_id": self.skill_id,
+            "version": self.version,
+            "purpose": self.purpose,
+            "scope": self.scope,
+            "isolation_domain_refs": list(self.isolation_domain_refs),
+            "required_isolation_domain_refs": list(self.required_isolation_domain_refs),
+            "procedure_markdown": self.procedure_markdown.strip(),
+            "provenance_refs": list(self.provenance_refs),
+            "validation_refs": list(self.validation_refs),
+            "constraints": list(self.constraints),
+            "action_templates": list(self.action_templates),
+            "activation_posture": self.activation_posture,
+            "skill_kind": self.skill_kind,
+            "management_effects": list(self.management_effects),
+        }
+
+    @property
+    def content_sha256(self) -> str:
+        canonical = json.dumps(self._payload(), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def serialize(self) -> str:
+        payload = self._payload()
+        procedure = payload.pop("procedure_markdown")
+        payload["content_sha256"] = self.content_sha256
+        metadata = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        return f"{SKILL_HEADER}{metadata}{SKILL_SEPARATOR}{procedure}"
+
+    @classmethod
+    def from_text(cls, text: str) -> "SkillArtifact":
+        if not text.startswith(SKILL_HEADER) or SKILL_SEPARATOR not in text:
+            raise ValueError("not an Agent Memory procedural skill artifact")
+        metadata_text, procedure = text[len(SKILL_HEADER) :].split(SKILL_SEPARATOR, 1)
+        metadata = json.loads(metadata_text)
+        expected_digest = str(metadata.pop("content_sha256"))
+        if metadata.pop("format", None) != SKILL_FORMAT:
+            raise ValueError("unsupported procedural skill format")
+        artifact = cls(
+            skill_id=str(metadata["skill_id"]),
+            version=int(metadata["version"]),
+            purpose=str(metadata["purpose"]),
+            scope=str(metadata["scope"]),
+            isolation_domain_refs=tuple(str(item) for item in metadata["isolation_domain_refs"]),
+            required_isolation_domain_refs=tuple(
+                str(item) for item in metadata.get("required_isolation_domain_refs", ())
+            ),
+            procedure_markdown=procedure.strip(),
+            provenance_refs=tuple(str(item) for item in metadata.get("provenance_refs", ())),
+            validation_refs=tuple(str(item) for item in metadata.get("validation_refs", ())),
+            constraints=tuple(str(item) for item in metadata.get("constraints", ())),
+            action_templates=tuple(str(item) for item in metadata.get("action_templates", ())),
+            activation_posture=str(metadata.get("activation_posture", PLAN_INFLUENCE_ONLY)),
+            skill_kind=str(metadata.get("skill_kind", TASK_PROCEDURE)),
+            management_effects=tuple(str(item) for item in metadata.get("management_effects", ())),
+        )
+        if artifact.content_sha256 != expected_digest:
+            raise ValueError("procedural skill content digest mismatch")
+        return artifact
+
+
+@dataclass(frozen=True)
+class SkillProposal:
+    artifact: SkillArtifact
+    proposal: policy.Proposal
+
+
+@dataclass(frozen=True)
+class SkillCommitResult:
+    artifact: SkillArtifact
+    resolution: ResolvedCapability
+    commit: CommitResult
+
+
+@dataclass(frozen=True)
+class SkillActivationResult:
+    query: str
+    purpose: str
+    resolution: ResolvedCapability
+    candidate_fact_uuids: tuple[str, ...]
+    memory_admitted_fact_uuids: tuple[str, ...]
+    activated_skills: tuple[SkillArtifact, ...]
+    refusals: dict[str, str]
+    evidence: dict
+
+
+@dataclass(frozen=True)
+class ActionProposal:
+    action_id: str
+    description: str
+    skill_version_ref: str
+    requires_governance: bool = True
+    governance_decision_ref: str = ""
+    execution_status: str = "not_executed"
+    execution_ref: str = ""
+
+
+@dataclass(frozen=True)
+class ActionGovernanceDecision:
+    decision_ref: str
+    action_id: str
+    outcome: str
+
+    def __post_init__(self) -> None:
+        if self.outcome not in {"allow", "deny"}:
+            raise ValueError("action governance outcome must be allow or deny")
+
+
+@dataclass(frozen=True)
+class PlanResult:
+    goal: str
+    steps: tuple[str, ...]
+    activated_skill_refs: tuple[str, ...]
+    action_proposals: tuple[ActionProposal, ...]
+    execution_status: str = "not_executed"
+
+
+@dataclass(frozen=True)
+class RevocationResult:
+    skill_id: str
+    fact_uuid: str
+    commit: CommitResult
+    active_influence_removed: bool
+    physical_content_retained: bool
+    undeclared_residue: tuple[str, ...]
+
+
+class ProceduralMemoryRuntime:
+    """Narrow reference runtime for one governed procedural-memory capability."""
+
+    def __init__(
+        self,
+        *,
+        substrate: TemporalGraphPort,
+        adapter: GovernedMemoryAdapter,
+        registry: ComponentRegistry,
+    ) -> None:
+        self.substrate = substrate
+        self.adapter = adapter
+        self.registry = registry
+
+    def resolve_capability(self) -> ResolvedCapability:
+        return self.registry.resolve(
+            CapabilityRequirement(
+                capability_id=PROCEDURAL_CAPABILITY,
+                minimum_maturity=PROCEDURAL_MINIMUM_MATURITY,
+                required_scope_postures=("enforces_agent_memory_scope",),
+            )
+        )
+
+    def propose_skill(
+        self,
+        artifact: SkillArtifact,
+        *,
+        actor_id: str,
+        approval_refs: tuple[str, ...] = (),
+        review_satisfied: bool = False,
+        proposal_id: str | None = None,
+    ) -> SkillProposal:
+        current_version = self.adapter.state_version(artifact.memory_reference)
+        if artifact.version != current_version + 1:
+            raise ValueError(
+                f"skill version must advance current state exactly once: current=v{current_version}, "
+                f"proposed=v{artifact.version}"
+            )
+        operation = "promotion" if current_version == 0 else "correction"
+        evidence_refs = _unique(artifact.provenance_refs + artifact.validation_refs)
+        proposal = policy.Proposal(
+            proposal_id=proposal_id or f"proposal:{artifact.version_reference}",
+            actor_id=actor_id,
+            charter_version="procedural-memory-v1",
+            target_reference=artifact.memory_reference,
+            target_class=policy.M3,
+            scope=artifact.scope,
+            operation=operation,
+            current_strength="candidate" if current_version == 0 else "durable",
+            proposed_strength="durable",
+            downstream_authority=policy.A2,
+            reversibility="reversible",
+            risk_class="low" if operation == "promotion" else "medium",
+            evidence_refs=evidence_refs,
+            approval_refs=approval_refs,
+            review_satisfied=review_satisfied,
+            state_snapshot=f"v{current_version}",
+            tenant_ref=artifact.scope,
+            purpose=artifact.purpose,
+            isolation_domain_refs=artifact.isolation_domain_refs,
+            required_isolation_domain_refs=artifact.required_isolation_domain_refs,
+            project_ref=_project_ref(artifact.isolation_domain_refs),
+        )
+        return SkillProposal(artifact=artifact, proposal=proposal)
+
+    def commit_skill(self, skill_proposal: SkillProposal) -> SkillCommitResult:
+        resolution = self.resolve_capability()
+        # Round-trip validation makes the exact committed payload and digest the
+        # thing we subsequently trust, not the in-memory dataclass alone.
+        serialized = skill_proposal.artifact.serialize()
+        SkillArtifact.from_text(serialized)
+        result = self.adapter.commit_proposal(skill_proposal.proposal, serialized)
+        if result.committed and self.adapter.state_version(skill_proposal.artifact.memory_reference) != skill_proposal.artifact.version:
+            raise RuntimeError("committed procedural skill version diverged from governed state version")
+        return SkillCommitResult(skill_proposal.artifact, resolution, result)
+
+    def recall_and_activate(
+        self,
+        query: str,
+        *,
+        context: RecallContext,
+        purpose: str,
+    ) -> SkillActivationResult:
+        resolution = self.resolve_capability()
+        admission = self.adapter.governed_recall(query, context)
+        refusals = dict(admission.refusals)
+        activated: list[SkillArtifact] = []
+        memory_admitted: list[str] = []
+
+        for fact_uuid in admission.candidates:
+            fact = self.substrate.get_fact(fact_uuid)
+            if fact is None:
+                refusals[fact_uuid] = "candidate_missing"
+                continue
+            try:
+                artifact = SkillArtifact.from_text(fact.fact_text)
+            except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+                refusals.setdefault(fact_uuid, "not_valid_procedural_skill")
+                continue
+
+            if fact_uuid not in admission.admitted:
+                continue
+            memory_admitted.append(fact_uuid)
+
+            if artifact.purpose and artifact.purpose != purpose:
+                refusals[fact_uuid] = "purpose_mismatch"
+                continue
+            if artifact.activation_posture != PLAN_INFLUENCE_ONLY:
+                refusals[fact_uuid] = "activation_posture_not_supported"
+                continue
+            if artifact.skill_kind == METAMEMORY or artifact.management_effects:
+                refusals[fact_uuid] = "metamemory_requires_configuration_governance"
+                continue
+            activated.append(artifact)
+
+        evidence = {
+            "capability_resolution": resolution.to_dict(),
+            "candidate_fact_uuids": list(admission.candidates),
+            "memory_admitted_fact_uuids": memory_admitted,
+            "activated_skill_refs": [artifact.version_reference for artifact in activated],
+            "refusals": dict(sorted(refusals.items())),
+            "authority_effect": "plan_context_influence_only",
+            "execution_status": "not_executed",
+        }
+        return SkillActivationResult(
+            query=query,
+            purpose=purpose,
+            resolution=resolution,
+            candidate_fact_uuids=tuple(admission.candidates),
+            memory_admitted_fact_uuids=tuple(memory_admitted),
+            activated_skills=tuple(activated),
+            refusals=refusals,
+            evidence=evidence,
+        )
+
+    def build_plan(self, goal: str, activation: SkillActivationResult) -> PlanResult:
+        steps: list[str] = [f"Inspect current state for: {goal}"]
+        actions: list[ActionProposal] = []
+        active_refs: list[str] = []
+        for artifact in activation.activated_skills:
+            active_refs.append(artifact.version_reference)
+            steps.append(f"Apply admitted procedure {artifact.version_reference}")
+            steps.extend(_procedure_steps(artifact.procedure_markdown))
+            for index, description in enumerate(artifact.action_templates, start=1):
+                action_id = _stable_id("action", artifact.version_reference, str(index), description)
+                actions.append(
+                    ActionProposal(
+                        action_id=action_id,
+                        description=description,
+                        skill_version_ref=artifact.version_reference,
+                    )
+                )
+        return PlanResult(
+            goal=goal,
+            steps=tuple(steps),
+            activated_skill_refs=tuple(active_refs),
+            action_proposals=tuple(actions),
+        )
+
+    def revoke_skill(
+        self,
+        skill_id: str,
+        *,
+        actor_id: str,
+        evidence_refs: tuple[str, ...],
+        proposal_id: str | None = None,
+    ) -> RevocationResult:
+        self.resolve_capability()
+        memory_ref = f"skill:{skill_id}"
+        fact_uuid = self.adapter.current_fact_uuid(memory_ref)
+        if not fact_uuid:
+            raise ValueError(f"no current procedural skill exists for {skill_id!r}")
+        current_version = self.adapter.state_version(memory_ref)
+        proposal = policy.Proposal(
+            proposal_id=proposal_id or f"proposal:revoke:{skill_id}:v{current_version}",
+            actor_id=actor_id,
+            charter_version="procedural-memory-v1",
+            target_reference=memory_ref,
+            target_class=policy.M3,
+            scope="procedural-memory",
+            operation="pruning",
+            current_strength="durable",
+            proposed_strength="pruned",
+            downstream_authority=policy.A1,
+            reversibility="reversible",
+            risk_class="low",
+            evidence_refs=evidence_refs,
+            state_snapshot=f"v{current_version}",
+        )
+        result = self.adapter.governed_delete(proposal, fact_uuid)
+        residue = tuple(self.adapter.undeclared_residue(fact_uuid))
+        return RevocationResult(
+            skill_id=skill_id,
+            fact_uuid=fact_uuid,
+            commit=result,
+            active_influence_removed=result.committed,
+            physical_content_retained=self.substrate.get_fact(fact_uuid) is not None,
+            undeclared_residue=residue,
+        )
+
+    def propose_management_change(
+        self,
+        artifact: SkillArtifact,
+        *,
+        actor_id: str,
+        proposal_id: str | None = None,
+    ) -> policy.Proposal:
+        if artifact.skill_kind != METAMEMORY or not artifact.management_effects:
+            raise ValueError("management change proposals require a metamemory artifact")
+        return policy.Proposal(
+            proposal_id=proposal_id or f"proposal:metamemory:{artifact.version_reference}",
+            actor_id=actor_id,
+            charter_version="procedural-memory-v1",
+            target_reference=f"memory-profile:{artifact.skill_id}",
+            target_class=policy.M5,
+            scope=artifact.scope,
+            operation="policy_mutation",
+            current_strength="candidate",
+            proposed_strength="durable",
+            downstream_authority=policy.A5,
+            reversibility="reversible",
+            risk_class="high",
+            evidence_refs=_unique(artifact.provenance_refs + artifact.validation_refs),
+            purpose="memory-management-profile-change",
+            isolation_domain_refs=artifact.isolation_domain_refs,
+            required_isolation_domain_refs=artifact.required_isolation_domain_refs,
+        )
+
+
+def reference_procedural_component() -> ComponentDeclaration:
+    return ComponentDeclaration(
+        component_id="agent-memory-reference-procedural",
+        component_version="0.1.0",
+        profile_version="component-capability-v1",
+        failure_posture="fail_closed",
+        runtime_ref="reference/agentmem_ref/procedural_memory.py",
+        provenance_refs=("issue:#295", "adr:ADR-034"),
+        capabilities=(
+            CapabilityDeclaration(
+                capability_id=PROCEDURAL_CAPABILITY,
+                capability_version=PROCEDURAL_CAPABILITY_VERSION,
+                maturity="runtime_wired",
+                state_posture="canonical",
+                scope_posture="enforces_agent_memory_scope",
+                failure_posture="fail_closed",
+                authority_effect="none",
+                evidence_refs=("reference:test_procedural_memory",),
+            ),
+        ),
+    )
+
+
+def apply_action_governance(action: ActionProposal, decision: ActionGovernanceDecision) -> ActionProposal:
+    """Apply a separate governance decision to a proposed runtime action.
+
+    This is intentionally not a skill-memory method. A skill cannot manufacture
+    this decision; the caller must supply it from the Runtime/Governance path.
+    """
+    if decision.action_id != action.action_id:
+        raise ValueError("governance decision does not bind the proposed action")
+    if decision.outcome == "deny":
+        return replace(
+            action,
+            governance_decision_ref=decision.decision_ref,
+            execution_status="blocked_by_governance",
+        )
+    return replace(
+        action,
+        governance_decision_ref=decision.decision_ref,
+        execution_status="authorized_not_executed",
+    )
+
+
+def record_runtime_execution(action: ActionProposal, execution_ref: str) -> ActionProposal:
+    """Record execution evidence only after a separate allow decision exists."""
+    if action.execution_status != "authorized_not_executed" or not action.governance_decision_ref:
+        raise ValueError("runtime execution requires a bound external governance allow decision")
+    if not execution_ref:
+        raise ValueError("runtime execution evidence reference is required")
+    return replace(action, execution_status="executed_by_runtime", execution_ref=execution_ref)
+
+
+def _procedure_steps(markdown: str) -> tuple[str, ...]:
+    bullets = tuple(line.strip()[2:].strip() for line in markdown.splitlines() if line.strip().startswith("- "))
+    if bullets:
+        return bullets
+    return (markdown.strip(),)
+
+
+def _stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}:{digest}"
+
+
+def _unique(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+def _project_ref(domain_refs: tuple[str, ...]) -> str:
+    for value in domain_refs:
+        if value.startswith("project:"):
+            return value
+    return ""

--- a/reference/agentmem_ref/procedural_memory.py
+++ b/reference/agentmem_ref/procedural_memory.py
@@ -146,9 +146,31 @@ class SkillArtifact:
 
 
 @dataclass(frozen=True)
+class SkillApproval:
+    """Exact approval binding for a review-required procedural mutation."""
+
+    approval_ref: str
+    proposal_id: str
+    skill_version_ref: str
+    content_sha256: str
+    state_snapshot: str
+
+    def to_dict(self) -> dict:
+        return {
+            "approval_ref": self.approval_ref,
+            "proposal_id": self.proposal_id,
+            "skill_version_ref": self.skill_version_ref,
+            "content_sha256": self.content_sha256,
+            "state_snapshot": self.state_snapshot,
+        }
+
+
+@dataclass(frozen=True)
 class SkillProposal:
     artifact: SkillArtifact
     proposal: policy.Proposal
+    content_sha256: str
+    approval: SkillApproval | None = None
 
 
 @dataclass(frozen=True)
@@ -239,8 +261,6 @@ class ProceduralMemoryRuntime:
         artifact: SkillArtifact,
         *,
         actor_id: str,
-        approval_refs: tuple[str, ...] = (),
-        review_satisfied: bool = False,
         proposal_id: str | None = None,
     ) -> SkillProposal:
         current_version = self.adapter.state_version(artifact.memory_reference)
@@ -250,7 +270,8 @@ class ProceduralMemoryRuntime:
                 f"proposed=v{artifact.version}"
             )
         operation = "promotion" if current_version == 0 else "correction"
-        evidence_refs = _unique(artifact.provenance_refs + artifact.validation_refs)
+        digest_ref = f"skill-content:{artifact.content_sha256}"
+        evidence_refs = _unique(artifact.provenance_refs + artifact.validation_refs + (digest_ref,))
         proposal = policy.Proposal(
             proposal_id=proposal_id or f"proposal:{artifact.version_reference}",
             actor_id=actor_id,
@@ -265,8 +286,6 @@ class ProceduralMemoryRuntime:
             reversibility="reversible",
             risk_class="low" if operation == "promotion" else "medium",
             evidence_refs=evidence_refs,
-            approval_refs=approval_refs,
-            review_satisfied=review_satisfied,
             state_snapshot=f"v{current_version}",
             tenant_ref=artifact.scope,
             purpose=artifact.purpose,
@@ -274,16 +293,83 @@ class ProceduralMemoryRuntime:
             required_isolation_domain_refs=artifact.required_isolation_domain_refs,
             project_ref=_project_ref(artifact.isolation_domain_refs),
         )
-        return SkillProposal(artifact=artifact, proposal=proposal)
+        return SkillProposal(
+            artifact=artifact,
+            proposal=proposal,
+            content_sha256=artifact.content_sha256,
+        )
+
+    def approve_skill_proposal(self, skill_proposal: SkillProposal, *, approval_ref: str) -> SkillProposal:
+        """Bind a human/external approval to one exact skill payload and state."""
+        if not approval_ref:
+            raise ValueError("approval reference is required")
+        self._validate_skill_proposal_binding(skill_proposal, require_approval=False)
+        approval = SkillApproval(
+            approval_ref=approval_ref,
+            proposal_id=skill_proposal.proposal.proposal_id,
+            skill_version_ref=skill_proposal.artifact.version_reference,
+            content_sha256=skill_proposal.content_sha256,
+            state_snapshot=skill_proposal.proposal.state_snapshot,
+        )
+        approved_proposal = replace(
+            skill_proposal.proposal,
+            approval_refs=(approval_ref,),
+            review_satisfied=True,
+        )
+        return replace(skill_proposal, proposal=approved_proposal, approval=approval)
 
     def commit_skill(self, skill_proposal: SkillProposal) -> SkillCommitResult:
         resolution = self.resolve_capability()
+        self._validate_skill_proposal_binding(skill_proposal, require_approval=None)
         serialized = skill_proposal.artifact.serialize()
         SkillArtifact.from_text(serialized)
         result = self.adapter.commit_proposal(skill_proposal.proposal, serialized)
         if result.committed and self.adapter.state_version(skill_proposal.artifact.memory_reference) != skill_proposal.artifact.version:
             raise RuntimeError("committed procedural skill version diverged from governed state version")
         return SkillCommitResult(skill_proposal.artifact, resolution, result)
+
+    def _validate_skill_proposal_binding(
+        self,
+        skill_proposal: SkillProposal,
+        *,
+        require_approval: bool | None,
+    ) -> None:
+        artifact_digest = skill_proposal.artifact.content_sha256
+        if artifact_digest != skill_proposal.content_sha256:
+            raise ValueError("skill_proposal_content_mismatch")
+        digest_ref = f"skill-content:{artifact_digest}"
+        if digest_ref not in skill_proposal.proposal.evidence_refs:
+            raise ValueError("skill_proposal_digest_not_bound_to_pama_evidence")
+        if skill_proposal.proposal.target_reference != skill_proposal.artifact.memory_reference:
+            raise ValueError("skill_proposal_target_mismatch")
+
+        approval_present = bool(
+            skill_proposal.approval
+            or skill_proposal.proposal.approval_refs
+            or skill_proposal.proposal.review_satisfied
+        )
+        if require_approval is True and not approval_present:
+            raise ValueError("skill_approval_required")
+        if require_approval is False and approval_present:
+            raise ValueError("unexpected_skill_approval")
+        if not approval_present:
+            return
+
+        approval = skill_proposal.approval
+        if approval is None:
+            raise ValueError("skill_approval_binding_missing")
+        if not skill_proposal.proposal.review_satisfied:
+            raise ValueError("skill_approval_review_not_satisfied")
+        if tuple(skill_proposal.proposal.approval_refs) != (approval.approval_ref,):
+            raise ValueError("skill_approval_reference_mismatch")
+        if approval.proposal_id != skill_proposal.proposal.proposal_id:
+            raise ValueError("skill_approval_proposal_mismatch")
+        if approval.skill_version_ref != skill_proposal.artifact.version_reference:
+            raise ValueError("skill_approval_version_mismatch")
+        if approval.content_sha256 != artifact_digest:
+            raise ValueError("skill_approval_content_mismatch")
+        if approval.state_snapshot != skill_proposal.proposal.state_snapshot:
+            raise ValueError("skill_approval_state_mismatch")
 
     def recall_and_activate(
         self,

--- a/reference/fixtures/component-capabilities/codegenome.example.json
+++ b/reference/fixtures/component-capabilities/codegenome.example.json
@@ -1,0 +1,47 @@
+{
+  "component_id": "codegenome-example",
+  "component_version": "d2578729",
+  "profile_version": "component-capability-v1",
+  "enabled": true,
+  "runtime_ref": "MythologIQ-Labs-LLC/CodeGenome@d2578729a46d495369bd7613845002d50cf20f4c",
+  "failure_posture": "fail_closed",
+  "provenance_refs": ["docs/programs/memory-modules/first-party-capability-inventory.md"],
+  "capabilities": [
+    {
+      "capability_id": "graph_traversal",
+      "capability_version": "1.0",
+      "maturity": "runtime_wired",
+      "state_posture": "derived",
+      "scope_posture": "inherits_agent_memory_scope",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": ["inventory:codegenome:graph-traversal"],
+      "limitations": ["code_domain_ontology_is_not_agent_memory_core"]
+    },
+    {
+      "capability_id": "vector_similarity",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "inherits_agent_memory_scope",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": ["inventory:codegenome:vector-similarity"],
+      "limitations": ["primary_product_runtime_path_not_yet_qualified"]
+    },
+    {
+      "capability_id": "impact_propagation",
+      "capability_version": "1.0",
+      "maturity": "runtime_wired",
+      "state_posture": "derived",
+      "scope_posture": "inherits_agent_memory_scope",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "proposal_only",
+      "enabled": true,
+      "evidence_refs": ["inventory:codegenome:impact-propagation"],
+      "limitations": ["impact_evidence_does_not_create_mutation_authority"]
+    }
+  ]
+}

--- a/reference/fixtures/component-capabilities/evolveai.example.json
+++ b/reference/fixtures/component-capabilities/evolveai.example.json
@@ -1,0 +1,59 @@
+{
+  "component_id": "evolveai-example",
+  "component_version": "7cd42412",
+  "profile_version": "component-capability-v1",
+  "enabled": true,
+  "runtime_ref": "MythologIQ-Labs-LLC/EvolveAI@7cd42412ceed2ab638249a1517b2a6dac46f1312",
+  "failure_posture": "fail_closed",
+  "provenance_refs": ["docs/programs/memory-modules/first-party-capability-inventory.md"],
+  "capabilities": [
+    {
+      "capability_id": "temporal_graph",
+      "capability_version": "1.0",
+      "maturity": "runtime_wired",
+      "state_posture": "derived",
+      "scope_posture": "inherits_agent_memory_scope",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": ["inventory:evolveai:temporal-graph"],
+      "limitations": []
+    },
+    {
+      "capability_id": "vector_candidate_retrieval",
+      "capability_version": "1.0",
+      "maturity": "runtime_wired",
+      "state_posture": "derived",
+      "scope_posture": "inherits_agent_memory_scope",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": ["inventory:evolveai:vector-retrieval"],
+      "limitations": ["mock_default_representation"]
+    },
+    {
+      "capability_id": "graph_augmented_context_assembly",
+      "capability_version": "1.0",
+      "maturity": "declared",
+      "state_posture": "derived",
+      "scope_posture": "inherits_agent_memory_scope",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": ["inventory:evolveai:graphrag-design"],
+      "limitations": ["end_to_end_runtime_path_not_qualified"]
+    },
+    {
+      "capability_id": "lifecycle_decay",
+      "capability_version": "1.0",
+      "maturity": "runtime_wired",
+      "state_posture": "derived",
+      "scope_posture": "inherits_agent_memory_scope",
+      "failure_posture": "fail_closed",
+      "authority_effect": "proposal_only",
+      "enabled": true,
+      "evidence_refs": ["inventory:evolveai:decay"],
+      "limitations": ["does_not_self_authorize_lifecycle_mutation"]
+    }
+  ]
+}

--- a/reference/fixtures/component-capabilities/procedural-reference.json
+++ b/reference/fixtures/component-capabilities/procedural-reference.json
@@ -1,0 +1,23 @@
+{
+  "component_id": "agent-memory-reference-procedural",
+  "component_version": "0.1.0",
+  "profile_version": "component-capability-v1",
+  "enabled": true,
+  "runtime_ref": "reference/agentmem_ref/procedural_memory.py",
+  "failure_posture": "fail_closed",
+  "provenance_refs": ["issue:#295", "adr:ADR-034"],
+  "capabilities": [
+    {
+      "capability_id": "procedural_skill_memory",
+      "capability_version": "1.0",
+      "maturity": "runtime_wired",
+      "state_posture": "canonical",
+      "scope_posture": "enforces_agent_memory_scope",
+      "failure_posture": "fail_closed",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": ["reference:test_procedural_memory"],
+      "limitations": ["reference_runtime_only", "process_restart_durability_not_claimed"]
+    }
+  ]
+}

--- a/reference/run_procedural_memory.py
+++ b/reference/run_procedural_memory.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Emit reconstructable #295 governed procedural-memory evidence.
+
+This harness is intentionally deterministic and side-effect free outside the
+in-memory reference substrate. Runtime action execution is represented only by
+separate governance/execution evidence records; no real tool is invoked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext
+from agentmem_ref.capabilities import ComponentRegistry
+from agentmem_ref.procedural_memory import (
+    ActionGovernanceDecision,
+    METAMEMORY,
+    ProceduralMemoryRuntime,
+    SkillArtifact,
+    apply_action_governance,
+    record_runtime_execution,
+    reference_procedural_component,
+)
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+TENANT = "tenant:fixture"
+PROJECT = "project:fixture"
+PURPOSE = "release_planning"
+
+
+def release_skill(version: int, branch: str) -> SkillArtifact:
+    return SkillArtifact(
+        skill_id="release-workflow",
+        version=version,
+        purpose=PURPOSE,
+        scope=TENANT,
+        isolation_domain_refs=(TENANT, PROJECT),
+        required_isolation_domain_refs=(TENANT, PROJECT),
+        procedure_markdown=(
+            "# Release workflow\n"
+            f"- Target the `{branch}` branch for the release PR.\n"
+            "- Run release checks before proposing repository mutation.\n"
+            "- Submit repository actions to normal runtime governance."
+        ),
+        provenance_refs=(f"episode:release-{version}",),
+        validation_refs=(f"validation:release-{version}",),
+        constraints=("repository state must be current",),
+        action_templates=(f"open release PR against {branch}", "run release checks"),
+    )
+
+
+def run() -> dict:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    registry = ComponentRegistry()
+    registry.register(reference_procedural_component())
+    runtime = ProceduralMemoryRuntime(substrate=substrate, adapter=adapter, registry=registry)
+    context = RecallContext(
+        target_domain_refs=(TENANT, PROJECT),
+        principal_ref="agent:release",
+        project_ref=PROJECT,
+        purpose=PURPOSE,
+    )
+
+    v1 = release_skill(1, "release")
+    v1_proposal = runtime.propose_skill(v1, actor_id="agent:release", proposal_id="proposal:v1")
+    proposal_writes = len(substrate.write_log)
+    v1_commit = runtime.commit_skill(v1_proposal)
+
+    no_memory = runtime.recall_and_activate("unrelated banana tokens", context=context, purpose=PURPOSE)
+    baseline_plan = runtime.build_plan("prepare release", no_memory)
+    v1_activation = runtime.recall_and_activate("release workflow branch", context=context, purpose=PURPOSE)
+    v1_plan = runtime.build_plan("prepare release", v1_activation)
+
+    action = v1_plan.action_proposals[0]
+    governance = ActionGovernanceDecision(
+        decision_ref="governance:allow-release-action",
+        action_id=action.action_id,
+        outcome="allow",
+    )
+    governed_action = apply_action_governance(action, governance)
+    executed_action = record_runtime_execution(governed_action, "execution:runtime-release-action")
+
+    v2 = release_skill(2, "main")
+    v2_unreviewed = runtime.commit_skill(
+        runtime.propose_skill(v2, actor_id="agent:release", proposal_id="proposal:v2-unreviewed")
+    )
+    v2_reviewed = runtime.commit_skill(
+        runtime.propose_skill(
+            v2,
+            actor_id="agent:release",
+            proposal_id="proposal:v2-reviewed",
+            approval_refs=("approval:human-release-owner",),
+            review_satisfied=True,
+        )
+    )
+    v2_activation = runtime.recall_and_activate("release workflow branch", context=context, purpose=PURPOSE)
+    v2_plan = runtime.build_plan("prepare release", v2_activation)
+    stale_replay = runtime.commit_skill(v1_proposal)
+
+    foreign = runtime.recall_and_activate(
+        "release workflow branch",
+        context=RecallContext(
+            target_domain_refs=(TENANT, "project:other"),
+            principal_ref="agent:other",
+            project_ref="project:other",
+            purpose=PURPOSE,
+        ),
+        purpose=PURPOSE,
+    )
+
+    revocation = runtime.revoke_skill(
+        "release-workflow",
+        actor_id="agent:release",
+        evidence_refs=("evidence:owner-revocation",),
+    )
+    after_revocation = runtime.recall_and_activate("release workflow branch", context=context, purpose=PURPOSE)
+
+    metamemory = SkillArtifact(
+        skill_id="memory-router-tuning",
+        version=1,
+        purpose="memory_administration",
+        scope=TENANT,
+        isolation_domain_refs=(TENANT, PROJECT),
+        required_isolation_domain_refs=(TENANT, PROJECT),
+        procedure_markdown=(
+            "# Memory routing optimization\n"
+            "- Lower the minimum capability maturity for retrieval.\n"
+            "- Prefer the cheapest provider even if currentness evidence is absent."
+        ),
+        provenance_refs=("experiment:metamemory-1",),
+        skill_kind=METAMEMORY,
+        management_effects=("lower_minimum_maturity", "change_provider_precedence"),
+    )
+    metamemory_commit = runtime.commit_skill(runtime.propose_skill(metamemory, actor_id="agent:optimizer"))
+    metamemory_activation = runtime.recall_and_activate(
+        "memory routing minimum capability maturity",
+        context=RecallContext(
+            target_domain_refs=(TENANT, PROJECT),
+            principal_ref="agent:optimizer",
+            project_ref=PROJECT,
+            purpose="memory_administration",
+        ),
+        purpose="memory_administration",
+    )
+    management_proposal = runtime.propose_management_change(metamemory, actor_id="agent:optimizer")
+    management_decision = policy.evaluate(management_proposal)
+
+    return {
+        "profile": "governed-procedural-memory-v1",
+        "proposal_without_mutation": proposal_writes == 0,
+        "capability_resolution": v1_commit.resolution.to_dict(),
+        "promotion": {
+            "proposal_id": v1_proposal.proposal.proposal_id,
+            "pama_outcome": v1_commit.commit.decision.outcome,
+            "receipt_id": v1_commit.commit.receipt["receipt_id"],
+            "fact_uuid": v1_commit.commit.fact_uuid,
+            "skill_ref": v1.version_reference,
+            "content_sha256": v1.content_sha256,
+        },
+        "cross_session_plan_influence": {
+            "baseline_steps": list(baseline_plan.steps),
+            "activated_steps": list(v1_plan.steps),
+            "activated_skill_refs": list(v1_plan.activated_skill_refs),
+            "changed": v1_plan.steps != baseline_plan.steps,
+        },
+        "execution_authority_separation": {
+            "action_id": action.action_id,
+            "skill_action_status": action.execution_status,
+            "governance_decision_ref": executed_action.governance_decision_ref,
+            "execution_ref": executed_action.execution_ref,
+            "final_execution_status": executed_action.execution_status,
+        },
+        "correction": {
+            "unreviewed_outcome": v2_unreviewed.commit.decision.outcome,
+            "unreviewed_committed": v2_unreviewed.commit.committed,
+            "reviewed_outcome": v2_reviewed.commit.decision.outcome,
+            "reviewed_committed": v2_reviewed.commit.committed,
+            "current_skill_refs": [item.version_reference for item in v2_activation.activated_skills],
+            "v1_refusal": v2_activation.refusals.get(v1_commit.commit.fact_uuid),
+            "plan_steps": list(v2_plan.steps),
+        },
+        "stale_replay": {
+            "committed": stale_replay.commit.committed,
+            "refusal": stale_replay.commit.refusal,
+            "state_version": adapter.state_version(v1.memory_reference),
+        },
+        "cross_scope": {
+            "candidate_count": len(foreign.candidate_fact_uuids),
+            "activated_count": len(foreign.activated_skills),
+            "refusals": foreign.refusals,
+        },
+        "revocation": {
+            "committed": revocation.commit.committed,
+            "active_influence_removed": revocation.active_influence_removed,
+            "physical_content_retained": revocation.physical_content_retained,
+            "undeclared_residue": list(revocation.undeclared_residue),
+            "post_revocation_activated_count": len(after_revocation.activated_skills),
+        },
+        "metamemory": {
+            "retained": metamemory_commit.commit.committed,
+            "ordinary_activation_count": len(metamemory_activation.activated_skills),
+            "ordinary_activation_refusals": metamemory_activation.refusals,
+            "management_operation": management_proposal.operation,
+            "management_target_class": management_proposal.target_class,
+            "management_authority": management_proposal.downstream_authority,
+            "management_pama_outcome": management_decision.outcome,
+        },
+        "identities_remain_distinct": {
+            "skill_ref": v2.version_reference,
+            "skill_digest": v2.content_sha256,
+            "memory_receipt": v2_reviewed.commit.receipt["receipt_id"],
+            "action_id": action.action_id,
+            "governance_decision_ref": executed_action.governance_decision_ref,
+            "execution_ref": executed_action.execution_ref,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    report = run()
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/run_procedural_memory.py
+++ b/reference/run_procedural_memory.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import replace
 from pathlib import Path
 
 from agentmem_ref import policy
@@ -85,18 +86,21 @@ def run() -> dict:
     executed_action = record_runtime_execution(governed_action, "execution:runtime-release-action")
 
     v2 = release_skill(2, "main")
-    v2_unreviewed = runtime.commit_skill(
-        runtime.propose_skill(v2, actor_id="agent:release", proposal_id="proposal:v2-unreviewed")
+    v2_candidate = runtime.propose_skill(v2, actor_id="agent:release", proposal_id="proposal:v2")
+    v2_unreviewed = runtime.commit_skill(v2_candidate)
+    v2_reviewed_proposal = runtime.approve_skill_proposal(
+        v2_candidate,
+        approval_ref="approval:human-release-owner",
     )
-    v2_reviewed = runtime.commit_skill(
-        runtime.propose_skill(
-            v2,
-            actor_id="agent:release",
-            proposal_id="proposal:v2-reviewed",
-            approval_refs=("approval:human-release-owner",),
-            review_satisfied=True,
-        )
-    )
+
+    substituted_artifact = release_skill(2, "develop")
+    substitution_refusal = "not_attempted"
+    try:
+        runtime.commit_skill(replace(v2_reviewed_proposal, artifact=substituted_artifact))
+    except ValueError as exc:
+        substitution_refusal = str(exc)
+
+    v2_reviewed = runtime.commit_skill(v2_reviewed_proposal)
     v2_activation = runtime.recall_and_activate("release workflow branch", context=context, purpose=PURPOSE)
     v2_plan = runtime.build_plan("prepare release", v2_activation)
     stale_replay = runtime.commit_skill(v1_proposal)
@@ -149,6 +153,7 @@ def run() -> dict:
     management_proposal = runtime.propose_management_change(metamemory, actor_id="agent:optimizer")
     management_decision = policy.evaluate(management_proposal)
 
+    approval = v2_reviewed_proposal.approval
     return {
         "profile": "governed-procedural-memory-v1",
         "proposal_without_mutation": proposal_writes == 0,
@@ -177,8 +182,10 @@ def run() -> dict:
         "correction": {
             "unreviewed_outcome": v2_unreviewed.commit.decision.outcome,
             "unreviewed_committed": v2_unreviewed.commit.committed,
+            "approval_binding": approval.to_dict() if approval else None,
             "reviewed_outcome": v2_reviewed.commit.decision.outcome,
             "reviewed_committed": v2_reviewed.commit.committed,
+            "substituted_content_refusal": substitution_refusal,
             "current_skill_refs": [item.version_reference for item in v2_activation.activated_skills],
             "v1_refusal": v2_activation.refusals.get(v1_commit.commit.fact_uuid),
             "plan_steps": list(v2_plan.steps),
@@ -212,6 +219,7 @@ def run() -> dict:
         "identities_remain_distinct": {
             "skill_ref": v2.version_reference,
             "skill_digest": v2.content_sha256,
+            "approval_ref": approval.approval_ref if approval else None,
             "memory_receipt": v2_reviewed.commit.receipt["receipt_id"],
             "action_id": action.action_id,
             "governance_decision_ref": executed_action.governance_decision_ref,

--- a/reference/tests/test_component_capabilities.py
+++ b/reference/tests/test_component_capabilities.py
@@ -1,0 +1,155 @@
+"""Capability declaration and deterministic routing tests for #287/#290."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.capabilities import (  # noqa: E402
+    AmbiguousCapabilityError,
+    CapabilityDeclaration,
+    CapabilityRequirement,
+    CapabilityResolutionError,
+    ComponentDeclaration,
+    ComponentRegistry,
+    maturity_satisfies,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "reference" / "fixtures" / "component-capabilities"
+
+
+class ComponentCapabilityTests(unittest.TestCase):
+    def _component(self, component_id: str, maturity: str, *, version: str = "1.0.0") -> ComponentDeclaration:
+        return ComponentDeclaration(
+            component_id=component_id,
+            component_version=version,
+            profile_version="component-capability-v1",
+            failure_posture="fail_closed",
+            capabilities=(
+                CapabilityDeclaration(
+                    capability_id="procedural_skill_memory",
+                    capability_version="1.0",
+                    maturity=maturity,
+                    state_posture="canonical",
+                    scope_posture="enforces_agent_memory_scope",
+                    failure_posture="fail_closed",
+                    authority_effect="none",
+                ),
+            ),
+        )
+
+    def test_machine_readable_schema_accepts_reference_fixtures(self):
+        schema = json.loads((ROOT / "schemas" / "component-capability-profile.schema.json").read_text(encoding="utf-8"))
+        validator = jsonschema.Draft202012Validator(schema)
+        files = sorted(FIXTURES.glob("*.json"))
+        self.assertGreaterEqual(len(files), 3)
+        for path in files:
+            value = json.loads(path.read_text(encoding="utf-8"))
+            errors = list(validator.iter_errors(value))
+            self.assertEqual(errors, [], f"{path.name}: {[error.message for error in errors]}")
+            component = ComponentDeclaration.from_dict(value)
+            self.assertGreaterEqual(len(component.capabilities), 1)
+
+    def test_maturity_order_is_explicit_and_enforced(self):
+        self.assertTrue(maturity_satisfies("runtime_wired", "implemented"))
+        self.assertFalse(maturity_satisfies("implemented", "runtime_wired"))
+        registry = ComponentRegistry()
+        registry.register(self._component("declared-only", "declared"))
+        with self.assertRaises(CapabilityResolutionError):
+            registry.resolve(CapabilityRequirement("procedural_skill_memory", "runtime_wired"))
+
+    def test_ambiguous_overlap_fails_instead_of_using_registration_order(self):
+        registry = ComponentRegistry()
+        registry.register(self._component("provider-b", "runtime_wired"))
+        registry.register(self._component("provider-a", "runtime_wired"))
+        with self.assertRaises(AmbiguousCapabilityError) as context:
+            registry.resolve(CapabilityRequirement("procedural_skill_memory", "runtime_wired"))
+        self.assertIn("provider-a", str(context.exception))
+        self.assertIn("provider-b", str(context.exception))
+
+    def test_explicit_preference_resolves_overlap_without_downgrade(self):
+        registry = ComponentRegistry(preferences={"procedural_skill_memory": "provider-b"})
+        registry.register(self._component("provider-a", "runtime_wired"))
+        registry.register(self._component("provider-b", "evidence_proven"))
+        resolved = registry.resolve(CapabilityRequirement("procedural_skill_memory", "runtime_wired"))
+        self.assertEqual(resolved.component_id, "provider-b")
+        self.assertEqual(resolved.maturity, "evidence_proven")
+        self.assertEqual(resolved.authority_effect, "none")
+
+    def test_ineligible_preferred_provider_does_not_fallback_to_weaker_semantics(self):
+        registry = ComponentRegistry(preferences={"procedural_skill_memory": "preferred"})
+        registry.register(self._component("preferred", "implemented"))
+        registry.register(self._component("eligible-but-not-preferred", "runtime_wired"))
+        with self.assertRaises(CapabilityResolutionError) as context:
+            registry.resolve(CapabilityRequirement("procedural_skill_memory", "runtime_wired"))
+        self.assertIn("preferred provider", str(context.exception))
+
+    def test_component_version_change_cannot_imply_capability_maturity_upgrade(self):
+        registry = ComponentRegistry()
+        registry.register(self._component("same-component", "declared", version="9.0.0"))
+        with self.assertRaises(CapabilityResolutionError):
+            registry.resolve(CapabilityRequirement("procedural_skill_memory", "runtime_wired"))
+
+    def test_multi_capability_component_and_cross_component_composition(self):
+        graph_and_lifecycle = ComponentDeclaration(
+            component_id="multi",
+            component_version="1.0.0",
+            profile_version="component-capability-v1",
+            failure_posture="fail_closed",
+            capabilities=(
+                CapabilityDeclaration(
+                    "temporal_graph",
+                    "1.0",
+                    "runtime_wired",
+                    "derived",
+                    "enforces_agent_memory_scope",
+                    "explicit_unavailable",
+                ),
+                CapabilityDeclaration(
+                    "lifecycle_decay",
+                    "1.0",
+                    "runtime_wired",
+                    "derived",
+                    "enforces_agent_memory_scope",
+                    "fail_closed",
+                ),
+            ),
+        )
+        vector = ComponentDeclaration(
+            component_id="vector",
+            component_version="1.0.0",
+            profile_version="component-capability-v1",
+            failure_posture="fail_closed",
+            capabilities=(
+                CapabilityDeclaration(
+                    "vector_candidate_retrieval",
+                    "1.0",
+                    "runtime_wired",
+                    "derived",
+                    "enforces_agent_memory_scope",
+                    "explicit_unavailable",
+                ),
+            ),
+        )
+        registry = ComponentRegistry()
+        registry.register_many((graph_and_lifecycle, vector))
+        resolved = registry.resolve_many(
+            (
+                CapabilityRequirement("temporal_graph", "runtime_wired"),
+                CapabilityRequirement("lifecycle_decay", "runtime_wired"),
+                CapabilityRequirement("vector_candidate_retrieval", "runtime_wired"),
+            )
+        )
+        self.assertEqual([item.component_id for item in resolved], ["multi", "multi", "vector"])
+        self.assertTrue(all(item.authority_effect == "none" for item in resolved))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_procedural_memory.py
+++ b/reference/tests/test_procedural_memory.py
@@ -1,0 +1,280 @@
+"""Executable governed procedural-memory vertical slice for #295 / ADR-034."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext  # noqa: E402
+from agentmem_ref.capabilities import CapabilityDeclaration, ComponentDeclaration, ComponentRegistry  # noqa: E402
+from agentmem_ref.procedural_memory import (  # noqa: E402
+    ActionGovernanceDecision,
+    METAMEMORY,
+    ProceduralMemoryRuntime,
+    SkillArtifact,
+    apply_action_governance,
+    record_runtime_execution,
+    reference_procedural_component,
+)
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+
+TENANT = "tenant:fixture"
+PROJECT = "project:fixture"
+OTHER_PROJECT = "project:other"
+PURPOSE = "release_planning"
+
+
+class ProceduralMemoryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.substrate = InMemoryTemporalGraph()
+        self.adapter = GovernedMemoryAdapter(self.substrate, tenant=TENANT, clock=Clock())
+        self.registry = ComponentRegistry()
+        self.registry.register(reference_procedural_component())
+        self.runtime = ProceduralMemoryRuntime(
+            substrate=self.substrate,
+            adapter=self.adapter,
+            registry=self.registry,
+        )
+        self.context = RecallContext(
+            target_domain_refs=(TENANT, PROJECT),
+            principal_ref="agent:release",
+            project_ref=PROJECT,
+            purpose=PURPOSE,
+        )
+
+    def skill(self, *, version: int, branch: str, skill_id: str = "release-workflow") -> SkillArtifact:
+        return SkillArtifact(
+            skill_id=skill_id,
+            version=version,
+            purpose=PURPOSE,
+            scope=TENANT,
+            isolation_domain_refs=(TENANT, PROJECT),
+            required_isolation_domain_refs=(TENANT, PROJECT),
+            procedure_markdown=(
+                "# Release workflow\n"
+                f"- Target the `{branch}` branch for the release PR.\n"
+                "- Run release checks before proposing repository mutation.\n"
+                "- Present the action proposal to normal runtime governance."
+            ),
+            provenance_refs=(f"episode:release-{version}",),
+            validation_refs=(f"validation:release-{version}",),
+            constraints=("repository state must be current",),
+            action_templates=(
+                f"open release PR against {branch}",
+                "run release checks",
+            ),
+        )
+
+    def test_proposal_does_not_mutate_and_governed_promotion_does(self):
+        artifact = self.skill(version=1, branch="release")
+        before_writes = list(self.substrate.write_log)
+        proposed = self.runtime.propose_skill(artifact, actor_id="agent:release")
+
+        self.assertEqual(self.adapter.state_version(artifact.memory_reference), 0)
+        self.assertEqual(self.substrate.write_log, before_writes)
+        self.assertEqual(proposed.proposal.target_class, policy.M3)
+        self.assertEqual(proposed.proposal.downstream_authority, policy.A2)
+
+        committed = self.runtime.commit_skill(proposed)
+        self.assertTrue(committed.commit.committed)
+        self.assertEqual(committed.commit.decision.outcome, policy.ALLOW_WITH_LEDGER)
+        self.assertEqual(self.adapter.state_version(artifact.memory_reference), 1)
+        self.assertEqual(committed.resolution.capability_id, "procedural_skill_memory")
+        self.assertEqual(committed.resolution.authority_effect, "none")
+        stored = self.substrate.get_fact(committed.commit.fact_uuid)
+        self.assertIsNotNone(stored)
+        restored = SkillArtifact.from_text(stored.fact_text)
+        self.assertEqual(restored.version_reference, artifact.version_reference)
+        self.assertEqual(restored.content_sha256, artifact.content_sha256)
+        self.assertEqual(restored.provenance_refs, artifact.provenance_refs)
+
+    def test_later_session_activation_changes_plan_but_does_not_authorize_execution(self):
+        artifact = self.skill(version=1, branch="release")
+        self.runtime.commit_skill(self.runtime.propose_skill(artifact, actor_id="agent:release"))
+
+        no_memory = self.runtime.recall_and_activate("unrelated banana tokens", context=self.context, purpose=PURPOSE)
+        baseline = self.runtime.build_plan("prepare release", no_memory)
+        activated = self.runtime.recall_and_activate("release workflow branch", context=self.context, purpose=PURPOSE)
+        plan = self.runtime.build_plan("prepare release", activated)
+
+        self.assertEqual(baseline.activated_skill_refs, ())
+        self.assertEqual(activated.activated_skills[0].version_reference, "skill:release-workflow@v1")
+        self.assertGreater(len(plan.steps), len(baseline.steps))
+        self.assertTrue(any("release" in step for step in plan.steps))
+        self.assertEqual(plan.execution_status, "not_executed")
+        self.assertGreaterEqual(len(plan.action_proposals), 1)
+        action = plan.action_proposals[0]
+        self.assertTrue(action.requires_governance)
+        self.assertEqual(action.governance_decision_ref, "")
+        self.assertEqual(action.execution_status, "not_executed")
+
+        with self.assertRaises(ValueError):
+            record_runtime_execution(action, "execution:should-not-exist")
+
+        allowed = apply_action_governance(
+            action,
+            ActionGovernanceDecision(
+                decision_ref="governance:allow-1",
+                action_id=action.action_id,
+                outcome="allow",
+            ),
+        )
+        self.assertEqual(allowed.execution_status, "authorized_not_executed")
+        executed = record_runtime_execution(allowed, "execution:runtime-1")
+        self.assertEqual(executed.execution_status, "executed_by_runtime")
+        self.assertEqual(executed.governance_decision_ref, "governance:allow-1")
+        self.assertEqual(executed.execution_ref, "execution:runtime-1")
+
+    def test_correction_requires_review_supersedes_v1_and_stale_replay_fails(self):
+        v1 = self.skill(version=1, branch="release")
+        v1_proposal = self.runtime.propose_skill(v1, actor_id="agent:release", proposal_id="proposal:v1")
+        v1_commit = self.runtime.commit_skill(v1_proposal)
+        self.assertTrue(v1_commit.commit.committed)
+
+        v2 = self.skill(version=2, branch="main")
+        unreviewed = self.runtime.propose_skill(v2, actor_id="agent:release", proposal_id="proposal:v2-unreviewed")
+        blocked = self.runtime.commit_skill(unreviewed)
+        self.assertFalse(blocked.commit.committed)
+        self.assertEqual(blocked.commit.decision.outcome, policy.REQUIRE_REVIEW)
+
+        reviewed = self.runtime.propose_skill(
+            v2,
+            actor_id="agent:release",
+            proposal_id="proposal:v2-reviewed",
+            approval_refs=("approval:human-release-owner",),
+            review_satisfied=True,
+        )
+        committed = self.runtime.commit_skill(reviewed)
+        self.assertTrue(committed.commit.committed)
+        self.assertEqual(self.adapter.state_version(v2.memory_reference), 2)
+
+        recalled = self.runtime.recall_and_activate("release workflow branch", context=self.context, purpose=PURPOSE)
+        self.assertEqual([skill.version for skill in recalled.activated_skills], [2])
+        self.assertIn(v1_commit.commit.fact_uuid, recalled.candidate_fact_uuids)
+        self.assertEqual(recalled.refusals[v1_commit.commit.fact_uuid], "superseded_not_current")
+        plan = self.runtime.build_plan("prepare release", recalled)
+        self.assertTrue(any("main" in step for step in plan.steps))
+        self.assertFalse(any("`release` branch" in step for step in plan.steps))
+
+        replay = self.runtime.commit_skill(v1_proposal)
+        self.assertFalse(replay.commit.committed)
+        self.assertEqual(replay.commit.refusal, "stale_authorization")
+        self.assertEqual(self.adapter.state_version(v1.memory_reference), 2)
+
+    def test_high_relevance_foreign_project_skill_is_candidate_but_not_activated(self):
+        artifact = self.skill(version=1, branch="release")
+        committed = self.runtime.commit_skill(self.runtime.propose_skill(artifact, actor_id="agent:release"))
+        foreign_context = RecallContext(
+            target_domain_refs=(TENANT, OTHER_PROJECT),
+            principal_ref="agent:other",
+            project_ref=OTHER_PROJECT,
+            purpose=PURPOSE,
+        )
+        result = self.runtime.recall_and_activate("release workflow branch", context=foreign_context, purpose=PURPOSE)
+        self.assertIn(committed.commit.fact_uuid, result.candidate_fact_uuids)
+        self.assertEqual(result.activated_skills, ())
+        self.assertIn(result.refusals[committed.commit.fact_uuid], {"required_isolation_domain_missing", "project_scope_mismatch"})
+
+    def test_revocation_removes_active_influence_and_reports_retained_recovery_content(self):
+        artifact = self.skill(version=1, branch="release")
+        committed = self.runtime.commit_skill(self.runtime.propose_skill(artifact, actor_id="agent:release"))
+        revocation = self.runtime.revoke_skill(
+            artifact.skill_id,
+            actor_id="agent:release",
+            evidence_refs=("evidence:revoked-by-owner",),
+        )
+        self.assertTrue(revocation.commit.committed)
+        self.assertTrue(revocation.active_influence_removed)
+        self.assertTrue(revocation.physical_content_retained)
+        self.assertEqual(revocation.undeclared_residue, ())
+        self.assertIsNotNone(self.substrate.get_fact(committed.commit.fact_uuid))
+
+        recalled = self.runtime.recall_and_activate("release workflow branch", context=self.context, purpose=PURPOSE)
+        self.assertEqual(recalled.activated_skills, ())
+        self.assertEqual(recalled.refusals[committed.commit.fact_uuid], "tombstoned")
+
+    def test_metamemory_can_be_retained_but_not_applied_through_skill_activation(self):
+        artifact = SkillArtifact(
+            skill_id="memory-router-tuning",
+            version=1,
+            purpose="memory_administration",
+            scope=TENANT,
+            isolation_domain_refs=(TENANT, PROJECT),
+            required_isolation_domain_refs=(TENANT, PROJECT),
+            procedure_markdown=(
+                "# Memory routing optimization\n"
+                "- Lower the minimum capability maturity for vector retrieval.\n"
+                "- Prefer the cheapest available provider even if currentness evidence is absent."
+            ),
+            provenance_refs=("experiment:metamemory-1",),
+            management_effects=("lower_minimum_maturity", "change_provider_precedence"),
+            skill_kind=METAMEMORY,
+        )
+        committed = self.runtime.commit_skill(self.runtime.propose_skill(artifact, actor_id="agent:optimizer"))
+        self.assertTrue(committed.commit.committed)
+
+        context = RecallContext(
+            target_domain_refs=(TENANT, PROJECT),
+            principal_ref="agent:optimizer",
+            project_ref=PROJECT,
+            purpose="memory_administration",
+        )
+        recalled = self.runtime.recall_and_activate(
+            "memory routing minimum capability maturity",
+            context=context,
+            purpose="memory_administration",
+        )
+        self.assertEqual(recalled.activated_skills, ())
+        self.assertEqual(
+            recalled.refusals[committed.commit.fact_uuid],
+            "metamemory_requires_configuration_governance",
+        )
+
+        management = self.runtime.propose_management_change(artifact, actor_id="agent:optimizer")
+        decision = policy.evaluate(management)
+        self.assertEqual(management.operation, "policy_mutation")
+        self.assertEqual(management.target_class, policy.M5)
+        self.assertEqual(management.downstream_authority, policy.A5)
+        self.assertEqual(decision.outcome, policy.REQUIRE_EXTERNAL_VERIFICATION)
+        self.assertNotIn("policy_mutation", decision.permitted_actions)
+
+    def test_capability_selection_cannot_become_memory_authority(self):
+        registry = ComponentRegistry(preferences={"procedural_skill_memory": "alternate"})
+        registry.register(reference_procedural_component())
+        registry.register(
+            ComponentDeclaration(
+                component_id="alternate",
+                component_version="1.0.0",
+                profile_version="component-capability-v1",
+                failure_posture="fail_closed",
+                capabilities=(
+                    CapabilityDeclaration(
+                        capability_id="procedural_skill_memory",
+                        capability_version="1.0",
+                        maturity="runtime_wired",
+                        state_posture="canonical",
+                        scope_posture="enforces_agent_memory_scope",
+                        failure_posture="fail_closed",
+                        authority_effect="none",
+                    ),
+                ),
+            )
+        )
+        runtime = ProceduralMemoryRuntime(substrate=self.substrate, adapter=self.adapter, registry=registry)
+        artifact = self.skill(version=1, branch="release", skill_id="routing-authority-test")
+        proposal = runtime.propose_skill(artifact, actor_id="agent:test")
+        resolved = runtime.resolve_capability()
+        self.assertEqual(resolved.component_id, "alternate")
+        self.assertEqual(resolved.authority_effect, "none")
+        self.assertEqual(self.adapter.state_version(artifact.memory_reference), 0)
+        result = runtime.commit_skill(proposal)
+        self.assertTrue(result.commit.committed)
+        self.assertEqual(result.commit.decision.policy_version, policy.POLICY_VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_procedural_memory.py
+++ b/reference/tests/test_procedural_memory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import unittest
+from dataclasses import replace
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -78,6 +79,8 @@ class ProceduralMemoryTests(unittest.TestCase):
         self.assertEqual(self.substrate.write_log, before_writes)
         self.assertEqual(proposed.proposal.target_class, policy.M3)
         self.assertEqual(proposed.proposal.downstream_authority, policy.A2)
+        self.assertEqual(proposed.content_sha256, artifact.content_sha256)
+        self.assertIn(f"skill-content:{artifact.content_sha256}", proposed.proposal.evidence_refs)
 
         committed = self.runtime.commit_skill(proposed)
         self.assertTrue(committed.commit.committed)
@@ -129,28 +132,27 @@ class ProceduralMemoryTests(unittest.TestCase):
         self.assertEqual(executed.governance_decision_ref, "governance:allow-1")
         self.assertEqual(executed.execution_ref, "execution:runtime-1")
 
-    def test_correction_requires_review_supersedes_v1_and_stale_replay_fails(self):
+    def test_correction_requires_exact_approval_supersedes_v1_and_stale_replay_fails(self):
         v1 = self.skill(version=1, branch="release")
         v1_proposal = self.runtime.propose_skill(v1, actor_id="agent:release", proposal_id="proposal:v1")
         v1_commit = self.runtime.commit_skill(v1_proposal)
         self.assertTrue(v1_commit.commit.committed)
 
         v2 = self.skill(version=2, branch="main")
-        unreviewed = self.runtime.propose_skill(v2, actor_id="agent:release", proposal_id="proposal:v2-unreviewed")
-        blocked = self.runtime.commit_skill(unreviewed)
+        v2_candidate = self.runtime.propose_skill(v2, actor_id="agent:release", proposal_id="proposal:v2")
+        blocked = self.runtime.commit_skill(v2_candidate)
         self.assertFalse(blocked.commit.committed)
         self.assertEqual(blocked.commit.decision.outcome, policy.REQUIRE_REVIEW)
 
-        reviewed = self.runtime.propose_skill(
-            v2,
-            actor_id="agent:release",
-            proposal_id="proposal:v2-reviewed",
-            approval_refs=("approval:human-release-owner",),
-            review_satisfied=True,
+        reviewed = self.runtime.approve_skill_proposal(
+            v2_candidate,
+            approval_ref="approval:human-release-owner",
         )
         committed = self.runtime.commit_skill(reviewed)
         self.assertTrue(committed.commit.committed)
         self.assertEqual(self.adapter.state_version(v2.memory_reference), 2)
+        self.assertEqual(reviewed.approval.content_sha256, v2.content_sha256)
+        self.assertEqual(reviewed.approval.state_snapshot, "v1")
 
         recalled = self.runtime.recall_and_activate("release workflow branch", context=self.context, purpose=PURPOSE)
         self.assertEqual([skill.version for skill in recalled.activated_skills], [2])
@@ -164,6 +166,48 @@ class ProceduralMemoryTests(unittest.TestCase):
         self.assertFalse(replay.commit.committed)
         self.assertEqual(replay.commit.refusal, "stale_authorization")
         self.assertEqual(self.adapter.state_version(v1.memory_reference), 2)
+
+    def test_approval_for_exact_skill_payload_cannot_authorize_substituted_content(self):
+        v1 = self.skill(version=1, branch="release")
+        self.runtime.commit_skill(self.runtime.propose_skill(v1, actor_id="agent:release"))
+
+        approved_artifact = self.skill(version=2, branch="main")
+        candidate = self.runtime.propose_skill(
+            approved_artifact,
+            actor_id="agent:release",
+            proposal_id="proposal:v2-exact",
+        )
+        approved = self.runtime.approve_skill_proposal(
+            candidate,
+            approval_ref="approval:exact-v2-main",
+        )
+
+        substituted_artifact = self.skill(version=2, branch="develop")
+        substituted = replace(approved, artifact=substituted_artifact)
+        with self.assertRaisesRegex(ValueError, "skill_proposal_content_mismatch"):
+            self.runtime.commit_skill(substituted)
+
+        self.assertEqual(self.adapter.state_version(v1.memory_reference), 1)
+        committed = self.runtime.commit_skill(approved)
+        self.assertTrue(committed.commit.committed)
+        self.assertEqual(self.adapter.state_version(v1.memory_reference), 2)
+
+    def test_review_flag_or_approval_ref_without_exact_binding_is_rejected(self):
+        v1 = self.skill(version=1, branch="release")
+        self.runtime.commit_skill(self.runtime.propose_skill(v1, actor_id="agent:release"))
+        v2 = self.skill(version=2, branch="main")
+        candidate = self.runtime.propose_skill(v2, actor_id="agent:release")
+        forged = replace(
+            candidate,
+            proposal=replace(
+                candidate.proposal,
+                approval_refs=("approval:unbound",),
+                review_satisfied=True,
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "skill_approval_binding_missing"):
+            self.runtime.commit_skill(forged)
+        self.assertEqual(self.adapter.state_version(v1.memory_reference), 1)
 
     def test_high_relevance_foreign_project_skill_is_candidate_but_not_activated(self):
         artifact = self.skill(version=1, branch="release")

--- a/schemas/component-capability-profile.schema.json
+++ b/schemas/component-capability-profile.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/component-capability-profile.schema.json",
+  "title": "Agent Memory Component Capability Profile",
+  "description": "Machine-readable reference contract for independently matured component capabilities. Capability selection does not create memory authority.",
+  "type": "object",
+  "required": [
+    "component_id",
+    "component_version",
+    "profile_version",
+    "enabled",
+    "failure_posture",
+    "capabilities"
+  ],
+  "properties": {
+    "component_id": { "type": "string", "minLength": 1 },
+    "component_version": { "type": "string", "minLength": 1 },
+    "profile_version": { "type": "string", "minLength": 1 },
+    "enabled": { "type": "boolean" },
+    "runtime_ref": { "type": "string" },
+    "failure_posture": {
+      "type": "string",
+      "enum": ["fail_closed", "explicit_unavailable", "fail_open_candidate_only"]
+    },
+    "provenance_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/capability" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "capability": {
+      "type": "object",
+      "required": [
+        "capability_id",
+        "capability_version",
+        "maturity",
+        "state_posture",
+        "scope_posture",
+        "failure_posture",
+        "authority_effect",
+        "enabled"
+      ],
+      "properties": {
+        "capability_id": { "type": "string", "minLength": 1 },
+        "capability_version": { "type": "string", "minLength": 1 },
+        "maturity": {
+          "type": "string",
+          "enum": [
+            "declared",
+            "implemented",
+            "runtime_wired",
+            "evidence_proven",
+            "reference_qualified"
+          ]
+        },
+        "state_posture": {
+          "type": "string",
+          "enum": ["canonical", "historical", "derived", "learned", "external"]
+        },
+        "scope_posture": {
+          "type": "string",
+          "enum": [
+            "enforces_agent_memory_scope",
+            "inherits_agent_memory_scope",
+            "external_scope_bridge"
+          ]
+        },
+        "failure_posture": {
+          "type": "string",
+          "enum": ["fail_closed", "explicit_unavailable", "fail_open_candidate_only"]
+        },
+        "authority_effect": {
+          "type": "string",
+          "enum": ["none", "proposal_only"]
+        },
+        "enabled": { "type": "boolean" },
+        "evidence_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "limitations": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/wiki-src/Architecture-Decisions.md
+++ b/wiki-src/Architecture-Decisions.md
@@ -31,7 +31,7 @@ An Accepted ADR does **not** mean every mapped product implements it. That would
 - **ADR-031:** Accepted, deterministic temporal commitments with separate evidence and authority layers
 - **ADR-032:** Accepted, governed mutable memory structure with deterministic or explicit-human canonical structural authority
 - **ADR-033:** Accepted, independent capability maturity and deterministic component/capability composition
-- **ADR-034:** Proposed, procedural/skill memory as retained state rather than standing execution authority
+- **ADR-034:** Accepted, procedural/skill memory as retained state rather than standing execution authority
 
 Each Proposed ADR has its own acceptance evidence. A green implementation slice does not silently accept a doctrine decision whose ADR demands broader evidence.
 
@@ -61,11 +61,9 @@ shared write intent
   -> durable mutation or refusal
 ```
 
-A valid claim gives a writer the bounded opportunity to attempt a shared mutation. It does not grant permission to make that mutation durable. ADR-024 was accepted only after executable valid, conflicting, stale, expired, unauthorized, audit, and PAMA-non-override paths passed the repository evidence gates.
+A valid claim gives a writer the bounded opportunity to attempt a shared mutation. It does not grant permission to make that mutation durable.
 
 ### Composition and security
-
-Decisions about component boundaries, scope, isolation domains, privacy, trust, conflict, and multi-memory behavior.
 
 ADR-033 establishes the component/capability composition model:
 
@@ -94,28 +92,35 @@ probabilistic / learned structural discovery
         -> bounded autonomous commit OR explicit human decision
 ```
 
-Memory shape may adapt. A probabilistic system may discover and recommend a better shape, but it cannot be the authority that commits canonical structural semantics. Bounded rebuild-only and additive changes may be autonomous under versioned deterministic policy. Semantic migrations, destructive changes, scope/isolation widening, and authority-bearing structure require explicit human authority unless a future Accepted ADR defines an exact narrower delegation.
+Memory shape may adapt. A probabilistic system may discover and recommend a better shape, but it cannot be the authority that commits canonical structural semantics. Bounded rebuild-only and additive changes may be autonomous under versioned deterministic policy. Semantic migrations, destructive changes, scope/isolation widening, and authority-bearing structure require explicit authority unless a future Accepted ADR defines an exact narrower delegation.
 
-Current PAMA 1.2 remains conservatively review-first for `domain_schema_mutation` until the narrower implementation evidence is earned.
+Current PAMA 1.2 remains conservatively review-first for `domain_schema_mutation` until narrower implementation evidence is earned.
 
 See **[Governed Uncertainty](Governed-Uncertainty)** and **[Mutable Memory Fabric](Mutable-Memory-Fabric)**.
 
 ### Procedural memory and skills
 
-ADR-034 proposes a separate boundary for retained procedures:
+ADR-034 establishes:
 
 ```text
 skill retained
   != skill retrieved
   != skill admitted / activated
-  != action execution authorized
+  != action authorized
+  != execution evidence
 ```
 
-A remembered procedure may shape a plan after governed recall admission. It does not become standing permission to execute shell commands, repository changes, external calls, deployments, payments, or any other consequential action.
+A remembered procedure may shape a plan after governed recall admission. It does not become standing permission to execute shell commands, repository changes, external calls, deployments, payments, or other consequential actions.
+
+The accepted #295 reference slice proves proposal without mutation, governed promotion, cross-session plan influence, separate action-governance/execution evidence, correction/supersession, exact-content approval binding, stale replay refusal, cross-project refusal, revocation/residue honesty, and metamemory refusal.
+
+The approval path binds the exact proposal, procedure version, content SHA-256, and state snapshot. Approval for one procedure cannot be reused to commit a substituted payload.
 
 ADR-034 also distinguishes ordinary task skills from **metamemory**. A remembered routine for changing how Agent Memory extracts, consolidates, routes, retrieves, ranks, prunes, archives, or forgets memory is a memory-management/profile-change proposal. It remains subject to PAMA and ADR-032 rather than applying itself because it was recalled.
 
-Issue #295 owns the first executable procedural-memory acceptance path and the evidence required before ADR-034 can be promoted.
+The evidence remains bounded to the reference runtime. It does not claim process-restart durability, a universal skill format, or universal production conformance.
+
+See the canonical runtime evidence at `docs/programs/runtime-evidence/procedural-memory.md` in the repository.
 
 ### Implementation portability
 
@@ -129,7 +134,7 @@ reference implementation language
 optional implementation or interoperability profile
 ```
 
-Python, Rust, UOR, AGT, MCP, and future ecosystems may participate without becoming the definition of Agent Memory. ADR-028 is Accepted.
+Python, Rust, UOR, AGT, MCP, and future ecosystems may participate without becoming the definition of Agent Memory.
 
 ### Interoperability and governance projection
 
@@ -145,16 +150,9 @@ Agent Memory decision / execution evidence
   -> external verifier / attestation system
 ```
 
-ADR-029's core ownership model is:
+ADR-029 keeps Governance Context Projection vendor-neutral and non-authoritative. ADR-021 keeps external evidence verification distinct from memory-semantic authority.
 
-```text
-Agent Memory core
-  -> Governance Context Projection
-  -> consumer-specific adapter
-  -> governance / approval / enforcement system
-```
-
-The projection is remembered context, not standing permission or a final policy verdict. ADR-029 complements ADR-028 by keeping the projection vendor-neutral while the normative core remains language-neutral. See **[Governance Projection](Governance-Projection)**.
+See **[Governance Projection](Governance-Projection)**.
 
 ### Temporal policy and temporal commitments
 
@@ -162,18 +160,18 @@ ADR-030 requires versioned compatibility/currentness before memory-derived conte
 
 ADR-031 establishes deterministic temporal commitments while keeping historical identity, evidence, lifecycle currentness, and PAMA authority distinct.
 
-See **[Temporal Commitments](Cryptographic-Temporal-Commitments)** for the reader-facing model and visual explanation.
+See **[Temporal Commitments](Cryptographic-Temporal-Commitments)**.
 
 ## When an ADR should change
 
 An accepted decision should be revisited when there is:
 
-- contradictory research with material architectural consequences
-- a reproducible implementation failure
-- a security or privacy failure mode the decision does not contain
-- a semantic incompatibility discovered in schemas or composition
-- evidence that a simpler architecture satisfies the same constraints
-- new interoperability requirements that invalidate the original boundary
+- contradictory research with material architectural consequences;
+- a reproducible implementation failure;
+- a security or privacy failure mode the decision does not contain;
+- a semantic incompatibility discovered in schemas or composition;
+- evidence that a simpler architecture satisfies the same constraints;
+- new interoperability requirements that invalidate the original boundary.
 
 Preference alone is not enough. Neither is “the new framework has a nicer README.”
 
@@ -181,12 +179,12 @@ Preference alone is not enough. Neither is “the new framework has a nicer READ
 
 A strong proposal states:
 
-1. current decision
-2. new evidence or failure mode
-3. proposed replacement or clarification
-4. affected docs, schemas, fixtures, and implementations
-5. compatibility impact
-6. falsification/rejection criteria
+1. current decision;
+2. new evidence or failure mode;
+3. proposed replacement or clarification;
+4. affected docs, schemas, fixtures, and implementations;
+5. compatibility impact;
+6. falsification/rejection criteria.
 
 Use the **Doctrine or architecture proposal** issue form for new ADR work.
 


### PR DESCRIPTION
## Summary

Implements the selected #295 governed procedural-memory vertical slice plus the minimum reusable #287/#290 capability declaration and deterministic-routing surfaces required to make it real.

The implementation proves the architecture boundary:

```text
component selection != memory authority
skill retention != activation
skill activation != action authority
action authority != execution evidence
```

## Capability contract (#287 / #290)

Adds:

- `schemas/component-capability-profile.schema.json`
- `reference/agentmem_ref/capabilities.py`
- evidence-bounded EvolveAI, CodeGenome, and procedural-reference profiles
- independent per-capability maturity enforcement
- deterministic overlap resolution
- explicit ambiguity failure
- preferred-provider eligibility checks with no silent fallback downgrade
- multi-capability and cross-component composition
- `authority_effect` preserved as `none | proposal_only`, never inferred from provider choice

The first-party examples preserve known maturity limitations and do not grant EvolveAI or CodeGenome `reference_qualified` status merely because they are first-party.

## Governed procedural-memory vertical slice (#295)

Adds `reference/agentmem_ref/procedural_memory.py` on top of the existing `GovernedMemoryAdapter`, rather than introducing another skill database.

The reference skill artifact binds:

- logical skill identity + version
- exact content SHA-256
- purpose
- scope/isolation domains
- provenance/validation refs
- constraints
- action templates
- activation posture
- task-procedure vs metamemory classification

The runtime proves:

1. proposal without mutation;
2. PAMA-governed durable promotion;
3. later-session retrieval and governed admission;
4. measurable plan influence without automatic execution;
5. separately bound action-governance and execution evidence;
6. correction requiring review and append-only supersession;
7. exact approval binding to proposal + skill version + content digest + state snapshot;
8. substitution attack refusal: approval for v2 `main` cannot commit a different v2 payload targeting `develop`;
9. forged generic `review_satisfied` / approval reference without exact binding is refused;
10. stale v1 proposal replay refusal after v2 becomes current;
11. high-relevance cross-project candidate refusal;
12. governed revocation/tombstone with honest retained recovery content/residue reporting;
13. metamemory can be retained but cannot alter the active memory profile through ordinary skill activation;
14. metamemory application becomes a separate M5/A5 `policy_mutation` proposal.

## ADR-034

ADR-034 is promoted to **Accepted** only after the executable gate passed.

The accepted doctrine is:

```text
skill retention
  != retrieval
  != recall admission / activation
  != action authority
  != execution evidence
```

The accepted evidence remains intentionally bounded. This PR does not claim process-restart durability, universal production conformance, a universal skill serialization, or a specific external governance runtime.

## Evidence

Adds/updates:

- `reference/tests/test_component_capabilities.py`
- `reference/tests/test_procedural_memory.py`
- `reference/run_procedural_memory.py`
- `.github/workflows/procedural-memory-evidence.yml`
- `docs/programs/runtime-evidence/procedural-memory.md`
- ADR/Wiki status and capability-program documentation

Exact final PR head: `147f2f4a39bb2431f27d0762c42601904ec347f3`.

At that head:

- **Procedural Memory Evidence** run #4: success
- focused capability schema/tests: success
- focused procedural-memory adversarial tests: success
- deterministic evidence artifact emitted successfully
- artifact digest: `sha256:261711d45a766368f5ad634cb508974893f1e6e59aa05a265f20e04460458e9a`
- artifact records `substituted_content_refusal = skill_proposal_content_mismatch`
- **Validate Doctrine Evidence** run #1718: success
- full reference test suite: success
- source/schema/doctrine validation: success
- deletion/comparator evidence: success
- real-substrate governed paths: success
- conformance report: success
- top-level and Wiki links: success

## Scope boundaries

This PR does not:

- create a proprietary skill-memory repository;
- make Markdown or this reference serialization canonical doctrine;
- claim process-restart durability (#282 remains separate);
- make EvolveAI or CodeGenome exclusive or reference-qualified providers;
- allow capability routing to bypass PAMA or recall admission;
- let a retained skill grant standing action authority;
- let learned/metamemory instructions self-modify Agent Memory configuration;
- treat reference action-governance evidence as a shipped external governance integration.

Closes #287.
Closes #290.
Closes #295.