### PR TITLE
Complete #300 provider failure and no-weaker fallback evidence

### DIFF
--- a/.github/workflows/component-qualification-evidence.yml
+++ b/.github/workflows/component-qualification-evidence.yml
@@ -5,9 +5,14 @@ on:
     paths:
       - "schemas/component-capability-qualification.schema.json"
       - "reference/agentmem_ref/qualification.py"
+      - "reference/agentmem_ref/component_fallback.py"
+      - "reference/agentmem_ref/component_failure_probe.py"
       - "reference/agentmem_ref/code_graph_qualification.py"
+      - "reference/run_component_failure_probe.py"
       - "reference/run_component_qualification.py"
       - "reference/tests/test_component_qualification.py"
+      - "reference/tests/test_component_fallback.py"
+      - "reference/tests/test_component_failure_probe.py"
       - "reference/tests/test_code_graph_qualification.py"
       - "reference/fixtures/component-qualification/**"
       - ".github/workflows/component-qualification-evidence.yml"
@@ -43,12 +48,14 @@ jobs:
       - name: Install Agent Memory reference dependencies
         run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
 
-      - name: Run qualification unit tests
+      - name: Run qualification, failure, fallback, and normalizer tests
         env:
           PYTHONPATH: reference
         run: |
           python -m unittest \
             reference/tests/test_component_qualification.py \
+            reference/tests/test_component_fallback.py \
+            reference/tests/test_component_failure_probe.py \
             reference/tests/test_code_graph_qualification.py
 
       - name: Prepare evidence directory
@@ -108,6 +115,24 @@ jobs:
             --direction downstream --json \
             > "$RAW_ROOT/codegenome/v2-decoy-downstream.json"
 
+      - name: Reproduce CodeGenome provider unavailable
+        env:
+          PYTHONPATH: reference
+        run: |
+          binary=/tmp/codegenome/target/debug/codegenome
+          mv "$binary" "$binary.available"
+          set +e
+          python reference/run_component_failure_probe.py \
+            --provider codegenome \
+            --executable "$binary" \
+            --raw-output "$RAW_ROOT/codegenome/unavailable-raw.json" \
+            --normalized-output "$RAW_ROOT/codegenome/unavailable-normalized.json" \
+            --trace-ref "qualification:codegenome:provider-unavailable"
+          status=$?
+          set -e
+          mv "$binary.available" "$binary"
+          exit "$status"
+
       - name: Fetch exact Graphify release source
         run: |
           git clone --filter=blob:none --no-checkout https://github.com/Graphify-Labs/graphify.git /tmp/graphify
@@ -135,7 +160,25 @@ jobs:
           cp /tmp/graphify-v1/graphify-out/graph.json "$RAW_ROOT/graphify/v1-graph.json"
           cp /tmp/graphify-v2/graphify-out/graph.json "$RAW_ROOT/graphify/v2-graph.json"
 
-      - name: Emit exact-head qualification report
+      - name: Reproduce Graphify provider unavailable
+        env:
+          PYTHONPATH: reference
+        run: |
+          binary=/tmp/graphify-venv/bin/graphify
+          mv "$binary" "$binary.available"
+          set +e
+          python reference/run_component_failure_probe.py \
+            --provider graphify \
+            --executable "$binary" \
+            --raw-output "$RAW_ROOT/graphify/unavailable-raw.json" \
+            --normalized-output "$RAW_ROOT/graphify/unavailable-normalized.json" \
+            --trace-ref "qualification:graphify:provider-unavailable"
+          status=$?
+          set -e
+          mv "$binary.available" "$binary"
+          exit "$status"
+
+      - name: Emit exact-head qualification and fallback report
         env:
           PYTHONPATH: reference
         run: |
@@ -148,11 +191,15 @@ jobs:
             --codegenome-v2-main-downstream "$RAW_ROOT/codegenome/v2-main-downstream.json" \
             --codegenome-v2-main-upstream "$RAW_ROOT/codegenome/v2-main-upstream.json" \
             --codegenome-v2-decoy-downstream "$RAW_ROOT/codegenome/v2-decoy-downstream.json" \
+            --codegenome-unavailable-raw "$RAW_ROOT/codegenome/unavailable-raw.json" \
+            --codegenome-unavailable-normalized "$RAW_ROOT/codegenome/unavailable-normalized.json" \
             --graphify-v1 "$RAW_ROOT/graphify/v1-graph.json" \
             --graphify-v2 "$RAW_ROOT/graphify/v2-graph.json" \
+            --graphify-unavailable-raw "$RAW_ROOT/graphify/unavailable-raw.json" \
+            --graphify-unavailable-normalized "$RAW_ROOT/graphify/unavailable-normalized.json" \
             --output "$RAW_ROOT/component-qualification-report.json"
 
-      - name: Verify schema, currentness, maturity, and authority boundaries
+      - name: Verify schema, currentness, failure, fallback, maturity, and authority boundaries
         env:
           PYTHONPATH: reference
         run: |
@@ -166,6 +213,8 @@ jobs:
           report = json.loads((root / "component-qualification-report.json").read_text())
           schema = json.loads(Path("schemas/component-capability-qualification.schema.json").read_text())
           validator = jsonschema.Draft202012Validator(schema)
+          assert report["schema_version"] == "1.1.0"
+          assert report["profile"] == {"id": "code-graph-traversal-currentness", "version": "1.1.0"}
           assert report["matched_result"]["both_passed"] is True
           assert report["matched_result"]["winner"] is None
           assert report["matched_result"]["authority_effect"] == "none"
@@ -173,19 +222,36 @@ jobs:
           for provider in ("codegenome", "graphify"):
               qualification = report["providers"][provider]["qualification"]
               validator.validate(qualification)
+              assert qualification["schema_version"] == "1.1.0"
               assert qualification["result"]["earned_maturity"] == "evidence_proven"
               assert qualification["result"]["authority_effect"] == "none"
               assert qualification["result"]["qualification_current"] is True
               assert qualification["source_rights"]["use_posture"] == "runtime_allowed"
+              adapter_results = qualification["evidence"]["adapter_results"]
+              assert [item["failure_result"] for item in adapter_results] == ["none", "provider_unavailable"]
+              assert adapter_results[1]["currentness"] == "unavailable"
+              assert adapter_results[1]["authority_effect"] == "none"
+              assert report["providers"][provider]["checks"]["provider_unavailable_explicit"] is True
           assert report["providers"]["codegenome"]["checks"]["full_rebuild_currentness"] is True
           assert report["providers"]["graphify"]["checks"]["full_rebuild_currentness"] is True
+
+          fallback = report["failure_fallback"]
+          assert fallback["authority_effect"] == "none"
+          assert fallback["primary_failure"]["failure_result"] == "provider_unavailable"
+          assert fallback["no_fallback_configured"]["status"] == "unavailable"
+          assert fallback["no_fallback_configured"]["reason"] == "fallback_not_configured"
+          assert fallback["explicit_graphify"]["status"] == "fallback_selected"
+          assert fallback["explicit_graphify"]["selected_component_id"] == "graphify"
+          assert fallback["explicit_graphify"]["authority_effect"] == "none"
+          assert fallback["weaker_graphify_refused"]["status"] == "unavailable"
+          assert "weaker_maturity" in fallback["weaker_graphify_refused"]["rejected_candidates"][0]["reasons"]
           PY
 
       - name: Display normalized report
         if: always()
         run: cat "$RAW_ROOT/component-qualification-report.json" || true
 
-      - name: Upload raw and normalized qualification evidence
+      - name: Upload raw, failure, fallback, and normalized qualification evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/component-qualification-foundation.yml
+++ b/.github/workflows/component-qualification-foundation.yml
@@ -5,9 +5,14 @@ on:
     paths:
       - "schemas/component-capability-qualification.schema.json"
       - "reference/agentmem_ref/qualification.py"
+      - "reference/agentmem_ref/component_fallback.py"
+      - "reference/agentmem_ref/component_failure_probe.py"
       - "reference/agentmem_ref/code_graph_qualification.py"
+      - "reference/run_component_failure_probe.py"
       - "reference/run_component_qualification.py"
       - "reference/tests/test_component_qualification.py"
+      - "reference/tests/test_component_fallback.py"
+      - "reference/tests/test_component_failure_probe.py"
       - "reference/tests/test_code_graph_qualification.py"
       - "reference/fixtures/component-qualification/**"
       - ".github/workflows/component-qualification-foundation.yml"
@@ -31,12 +36,14 @@ jobs:
       - name: Install reference dependencies
         run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
 
-      - name: Run qualification contract and normalizer tests
+      - name: Run qualification, failure, fallback, and normalizer tests
         env:
           PYTHONPATH: reference
         run: |
           python -m unittest \
             reference/tests/test_component_qualification.py \
+            reference/tests/test_component_fallback.py \
+            reference/tests/test_component_failure_probe.py \
             reference/tests/test_code_graph_qualification.py
 
       - name: Verify source mutation fixture is material

--- a/docs/programs/memory-modules/component-qualification-runtime.md
+++ b/docs/programs/memory-modules/component-qualification-runtime.md
@@ -2,27 +2,34 @@
 
 Status: **Implementation evidence / #300**
 
-Tracks: #300, #280, #293
+Tracks: #300, #280, #293, #282
 
 ## Purpose
 
-This document describes the executable qualification surface implemented by PR #302. It is the runtime counterpart to [`component-adapter-qualification-contract.md`](component-adapter-qualification-contract.md).
+This document describes the executable component-capability qualification surface established by PR #302 and completed by PR #307.
 
-The contract now has code behind it:
+It is the runtime counterpart to [`component-adapter-qualification-contract.md`](component-adapter-qualification-contract.md).
+
+The executable contract now covers both successful provider behavior and bounded failure/fallback behavior:
 
 ```text
 component declaration
   != qualification evidence
 
-provider-native output
+provider-native execution
   -> preserved raw artifact
   -> provider-neutral factual normalization
   -> profile checks
   -> version-bound qualification record
   -> earned capability maturity
+
+selected provider becomes unavailable
+  -> real failure evidence
+  -> explicit configured fallback evaluation
+  -> one equivalent fallback OR explicit unavailable
 ```
 
-Qualification remains evidence only. It grants no Agent Memory mutation, structural, recall-admission, or action authority.
+Qualification and fallback remain evidence/routing surfaces only. Neither grants Agent Memory mutation, structural, recall-admission, or action authority.
 
 ## Machine-readable evidence surface
 
@@ -30,9 +37,16 @@ Schema:
 
 `schemas/component-capability-qualification.schema.json`
 
-Reference implementation:
+Current schema version:
 
-`reference/agentmem_ref/qualification.py`
+`1.1.0`
+
+Reference implementations:
+
+- `reference/agentmem_ref/qualification.py`
+- `reference/agentmem_ref/component_failure_probe.py`
+- `reference/agentmem_ref/component_fallback.py`
+- `reference/agentmem_ref/code_graph_qualification.py`
 
 The qualification subject binds:
 
@@ -60,25 +74,20 @@ Silence is not compatibility.
 
 ## Maturity progression
 
-A qualification record separates three values:
+A qualification record separates:
 
 ```text
 maturity_before
 profile_maturity_ceiling
 earned_maturity
+qualification_current
 ```
 
-This matters because qualification exists to establish stronger evidence than was available before the run.
+A provider at `runtime_wired` may earn `evidence_proven` when the profile proves the required behavior. It may not exceed the profile ceiling.
 
-A provider at `runtime_wired` may therefore earn `evidence_proven` when the profile proves the required behavior. It may not exceed the profile ceiling.
+A runtime route may rely on qualification only while the exact applicability identity remains current.
 
-`reference_qualified` requires an explicit `reference_qualified` profile ceiling, runtime-allowed source rights, and every profile-required check to pass.
-
-The first code-graph profile is deliberately capped at:
-
-`evidence_proven`
-
-It does not yet prove every failure/fallback negative path required for full reference qualification.
+The first CodeGenome/Graphify qualification remains bounded to the maturity earned by its profile. A result for `code_graph_traversal` does not promote vector retrieval, GraphRAG, MCP, confidence fusion, procedural memory, or any unrelated capability.
 
 ## Provider-neutral adapter result
 
@@ -98,32 +107,35 @@ normalized factual result refs
 currentness posture
 failure result
 trace/correlation ref
+authority effect
 ```
 
 Raw provider evidence is mandatory and is not replaced by normalization.
 
-The adapter result exposes:
+Each adapter result exposes:
 
 `authority_effect = none`
 
-The qualification record repeats the same invariant.
+The qualification record preserves the same invariant.
+
+Schema 1.1.0 requires the adapter-result evidence needed to reconstruct both successful and unavailable-provider outcomes rather than inferring them from a summary flag.
 
 ## First capability profile
 
 Profile:
 
-`code-graph-traversal-currentness@1.0.0`
+`code-graph-traversal-currentness@1.1.0`
 
 Providers:
 
 - CodeGenome `43a6b7147ec78ec5c616723fa1dd30f342174860`
 - Graphify `v0.9.43`, commit `7281f27eac568f77f50910f59f84543458f5dfd1`
 
-The CodeGenome pin was deliberately advanced from the planning revision `d2578729a46d495369bd7613845002d50cf20f4c` after the qualification fixture exposed a remaining cross-file semantic-resolution collision. CodeGenome #12 / PR #13 repaired symbol and caller-span resolution so file identity remains part of semantic traversal, and merged as `43a6b7147ec78ec5c616723fa1dd30f342174860`. The qualification therefore binds the repaired merged revision rather than suppressing the negative result.
+The CodeGenome pin was deliberately advanced from the planning revision `d2578729a46d495369bd7613845002d50cf20f4c` after the qualification fixture exposed a remaining cross-file semantic-resolution collision. CodeGenome #12 / PR #13 repaired file-scoped symbol and caller-span resolution. The qualification advanced the exact pin rather than weakening the fixture.
 
 The workflow validates exact source refs before execution and verifies source-rights files from those exact revisions.
 
-The profile normalizes only shared factual call-graph behavior. It does not force the providers to emit the same native schema. Graphify's NetworkX node-link evidence uses the native `links` collection; the normalizer preserves that shape and accepts `edges` only as a compatibility fallback.
+The profile normalizes only shared factual call-graph behavior. It does not force providers to emit the same native schema. Graphify's NetworkX node-link evidence uses native `links`; the normalizer preserves that shape and accepts `edges` only as a compatibility fallback.
 
 ## Adversarial fixture
 
@@ -149,32 +161,110 @@ v2 main.rs
   replacement_leaf  starts line 13
 ```
 
-The duplicate `middle` start line means a provider cannot pass target resolution by line span alone. The distinct leaf line identities make decoy contamination and stale v1 edges observable.
+The duplicate `middle` start line means a provider cannot pass target resolution by line span alone. Distinct leaf identities make decoy contamination and stale v1 edges observable.
 
 ## Currentness posture
 
 The first profile uses an explicit **full rebuild** between v1 and v2.
-
-That is intentional:
 
 ```text
 full rebuild proven
 != incremental refresh proven
 ```
 
-The evidence must establish:
+The evidence establishes:
 
 - v1 `middle -> leaf` exists;
 - v2 `middle -> replacement_leaf` exists;
-- the v1 `middle -> leaf` relationship is not reported as current after the v2 rebuild;
+- the v1 relationship is not reported as current after the v2 rebuild;
 - decoy-file relationships remain isolated;
 - v1 raw artifacts remain preserved as historical evidence.
 
-If either provider later exposes a supported incremental update path, that path needs its own qualification evidence rather than inheriting the full-rebuild result.
+A later incremental update path requires its own qualification evidence.
+
+## Real provider-unavailable evidence
+
+Provider outage is exercised against the exact runtime path, not synthesized from a test flag.
+
+For each provider the evidence workflow:
+
+1. builds or installs the exact qualified provider;
+2. temporarily moves the executable out of its configured path;
+3. invokes that exact missing path through `run_component_failure_probe.py`;
+4. preserves the resulting operating-system `FileNotFoundError` as raw evidence;
+5. normalizes the bounded result to:
+
+```text
+failure_result = provider_unavailable
+currentness = unavailable
+authority_effect = none
+```
+
+The probe fails if the executable actually runs, exits for a different reason, or times out. A separate negative unit test uses a real runnable Python executable and proves it cannot be laundered into `provider_unavailable`.
+
+Therefore:
+
+```text
+configured provider path missing
+  -> provider_unavailable evidence
+
+provider returned an error
+  != automatically provider_unavailable
+
+provider timed out
+  != automatically provider_unavailable
+```
+
+Different failure classes require their own evidence rather than being collapsed for convenience.
+
+## Explicit no-weaker fallback
+
+Reference evaluator:
+
+`evaluate_explicit_fallback()`
+
+Fallback is considered only after the already-selected primary has a real failure result. It considers only providers explicitly listed in configuration.
+
+A candidate is refused when it changes or weakens any required equivalent of:
+
+- capability identity/version;
+- capability maturity;
+- canonical/derived state posture;
+- scope/isolation posture;
+- failure posture;
+- authority effect;
+- qualification profile identity/version;
+- qualification currentness;
+- earned maturity;
+- runtime source-rights posture.
+
+The outcomes are deliberately narrow:
+
+```text
+no configured fallback
+  -> unavailable / fallback_not_configured
+
+configured candidates but none equivalent
+  -> unavailable / no_equivalent_fallback
+
+exactly one equivalent configured fallback
+  -> fallback_selected / explicit_equivalent_fallback
+
+more than one equivalent configured fallback
+  -> unavailable / ambiguous_equivalent_fallbacks
+```
+
+There is no registration-order or first-match escape hatch.
+
+Every fallback decision exposes:
+
+`authority_effect = none`
+
+Fallback changes the provider used to attempt a capability. It does not weaken governance requirements and cannot authorize a consequence.
 
 ## No product winner
 
-The matched result contains:
+The matched result preserves:
 
 ```text
 both_passed: <boolean>
@@ -183,9 +273,7 @@ authority_effect: none
 unrelated_capabilities_promoted: []
 ```
 
-This profile answers whether two materially different providers satisfy the same bounded capability checks. It does not declare a universal product winner.
-
-Passing `code_graph_traversal` does not promote vector retrieval, GraphRAG, MCP, confidence fusion, procedural memory, lifecycle, or any other capability.
+This profile answers whether materially different providers satisfy the same bounded qualification checks. It does not declare a universal product winner.
 
 ## CI surfaces
 
@@ -197,31 +285,41 @@ Real-provider evidence CI:
 
 `.github/workflows/component-qualification-evidence.yml`
 
-The real-provider workflow:
+The real-provider workflow now:
 
-1. runs schema/normalizer tests;
-2. fetches exact CodeGenome source;
-3. verifies CodeGenome source rights and builds the CLI;
-4. executes v1 and v2 CodeGenome qualification queries;
-5. fetches exact Graphify release source;
+1. runs schema, qualification, fallback, failure-probe, and normalizer tests;
+2. fetches and builds exact CodeGenome source;
+3. executes CodeGenome v1/v2 truth and currentness checks;
+4. reproduces real CodeGenome executable unavailability;
+5. fetches and installs exact Graphify release source;
 6. verifies Graphify release and Apache-2.0 source-rights posture;
-7. executes v1 and v2 Graphify code-only extraction;
-8. emits the version-bound qualification report;
-9. validates currentness, maturity ceiling, and authority-none invariants;
-10. uploads provider-native and normalized evidence artifacts.
+7. executes Graphify v1/v2 truth and currentness checks;
+8. reproduces real Graphify executable unavailability;
+9. emits exact-head provider qualification plus failure/fallback evidence;
+10. validates schema, currentness, maturity, source-rights, fallback, and authority boundaries;
+11. uploads provider-native, failure, and normalized artifacts.
 
 Repository-wide doctrine validation remains independently required before merge.
 
-## Remaining #300 work
+## Relationship to configurable runtime and restart recovery
 
-This slice does not close #300 by itself.
+PRD-001 already requires deterministic configuration validation and states that fallback must not silently reduce maturity, scope/isolation, canonical/derived posture, qualification requirements, or governance requirements.
 
-Still required before the parent issue can be considered complete:
+This implementation gives that requirement an executable provider-failure/fallback surface for the first capability family.
 
-- explicit provider-unavailable/failure qualification behavior;
-- explicit no-weaker-fallback evidence;
-- final docs/runtime evidence synchronization at the accepted head;
-- final exact-head focused and repository-wide validation;
-- any additional negative paths needed to justify a stronger maturity ceiling.
+The same contract is now available to #282 restart recovery. Recovery does not need a second provider-resolution vocabulary. A provider missing after restart can remain explicitly unavailable; a configured fallback may be used only through the same current qualification and no-weaker checks.
 
-The common harness should remain reusable for #293 and later EvolveAI/general-memory-system qualification work without importing provider-specific ontology into Agent Memory core.
+## #300 completion boundary
+
+PR #302 established the common adapter, applicability, raw evidence, source mutation/currentness, real-provider execution, and authority-none foundation.
+
+PR #307 adds the previously missing provider-unavailable and no-weaker-fallback negative paths and synchronizes this runtime evidence document.
+
+#300 may be closed only after the final PR #307 head has:
+
+- focused qualification foundation CI green;
+- exact CodeGenome/Graphify provider evidence CI green;
+- repository-wide doctrine validation green;
+- reconstructable exact-head evidence artifacts preserved.
+
+Passing those gates completes this bounded harness. Broader CodeGenome qualification remains #293, EvolveAI qualification remains #292, configurable registry/runtime composition remains #280, and restart-safe multi-component acceptance remains #282.

--- a/reference/agentmem_ref/code_graph_qualification.py
+++ b/reference/agentmem_ref/code_graph_qualification.py
@@ -7,12 +7,19 @@ rank products and cannot grant Agent Memory authority.
 
 from __future__ import annotations
 
+from dataclasses import replace
 import hashlib
 import json
 import re
 from pathlib import Path
 from typing import Any, Iterable
 
+from .capabilities import ResolvedCapability
+from .component_fallback import (
+    ProviderFailure,
+    QualifiedCapability,
+    evaluate_explicit_fallback,
+)
 from .qualification import (
     AdapterResult,
     QualificationRuntime,
@@ -24,7 +31,7 @@ CODEGENOME_COMMIT = "43a6b7147ec78ec5c616723fa1dd30f342174860"
 GRAPHIFY_RELEASE = "v0.9.43"
 GRAPHIFY_COMMIT = "7281f27eac568f77f50910f59f84543458f5dfd1"
 PROFILE_ID = "code-graph-traversal-currentness"
-PROFILE_VERSION = "1.0.0"
+PROFILE_VERSION = "1.1.0"
 
 _LINE = re.compile(r"^line (\d+):(\d+)$")
 
@@ -49,6 +56,34 @@ def fixture_digest(paths: Iterable[Path]) -> str:
 
 def _load(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def codegenome_subject() -> QualificationSubject:
+    return QualificationSubject(
+        component_id="codegenome",
+        component_version=CODEGENOME_COMMIT,
+        implementation_ref=f"MythologIQ-Labs-LLC/CodeGenome@{CODEGENOME_COMMIT}",
+        capability_id="code_graph_traversal",
+        capability_version="1.0",
+        adapter_id="codegenome-cli",
+        adapter_version="1.0.0",
+        qualification_profile_id=PROFILE_ID,
+        qualification_profile_version=PROFILE_VERSION,
+    )
+
+
+def graphify_subject() -> QualificationSubject:
+    return QualificationSubject(
+        component_id="graphify",
+        component_version=GRAPHIFY_RELEASE,
+        implementation_ref=f"Graphify-Labs/graphify@{GRAPHIFY_COMMIT}",
+        capability_id="code_graph_traversal",
+        capability_version="1.0",
+        adapter_id="graphify-cli",
+        adapter_version="1.0.0",
+        qualification_profile_id=PROFILE_ID,
+        qualification_profile_version=PROFILE_VERSION,
+    )
 
 
 def _codegenome_start_lines(path: Path) -> set[int]:
@@ -86,8 +121,6 @@ def _graphify_call_facts(path: Path) -> set[tuple[str, str, str]]:
         for node in payload.get("nodes", [])
         if isinstance(node, dict) and node.get("id")
     }
-    # Graphify exports NetworkX node-link JSON using `links`. Accept `edges`
-    # only as a compatibility fallback for older/synthetic evidence.
     relationships = payload.get("links")
     if relationships is None:
         relationships = payload.get("edges", [])
@@ -120,19 +153,87 @@ def _runtime(agent_memory_commit: str, all_fixture_paths: list[Path]) -> Qualifi
         "codegenome": CODEGENOME_COMMIT,
         "graphify": f"{GRAPHIFY_RELEASE}@{GRAPHIFY_COMMIT}",
         "update_posture": "full_rebuild",
+        "failure_posture": "explicit_unavailable",
+        "fallback_posture": "explicit_equivalent_only",
     }
     configuration_digest = sha256_bytes(
         json.dumps(configuration, sort_keys=True, separators=(",", ":")).encode("utf-8")
     )
     return QualificationRuntime(
         configuration_digest=configuration_digest,
-        fixture_id="component-qualification-code-graph-v1-v2",
+        fixture_id="component-qualification-code-graph-v1-v2-failure",
         fixture_digest=fixture_digest(all_fixture_paths),
         dependency_refs=(
             f"CodeGenome@{CODEGENOME_COMMIT}",
             f"Graphify@{GRAPHIFY_RELEASE}:{GRAPHIFY_COMMIT}",
         ),
         runtime_refs=(f"agent-memory@{agent_memory_commit}", "python:3.12", "rust:stable"),
+    )
+
+
+def _failure_result(
+    *,
+    subject: QualificationSubject,
+    raw_path: Path,
+    normalized_path: Path,
+) -> tuple[AdapterResult, ProviderFailure]:
+    raw = _load(raw_path)
+    normalized = _load(normalized_path)
+    if not isinstance(raw, dict) or raw.get("exception_type") != "FileNotFoundError":
+        raise ValueError(f"provider unavailable raw evidence is not a FileNotFoundError: {raw_path}")
+    if not isinstance(normalized, dict):
+        raise ValueError(f"provider unavailable normalized evidence must be an object: {normalized_path}")
+    if normalized.get("component_id") != subject.component_id:
+        raise ValueError("provider unavailable evidence component does not match qualification subject")
+    if normalized.get("capability_id") != subject.capability_id:
+        raise ValueError("provider unavailable evidence capability does not match qualification subject")
+    if normalized.get("failure_result") != "provider_unavailable":
+        raise ValueError("provider unavailable evidence has the wrong failure result")
+    if normalized.get("currentness") != "unavailable":
+        raise ValueError("provider unavailable evidence has the wrong currentness posture")
+    if normalized.get("authority_effect") != "none":
+        raise ValueError("provider unavailable evidence cannot grant authority")
+    runtime_identity = normalized.get("runtime_identity")
+    trace_ref = normalized.get("trace_ref")
+    if not isinstance(runtime_identity, str) or not runtime_identity:
+        raise ValueError("provider unavailable runtime identity is required")
+    if not isinstance(trace_ref, str) or not trace_ref:
+        raise ValueError("provider unavailable trace reference is required")
+
+    adapter = AdapterResult(
+        subject=subject,
+        operation="provider_availability_probe",
+        runtime_identity=runtime_identity,
+        input_refs=(f"executable:{runtime_identity}",),
+        raw_provider_refs=(str(raw_path),),
+        normalized_refs=(str(normalized_path),),
+        currentness="unavailable",
+        failure_result="provider_unavailable",
+        trace_ref=trace_ref,
+    )
+    failure = ProviderFailure(
+        component_id=subject.component_id,
+        capability_id=subject.capability_id,
+        failure_result="provider_unavailable",
+        evidence_ref=str(raw_path),
+        trace_ref=trace_ref,
+    )
+    return adapter, failure
+
+
+def _resolved_capability(component_id: str, component_version: str, maturity: str) -> ResolvedCapability:
+    return ResolvedCapability(
+        component_id=component_id,
+        component_version=component_version,
+        profile_version="component-profile-v1",
+        capability_id="code_graph_traversal",
+        capability_version="1.0",
+        maturity=maturity,
+        state_posture="derived",
+        scope_posture="inherits_agent_memory_scope",
+        failure_posture="explicit_unavailable",
+        authority_effect="none",
+        evidence_refs=(f"qualification:{component_id}:{PROFILE_ID}:{PROFILE_VERSION}",),
     )
 
 
@@ -146,8 +247,12 @@ def build_qualification_report(
     codegenome_v2_main_downstream: Path,
     codegenome_v2_main_upstream: Path,
     codegenome_v2_decoy_downstream: Path,
+    codegenome_unavailable_raw: Path,
+    codegenome_unavailable_normalized: Path,
     graphify_v1: Path,
     graphify_v2: Path,
+    graphify_unavailable_raw: Path,
+    graphify_unavailable_normalized: Path,
 ) -> dict[str, Any]:
     runtime = _runtime(agent_memory_commit, fixture_paths)
 
@@ -176,6 +281,7 @@ def build_qualification_report(
         "v2_decoy_downstream_decoy_leaf": 12 in cg_v2_decoy,
         "v2_decoy_excludes_replacement_leaf": 13 not in cg_v2_decoy,
         "full_rebuild_currentness": 1 in cg_v1_down and 1 not in cg_v2_down and 13 in cg_v2_down,
+        "provider_unavailable_explicit": True,
     }
 
     graphify_v1_facts = _graphify_call_facts(graphify_v1)
@@ -193,29 +299,20 @@ def build_qualification_report(
             and ("main.rs", "middle", "leaf") not in graphify_v2_facts
             and ("main.rs", "middle", "replacement_leaf") in graphify_v2_facts
         ),
+        "provider_unavailable_explicit": True,
     }
 
-    cg_subject = QualificationSubject(
-        component_id="codegenome",
-        component_version=CODEGENOME_COMMIT,
-        implementation_ref=f"MythologIQ-Labs-LLC/CodeGenome@{CODEGENOME_COMMIT}",
-        capability_id="code_graph_traversal",
-        capability_version="1.0",
-        adapter_id="codegenome-cli",
-        adapter_version="1.0.0",
-        qualification_profile_id=PROFILE_ID,
-        qualification_profile_version=PROFILE_VERSION,
+    cg_subject = codegenome_subject()
+    graphify_subject_value = graphify_subject()
+    cg_failure_result, cg_failure = _failure_result(
+        subject=cg_subject,
+        raw_path=codegenome_unavailable_raw,
+        normalized_path=codegenome_unavailable_normalized,
     )
-    graphify_subject = QualificationSubject(
-        component_id="graphify",
-        component_version=GRAPHIFY_RELEASE,
-        implementation_ref=f"Graphify-Labs/graphify@{GRAPHIFY_COMMIT}",
-        capability_id="code_graph_traversal",
-        capability_version="1.0",
-        adapter_id="graphify-cli",
-        adapter_version="1.0.0",
-        qualification_profile_id=PROFILE_ID,
-        qualification_profile_version=PROFILE_VERSION,
+    graphify_failure_result, _graphify_failure = _failure_result(
+        subject=graphify_subject_value,
+        raw_path=graphify_unavailable_raw,
+        normalized_path=graphify_unavailable_normalized,
     )
 
     cg_raw = (
@@ -240,7 +337,7 @@ def build_qualification_report(
         trace_ref="qualification:codegenome",
     )
     graphify_result = AdapterResult(
-        subject=graphify_subject,
+        subject=graphify_subject_value,
         operation="code_graph_traversal_v1_v2_full_rebuild",
         runtime_identity=f"Graphify@{GRAPHIFY_RELEASE}:{GRAPHIFY_COMMIT}",
         input_refs=("fixture:v1", "fixture:v2"),
@@ -253,39 +350,70 @@ def build_qualification_report(
 
     cg_passed = all(codegenome_checks.values())
     graphify_passed = all(graphify_checks.values())
+    cg_artifacts = (*cg_raw, codegenome_unavailable_raw, codegenome_unavailable_normalized)
+    graphify_artifacts = (*graphify_raw, graphify_unavailable_raw, graphify_unavailable_normalized)
     cg_record = qualification_from_adapter_results(
         subject=cg_subject,
         runtime=runtime,
         license_id="MIT",
         license_ref=f"MythologIQ-Labs-LLC/CodeGenome/LICENSE@{CODEGENOME_COMMIT}",
         use_posture="runtime_allowed",
-        results=(cg_result,),
+        results=(cg_result, cg_failure_result),
         checks=_checks(codegenome_checks, "normalized:codegenome-code-graph"),
-        artifact_digests=tuple(sha256_file(path) for path in cg_raw),
+        artifact_digests=tuple(sha256_file(path) for path in cg_artifacts),
         maturity_before="runtime_wired",
         profile_maturity_ceiling="evidence_proven",
         earned_maturity="runtime_wired" if not cg_passed else "evidence_proven",
         limitations=("Currentness in this slice is proven through explicit full rebuild, not incremental update.",),
     )
     graphify_record = qualification_from_adapter_results(
-        subject=graphify_subject,
+        subject=graphify_subject_value,
         runtime=runtime,
         license_id="Apache-2.0",
         license_ref=f"Graphify-Labs/graphify/LICENSE@{GRAPHIFY_COMMIT}",
         use_posture="runtime_allowed",
-        results=(graphify_result,),
+        results=(graphify_result, graphify_failure_result),
         checks=_checks(graphify_checks, "normalized:graphify-code-graph"),
-        artifact_digests=tuple(sha256_file(path) for path in graphify_raw),
+        artifact_digests=tuple(sha256_file(path) for path in graphify_artifacts),
         maturity_before="runtime_wired",
         profile_maturity_ceiling="evidence_proven",
         earned_maturity="runtime_wired" if not graphify_passed else "evidence_proven",
         limitations=("Currentness in this slice is proven through explicit full rebuild, not incremental update.",),
     )
 
+    cg_resolved = _resolved_capability("codegenome", CODEGENOME_COMMIT, cg_record.earned_maturity)
+    graphify_resolved = _resolved_capability("graphify", GRAPHIFY_RELEASE, graphify_record.earned_maturity)
+    primary = QualifiedCapability(cg_resolved, cg_record)
+    graphify_candidate = QualifiedCapability(graphify_resolved, graphify_record)
+
+    no_fallback = evaluate_explicit_fallback(
+        primary=primary,
+        failure=cg_failure,
+        candidates=(graphify_candidate,),
+        allowed_components=(),
+    )
+    explicit_graphify = evaluate_explicit_fallback(
+        primary=primary,
+        failure=cg_failure,
+        candidates=(graphify_candidate,),
+        allowed_components=("graphify",),
+    )
+    weaker_graphify = QualifiedCapability(
+        replace(graphify_resolved, maturity="runtime_wired"),
+        graphify_record,
+    )
+    weaker_refused = evaluate_explicit_fallback(
+        primary=primary,
+        failure=cg_failure,
+        candidates=(weaker_graphify,),
+        allowed_components=("graphify",),
+    )
+
     return {
-        "schema_version": "1.0.0",
+        "schema_version": "1.1.0",
         "profile": {"id": PROFILE_ID, "version": PROFILE_VERSION},
         "update_posture": "full_rebuild",
+        "failure_posture": "explicit_unavailable",
         "providers": {
             "codegenome": {
                 "checks": codegenome_checks,
@@ -309,6 +437,13 @@ def build_qualification_report(
                 "qualification": graphify_record.to_dict(),
                 "passed": graphify_passed,
             },
+        },
+        "failure_fallback": {
+            "primary_failure": cg_failure.to_dict(),
+            "no_fallback_configured": no_fallback.to_dict(),
+            "explicit_graphify": explicit_graphify.to_dict(),
+            "weaker_graphify_refused": weaker_refused.to_dict(),
+            "authority_effect": "none",
         },
         "matched_result": {
             "both_passed": cg_passed and graphify_passed,

--- a/reference/agentmem_ref/component_failure_probe.py
+++ b/reference/agentmem_ref/component_failure_probe.py
@@ -1,0 +1,119 @@
+"""Executable provider-unavailability probe for component qualification.
+
+The probe records the operating-system/runtime failure produced by invoking the
+configured provider path. It does not synthesize an outage record from a flag.
+A qualification workflow can deliberately make a provider path unavailable,
+invoke this probe, preserve the raw failure, and then evaluate explicit fallback
+without relabeling failure as success.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+from typing import Sequence
+
+from .component_fallback import ProviderFailure
+from .qualification import AdapterResult, QualificationSubject
+
+
+class ProviderProbeError(RuntimeError):
+    """The expected provider-unavailable condition was not reproduced."""
+
+
+@dataclass(frozen=True)
+class ProviderUnavailableProbe:
+    failure: ProviderFailure
+    adapter_result: AdapterResult
+    raw_path: Path
+    normalized_path: Path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def probe_missing_executable(
+    *,
+    subject: QualificationSubject,
+    executable: Path,
+    args: Sequence[str],
+    raw_path: Path,
+    normalized_path: Path,
+    trace_ref: str,
+    timeout_seconds: float = 10.0,
+) -> ProviderUnavailableProbe:
+    """Invoke an expected-missing executable and preserve the real OS result.
+
+    The probe succeeds only when the configured executable is actually missing.
+    An executable that runs, exits non-zero for another reason, or times out is a
+    different failure mode and must receive its own evidence profile rather than
+    being laundered into ``provider_unavailable``.
+    """
+
+    argv = [str(executable), *args]
+    try:
+        completed = subprocess.run(
+            argv,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as exc:
+        raw = {
+            "probe": "missing_executable",
+            "argv": argv,
+            "exception_type": type(exc).__name__,
+            "errno": exc.errno,
+            "strerror": exc.strerror,
+            "filename": exc.filename,
+        }
+        _write_json(raw_path, raw)
+        normalized = {
+            "component_id": subject.component_id,
+            "capability_id": subject.capability_id,
+            "failure_result": "provider_unavailable",
+            "currentness": "unavailable",
+            "runtime_identity": str(executable),
+            "raw_evidence_ref": str(raw_path),
+            "trace_ref": trace_ref,
+            "authority_effect": "none",
+        }
+        _write_json(normalized_path, normalized)
+        failure = ProviderFailure(
+            component_id=subject.component_id,
+            capability_id=subject.capability_id,
+            failure_result="provider_unavailable",
+            evidence_ref=str(raw_path),
+            trace_ref=trace_ref,
+        )
+        result = AdapterResult(
+            subject=subject,
+            operation="provider_availability_probe",
+            runtime_identity=str(executable),
+            input_refs=(f"executable:{executable}",),
+            raw_provider_refs=(str(raw_path),),
+            normalized_refs=(str(normalized_path),),
+            currentness="unavailable",
+            failure_result="provider_unavailable",
+            trace_ref=trace_ref,
+        )
+        return ProviderUnavailableProbe(
+            failure=failure,
+            adapter_result=result,
+            raw_path=raw_path,
+            normalized_path=normalized_path,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ProviderProbeError(
+            f"provider invocation timed out instead of reproducing missing-executable unavailability: {exc}"
+        ) from exc
+
+    raise ProviderProbeError(
+        "expected provider executable to be unavailable, but it executed "
+        f"with return code {completed.returncode}"
+    )

--- a/reference/agentmem_ref/component_fallback.py
+++ b/reference/agentmem_ref/component_fallback.py
@@ -1,0 +1,221 @@
+"""Explicit capability fallback evaluation for #300/#280.
+
+Fallback is a routing decision after an already-selected provider becomes
+unavailable. It is never implicit registration-order behavior and never grants
+memory, recall, structural, or action authority.
+
+The evaluator is deliberately conservative. A fallback candidate must be
+explicitly allowed and must preserve the selected capability's version,
+maturity floor, state posture, scope posture, failure posture, authority effect,
+qualification profile, qualification currentness, and runtime source-rights
+posture. Otherwise the operation remains explicitly unavailable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .capabilities import ResolvedCapability, maturity_satisfies
+from .qualification import QualificationRecord
+
+
+class FallbackError(ValueError):
+    """Fallback evidence or configuration is internally inconsistent."""
+
+
+@dataclass(frozen=True)
+class ProviderFailure:
+    component_id: str
+    capability_id: str
+    failure_result: str
+    evidence_ref: str
+    trace_ref: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("component_id", self.component_id),
+            ("capability_id", self.capability_id),
+            ("failure_result", self.failure_result),
+            ("evidence_ref", self.evidence_ref),
+            ("trace_ref", self.trace_ref),
+        ):
+            if not value:
+                raise ValueError(f"{name} is required")
+        if self.failure_result == "none":
+            raise ValueError("fallback requires an actual provider failure result")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "component_id": self.component_id,
+            "capability_id": self.capability_id,
+            "failure_result": self.failure_result,
+            "evidence_ref": self.evidence_ref,
+            "trace_ref": self.trace_ref,
+        }
+
+
+@dataclass(frozen=True)
+class QualifiedCapability:
+    resolved: ResolvedCapability
+    qualification: QualificationRecord
+
+    def __post_init__(self) -> None:
+        subject = self.qualification.subject
+        if subject.component_id != self.resolved.component_id:
+            raise FallbackError("qualification component does not match resolved component")
+        if subject.component_version != self.resolved.component_version:
+            raise FallbackError("qualification component version does not match resolved component")
+        if subject.capability_id != self.resolved.capability_id:
+            raise FallbackError("qualification capability does not match resolved capability")
+        if subject.capability_version != self.resolved.capability_version:
+            raise FallbackError("qualification capability version does not match resolved capability")
+        if self.qualification.authority_effect != "none":
+            raise FallbackError("qualification cannot grant fallback authority")
+
+
+@dataclass(frozen=True)
+class FallbackDecision:
+    status: str
+    primary_component_id: str
+    capability_id: str
+    failure_result: str
+    selected_component_id: str = ""
+    reason: str = ""
+    rejected_candidates: tuple[tuple[str, tuple[str, ...]], ...] = ()
+
+    @property
+    def authority_effect(self) -> str:
+        return "none"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "primary_component_id": self.primary_component_id,
+            "capability_id": self.capability_id,
+            "failure_result": self.failure_result,
+            "selected_component_id": self.selected_component_id or None,
+            "reason": self.reason,
+            "rejected_candidates": [
+                {"component_id": component_id, "reasons": list(reasons)}
+                for component_id, reasons in self.rejected_candidates
+            ],
+            "authority_effect": "none",
+        }
+
+
+def _qualification_reasons(
+    primary: QualifiedCapability,
+    candidate: QualifiedCapability,
+) -> list[str]:
+    reasons: list[str] = []
+    left = primary.resolved
+    right = candidate.resolved
+    left_q = primary.qualification
+    right_q = candidate.qualification
+
+    if right.capability_id != left.capability_id:
+        reasons.append("capability_id_mismatch")
+    if right.capability_version != left.capability_version:
+        reasons.append("capability_version_mismatch")
+    if not maturity_satisfies(right.maturity, left.maturity):
+        reasons.append("weaker_maturity")
+    if right.state_posture != left.state_posture:
+        reasons.append("state_posture_mismatch")
+    if right.scope_posture != left.scope_posture:
+        reasons.append("scope_posture_mismatch")
+    if right.failure_posture != left.failure_posture:
+        reasons.append("failure_posture_mismatch")
+    if right.authority_effect != left.authority_effect:
+        reasons.append("authority_effect_mismatch")
+
+    left_subject = left_q.subject
+    right_subject = right_q.subject
+    if right_subject.qualification_profile_id != left_subject.qualification_profile_id:
+        reasons.append("qualification_profile_mismatch")
+    if right_subject.qualification_profile_version != left_subject.qualification_profile_version:
+        reasons.append("qualification_profile_version_mismatch")
+    if not right_q.qualification_current:
+        reasons.append("qualification_not_current")
+    if right_q.use_posture != "runtime_allowed":
+        reasons.append("source_rights_not_runtime_allowed")
+    if not maturity_satisfies(right_q.earned_maturity, left.maturity):
+        reasons.append("qualification_maturity_below_primary")
+
+    return reasons
+
+
+def evaluate_explicit_fallback(
+    *,
+    primary: QualifiedCapability,
+    failure: ProviderFailure,
+    candidates: Iterable[QualifiedCapability],
+    allowed_components: Iterable[str],
+) -> FallbackDecision:
+    """Select one explicitly configured equivalent fallback or remain unavailable."""
+
+    if failure.component_id != primary.resolved.component_id:
+        raise FallbackError("failure component does not match selected primary")
+    if failure.capability_id != primary.resolved.capability_id:
+        raise FallbackError("failure capability does not match selected primary")
+
+    if primary.qualification.use_posture != "runtime_allowed":
+        raise FallbackError("primary runtime selection lacks runtime-allowed source rights")
+    if not primary.qualification.qualification_current:
+        raise FallbackError("primary runtime selection lacks a current qualification")
+
+    allowed = tuple(dict.fromkeys(allowed_components))
+    if not allowed:
+        return FallbackDecision(
+            status="unavailable",
+            primary_component_id=primary.resolved.component_id,
+            capability_id=primary.resolved.capability_id,
+            failure_result=failure.failure_result,
+            reason="fallback_not_configured",
+        )
+
+    candidate_by_id = {candidate.resolved.component_id: candidate for candidate in candidates}
+    compatible: list[QualifiedCapability] = []
+    rejected: list[tuple[str, tuple[str, ...]]] = []
+
+    for component_id in allowed:
+        candidate = candidate_by_id.get(component_id)
+        if candidate is None:
+            rejected.append((component_id, ("configured_fallback_not_available",)))
+            continue
+        reasons = _qualification_reasons(primary, candidate)
+        if reasons:
+            rejected.append((component_id, tuple(reasons)))
+            continue
+        compatible.append(candidate)
+
+    if not compatible:
+        return FallbackDecision(
+            status="unavailable",
+            primary_component_id=primary.resolved.component_id,
+            capability_id=primary.resolved.capability_id,
+            failure_result=failure.failure_result,
+            reason="no_equivalent_fallback",
+            rejected_candidates=tuple(rejected),
+        )
+
+    if len(compatible) > 1:
+        return FallbackDecision(
+            status="unavailable",
+            primary_component_id=primary.resolved.component_id,
+            capability_id=primary.resolved.capability_id,
+            failure_result=failure.failure_result,
+            reason="ambiguous_equivalent_fallbacks",
+            rejected_candidates=tuple(rejected),
+        )
+
+    selected = compatible[0]
+    return FallbackDecision(
+        status="fallback_selected",
+        primary_component_id=primary.resolved.component_id,
+        capability_id=primary.resolved.capability_id,
+        failure_result=failure.failure_result,
+        selected_component_id=selected.resolved.component_id,
+        reason="explicit_equivalent_fallback",
+        rejected_candidates=tuple(rejected),
+    )

--- a/reference/agentmem_ref/qualification.py
+++ b/reference/agentmem_ref/qualification.py
@@ -14,6 +14,8 @@ from typing import Sequence
 
 from .capabilities import MATURITY_ORDER, maturity_satisfies
 
+QUALIFICATION_SCHEMA_VERSION = "1.1.0"
+
 
 class QualificationError(ValueError):
     """Qualification evidence is invalid or not applicable."""
@@ -89,6 +91,10 @@ class AdapterResult:
     def __post_init__(self) -> None:
         if not self.operation or not self.runtime_identity or not self.trace_ref:
             raise ValueError("operation, runtime identity, and trace reference are required")
+        if not self.currentness:
+            raise ValueError("adapter currentness posture is required")
+        if not self.failure_result:
+            raise ValueError("adapter failure result is required")
         if not self.raw_provider_refs:
             raise ValueError("raw provider evidence must be preserved")
         if not self.normalized_refs:
@@ -97,6 +103,19 @@ class AdapterResult:
     @property
     def authority_effect(self) -> str:
         return "none"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "operation": self.operation,
+            "runtime_identity": self.runtime_identity,
+            "input_refs": list(self.input_refs),
+            "raw_provider_refs": list(self.raw_provider_refs),
+            "normalized_refs": list(self.normalized_refs),
+            "currentness": self.currentness,
+            "failure_result": self.failure_result,
+            "trace_ref": self.trace_ref,
+            "authority_effect": "none",
+        }
 
 
 @dataclass(frozen=True)
@@ -114,6 +133,7 @@ class QualificationRecord:
     maturity_before: str
     profile_maturity_ceiling: str
     earned_maturity: str
+    adapter_results: tuple[AdapterResult, ...] = ()
     limitations: tuple[str, ...] = ()
     qualification_current: bool = True
 
@@ -137,6 +157,11 @@ class QualificationRecord:
             raise QualificationError("qualification must exercise at least one operation")
         if not self.raw_provider_refs or not self.normalized_refs or not self.artifact_digests:
             raise QualificationError("qualification must preserve raw, normalized, and digest evidence")
+        for result in self.adapter_results:
+            if result.subject != self.subject:
+                raise QualificationError("stored adapter result subject does not match qualification subject")
+            if result.authority_effect != "none":
+                raise QualificationError("stored adapter result cannot grant authority")
         if self.earned_maturity == "reference_qualified":
             if self.profile_maturity_ceiling != "reference_qualified":
                 raise QualificationError("reference_qualified requires an explicit reference-qualified profile ceiling")
@@ -144,6 +169,8 @@ class QualificationRecord:
                 raise QualificationError("reference_qualified requires runtime-allowed source rights")
             if not self.checks or not all(passed for _, passed, _ in self.checks):
                 raise QualificationError("reference_qualified requires every required profile check to pass")
+            if not self.adapter_results:
+                raise QualificationError("reference_qualified requires reconstructable adapter-result evidence")
 
     @property
     def applicability_digest(self) -> str:
@@ -152,6 +179,11 @@ class QualificationRecord:
     @property
     def authority_effect(self) -> str:
         return "none"
+
+    @property
+    def failure_results(self) -> tuple[str, ...]:
+        """Failure outcomes preserved by the exact qualification run."""
+        return tuple(result.failure_result for result in self.adapter_results)
 
     def assert_applicable(self, subject: QualificationSubject, runtime: QualificationRuntime) -> None:
         expected = applicability_digest(subject, runtime)
@@ -164,7 +196,7 @@ class QualificationRecord:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema_version": "1.0.0",
+            "schema_version": QUALIFICATION_SCHEMA_VERSION,
             "subject": self.subject.to_dict(),
             "runtime": self.runtime.applicability_dict(),
             "source_rights": {
@@ -176,6 +208,7 @@ class QualificationRecord:
                 "operations": list(self.operations),
                 "raw_provider_refs": list(self.raw_provider_refs),
                 "normalized_refs": list(self.normalized_refs),
+                "adapter_results": [result.to_dict() for result in self.adapter_results],
                 "checks": [
                     {"check_id": check_id, "passed": passed, "evidence_ref": evidence_ref}
                     for check_id, passed, evidence_ref in self.checks
@@ -238,5 +271,6 @@ def qualification_from_adapter_results(
         maturity_before=maturity_before,
         profile_maturity_ceiling=profile_maturity_ceiling,
         earned_maturity=earned_maturity,
+        adapter_results=tuple(results),
         limitations=tuple(limitations),
     )

--- a/reference/run_component_failure_probe.py
+++ b/reference/run_component_failure_probe.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Emit real provider-unavailable evidence for the code-graph qualification."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from agentmem_ref.code_graph_qualification import codegenome_subject, graphify_subject
+from agentmem_ref.component_failure_probe import probe_missing_executable
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--provider", choices=("codegenome", "graphify"), required=True)
+    parser.add_argument("--executable", type=Path, required=True)
+    parser.add_argument("--raw-output", type=Path, required=True)
+    parser.add_argument("--normalized-output", type=Path, required=True)
+    parser.add_argument("--trace-ref", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    subject = codegenome_subject() if args.provider == "codegenome" else graphify_subject()
+    probe_missing_executable(
+        subject=subject,
+        executable=args.executable,
+        args=("--version",),
+        raw_path=args.raw_output,
+        normalized_path=args.normalized_output,
+        trace_ref=args.trace_ref,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/run_component_qualification.py
+++ b/reference/run_component_qualification.py
@@ -20,8 +20,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--codegenome-v2-main-downstream", type=Path, required=True)
     parser.add_argument("--codegenome-v2-main-upstream", type=Path, required=True)
     parser.add_argument("--codegenome-v2-decoy-downstream", type=Path, required=True)
+    parser.add_argument("--codegenome-unavailable-raw", type=Path, required=True)
+    parser.add_argument("--codegenome-unavailable-normalized", type=Path, required=True)
     parser.add_argument("--graphify-v1", type=Path, required=True)
     parser.add_argument("--graphify-v2", type=Path, required=True)
+    parser.add_argument("--graphify-unavailable-raw", type=Path, required=True)
+    parser.add_argument("--graphify-unavailable-normalized", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     return parser.parse_args()
 
@@ -38,8 +42,12 @@ def main() -> int:
         codegenome_v2_main_downstream=args.codegenome_v2_main_downstream,
         codegenome_v2_main_upstream=args.codegenome_v2_main_upstream,
         codegenome_v2_decoy_downstream=args.codegenome_v2_decoy_downstream,
+        codegenome_unavailable_raw=args.codegenome_unavailable_raw,
+        codegenome_unavailable_normalized=args.codegenome_unavailable_normalized,
         graphify_v1=args.graphify_v1,
         graphify_v2=args.graphify_v2,
+        graphify_unavailable_raw=args.graphify_unavailable_raw,
+        graphify_unavailable_normalized=args.graphify_unavailable_normalized,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/reference/tests/test_code_graph_qualification.py
+++ b/reference/tests/test_code_graph_qualification.py
@@ -47,15 +47,91 @@ def _graph(path: Path, calls: list[tuple[str, str, str]]) -> None:
     path.write_text(json.dumps({"nodes": nodes, "links": links}), encoding="utf-8")
 
 
+def _unavailable(raw_path: Path, normalized_path: Path, *, component_id: str, runtime_identity: str) -> None:
+    raw_path.write_text(
+        json.dumps(
+            {
+                "probe": "missing_executable",
+                "argv": [runtime_identity, "--version"],
+                "exception_type": "FileNotFoundError",
+                "errno": 2,
+                "strerror": "No such file or directory",
+                "filename": runtime_identity,
+            }
+        ),
+        encoding="utf-8",
+    )
+    normalized_path.write_text(
+        json.dumps(
+            {
+                "component_id": component_id,
+                "capability_id": "code_graph_traversal",
+                "failure_result": "provider_unavailable",
+                "currentness": "unavailable",
+                "runtime_identity": runtime_identity,
+                "raw_evidence_ref": str(raw_path),
+                "trace_ref": f"trace:{component_id}:unavailable",
+                "authority_effect": "none",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _paths(root: Path) -> dict[str, Path]:
+    names = (
+        "cg-v1-down.json",
+        "cg-v1-up.json",
+        "cg-v1-decoy.json",
+        "cg-v2-down.json",
+        "cg-v2-up.json",
+        "cg-v2-decoy.json",
+        "cg-unavailable-raw.json",
+        "cg-unavailable-normalized.json",
+        "graph-v1.json",
+        "graph-v2.json",
+        "graph-unavailable-raw.json",
+        "graph-unavailable-normalized.json",
+    )
+    paths = {name: root / name for name in names}
+    _unavailable(
+        paths["cg-unavailable-raw.json"],
+        paths["cg-unavailable-normalized.json"],
+        component_id="codegenome",
+        runtime_identity="/tmp/codegenome",
+    )
+    _unavailable(
+        paths["graph-unavailable-raw.json"],
+        paths["graph-unavailable-normalized.json"],
+        component_id="graphify",
+        runtime_identity="/tmp/graphify",
+    )
+    return paths
+
+
+def _report(paths: dict[str, Path]) -> dict:
+    return build_qualification_report(
+        agent_memory_commit="a" * 40,
+        fixture_paths=sorted(FIXTURE_ROOT.glob("v*/*.rs")),
+        codegenome_v1_main_downstream=paths["cg-v1-down.json"],
+        codegenome_v1_main_upstream=paths["cg-v1-up.json"],
+        codegenome_v1_decoy_downstream=paths["cg-v1-decoy.json"],
+        codegenome_v2_main_downstream=paths["cg-v2-down.json"],
+        codegenome_v2_main_upstream=paths["cg-v2-up.json"],
+        codegenome_v2_decoy_downstream=paths["cg-v2-decoy.json"],
+        codegenome_unavailable_raw=paths["cg-unavailable-raw.json"],
+        codegenome_unavailable_normalized=paths["cg-unavailable-normalized.json"],
+        graphify_v1=paths["graph-v1.json"],
+        graphify_v2=paths["graph-v2.json"],
+        graphify_unavailable_raw=paths["graph-unavailable-raw.json"],
+        graphify_unavailable_normalized=paths["graph-unavailable-normalized.json"],
+    )
+
+
 class CodeGraphQualificationTests(unittest.TestCase):
-    def test_matched_v1_v2_report_preserves_currentness_and_no_winner(self):
+    def test_matched_v1_v2_report_preserves_currentness_failure_and_no_winner(self):
         with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp)
-            paths = {name: root / name for name in (
-                "cg-v1-down.json", "cg-v1-up.json", "cg-v1-decoy.json",
-                "cg-v2-down.json", "cg-v2-up.json", "cg-v2-decoy.json",
-                "graph-v1.json", "graph-v2.json",
-            )}
+            paths = _paths(Path(temp))
             _cg(paths["cg-v1-down.json"], [5, 1])
             _cg(paths["cg-v1-up.json"], [5, 9])
             _cg(paths["cg-v1-decoy.json"], [5, 12])
@@ -78,24 +154,16 @@ class CodeGraphQualificationTests(unittest.TestCase):
                     ("decoy.rs", "middle", "decoy_leaf"),
                 ],
             )
-            report = build_qualification_report(
-                agent_memory_commit="a" * 40,
-                fixture_paths=sorted(FIXTURE_ROOT.glob("v*/*.rs")),
-                codegenome_v1_main_downstream=paths["cg-v1-down.json"],
-                codegenome_v1_main_upstream=paths["cg-v1-up.json"],
-                codegenome_v1_decoy_downstream=paths["cg-v1-decoy.json"],
-                codegenome_v2_main_downstream=paths["cg-v2-down.json"],
-                codegenome_v2_main_upstream=paths["cg-v2-up.json"],
-                codegenome_v2_decoy_downstream=paths["cg-v2-decoy.json"],
-                graphify_v1=paths["graph-v1.json"],
-                graphify_v2=paths["graph-v2.json"],
-            )
+            report = _report(paths)
+            self.assertEqual(report["schema_version"], "1.1.0")
             self.assertTrue(report["matched_result"]["both_passed"])
             self.assertIsNone(report["matched_result"]["winner"])
             self.assertEqual(report["matched_result"]["authority_effect"], "none")
             self.assertEqual(report["matched_result"]["unrelated_capabilities_promoted"], [])
             self.assertTrue(report["providers"]["codegenome"]["checks"]["full_rebuild_currentness"])
             self.assertTrue(report["providers"]["graphify"]["checks"]["full_rebuild_currentness"])
+            self.assertTrue(report["providers"]["codegenome"]["checks"]["provider_unavailable_explicit"])
+            self.assertTrue(report["providers"]["graphify"]["checks"]["provider_unavailable_explicit"])
 
             schema = json.loads((ROOT / "schemas" / "component-capability-qualification.schema.json").read_text())
             validator = jsonschema.Draft202012Validator(schema)
@@ -103,18 +171,27 @@ class CodeGraphQualificationTests(unittest.TestCase):
                 qualification = report["providers"][provider]["qualification"]
                 errors = list(validator.iter_errors(qualification))
                 self.assertEqual(errors, [], [error.message for error in errors])
+                self.assertEqual(qualification["schema_version"], "1.1.0")
                 self.assertEqual(qualification["result"]["earned_maturity"], "evidence_proven")
                 self.assertEqual(qualification["result"]["authority_effect"], "none")
+                failure_results = [item["failure_result"] for item in qualification["evidence"]["adapter_results"]]
+                self.assertEqual(failure_results, ["none", "provider_unavailable"])
+
+            fallback = report["failure_fallback"]
+            self.assertEqual(fallback["authority_effect"], "none")
+            self.assertEqual(fallback["no_fallback_configured"]["status"], "unavailable")
+            self.assertEqual(fallback["no_fallback_configured"]["reason"], "fallback_not_configured")
+            self.assertEqual(fallback["explicit_graphify"]["status"], "fallback_selected")
+            self.assertEqual(fallback["explicit_graphify"]["selected_component_id"], "graphify")
+            self.assertEqual(fallback["weaker_graphify_refused"]["status"], "unavailable")
+            self.assertIn(
+                "weaker_maturity",
+                fallback["weaker_graphify_refused"]["rejected_candidates"][0]["reasons"],
+            )
 
     def test_stale_v1_relationship_fails_currentness(self):
         with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp)
-            names = [
-                "cg-v1-down.json", "cg-v1-up.json", "cg-v1-decoy.json",
-                "cg-v2-down.json", "cg-v2-up.json", "cg-v2-decoy.json",
-                "graph-v1.json", "graph-v2.json",
-            ]
-            paths = {name: root / name for name in names}
+            paths = _paths(Path(temp))
             _cg(paths["cg-v1-down.json"], [5, 1])
             _cg(paths["cg-v1-up.json"], [5, 9])
             _cg(paths["cg-v1-decoy.json"], [5, 12])
@@ -126,18 +203,7 @@ class CodeGraphQualificationTests(unittest.TestCase):
                 paths["graph-v2.json"],
                 [("main.rs", "middle", "leaf"), ("main.rs", "middle", "replacement_leaf")],
             )
-            report = build_qualification_report(
-                agent_memory_commit="a" * 40,
-                fixture_paths=sorted(FIXTURE_ROOT.glob("v*/*.rs")),
-                codegenome_v1_main_downstream=paths["cg-v1-down.json"],
-                codegenome_v1_main_upstream=paths["cg-v1-up.json"],
-                codegenome_v1_decoy_downstream=paths["cg-v1-decoy.json"],
-                codegenome_v2_main_downstream=paths["cg-v2-down.json"],
-                codegenome_v2_main_upstream=paths["cg-v2-up.json"],
-                codegenome_v2_decoy_downstream=paths["cg-v2-decoy.json"],
-                graphify_v1=paths["graph-v1.json"],
-                graphify_v2=paths["graph-v2.json"],
-            )
+            report = _report(paths)
             self.assertFalse(report["matched_result"]["both_passed"])
             self.assertFalse(report["providers"]["codegenome"]["checks"]["full_rebuild_currentness"])
             self.assertFalse(report["providers"]["graphify"]["checks"]["full_rebuild_currentness"])

--- a/reference/tests/test_component_failure_probe.py
+++ b/reference/tests/test_component_failure_probe.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from agentmem_ref.code_graph_qualification import codegenome_subject
+from agentmem_ref.component_failure_probe import ProviderProbeError, probe_missing_executable
+
+
+class ComponentFailureProbeTests(unittest.TestCase):
+    def test_missing_executable_preserves_real_os_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            missing = root / "provider-that-does-not-exist"
+            raw = root / "raw.json"
+            normalized = root / "normalized.json"
+            probe = probe_missing_executable(
+                subject=codegenome_subject(),
+                executable=missing,
+                args=("--version",),
+                raw_path=raw,
+                normalized_path=normalized,
+                trace_ref="trace:test-unavailable",
+            )
+
+            raw_payload = json.loads(raw.read_text())
+            normalized_payload = json.loads(normalized.read_text())
+            self.assertEqual(raw_payload["exception_type"], "FileNotFoundError")
+            self.assertEqual(raw_payload["errno"], 2)
+            self.assertEqual(normalized_payload["failure_result"], "provider_unavailable")
+            self.assertEqual(normalized_payload["currentness"], "unavailable")
+            self.assertEqual(normalized_payload["authority_effect"], "none")
+            self.assertEqual(probe.failure.failure_result, "provider_unavailable")
+            self.assertEqual(probe.adapter_result.failure_result, "provider_unavailable")
+            self.assertEqual(probe.adapter_result.currentness, "unavailable")
+            self.assertEqual(probe.adapter_result.authority_effect, "none")
+
+    def test_available_executable_cannot_be_laundered_into_unavailable(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            with self.assertRaises(ProviderProbeError):
+                probe_missing_executable(
+                    subject=codegenome_subject(),
+                    executable=Path(sys.executable),
+                    args=("--version",),
+                    raw_path=root / "raw.json",
+                    normalized_path=root / "normalized.json",
+                    trace_ref="trace:test-available",
+                )
+            self.assertFalse((root / "raw.json").exists())
+            self.assertFalse((root / "normalized.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_component_fallback.py
+++ b/reference/tests/test_component_fallback.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.capabilities import ResolvedCapability
+from agentmem_ref.component_fallback import (
+    FallbackError,
+    ProviderFailure,
+    QualifiedCapability,
+    evaluate_explicit_fallback,
+)
+from agentmem_ref.qualification import (
+    AdapterResult,
+    QualificationRuntime,
+    QualificationSubject,
+    qualification_from_adapter_results,
+)
+
+
+CAPABILITY = "code_graph_traversal"
+PROFILE = "code-graph-traversal-currentness-failure"
+
+
+def resolved(
+    component_id: str,
+    *,
+    maturity: str = "evidence_proven",
+    state_posture: str = "derived",
+    scope_posture: str = "inherits_agent_memory_scope",
+    failure_posture: str = "explicit_unavailable",
+    authority_effect: str = "none",
+) -> ResolvedCapability:
+    return ResolvedCapability(
+        component_id=component_id,
+        component_version="1.0.0",
+        profile_version="component-profile-v1",
+        capability_id=CAPABILITY,
+        capability_version="1.0",
+        maturity=maturity,
+        state_posture=state_posture,
+        scope_posture=scope_posture,
+        failure_posture=failure_posture,
+        authority_effect=authority_effect,
+        evidence_refs=(f"evidence:{component_id}",),
+    )
+
+
+def qualification(
+    component_id: str,
+    *,
+    earned: str = "evidence_proven",
+    use_posture: str = "runtime_allowed",
+    profile: str = PROFILE,
+    profile_version: str = "1.0.0",
+    current: bool = True,
+):
+    subject = QualificationSubject(
+        component_id=component_id,
+        component_version="1.0.0",
+        implementation_ref=f"fixture/{component_id}@1.0.0",
+        capability_id=CAPABILITY,
+        capability_version="1.0",
+        adapter_id=f"{component_id}-adapter",
+        adapter_version="1.0.0",
+        qualification_profile_id=profile,
+        qualification_profile_version=profile_version,
+    )
+    runtime = QualificationRuntime(
+        configuration_digest="sha256:" + "a" * 64,
+        fixture_id="fallback-fixture",
+        fixture_digest="sha256:" + "b" * 64,
+        runtime_refs=("python:3.12",),
+    )
+    result = AdapterResult(
+        subject=subject,
+        operation="query",
+        runtime_identity=f"runtime:{component_id}",
+        input_refs=("fixture:query",),
+        raw_provider_refs=(f"raw:{component_id}",),
+        normalized_refs=(f"normalized:{component_id}",),
+        currentness="current",
+        failure_result="none",
+        trace_ref=f"trace:{component_id}",
+    )
+    record = qualification_from_adapter_results(
+        subject=subject,
+        runtime=runtime,
+        license_id="MIT",
+        license_ref=f"license:{component_id}",
+        use_posture=use_posture,
+        results=(result,),
+        checks=(("query", True, f"normalized:{component_id}"),),
+        artifact_digests=("sha256:" + "c" * 64,),
+        maturity_before="runtime_wired",
+        profile_maturity_ceiling="evidence_proven",
+        earned_maturity=earned,
+    )
+    if current:
+        return record
+    return type(record)(
+        subject=record.subject,
+        runtime=record.runtime,
+        license_id=record.license_id,
+        license_ref=record.license_ref,
+        use_posture=record.use_posture,
+        operations=record.operations,
+        raw_provider_refs=record.raw_provider_refs,
+        normalized_refs=record.normalized_refs,
+        checks=record.checks,
+        artifact_digests=record.artifact_digests,
+        maturity_before=record.maturity_before,
+        profile_maturity_ceiling=record.profile_maturity_ceiling,
+        earned_maturity=record.earned_maturity,
+        adapter_results=record.adapter_results,
+        limitations=record.limitations,
+        qualification_current=False,
+    )
+
+
+def qualified(component_id: str, **kwargs) -> QualifiedCapability:
+    resolved_kwargs = {
+        key: kwargs[key]
+        for key in ("maturity", "state_posture", "scope_posture", "failure_posture", "authority_effect")
+        if key in kwargs
+    }
+    qualification_kwargs = {
+        key: kwargs[key]
+        for key in ("earned", "use_posture", "profile", "profile_version", "current")
+        if key in kwargs
+    }
+    return QualifiedCapability(
+        resolved(component_id, **resolved_kwargs),
+        qualification(component_id, **qualification_kwargs),
+    )
+
+
+class ComponentFallbackTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.primary = qualified("primary")
+        self.failure = ProviderFailure(
+            component_id="primary",
+            capability_id=CAPABILITY,
+            failure_result="provider_unavailable",
+            evidence_ref="raw:primary-unavailable",
+            trace_ref="trace:primary-unavailable",
+        )
+
+    def test_no_configured_fallback_remains_explicitly_unavailable(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("equivalent"),),
+            allowed_components=(),
+        )
+        self.assertEqual(decision.status, "unavailable")
+        self.assertEqual(decision.reason, "fallback_not_configured")
+        self.assertEqual(decision.authority_effect, "none")
+
+    def test_explicit_equivalent_fallback_is_selected(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("equivalent"),),
+            allowed_components=("equivalent",),
+        )
+        self.assertEqual(decision.status, "fallback_selected")
+        self.assertEqual(decision.selected_component_id, "equivalent")
+        self.assertEqual(decision.reason, "explicit_equivalent_fallback")
+
+    def test_weaker_maturity_is_not_fallback(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("weaker", maturity="runtime_wired", earned="evidence_proven"),),
+            allowed_components=("weaker",),
+        )
+        self.assertEqual(decision.status, "unavailable")
+        self.assertIn("weaker_maturity", decision.rejected_candidates[0][1])
+
+    def test_scope_posture_cannot_weaken_or_change(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("scope-change", scope_posture="external_scope_bridge"),),
+            allowed_components=("scope-change",),
+        )
+        self.assertEqual(decision.status, "unavailable")
+        self.assertIn("scope_posture_mismatch", decision.rejected_candidates[0][1])
+
+    def test_state_posture_cannot_change(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("state-change", state_posture="external"),),
+            allowed_components=("state-change",),
+        )
+        self.assertEqual(decision.status, "unavailable")
+        self.assertIn("state_posture_mismatch", decision.rejected_candidates[0][1])
+
+    def test_failure_posture_cannot_change_silently(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("failure-change", failure_posture="fail_open_candidate_only"),),
+            allowed_components=("failure-change",),
+        )
+        self.assertEqual(decision.status, "unavailable")
+        self.assertIn("failure_posture_mismatch", decision.rejected_candidates[0][1])
+
+    def test_comparator_only_source_rights_cannot_be_runtime_fallback(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("comparator", use_posture="comparator_only"),),
+            allowed_components=("comparator",),
+        )
+        self.assertEqual(decision.status, "unavailable")
+        self.assertIn("source_rights_not_runtime_allowed", decision.rejected_candidates[0][1])
+
+    def test_stale_qualification_cannot_be_runtime_fallback(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("stale", current=False),),
+            allowed_components=("stale",),
+        )
+        self.assertEqual(decision.status, "unavailable")
+        self.assertIn("qualification_not_current", decision.rejected_candidates[0][1])
+
+    def test_different_qualification_profile_cannot_inherit_currentness_semantics(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("different-profile", profile="different-profile"),),
+            allowed_components=("different-profile",),
+        )
+        self.assertEqual(decision.status, "unavailable")
+        self.assertIn("qualification_profile_mismatch", decision.rejected_candidates[0][1])
+
+    def test_multiple_equivalent_fallbacks_are_ambiguous_not_first_match(self) -> None:
+        decision = evaluate_explicit_fallback(
+            primary=self.primary,
+            failure=self.failure,
+            candidates=(qualified("a"), qualified("b")),
+            allowed_components=("a", "b"),
+        )
+        self.assertEqual(decision.status, "unavailable")
+        self.assertEqual(decision.reason, "ambiguous_equivalent_fallbacks")
+        self.assertIsNone(decision.to_dict()["selected_component_id"])
+
+    def test_failure_must_belong_to_selected_primary(self) -> None:
+        wrong = ProviderFailure(
+            component_id="someone-else",
+            capability_id=CAPABILITY,
+            failure_result="provider_unavailable",
+            evidence_ref="raw:failure",
+            trace_ref="trace:failure",
+        )
+        with self.assertRaises(FallbackError):
+            evaluate_explicit_fallback(
+                primary=self.primary,
+                failure=wrong,
+                candidates=(qualified("equivalent"),),
+                allowed_components=("equivalent",),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_component_qualification.py
+++ b/reference/tests/test_component_qualification.py
@@ -47,19 +47,33 @@ class ComponentQualificationTests(unittest.TestCase):
             runtime_refs=("ubuntu-latest",),
         )
 
-    def _record(self, *, earned: str = "evidence_proven") -> QualificationRecord:
-        subject = self._subject()
-        result = AdapterResult(
-            subject=subject,
-            operation="impact_downstream",
+    def _adapter_result(
+        self,
+        *,
+        currentness: str = "current",
+        failure_result: str = "none",
+        operation: str = "impact_downstream",
+    ) -> AdapterResult:
+        return AdapterResult(
+            subject=self._subject(),
+            operation=operation,
             runtime_identity="codegenome-cli:test",
             input_refs=("fixture:main.rs:8",),
             raw_provider_refs=("artifact:raw-codegenome.json",),
             normalized_refs=("artifact:normalized.json",),
-            currentness="current",
-            failure_result="none",
+            currentness=currentness,
+            failure_result=failure_result,
             trace_ref="trace:1",
         )
+
+    def _record(
+        self,
+        *,
+        earned: str = "evidence_proven",
+        result: AdapterResult | None = None,
+    ) -> QualificationRecord:
+        subject = self._subject()
+        result = result or self._adapter_result()
         return qualification_from_adapter_results(
             subject=subject,
             runtime=self._runtime(),
@@ -80,8 +94,52 @@ class ComponentQualificationTests(unittest.TestCase):
     def test_record_validates_against_machine_readable_schema(self):
         schema = json.loads((ROOT / "schemas" / "component-capability-qualification.schema.json").read_text())
         validator = jsonschema.Draft202012Validator(schema)
-        errors = list(validator.iter_errors(self._record().to_dict()))
+        record = self._record().to_dict()
+        self.assertEqual(record["schema_version"], "1.1.0")
+        errors = list(validator.iter_errors(record))
         self.assertEqual(errors, [], [error.message for error in errors])
+
+    def test_adapter_currentness_and_failure_result_are_machine_readable(self):
+        record = self._record(
+            result=self._adapter_result(
+                currentness="unavailable",
+                failure_result="provider_unavailable",
+                operation="provider_availability_probe",
+            )
+        )
+        evidence = record.to_dict()["evidence"]
+        self.assertEqual(len(evidence["adapter_results"]), 1)
+        adapter = evidence["adapter_results"][0]
+        self.assertEqual(adapter["currentness"], "unavailable")
+        self.assertEqual(adapter["failure_result"], "provider_unavailable")
+        self.assertEqual(adapter["authority_effect"], "none")
+        self.assertEqual(record.failure_results, ("provider_unavailable",))
+
+    def test_adapter_requires_currentness_and_failure_result(self):
+        with self.assertRaises(ValueError):
+            AdapterResult(
+                subject=self._subject(),
+                operation="query",
+                runtime_identity="runtime",
+                input_refs=(),
+                raw_provider_refs=("raw",),
+                normalized_refs=("normalized",),
+                currentness="",
+                failure_result="none",
+                trace_ref="trace",
+            )
+        with self.assertRaises(ValueError):
+            AdapterResult(
+                subject=self._subject(),
+                operation="query",
+                runtime_identity="runtime",
+                input_refs=(),
+                raw_provider_refs=("raw",),
+                normalized_refs=("normalized",),
+                currentness="current",
+                failure_result="",
+                trace_ref="trace",
+            )
 
     def test_component_version_drift_invalidates_old_qualification(self):
         record = self._record()
@@ -152,6 +210,7 @@ class ComponentQualificationTests(unittest.TestCase):
                 maturity_before="evidence_proven",
                 profile_maturity_ceiling="reference_qualified",
                 earned_maturity="reference_qualified",
+                adapter_results=(self._adapter_result(),),
             )
 
     def test_reference_qualified_requires_runtime_allowed_source_rights(self):
@@ -170,12 +229,32 @@ class ComponentQualificationTests(unittest.TestCase):
                 maturity_before="evidence_proven",
                 profile_maturity_ceiling="reference_qualified",
                 earned_maturity="reference_qualified",
+                adapter_results=(self._adapter_result(),),
+            )
+
+    def test_reference_qualified_requires_reconstructable_adapter_results(self):
+        with self.assertRaisesRegex(QualificationError, "adapter-result evidence"):
+            QualificationRecord(
+                subject=self._subject(),
+                runtime=self._runtime(),
+                license_id="MIT",
+                license_ref="license",
+                use_posture="runtime_allowed",
+                operations=("query",),
+                raw_provider_refs=("raw",),
+                normalized_refs=("normalized",),
+                checks=(("positive", True, "evidence"),),
+                artifact_digests=("sha256:" + "f" * 64,),
+                maturity_before="evidence_proven",
+                profile_maturity_ceiling="reference_qualified",
+                earned_maturity="reference_qualified",
             )
 
     def test_qualification_and_adapter_never_grant_authority(self):
         record = self._record()
         self.assertEqual(record.authority_effect, "none")
         self.assertEqual(record.to_dict()["result"]["authority_effect"], "none")
+        self.assertEqual(record.to_dict()["evidence"]["adapter_results"][0]["authority_effect"], "none")
 
     def test_qualification_is_capability_specific_not_component_wide(self):
         record = self._record()

--- a/schemas/component-capability-qualification.schema.json
+++ b/schemas/component-capability-qualification.schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "required": ["schema_version", "subject", "runtime", "source_rights", "evidence", "result"],
   "properties": {
-    "schema_version": {"const": "1.0.0"},
+    "schema_version": {"const": "1.1.0"},
     "subject": {"$ref": "#/$defs/subject"},
     "runtime": {"$ref": "#/$defs/runtime"},
     "source_rights": {"$ref": "#/$defs/sourceRights"},
@@ -66,13 +66,40 @@
       },
       "additionalProperties": false
     },
+    "adapterResult": {
+      "type": "object",
+      "required": [
+        "operation",
+        "runtime_identity",
+        "input_refs",
+        "raw_provider_refs",
+        "normalized_refs",
+        "currentness",
+        "failure_result",
+        "trace_ref",
+        "authority_effect"
+      ],
+      "properties": {
+        "operation": {"$ref": "#/$defs/nonEmpty"},
+        "runtime_identity": {"$ref": "#/$defs/nonEmpty"},
+        "input_refs": {"type": "array", "items": {"$ref": "#/$defs/nonEmpty"}},
+        "raw_provider_refs": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/nonEmpty"}},
+        "normalized_refs": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/nonEmpty"}},
+        "currentness": {"$ref": "#/$defs/nonEmpty"},
+        "failure_result": {"$ref": "#/$defs/nonEmpty"},
+        "trace_ref": {"$ref": "#/$defs/nonEmpty"},
+        "authority_effect": {"const": "none"}
+      },
+      "additionalProperties": false
+    },
     "evidence": {
       "type": "object",
-      "required": ["operations", "raw_provider_refs", "normalized_refs", "checks", "artifact_digests"],
+      "required": ["operations", "raw_provider_refs", "normalized_refs", "adapter_results", "checks", "artifact_digests"],
       "properties": {
         "operations": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/nonEmpty"}, "uniqueItems": true},
         "raw_provider_refs": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/nonEmpty"}},
         "normalized_refs": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/nonEmpty"}},
+        "adapter_results": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/adapterResult"}},
         "checks": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/check"}},
         "artifact_digests": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/digest"}, "uniqueItems": true}
       },


### PR DESCRIPTION
## Summary

Completes the failure/fallback half of #300 on current `main@41bb10651cf3c0205c1d86e551c618e5e5250410`.

The branch was mechanically rebased after #309/#310/#311 by reusing the exact 13-file blob set from the prior head. A fresh comparison confirmed zero path overlap with the intervening main changes.

This slice adds:

- qualification evidence schema **1.1.0**, because mandatory adapter-result preservation is a real contract evolution;
- machine-readable preservation of each adapter result's exact `currentness`, `failure_result`, runtime identity, trace, raw provider evidence, normalized evidence, and authority-none posture;
- stronger `reference_qualified` requirements for reconstructable adapter-result evidence;
- an explicit `ProviderFailure` evidence surface;
- deterministic no-weaker fallback evaluation over explicitly configured providers only;
- refusal of fallback when capability version, maturity, state posture, scope posture, failure posture, authority effect, qualification profile/version/currentness, earned evidence, or runtime source rights are incompatible;
- explicit unavailable result when fallback is absent or incompatible;
- explicit ambiguity failure when more than one equivalent fallback is configured, rather than hidden first-match behavior;
- real provider-unavailable evidence for both CodeGenome and Graphify by temporarily removing the exact built/installed executable, invoking the configured path, preserving the resulting OS `FileNotFoundError`, and normalizing it as `provider_unavailable`;
- a negative probe test proving an executable that actually runs cannot be laundered into `provider_unavailable`;
- exact-head CodeGenome/Graphify qualification, failure, fallback, currentness, source-rights, maturity, and authority assertions in Component Qualification Evidence CI.

## Failure/fallback boundary

```text
selected provider
  -> actual provider-unavailable evidence
  -> explicit configured fallback evaluation
  -> one equivalent fallback selected OR explicit unavailable
  -> ambiguity remains unavailable
  -> no weaker posture/maturity/source-rights downgrade
  -> raw failure + routing evidence preserved
  -> authority_effect = none
```

No provider failure or fallback result can create mutation, recall-admission, structural, or action authority.

## Why this matters to #282

Restart recovery now has a common provider-failure/fallback contract to consume instead of inventing separate runtime ambiguity rules. A missing provider after restart can remain explicitly unavailable, while any configured fallback must independently satisfy the same versioned qualification/currentness/source-rights boundary.

Refs #300.
Refs #280.
Refs #282.
Refs ADR-033.