### PR TITLE
Measure write-to-readable visibility and runtime quiescence

### DIFF
--- a/.github/workflows/write-readable-visibility.yml
+++ b/.github/workflows/write-readable-visibility.yml
@@ -1,0 +1,86 @@
+name: Write-to-Readable Visibility
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  characterize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Execute targeted visibility tests
+        run: python -m unittest reference.tests.test_write_readable_visibility
+
+      - name: Execute full reference regression suite
+        run: python -m unittest discover -s reference/tests -t reference
+
+      - name: Emit exact-head visibility characterization
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_write_readable_visibility.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --repeats 5
+          --output write-readable-visibility.json
+
+      - name: Validate operation evidence schema
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from jsonschema import Draft202012Validator
+
+          schema = json.loads(Path("schemas/write-readable-visibility.schema.json").read_text())
+          report = json.loads(Path("write-readable-visibility.json").read_text())
+          validator = Draft202012Validator(schema)
+          scenarios = report["scenarios"]
+          evidence = {
+              "sync_canonical_only": scenarios["sync_canonical_only"],
+              "deferred_projection": scenarios["deferred_projection"]["evidence"],
+              "required_refresh_failure": scenarios["required_refresh_failure"],
+              "restart_during_lag": scenarios["restart_during_lag"],
+              "deletion_residue": scenarios["deletion_residue"]["evidence"],
+          }
+          for name, record in evidence.items():
+              errors = sorted(validator.iter_errors(record), key=lambda error: list(error.path))
+              if errors:
+                  raise SystemExit(f"{name}: " + "; ".join(error.message for error in errors))
+          print(f"validated {len(evidence)} write-to-readable evidence records")
+          PY
+
+      - name: Upload visibility evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: write-readable-visibility
+          path: write-readable-visibility.json
+          if-no-files-found: error
+
+      - name: Publish visibility summary
+        if: always()
+        run: |
+          {
+            echo "## Write-to-readable visibility"
+            echo ""
+            echo "Structural gates distinguish canonical durability, required projection currentness, governed read visibility, settlement, and quiescence."
+            echo ""
+            echo "Latency is observational, environment-specific, non-authoritative, and non-gating."
+            echo ""
+            echo '```'
+            echo "python -m unittest reference.tests.test_write_readable_visibility"
+            echo "python reference/run_write_readable_visibility.py --agent-memory-commit <exact-40-hex-commit> --repeats 5 --output write-readable-visibility.json"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/programs/runtime-evidence/write-readable-visibility.md
+++ b/docs/programs/runtime-evidence/write-readable-visibility.md
@@ -1,0 +1,183 @@
+# Write-to-readable visibility and runtime quiescence
+
+Issue: #308
+Related: #46 / P9, #282, #280
+
+## Purpose
+
+A successful Agent Memory mutation is not proof that every required read path is current.
+
+This evidence slice makes the following boundaries explicit:
+
+```text
+request received
+  -> policy decision complete
+  -> canonical outcome durable or refused
+  -> required derived refresh reaches a terminal state
+  -> governed recall can observe the required current outcome
+  -> active context can safely use that outcome
+  -> runtime settles
+  -> runtime is quiescent only when every correctness-required obligation is satisfied
+```
+
+The model is provider-neutral. It does not require a queue, index, database, vector store, graph store, or synchronous projection strategy.
+
+## Why this is separate from P9
+
+P9 already characterizes structural work and observational timing for governed writes, recall candidate/admission growth, and deletion derivation closure.
+
+This slice does not replace those measurements. It answers a different question:
+
+> after Agent Memory accepts or refuses a bounded mutation, when can the caller safely conclude that all read-path obligations required by the active profile are current?
+
+Latency remains observational and environment-specific. It does not create authority, change maturity, or become a conformance threshold merely because CI measured it.
+
+## Evidence boundary
+
+The machine-readable contract is `schemas/write-readable-visibility.schema.json`.
+
+The reference implementation lives in `reference/agentmem_ref/visibility.py` and emits exact-head evidence through `reference/run_write_readable_visibility.py`.
+
+Every operation binds evidence to:
+
+- logical memory identity and version;
+- operation type;
+- Agent Memory commit;
+- runtime and profile versions;
+- component and capability versions;
+- required and optional projection identities;
+- receipt and correlation references where available;
+- requested visibility target;
+- runtime/environment identity.
+
+## Phases
+
+The reference contract records equivalent observations for:
+
+```text
+request_received
+policy_decision_complete
+canonical_commit_complete
+required_projection_refresh_started
+required_projection_refresh_complete
+governed_recall_current_visible
+context_current_visible
+settlement_reached
+quiescence_reached
+```
+
+A phase that does not apply is recorded as `not_applicable`; it is not assigned a fabricated zero duration.
+
+Phase order fails closed in the reference tracker. A projection cannot become complete before canonical commit, context cannot become current before governed recall currentness, and downstream visibility cannot be asserted before the canonical outcome exists.
+
+## Obligations
+
+Phases say what was observed. Obligations say what must be true.
+
+Each obligation is explicitly:
+
+```text
+required: true | false
+status: pending | satisfied | failed | quarantined | not_applicable
+```
+
+Typical required obligations include:
+
+- canonical outcome;
+- active-profile required projection currentness;
+- governed recall currentness;
+- context currentness;
+- proof that a stale physical version is not admissible as current.
+
+Optional projections may remain as disclosed residual work without blocking quiescence unless the active profile declares them correctness-required.
+
+## Settled is not quiescent
+
+A failed required background operation can reach a known terminal state without making the runtime fully current.
+
+```text
+pending required work
+  -> settled = false
+  -> quiescent = false
+  -> posture = pending
+
+explicit required failure or quarantine
+  -> settled = true
+  -> quiescent = false
+  -> posture = degraded
+
+all correctness-required obligations satisfied
+  -> settled = true
+  -> quiescent = true
+  -> posture = quiescent
+```
+
+This distinction prevents a queue-empty or worker-returned signal from being mistaken for correctness.
+
+An explicitly refused mutation can be settled and quiescent for that refused operation because no mutation/read-currentness obligations were created. The refusal does not become a successful write.
+
+## Stale physical state
+
+Physical presence and current admissibility are separate.
+
+The reference deferred-projection scenario preserves a superseded canonical fact physically while governed recall rejects it as `superseded_not_current`. A required projection remains stale during that lag window, so the operation remains non-quiescent even though the new canonical value is already recallable.
+
+This is deliberate:
+
+```text
+physically present != current
+current canonical != all required projections current
+recallable current value != profile quiescence
+```
+
+## Restart
+
+`VisibilityTracker.snapshot_for_restart()` serializes the declared operation, observed phases, and pending/terminal obligations. `restore_after_restart()` creates a new timing segment and retains the correctness state.
+
+Process-local monotonic clocks are not stitched together across restart. Any metric whose endpoints fall in different timing segments reports:
+
+```text
+reason = cross_restart_monotonic_segments
+value_ns = null
+```
+
+This loses a timing number rather than inventing one. #282 remains responsible for the durable runtime mechanism that stores and reconstructs these obligations in a real restart-safe runtime.
+
+## Deletion
+
+Deletion is not quiescent merely because the canonical delete returns success.
+
+If the active profile declares derived residue, rebuild, index, or absence-visibility obligations as required, those obligations must be satisfied before quiescence. A deletion can therefore be canonically durable and still remain pending.
+
+## Comparator pressure
+
+Two independently checked primary-source architectures informed this contract:
+
+1. Claude-Mem demonstrates canonical persistence preceding a later derived/vector synchronization step that can lag or fail.
+2. Nanobot at `HKUDS/nanobot@b99e0f937e828504e0f93dbe35dfd6b1540e20b2` persists producer and consumer progress separately and advances its Dream consumption cursor only after clean completion without tool errors.
+
+Agent Memory does not import either implementation's completion marker as authority. They are failure-shape comparators that pressure the provider-neutral obligation model.
+
+## Required reference scenarios
+
+The characterization runner exercises:
+
+1. synchronous canonical-only write;
+2. deferred required projection refresh;
+3. required refresh failure;
+4. restart during a pending refresh obligation;
+5. deletion with required residue work.
+
+The structural gates are semantic. Timing summaries are p50/p95/p99 observations for the local runner where the relevant endpoints share a monotonic timing segment.
+
+## Non-goals
+
+This slice does not:
+
+- create a universal latency SLO;
+- require all projections to become synchronous;
+- choose a queue/index/database implementation;
+- make provider-native completion equal Agent Memory quiescence;
+- make speed an authority or maturity signal;
+- replace P9 structural cost characterization;
+- complete #282's persistent runtime by itself.

--- a/reference/agentmem_ref/visibility.py
+++ b/reference/agentmem_ref/visibility.py
@@ -69,8 +69,11 @@ class VisibilityOperation:
     def __post_init__(self) -> None:
         if self.memory_version < 0:
             raise ValueError("memory_version must be non-negative")
-        if len(self.agent_memory_commit) != 40:
-            raise ValueError("agent_memory_commit must be an exact 40-character commit SHA")
+        if (
+            len(self.agent_memory_commit) != 40
+            or any(character not in "0123456789abcdef" for character in self.agent_memory_commit)
+        ):
+            raise ValueError("agent_memory_commit must be an exact 40-character lowercase hex commit SHA")
         if self.visibility_target not in {CURRENT_VALUE, ABSENCE, NO_READ_VISIBILITY}:
             raise ValueError("unsupported visibility_target")
         if len(set(self.required_projection_ids)) != len(self.required_projection_ids):
@@ -286,12 +289,15 @@ class VisibilityTracker:
             raise ValueError("operation declares no stale-current admission obligation")
         self.set_obligation("stale_current_blocked", SATISFIED)
 
-    def _all_required_projection_obligations_terminal(self) -> bool:
-        required = [
+    def _required_projection_obligations(self) -> list[Obligation]:
+        return [
             obligation
             for obligation in self._obligations.values()
             if obligation.required and obligation.kind == "projection_currentness"
         ]
+
+    def _all_required_projection_obligations_terminal(self) -> bool:
+        required = self._required_projection_obligations()
         return bool(required) and all(obligation.status in TERMINAL_STATUSES for obligation in required)
 
     def evaluate(self) -> dict:
@@ -348,9 +354,11 @@ class VisibilityTracker:
         return {"value_ns": max(0, second.offset_ns - first.offset_ns), "reason": "observed"}
 
     def metrics(self) -> dict:
-        projection_end = self._phases.get("required_projection_refresh_complete")
-        if projection_end is None and not self.operation.required_projection_ids:
+        required_projections = self._required_projection_obligations()
+        if not required_projections:
             projection_metric = {"value_ns": None, "reason": "not_applicable"}
+        elif any(obligation.status in {FAILED, QUARANTINED} for obligation in required_projections):
+            projection_metric = {"value_ns": None, "reason": "required_obligation_failed"}
         else:
             projection_metric = self._duration("canonical_commit_complete", "required_projection_refresh_complete")
         return {

--- a/reference/agentmem_ref/visibility.py
+++ b/reference/agentmem_ref/visibility.py
@@ -17,7 +17,7 @@ The contract separates:
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 import time
 from typing import Callable
 
@@ -164,6 +164,13 @@ class VisibilityTracker:
     def _offset_ns(self) -> int:
         return self._clock_ns() - self._origin_ns
 
+    def _require_phase(self, phase: str, *, allow_not_applicable: bool = False) -> None:
+        observation = self._phases.get(phase)
+        if observation is None:
+            raise ValueError(f"required prior phase not observed: {phase}")
+        if observation.status == NOT_APPLICABLE and not allow_not_applicable:
+            raise ValueError(f"required prior phase is not applicable: {phase}")
+
     def observe_phase(self, phase: str, *, detail: str = "") -> PhaseObservation:
         if phase not in PHASES:
             raise ValueError(f"unsupported phase: {phase}")
@@ -207,16 +214,19 @@ class VisibilityTracker:
         return obligation
 
     def policy_decided(self) -> None:
+        self._require_phase("request_received")
         self.observe_phase("policy_decision_complete")
 
     def canonical_committed(self) -> None:
+        self._require_phase("policy_decision_complete")
         self.observe_phase("canonical_commit_complete")
         self.set_obligation("canonical_outcome", SATISFIED, detail="canonical mutation durable")
 
     def canonical_refused(self, *, detail: str = "mutation explicitly refused") -> None:
+        self._require_phase("policy_decision_complete")
         self.set_obligation("canonical_outcome", SATISFIED, detail=detail)
         self.phase_not_applicable("canonical_commit_complete", detail=detail)
-        for obligation_id, obligation in self._obligations.items():
+        for obligation_id in tuple(self._obligations):
             if obligation_id == "canonical_outcome":
                 continue
             self.set_obligation(obligation_id, NOT_APPLICABLE, detail="no mutation obligations created")
@@ -229,42 +239,49 @@ class VisibilityTracker:
             self.phase_not_applicable(phase, detail="no mutation obligations created")
 
     def projection_refresh_started(self, projection_id: str) -> None:
+        self._require_phase("canonical_commit_complete")
         obligation_id = f"projection:{projection_id}"
         if obligation_id not in self._obligations:
             raise KeyError(f"undeclared projection: {projection_id}")
         self.observe_phase("required_projection_refresh_started")
 
     def projection_refresh_satisfied(self, projection_id: str) -> None:
+        self._require_phase("required_projection_refresh_started")
         obligation_id = f"projection:{projection_id}"
         self.set_obligation(obligation_id, SATISFIED, detail="projection current")
         if self._all_required_projection_obligations_terminal():
             self.observe_phase("required_projection_refresh_complete")
 
     def projection_refresh_failed(self, projection_id: str, *, detail: str) -> None:
+        self._require_phase("required_projection_refresh_started")
         obligation_id = f"projection:{projection_id}"
         self.set_obligation(obligation_id, FAILED, detail=detail)
         if self._all_required_projection_obligations_terminal():
             self.observe_phase("required_projection_refresh_complete", detail="required refresh reached terminal state")
 
     def projection_refresh_quarantined(self, projection_id: str, *, detail: str) -> None:
+        self._require_phase("required_projection_refresh_started")
         obligation_id = f"projection:{projection_id}"
         self.set_obligation(obligation_id, QUARANTINED, detail=detail)
         if self._all_required_projection_obligations_terminal():
             self.observe_phase("required_projection_refresh_complete", detail="required refresh reached terminal state")
 
     def governed_recall_current_visible(self) -> None:
+        self._require_phase("canonical_commit_complete")
         if "governed_recall_current" not in self._obligations:
             raise ValueError("operation declares no governed recall visibility obligation")
         self.observe_phase("governed_recall_current_visible")
         self.set_obligation("governed_recall_current", SATISFIED)
 
     def context_current_visible(self) -> None:
+        self._require_phase("governed_recall_current_visible")
         if "context_current" not in self._obligations:
             raise ValueError("operation declares no context visibility obligation")
         self.observe_phase("context_current_visible")
         self.set_obligation("context_current", SATISFIED)
 
     def stale_current_blocked(self) -> None:
+        self._require_phase("canonical_commit_complete")
         if "stale_current_blocked" not in self._obligations:
             raise ValueError("operation declares no stale-current admission obligation")
         self.set_obligation("stale_current_blocked", SATISFIED)
@@ -293,7 +310,7 @@ class VisibilityTracker:
         optional_residual = [
             obligation.obligation_id
             for obligation in self._obligations.values()
-            if not obligation.required and obligation.status != SATISFIED
+            if not obligation.required and obligation.status in {PENDING, FAILED, QUARANTINED}
         ]
 
         settled = all(obligation.status in TERMINAL_STATUSES for obligation in required)

--- a/reference/agentmem_ref/visibility.py
+++ b/reference/agentmem_ref/visibility.py
@@ -1,0 +1,411 @@
+"""Provider-neutral write-to-readable visibility and quiescence evidence.
+
+A successful mutation response is not proof that every required read path is
+current. This module records those boundaries without turning latency into
+authority or assuming that all derived state is synchronous.
+
+The contract separates:
+
+* phase observations from correctness obligations;
+* canonical durability from projection/read visibility;
+* a known terminal state (settled) from fully satisfied currentness
+  (quiescent);
+* required work from optional residual work;
+* monotonic timing segments across process restart so cross-process latency is
+  never fabricated from unrelated monotonic clocks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import time
+from typing import Callable
+
+
+PENDING = "pending"
+SATISFIED = "satisfied"
+FAILED = "failed"
+QUARANTINED = "quarantined"
+NOT_APPLICABLE = "not_applicable"
+
+TERMINAL_STATUSES = frozenset({SATISFIED, FAILED, QUARANTINED, NOT_APPLICABLE})
+QUIESCENT_STATUSES = frozenset({SATISFIED, NOT_APPLICABLE})
+
+CURRENT_VALUE = "current_value"
+ABSENCE = "absence"
+NO_READ_VISIBILITY = "none"
+
+PHASES = (
+    "request_received",
+    "policy_decision_complete",
+    "canonical_commit_complete",
+    "required_projection_refresh_started",
+    "required_projection_refresh_complete",
+    "governed_recall_current_visible",
+    "context_current_visible",
+    "settlement_reached",
+    "quiescence_reached",
+)
+
+
+@dataclass(frozen=True)
+class VisibilityOperation:
+    operation_id: str
+    memory_id: str
+    memory_version: int
+    operation_type: str
+    runtime_version: str
+    profile_version: str
+    agent_memory_commit: str
+    required_projection_ids: tuple[str, ...] = ()
+    optional_projection_ids: tuple[str, ...] = ()
+    component_versions: tuple[str, ...] = ()
+    capability_versions: tuple[str, ...] = ()
+    receipt_ref: str = ""
+    correlation_ref: str = ""
+    visibility_target: str = CURRENT_VALUE
+    environment_ref: str = "reference-runtime"
+
+    def __post_init__(self) -> None:
+        if self.memory_version < 0:
+            raise ValueError("memory_version must be non-negative")
+        if len(self.agent_memory_commit) != 40:
+            raise ValueError("agent_memory_commit must be an exact 40-character commit SHA")
+        if self.visibility_target not in {CURRENT_VALUE, ABSENCE, NO_READ_VISIBILITY}:
+            raise ValueError("unsupported visibility_target")
+        if len(set(self.required_projection_ids)) != len(self.required_projection_ids):
+            raise ValueError("required_projection_ids must be unique")
+        if len(set(self.optional_projection_ids)) != len(self.optional_projection_ids):
+            raise ValueError("optional_projection_ids must be unique")
+        overlap = set(self.required_projection_ids).intersection(self.optional_projection_ids)
+        if overlap:
+            raise ValueError(f"projection cannot be both required and optional: {sorted(overlap)}")
+
+
+@dataclass
+class Obligation:
+    obligation_id: str
+    kind: str
+    required: bool
+    status: str = PENDING
+    detail: str = ""
+
+
+@dataclass
+class PhaseObservation:
+    phase: str
+    status: str
+    segment: int
+    offset_ns: int | None
+    detail: str = ""
+
+
+class VisibilityTracker:
+    """Track one bounded mutation from request through safe read visibility."""
+
+    def __init__(
+        self,
+        operation: VisibilityOperation,
+        *,
+        clock_ns: Callable[[], int] | None = None,
+        _segment: int = 0,
+        _restored_phases: dict[str, PhaseObservation] | None = None,
+        _restored_obligations: dict[str, Obligation] | None = None,
+    ) -> None:
+        self.operation = operation
+        self._clock_ns = clock_ns or time.perf_counter_ns
+        self._origin_ns = self._clock_ns()
+        self._segment = _segment
+        self._phases: dict[str, PhaseObservation] = dict(_restored_phases or {})
+        self._obligations: dict[str, Obligation] = dict(_restored_obligations or {})
+
+        if not self._obligations:
+            self._declare_default_obligations()
+        if "request_received" not in self._phases:
+            self.observe_phase("request_received")
+
+    def _declare_default_obligations(self) -> None:
+        self._obligations["canonical_outcome"] = Obligation(
+            obligation_id="canonical_outcome",
+            kind="canonical_outcome",
+            required=True,
+        )
+        for projection_id in self.operation.required_projection_ids:
+            obligation_id = f"projection:{projection_id}"
+            self._obligations[obligation_id] = Obligation(
+                obligation_id=obligation_id,
+                kind="projection_currentness",
+                required=True,
+            )
+        for projection_id in self.operation.optional_projection_ids:
+            obligation_id = f"projection:{projection_id}"
+            self._obligations[obligation_id] = Obligation(
+                obligation_id=obligation_id,
+                kind="projection_currentness",
+                required=False,
+            )
+        if self.operation.visibility_target != NO_READ_VISIBILITY:
+            self._obligations["governed_recall_current"] = Obligation(
+                obligation_id="governed_recall_current",
+                kind="governed_recall_currentness",
+                required=True,
+            )
+            self._obligations["context_current"] = Obligation(
+                obligation_id="context_current",
+                kind="context_currentness",
+                required=True,
+            )
+            self._obligations["stale_current_blocked"] = Obligation(
+                obligation_id="stale_current_blocked",
+                kind="stale_current_admission",
+                required=True,
+            )
+
+    def _offset_ns(self) -> int:
+        return self._clock_ns() - self._origin_ns
+
+    def observe_phase(self, phase: str, *, detail: str = "") -> PhaseObservation:
+        if phase not in PHASES:
+            raise ValueError(f"unsupported phase: {phase}")
+        existing = self._phases.get(phase)
+        if existing is not None:
+            return existing
+        observation = PhaseObservation(
+            phase=phase,
+            status="observed",
+            segment=self._segment,
+            offset_ns=self._offset_ns(),
+            detail=detail,
+        )
+        self._phases[phase] = observation
+        return observation
+
+    def phase_not_applicable(self, phase: str, *, detail: str) -> PhaseObservation:
+        if phase not in PHASES:
+            raise ValueError(f"unsupported phase: {phase}")
+        existing = self._phases.get(phase)
+        if existing is not None:
+            return existing
+        observation = PhaseObservation(
+            phase=phase,
+            status=NOT_APPLICABLE,
+            segment=self._segment,
+            offset_ns=None,
+            detail=detail,
+        )
+        self._phases[phase] = observation
+        return observation
+
+    def set_obligation(self, obligation_id: str, status: str, *, detail: str = "") -> Obligation:
+        if status not in {PENDING, SATISFIED, FAILED, QUARANTINED, NOT_APPLICABLE}:
+            raise ValueError(f"unsupported obligation status: {status}")
+        obligation = self._obligations.get(obligation_id)
+        if obligation is None:
+            raise KeyError(f"undeclared obligation: {obligation_id}")
+        obligation.status = status
+        obligation.detail = detail
+        return obligation
+
+    def policy_decided(self) -> None:
+        self.observe_phase("policy_decision_complete")
+
+    def canonical_committed(self) -> None:
+        self.observe_phase("canonical_commit_complete")
+        self.set_obligation("canonical_outcome", SATISFIED, detail="canonical mutation durable")
+
+    def canonical_refused(self, *, detail: str = "mutation explicitly refused") -> None:
+        self.set_obligation("canonical_outcome", SATISFIED, detail=detail)
+        self.phase_not_applicable("canonical_commit_complete", detail=detail)
+        for obligation_id, obligation in self._obligations.items():
+            if obligation_id == "canonical_outcome":
+                continue
+            self.set_obligation(obligation_id, NOT_APPLICABLE, detail="no mutation obligations created")
+        for phase in (
+            "required_projection_refresh_started",
+            "required_projection_refresh_complete",
+            "governed_recall_current_visible",
+            "context_current_visible",
+        ):
+            self.phase_not_applicable(phase, detail="no mutation obligations created")
+
+    def projection_refresh_started(self, projection_id: str) -> None:
+        obligation_id = f"projection:{projection_id}"
+        if obligation_id not in self._obligations:
+            raise KeyError(f"undeclared projection: {projection_id}")
+        self.observe_phase("required_projection_refresh_started")
+
+    def projection_refresh_satisfied(self, projection_id: str) -> None:
+        obligation_id = f"projection:{projection_id}"
+        self.set_obligation(obligation_id, SATISFIED, detail="projection current")
+        if self._all_required_projection_obligations_terminal():
+            self.observe_phase("required_projection_refresh_complete")
+
+    def projection_refresh_failed(self, projection_id: str, *, detail: str) -> None:
+        obligation_id = f"projection:{projection_id}"
+        self.set_obligation(obligation_id, FAILED, detail=detail)
+        if self._all_required_projection_obligations_terminal():
+            self.observe_phase("required_projection_refresh_complete", detail="required refresh reached terminal state")
+
+    def projection_refresh_quarantined(self, projection_id: str, *, detail: str) -> None:
+        obligation_id = f"projection:{projection_id}"
+        self.set_obligation(obligation_id, QUARANTINED, detail=detail)
+        if self._all_required_projection_obligations_terminal():
+            self.observe_phase("required_projection_refresh_complete", detail="required refresh reached terminal state")
+
+    def governed_recall_current_visible(self) -> None:
+        if "governed_recall_current" not in self._obligations:
+            raise ValueError("operation declares no governed recall visibility obligation")
+        self.observe_phase("governed_recall_current_visible")
+        self.set_obligation("governed_recall_current", SATISFIED)
+
+    def context_current_visible(self) -> None:
+        if "context_current" not in self._obligations:
+            raise ValueError("operation declares no context visibility obligation")
+        self.observe_phase("context_current_visible")
+        self.set_obligation("context_current", SATISFIED)
+
+    def stale_current_blocked(self) -> None:
+        if "stale_current_blocked" not in self._obligations:
+            raise ValueError("operation declares no stale-current admission obligation")
+        self.set_obligation("stale_current_blocked", SATISFIED)
+
+    def _all_required_projection_obligations_terminal(self) -> bool:
+        required = [
+            obligation
+            for obligation in self._obligations.values()
+            if obligation.required and obligation.kind == "projection_currentness"
+        ]
+        return bool(required) and all(obligation.status in TERMINAL_STATUSES for obligation in required)
+
+    def evaluate(self) -> dict:
+        required = [obligation for obligation in self._obligations.values() if obligation.required]
+        pending = [obligation.obligation_id for obligation in required if obligation.status == PENDING]
+        failed = [
+            obligation.obligation_id
+            for obligation in required
+            if obligation.status in {FAILED, QUARANTINED}
+        ]
+        unsatisfied = [
+            obligation.obligation_id
+            for obligation in required
+            if obligation.status not in QUIESCENT_STATUSES
+        ]
+        optional_residual = [
+            obligation.obligation_id
+            for obligation in self._obligations.values()
+            if not obligation.required and obligation.status != SATISFIED
+        ]
+
+        settled = all(obligation.status in TERMINAL_STATUSES for obligation in required)
+        quiescent = settled and not unsatisfied
+        if quiescent:
+            posture = "quiescent"
+            self.observe_phase("settlement_reached")
+            self.observe_phase("quiescence_reached")
+        elif settled:
+            posture = "degraded"
+            self.observe_phase("settlement_reached")
+        else:
+            posture = "pending"
+
+        return {
+            "settled": settled,
+            "quiescent": quiescent,
+            "posture": posture,
+            "pending_required_obligations": pending,
+            "failed_required_obligations": failed,
+            "unsatisfied_required_obligations": unsatisfied,
+            "optional_residual_work": optional_residual,
+        }
+
+    def _duration(self, start: str, end: str) -> dict:
+        first = self._phases.get(start)
+        second = self._phases.get(end)
+        if first is None or second is None:
+            return {"value_ns": None, "reason": "phase_missing"}
+        if first.status == NOT_APPLICABLE or second.status == NOT_APPLICABLE:
+            return {"value_ns": None, "reason": "not_applicable"}
+        if first.segment != second.segment:
+            return {"value_ns": None, "reason": "cross_restart_monotonic_segments"}
+        assert first.offset_ns is not None and second.offset_ns is not None
+        return {"value_ns": max(0, second.offset_ns - first.offset_ns), "reason": "observed"}
+
+    def metrics(self) -> dict:
+        projection_end = self._phases.get("required_projection_refresh_complete")
+        if projection_end is None and not self.operation.required_projection_ids:
+            projection_metric = {"value_ns": None, "reason": "not_applicable"}
+        else:
+            projection_metric = self._duration("canonical_commit_complete", "required_projection_refresh_complete")
+        return {
+            "request_to_canonical_durable": self._duration("request_received", "canonical_commit_complete"),
+            "canonical_to_required_projections_current": projection_metric,
+            "canonical_to_governed_recall_current_visible": self._duration(
+                "canonical_commit_complete", "governed_recall_current_visible"
+            ),
+            "canonical_to_context_current_visible": self._duration(
+                "canonical_commit_complete", "context_current_visible"
+            ),
+            "request_to_quiescence": self._duration("request_received", "quiescence_reached"),
+        }
+
+    def evidence(self) -> dict:
+        disposition = self.evaluate()
+        return {
+            "schema_version": "1.0.0",
+            "operation": asdict(self.operation),
+            "timing": {
+                "clock": "process_monotonic_ns",
+                "segment": self._segment,
+                "cross_restart_duration_policy": "unavailable_between_monotonic_segments",
+                "latency_is_observational_only": True,
+                "latency_is_not_authority": True,
+            },
+            "phases": [asdict(self._phases[phase]) for phase in PHASES if phase in self._phases],
+            "obligations": [
+                asdict(self._obligations[key]) for key in sorted(self._obligations)
+            ],
+            "disposition": disposition,
+            "metrics": self.metrics(),
+        }
+
+    def snapshot_for_restart(self) -> dict:
+        """Serialize obligation/currentness state without pretending clocks survive restart."""
+        return {
+            "schema_version": "1.0.0",
+            "operation": asdict(self.operation),
+            "segment": self._segment,
+            "phases": {key: asdict(value) for key, value in self._phases.items()},
+            "obligations": {key: asdict(value) for key, value in self._obligations.items()},
+        }
+
+    @classmethod
+    def restore_after_restart(
+        cls,
+        snapshot: dict,
+        *,
+        clock_ns: Callable[[], int] | None = None,
+    ) -> "VisibilityTracker":
+        operation_raw = dict(snapshot["operation"])
+        for field_name in (
+            "required_projection_ids",
+            "optional_projection_ids",
+            "component_versions",
+            "capability_versions",
+        ):
+            operation_raw[field_name] = tuple(operation_raw.get(field_name, ()))
+        operation = VisibilityOperation(**operation_raw)
+        phases = {
+            key: PhaseObservation(**value)
+            for key, value in snapshot.get("phases", {}).items()
+        }
+        obligations = {
+            key: Obligation(**value)
+            for key, value in snapshot.get("obligations", {}).items()
+        }
+        return cls(
+            operation,
+            clock_ns=clock_ns,
+            _segment=int(snapshot.get("segment", 0)) + 1,
+            _restored_phases=phases,
+            _restored_obligations=obligations,
+        )

--- a/reference/agentmem_ref/visibility_characterization.py
+++ b/reference/agentmem_ref/visibility_characterization.py
@@ -1,0 +1,330 @@
+"""Executable #308 write-to-readable visibility characterization.
+
+The scenarios exercise the provider-neutral contract against the reference
+adapter/projection surface where possible, and use deliberately controlled
+failure/restart seams where the reference runtime has no background worker.
+Timing is observational only. Structural posture is the portable evidence.
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+from typing import Callable
+
+from . import policy, projections
+from .adapter import Clock, GovernedMemoryAdapter
+from .projection_governance import ProjectionGovernor
+from .substrate import InMemoryTemporalGraph
+from .visibility import ABSENCE, VisibilityOperation, VisibilityTracker
+
+
+TENANT = "tenant:visibility-characterization"
+SOURCE = "memory:visibility-characterization"
+
+
+def _proposal(**overrides) -> policy.Proposal:
+    base = dict(
+        proposal_id="proposal:visibility-characterization",
+        actor_id="agent:visibility-characterization",
+        charter_version="charter:visibility-characterization",
+        target_reference=SOURCE,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("evidence:visibility-characterization",),
+        tenant_ref=TENANT,
+        purpose="write_to_readable_visibility_characterization",
+    )
+    base.update(overrides)
+    return policy.Proposal(**base)
+
+
+def _operation(
+    commit: str,
+    *,
+    memory_version: int,
+    operation_type: str,
+    required_projection_ids: tuple[str, ...] = (),
+    visibility_target: str = "current_value",
+) -> VisibilityOperation:
+    return VisibilityOperation(
+        operation_id=f"op:{operation_type}:{memory_version}",
+        memory_id=SOURCE,
+        memory_version=memory_version,
+        operation_type=operation_type,
+        runtime_version="reference-runtime:visibility:1",
+        profile_version="visibility-profile:1",
+        agent_memory_commit=commit,
+        required_projection_ids=required_projection_ids,
+        component_versions=("governed-adapter:reference", "projection-governor:reference"),
+        capability_versions=("governed-recall:reference", "projection-freshness:reference"),
+        receipt_ref="receipt:visibility-characterization",
+        correlation_ref="correlation:visibility-characterization",
+        visibility_target=visibility_target,
+        environment_ref="reference-characterization",
+    )
+
+
+def _finish_current_read(tracker: VisibilityTracker) -> None:
+    tracker.governed_recall_current_visible()
+    tracker.context_current_visible()
+    tracker.stale_current_blocked()
+
+
+def sync_canonical_only(commit: str) -> dict:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, TENANT, Clock())
+    tracker = VisibilityTracker(_operation(commit, memory_version=1, operation_type="promotion"))
+    tracker.policy_decided()
+    result = adapter.commit_proposal(_proposal(), "visibility current token")
+    if not result.committed:
+        raise RuntimeError("sync canonical-only characterization did not commit")
+    tracker.canonical_committed()
+    recall = adapter.governed_recall("visibility current token")
+    if recall.admitted != [result.fact_uuid]:
+        raise RuntimeError("sync canonical-only value did not become governed-recall visible")
+    _finish_current_read(tracker)
+    return tracker.evidence()
+
+
+def deferred_projection(commit: str) -> dict:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, TENANT, Clock())
+    first = adapter.commit_proposal(_proposal(), "deployment Thursday")
+    if not first.committed:
+        raise RuntimeError("deferred projection baseline did not commit")
+    governor = ProjectionGovernor(adapter)
+    governor.declare(
+        "idx:visibility",
+        (SOURCE,),
+        projections.DETERMINISTIC,
+        projections.REFERENCE_ONLY,
+        projections.REPRODUCIBLE,
+        TENANT,
+    )
+
+    tracker = VisibilityTracker(
+        _operation(
+            commit,
+            memory_version=2,
+            operation_type="correction",
+            required_projection_ids=("idx:visibility",),
+        )
+    )
+    tracker.policy_decided()
+    corrected = adapter.commit_proposal(
+        _proposal(
+            proposal_id="proposal:visibility-characterization:correction",
+            operation="correction",
+            current_strength="promoted",
+            proposed_strength="promoted",
+            approval_refs=("approval:owner",),
+            review_satisfied=True,
+        ),
+        "deployment Friday",
+    )
+    if not corrected.committed:
+        raise RuntimeError("deferred projection correction did not commit")
+    tracker.canonical_committed()
+    tracker.projection_refresh_started("idx:visibility")
+
+    if governor.freshness("idx:visibility") != projections.STALE:
+        raise RuntimeError("deferred projection was not stale during the lag window")
+    old = adapter.governed_recall("Thursday")
+    if first.fact_uuid in old.admitted or old.refusals.get(first.fact_uuid) != "superseded_not_current":
+        raise RuntimeError("superseded physical fact remained admissible as current")
+    current = adapter.governed_recall("Friday")
+    if current.admitted != [corrected.fact_uuid]:
+        raise RuntimeError("corrected fact was not governed-recall visible")
+    _finish_current_read(tracker)
+    before_refresh = tracker.evaluate()
+
+    rebuilt = governor.propose_rebuild("idx:visibility")
+    if not rebuilt.committed or governor.freshness("idx:visibility") != projections.CURRENT:
+        raise RuntimeError("deterministic required projection did not rebuild current")
+    tracker.projection_refresh_satisfied("idx:visibility")
+    after_refresh = tracker.evaluate()
+    return {
+        "before_required_refresh": before_refresh,
+        "after_required_refresh": after_refresh,
+        "evidence": tracker.evidence(),
+    }
+
+
+def required_refresh_failure(commit: str) -> dict:
+    tracker = VisibilityTracker(
+        _operation(
+            commit,
+            memory_version=1,
+            operation_type="promotion",
+            required_projection_ids=("idx:required",),
+        )
+    )
+    tracker.policy_decided()
+    tracker.canonical_committed()
+    tracker.projection_refresh_started("idx:required")
+    tracker.projection_refresh_failed("idx:required", detail="controlled provider failure")
+    _finish_current_read(tracker)
+    return tracker.evidence()
+
+
+def restart_during_lag(commit: str) -> dict:
+    tracker = VisibilityTracker(
+        _operation(
+            commit,
+            memory_version=1,
+            operation_type="promotion",
+            required_projection_ids=("idx:restart",),
+        )
+    )
+    tracker.policy_decided()
+    tracker.canonical_committed()
+    tracker.projection_refresh_started("idx:restart")
+    snapshot = tracker.snapshot_for_restart()
+    restored = VisibilityTracker.restore_after_restart(snapshot)
+    restored.projection_refresh_satisfied("idx:restart")
+    _finish_current_read(restored)
+    return restored.evidence()
+
+
+def deletion_residue(commit: str) -> dict:
+    tracker = VisibilityTracker(
+        _operation(
+            commit,
+            memory_version=2,
+            operation_type="permanent_deletion",
+            required_projection_ids=("projection:residue",),
+            visibility_target=ABSENCE,
+        )
+    )
+    tracker.policy_decided()
+    tracker.canonical_committed()
+    tracker.projection_refresh_started("projection:residue")
+    _finish_current_read(tracker)
+    before_residue = tracker.evaluate()
+    tracker.projection_refresh_satisfied("projection:residue")
+    after_residue = tracker.evaluate()
+    return {
+        "before_required_residue": before_residue,
+        "after_required_residue": after_residue,
+        "evidence": tracker.evidence(),
+    }
+
+
+def _nearest_rank(values: list[int], percentile: float) -> int | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = max(1, min(len(ordered), int((percentile * len(ordered) + 0.999999999))))
+    return ordered[rank - 1]
+
+
+def _timing_distribution(samples: list[dict], metric_name: str) -> dict:
+    values = [
+        metric["value_ns"]
+        for evidence in samples
+        if (metric := evidence["metrics"][metric_name])["reason"] == "observed"
+        and metric["value_ns"] is not None
+    ]
+    return {
+        "observed_samples": len(values),
+        "p50_ns": _nearest_rank(values, 0.50),
+        "p95_ns": _nearest_rank(values, 0.95),
+        "p99_ns": _nearest_rank(values, 0.99),
+    }
+
+
+def build_visibility_report(agent_memory_commit: str, repeats: int = 5) -> dict:
+    if len(agent_memory_commit) != 40:
+        raise ValueError("agent_memory_commit must be an exact 40-character commit SHA")
+    if repeats < 1:
+        raise ValueError("repeats must be positive")
+
+    sync_samples = [sync_canonical_only(agent_memory_commit) for _ in range(repeats)]
+    deferred_samples = [deferred_projection(agent_memory_commit) for _ in range(repeats)]
+    failure = required_refresh_failure(agent_memory_commit)
+    restart = restart_during_lag(agent_memory_commit)
+    deletion = deletion_residue(agent_memory_commit)
+
+    deferred_evidence = [sample["evidence"] for sample in deferred_samples]
+    structural_invariants = {
+        "sync_canonical_only_quiescent": all(
+            sample["disposition"]["quiescent"] for sample in sync_samples
+        ),
+        "deferred_projection_blocks_before_refresh": all(
+            not sample["before_required_refresh"]["quiescent"] for sample in deferred_samples
+        ),
+        "deferred_projection_quiescent_after_refresh": all(
+            sample["after_required_refresh"]["quiescent"] for sample in deferred_samples
+        ),
+        "required_failure_settled_not_quiescent": (
+            failure["disposition"]["settled"]
+            and not failure["disposition"]["quiescent"]
+            and failure["disposition"]["posture"] == "degraded"
+        ),
+        "restart_preserves_obligation_without_cross_clock_latency": (
+            restart["disposition"]["quiescent"]
+            and restart["metrics"]["request_to_quiescence"]["reason"]
+            == "cross_restart_monotonic_segments"
+        ),
+        "deletion_waits_for_required_residue": (
+            not deletion["before_required_residue"]["quiescent"]
+            and deletion["after_required_residue"]["quiescent"]
+        ),
+    }
+
+    return {
+        "profile": "agent-memory-write-readable-visibility",
+        "version": "1.0.0",
+        "agent_memory_commit": agent_memory_commit,
+        "runner": {
+            "python": sys.version.split()[0],
+            "implementation": platform.python_implementation(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+        },
+        "method": {
+            "repeats": repeats,
+            "latency_is_observational_only": True,
+            "latency_is_not_a_conformance_gate": True,
+            "latency_is_not_authority": True,
+            "restart_timing_is_segmented": True,
+        },
+        "scenarios": {
+            "sync_canonical_only": sync_samples[0],
+            "deferred_projection": deferred_samples[0],
+            "required_refresh_failure": failure,
+            "restart_during_lag": restart,
+            "deletion_residue": deletion,
+        },
+        "timing_distributions": {
+            "sync_request_to_canonical_durable": _timing_distribution(
+                sync_samples, "request_to_canonical_durable"
+            ),
+            "sync_request_to_quiescence": _timing_distribution(
+                sync_samples, "request_to_quiescence"
+            ),
+            "deferred_canonical_to_required_projections_current": _timing_distribution(
+                deferred_evidence, "canonical_to_required_projections_current"
+            ),
+            "deferred_request_to_quiescence": _timing_distribution(
+                deferred_evidence, "request_to_quiescence"
+            ),
+        },
+        "structural_invariants": structural_invariants,
+        "structural_invariants_passed": all(structural_invariants.values()),
+        "claim_boundary": [
+            "reference-runtime evidence, not universal provider performance",
+            "observed latency is environment-specific and non-authoritative",
+            "settled means all required obligations reached explicit terminal state",
+            "quiescent additionally requires every correctness-required obligation satisfied",
+            "cross-restart monotonic duration is unavailable rather than fabricated",
+            "provider-native completion markers do not establish Agent Memory quiescence by themselves",
+        ],
+    }

--- a/reference/run_write_readable_visibility.py
+++ b/reference/run_write_readable_visibility.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Emit #308 write-to-readable visibility and quiescence evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.visibility_characterization import build_visibility_report  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = build_visibility_report(args.agent_memory_commit, repeats=args.repeats)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report["structural_invariants_passed"]:
+        failed = [name for name, passed in report["structural_invariants"].items() if not passed]
+        print(f"write-to-readable structural invariant failed: {failed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_visibility_metric_semantics.py
+++ b/reference/tests/test_visibility_metric_semantics.py
@@ -1,0 +1,56 @@
+"""Focused truthfulness tests for #308 visibility metrics."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.visibility import VisibilityOperation, VisibilityTracker  # noqa: E402
+
+
+COMMIT = "a" * 40
+
+
+def operation() -> VisibilityOperation:
+    return VisibilityOperation(
+        operation_id="op:metric",
+        memory_id="memory:metric",
+        memory_version=1,
+        operation_type="promotion",
+        runtime_version="reference:1",
+        profile_version="profile:1",
+        agent_memory_commit=COMMIT,
+        required_projection_ids=("idx:required",),
+    )
+
+
+class VisibilityMetricSemanticsTests(unittest.TestCase):
+    def test_failed_projection_never_reports_currentness_latency(self):
+        tracker = VisibilityTracker(operation())
+        tracker.policy_decided()
+        tracker.canonical_committed()
+        tracker.projection_refresh_started("idx:required")
+        tracker.projection_refresh_failed("idx:required", detail="controlled failure")
+
+        metric = tracker.evidence()["metrics"]["canonical_to_required_projections_current"]
+        self.assertIsNone(metric["value_ns"])
+        self.assertEqual(metric["reason"], "required_obligation_failed")
+
+    def test_commit_identity_rejects_non_hex_lookalike(self):
+        with self.assertRaises(ValueError):
+            VisibilityOperation(
+                operation_id="op:bad-sha",
+                memory_id="memory:metric",
+                memory_version=1,
+                operation_type="promotion",
+                runtime_version="reference:1",
+                profile_version="profile:1",
+                agent_memory_commit="z" * 40,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_write_readable_visibility.py
+++ b/reference/tests/test_write_readable_visibility.py
@@ -1,0 +1,300 @@
+"""#308 write-to-readable visibility and runtime quiescence tests."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref import policy, projections  # noqa: E402
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter  # noqa: E402
+from agentmem_ref.projection_governance import ProjectionGovernor  # noqa: E402
+from agentmem_ref.substrate import InMemoryTemporalGraph  # noqa: E402
+from agentmem_ref.visibility import (  # noqa: E402
+    ABSENCE,
+    CURRENT_VALUE,
+    FAILED,
+    PENDING,
+    VisibilityOperation,
+    VisibilityTracker,
+)
+
+
+TENANT = "tenant:visibility"
+SOURCE = "memory:visibility"
+COMMIT = "a" * 40
+
+
+class StepClock:
+    def __init__(self, step: int = 100) -> None:
+        self.value = 0
+        self.step = step
+
+    def __call__(self) -> int:
+        current = self.value
+        self.value += self.step
+        return current
+
+
+def proposal(**overrides) -> policy.Proposal:
+    base = dict(
+        proposal_id="proposal:visibility",
+        actor_id="agent:visibility",
+        charter_version="charter:visibility",
+        target_reference=SOURCE,
+        target_class=policy.M2,
+        scope=TENANT,
+        operation="promotion",
+        current_strength="reinforced",
+        proposed_strength="promoted",
+        downstream_authority=policy.A1,
+        reversibility="reversible",
+        risk_class="low",
+        evidence_refs=("evidence:visibility",),
+        tenant_ref=TENANT,
+        purpose="write_to_readable_visibility",
+    )
+    base.update(overrides)
+    return policy.Proposal(**base)
+
+
+def operation(
+    *,
+    memory_version: int = 1,
+    operation_type: str = "promotion",
+    required_projection_ids: tuple[str, ...] = (),
+    optional_projection_ids: tuple[str, ...] = (),
+    visibility_target: str = CURRENT_VALUE,
+) -> VisibilityOperation:
+    return VisibilityOperation(
+        operation_id=f"op:{operation_type}:{memory_version}",
+        memory_id=SOURCE,
+        memory_version=memory_version,
+        operation_type=operation_type,
+        runtime_version="reference:1",
+        profile_version="profile:visibility:1",
+        agent_memory_commit=COMMIT,
+        required_projection_ids=required_projection_ids,
+        optional_projection_ids=optional_projection_ids,
+        component_versions=("reference-adapter:1",),
+        capability_versions=("governed-recall:1", "projection-freshness:1"),
+        receipt_ref="receipt:visibility",
+        correlation_ref="correlation:visibility",
+        visibility_target=visibility_target,
+        environment_ref="unit-test",
+    )
+
+
+class VisibilityContractTests(unittest.TestCase):
+    def test_sync_canonical_only_write_reaches_quiescence_without_fake_projection_latency(self):
+        substrate = InMemoryTemporalGraph()
+        adapter = GovernedMemoryAdapter(substrate, TENANT, Clock())
+        result = adapter.commit_proposal(proposal(), "visibility token current")
+        self.assertTrue(result.committed)
+
+        tracker = VisibilityTracker(operation(), clock_ns=StepClock())
+        tracker.policy_decided()
+        tracker.canonical_committed()
+
+        recall = adapter.governed_recall("visibility token current")
+        self.assertEqual(recall.admitted, [result.fact_uuid])
+        tracker.governed_recall_current_visible()
+        tracker.context_current_visible()
+        tracker.stale_current_blocked()
+
+        evidence = tracker.evidence()
+        self.assertTrue(evidence["disposition"]["settled"])
+        self.assertTrue(evidence["disposition"]["quiescent"])
+        self.assertEqual(evidence["disposition"]["posture"], "quiescent")
+        self.assertEqual(
+            evidence["metrics"]["canonical_to_required_projections_current"]["reason"],
+            "not_applicable",
+        )
+        self.assertEqual(
+            evidence["metrics"]["request_to_quiescence"]["reason"],
+            "observed",
+        )
+
+    def test_deferred_projection_blocks_quiescence_while_old_physical_fact_is_not_admitted(self):
+        substrate = InMemoryTemporalGraph()
+        adapter = GovernedMemoryAdapter(substrate, TENANT, Clock())
+        first = adapter.commit_proposal(proposal(), "deploy window Thursday")
+        self.assertTrue(first.committed)
+
+        governor = ProjectionGovernor(adapter)
+        governor.declare(
+            "idx:visibility",
+            (SOURCE,),
+            projections.DETERMINISTIC,
+            projections.REFERENCE_ONLY,
+            projections.REPRODUCIBLE,
+            TENANT,
+        )
+        self.assertEqual(governor.freshness("idx:visibility"), projections.CURRENT)
+
+        corrected = adapter.commit_proposal(
+            proposal(
+                proposal_id="proposal:visibility:correction",
+                operation="correction",
+                current_strength="promoted",
+                proposed_strength="promoted",
+                approval_refs=("approval:owner",),
+                review_satisfied=True,
+            ),
+            "deploy window Friday",
+        )
+        self.assertTrue(corrected.committed)
+        self.assertEqual(adapter.state_version(SOURCE), 2)
+        self.assertEqual(governor.freshness("idx:visibility"), projections.STALE)
+
+        tracker = VisibilityTracker(
+            operation(memory_version=2, operation_type="correction", required_projection_ids=("idx:visibility",)),
+            clock_ns=StepClock(),
+        )
+        tracker.policy_decided()
+        tracker.canonical_committed()
+        tracker.projection_refresh_started("idx:visibility")
+
+        old_recall = adapter.governed_recall("Thursday")
+        self.assertIn(first.fact_uuid, old_recall.candidates)
+        self.assertNotIn(first.fact_uuid, old_recall.admitted)
+        self.assertEqual(old_recall.refusals[first.fact_uuid], "superseded_not_current")
+        tracker.stale_current_blocked()
+
+        current_recall = adapter.governed_recall("Friday")
+        self.assertEqual(current_recall.admitted, [corrected.fact_uuid])
+        tracker.governed_recall_current_visible()
+        tracker.context_current_visible()
+
+        before_rebuild = tracker.evaluate()
+        self.assertFalse(before_rebuild["settled"])
+        self.assertFalse(before_rebuild["quiescent"])
+        self.assertIn("projection:idx:visibility", before_rebuild["pending_required_obligations"])
+
+        rebuilt = governor.propose_rebuild("idx:visibility")
+        self.assertTrue(rebuilt.committed)
+        self.assertTrue(rebuilt.categorical)
+        self.assertEqual(governor.freshness("idx:visibility"), projections.CURRENT)
+        tracker.projection_refresh_satisfied("idx:visibility")
+
+        after_rebuild = tracker.evaluate()
+        self.assertTrue(after_rebuild["settled"])
+        self.assertTrue(after_rebuild["quiescent"])
+
+    def test_explicit_required_refresh_failure_is_settled_but_not_quiescent(self):
+        tracker = VisibilityTracker(
+            operation(required_projection_ids=("idx:required",)),
+            clock_ns=StepClock(),
+        )
+        tracker.policy_decided()
+        tracker.canonical_committed()
+        tracker.projection_refresh_started("idx:required")
+        tracker.projection_refresh_failed("idx:required", detail="provider unavailable")
+        tracker.governed_recall_current_visible()
+        tracker.context_current_visible()
+        tracker.stale_current_blocked()
+
+        evidence = tracker.evidence()
+        self.assertTrue(evidence["disposition"]["settled"])
+        self.assertFalse(evidence["disposition"]["quiescent"])
+        self.assertEqual(evidence["disposition"]["posture"], "degraded")
+        self.assertIn("projection:idx:required", evidence["disposition"]["failed_required_obligations"])
+        self.assertEqual(
+            next(
+                item for item in evidence["obligations"]
+                if item["obligation_id"] == "projection:idx:required"
+            )["status"],
+            FAILED,
+        )
+        self.assertNotIn("quiescence_reached", [phase["phase"] for phase in evidence["phases"]])
+
+    def test_pending_projection_obligation_survives_restart_without_fabricated_duration(self):
+        tracker = VisibilityTracker(
+            operation(required_projection_ids=("idx:restart",)),
+            clock_ns=StepClock(),
+        )
+        tracker.policy_decided()
+        tracker.canonical_committed()
+        tracker.projection_refresh_started("idx:restart")
+        snapshot = tracker.snapshot_for_restart()
+
+        restored = VisibilityTracker.restore_after_restart(snapshot, clock_ns=StepClock(step=250))
+        projection = next(
+            obligation for obligation in restored.evidence()["obligations"]
+            if obligation["obligation_id"] == "projection:idx:restart"
+        )
+        self.assertEqual(projection["status"], PENDING)
+        self.assertEqual(restored.evidence()["timing"]["segment"], 1)
+
+        restored.projection_refresh_satisfied("idx:restart")
+        restored.governed_recall_current_visible()
+        restored.context_current_visible()
+        restored.stale_current_blocked()
+        final = restored.evidence()
+
+        self.assertTrue(final["disposition"]["quiescent"])
+        self.assertEqual(
+            final["metrics"]["request_to_quiescence"]["reason"],
+            "cross_restart_monotonic_segments",
+        )
+
+    def test_deletion_cannot_quiesce_while_required_residue_work_is_pending(self):
+        tracker = VisibilityTracker(
+            operation(
+                memory_version=2,
+                operation_type="permanent_deletion",
+                required_projection_ids=("projection:residue",),
+                visibility_target=ABSENCE,
+            ),
+            clock_ns=StepClock(),
+        )
+        tracker.policy_decided()
+        tracker.canonical_committed()
+        tracker.projection_refresh_started("projection:residue")
+        tracker.governed_recall_current_visible()
+        tracker.context_current_visible()
+        tracker.stale_current_blocked()
+
+        pending = tracker.evaluate()
+        self.assertFalse(pending["quiescent"])
+        self.assertIn("projection:projection:residue", pending["pending_required_obligations"])
+
+        tracker.projection_refresh_satisfied("projection:residue")
+        complete = tracker.evaluate()
+        self.assertTrue(complete["quiescent"])
+
+    def test_explicit_refusal_is_terminal_without_inventing_mutation_phases(self):
+        tracker = VisibilityTracker(operation(), clock_ns=StepClock())
+        tracker.policy_decided()
+        tracker.canonical_refused(detail="policy denied mutation")
+
+        evidence = tracker.evidence()
+        self.assertTrue(evidence["disposition"]["settled"])
+        self.assertTrue(evidence["disposition"]["quiescent"])
+        canonical = next(
+            phase for phase in evidence["phases"] if phase["phase"] == "canonical_commit_complete"
+        )
+        self.assertEqual(canonical["status"], "not_applicable")
+        self.assertIsNone(canonical["offset_ns"])
+
+    def test_configuration_fails_closed_on_ambiguous_projection_declarations(self):
+        with self.assertRaises(ValueError):
+            operation(required_projection_ids=("idx:1", "idx:1"))
+        with self.assertRaises(ValueError):
+            operation(required_projection_ids=("idx:1",), optional_projection_ids=("idx:1",))
+        with self.assertRaises(ValueError):
+            VisibilityOperation(
+                operation_id="op:bad",
+                memory_id=SOURCE,
+                memory_version=1,
+                operation_type="promotion",
+                runtime_version="reference:1",
+                profile_version="profile:1",
+                agent_memory_commit="short",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/write-readable-visibility.schema.json
+++ b/schemas/write-readable-visibility.schema.json
@@ -129,7 +129,7 @@
       "required": ["value_ns", "reason"],
       "properties": {
         "value_ns": { "type": ["integer", "null"], "minimum": 0 },
-        "reason": { "enum": ["observed", "phase_missing", "not_applicable", "cross_restart_monotonic_segments"] }
+        "reason": { "enum": ["observed", "phase_missing", "not_applicable", "cross_restart_monotonic_segments", "required_obligation_failed"] }
       },
       "additionalProperties": false
     }

--- a/schemas/write-readable-visibility.schema.json
+++ b/schemas/write-readable-visibility.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-memory.dev/schemas/write-readable-visibility.schema.json",
+  "title": "Agent Memory Write-to-Readable Visibility Evidence",
+  "type": "object",
+  "required": ["schema_version", "operation", "timing", "phases", "obligations", "disposition", "metrics"],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "operation": {
+      "type": "object",
+      "required": [
+        "operation_id", "memory_id", "memory_version", "operation_type",
+        "runtime_version", "profile_version", "agent_memory_commit",
+        "required_projection_ids", "optional_projection_ids", "component_versions",
+        "capability_versions", "receipt_ref", "correlation_ref", "visibility_target",
+        "environment_ref"
+      ],
+      "properties": {
+        "operation_id": { "type": "string", "minLength": 1 },
+        "memory_id": { "type": "string", "minLength": 1 },
+        "memory_version": { "type": "integer", "minimum": 0 },
+        "operation_type": { "type": "string", "minLength": 1 },
+        "runtime_version": { "type": "string", "minLength": 1 },
+        "profile_version": { "type": "string", "minLength": 1 },
+        "agent_memory_commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "required_projection_ids": { "$ref": "#/$defs/stringArray" },
+        "optional_projection_ids": { "$ref": "#/$defs/stringArray" },
+        "component_versions": { "$ref": "#/$defs/stringArray" },
+        "capability_versions": { "$ref": "#/$defs/stringArray" },
+        "receipt_ref": { "type": "string" },
+        "correlation_ref": { "type": "string" },
+        "visibility_target": { "enum": ["current_value", "absence", "none"] },
+        "environment_ref": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "timing": {
+      "type": "object",
+      "required": ["clock", "segment", "cross_restart_duration_policy", "latency_is_observational_only", "latency_is_not_authority"],
+      "properties": {
+        "clock": { "const": "process_monotonic_ns" },
+        "segment": { "type": "integer", "minimum": 0 },
+        "cross_restart_duration_policy": { "const": "unavailable_between_monotonic_segments" },
+        "latency_is_observational_only": { "const": true },
+        "latency_is_not_authority": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "phases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["phase", "status", "segment", "offset_ns", "detail"],
+        "properties": {
+          "phase": {
+            "enum": [
+              "request_received", "policy_decision_complete", "canonical_commit_complete",
+              "required_projection_refresh_started", "required_projection_refresh_complete",
+              "governed_recall_current_visible", "context_current_visible",
+              "settlement_reached", "quiescence_reached"
+            ]
+          },
+          "status": { "enum": ["observed", "not_applicable"] },
+          "segment": { "type": "integer", "minimum": 0 },
+          "offset_ns": { "type": ["integer", "null"], "minimum": 0 },
+          "detail": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "obligations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["obligation_id", "kind", "required", "status", "detail"],
+        "properties": {
+          "obligation_id": { "type": "string", "minLength": 1 },
+          "kind": { "type": "string", "minLength": 1 },
+          "required": { "type": "boolean" },
+          "status": { "enum": ["pending", "satisfied", "failed", "quarantined", "not_applicable"] },
+          "detail": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "disposition": {
+      "type": "object",
+      "required": [
+        "settled", "quiescent", "posture", "pending_required_obligations",
+        "failed_required_obligations", "unsatisfied_required_obligations", "optional_residual_work"
+      ],
+      "properties": {
+        "settled": { "type": "boolean" },
+        "quiescent": { "type": "boolean" },
+        "posture": { "enum": ["pending", "degraded", "quiescent"] },
+        "pending_required_obligations": { "$ref": "#/$defs/stringArray" },
+        "failed_required_obligations": { "$ref": "#/$defs/stringArray" },
+        "unsatisfied_required_obligations": { "$ref": "#/$defs/stringArray" },
+        "optional_residual_work": { "$ref": "#/$defs/stringArray" }
+      },
+      "additionalProperties": false
+    },
+    "metrics": {
+      "type": "object",
+      "required": [
+        "request_to_canonical_durable", "canonical_to_required_projections_current",
+        "canonical_to_governed_recall_current_visible", "canonical_to_context_current_visible",
+        "request_to_quiescence"
+      ],
+      "properties": {
+        "request_to_canonical_durable": { "$ref": "#/$defs/duration" },
+        "canonical_to_required_projections_current": { "$ref": "#/$defs/duration" },
+        "canonical_to_governed_recall_current_visible": { "$ref": "#/$defs/duration" },
+        "canonical_to_context_current_visible": { "$ref": "#/$defs/duration" },
+        "request_to_quiescence": { "$ref": "#/$defs/duration" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "stringArray": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "duration": {
+      "type": "object",
+      "required": ["value_ns", "reason"],
+      "properties": {
+        "value_ns": { "type": ["integer", "null"], "minimum": 0 },
+        "reason": { "enum": ["observed", "phase_missing", "not_applicable", "cross_restart_monotonic_segments"] }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the first executable slice of #308 from `main@0c2bf29fc3b36b192d60a5ba16239e33f0b833b6`.

The core contract makes a successful mutation response distinct from safe current visibility across all read paths required by the active profile.

### New provider-neutral evidence surface

`reference/agentmem_ref/visibility.py` records:

- request, policy, canonical, projection, governed recall, context, settlement, and quiescence phases;
- explicit `not_applicable` phases rather than fabricated zero latency;
- required versus optional currentness obligations;
- `pending | satisfied | failed | quarantined | not_applicable` obligation states;
- exact runtime/profile/component/capability/evidence identity;
- restart-serializable pending obligations;
- segmented monotonic timing that refuses to fabricate cross-process latency.

### Semantic refinement

This PR separates **settled** from **quiescent**:

```text
pending required work
  -> settled=false, quiescent=false, posture=pending

explicit required failure/quarantine
  -> settled=true, quiescent=false, posture=degraded

all correctness-required obligations satisfied
  -> settled=true, quiescent=true, posture=quiescent
```

That resolves the ambiguity where a failed background task can be known-terminal without falsely claiming the runtime is fully current.

### Executable scenarios

The reference characterization exercises:

1. synchronous canonical-only write;
2. deferred required projection refresh;
3. required projection refresh failure;
4. restart while a required refresh is pending;
5. deletion with required residue work.

The deferred scenario uses the existing governed adapter and projection governor to prove that a superseded physical fact can remain present while governed recall refuses it as current, and that a stale required projection prevents quiescence until rebuilt.

### Research pressure

Before freezing the contract, a second materially different comparator was independently checked at primary source:

`HKUDS/nanobot@b99e0f937e828504e0f93dbe35dfd6b1540e20b2`

Its durable producer/consumer cursor split and failure-aware Dream cursor advance supports the narrower portable rule: **background work should not be recorded complete merely because the worker returned.** Agent Memory does not import Nanobot's cursor as quiescence.

Claude-Mem remains the other verified comparator for canonical-first, projection-later visibility.

### Evidence and CI

Adds:

- `schemas/write-readable-visibility.schema.json`;
- `reference/run_write_readable_visibility.py` exact-head runner;
- targeted unit tests plus full reference regression suite;
- machine-readable evidence artifact with observational p50/p95/p99 summaries;
- `docs/programs/runtime-evidence/write-readable-visibility.md`.

Timing is explicitly observational, environment-specific, non-authoritative, and non-gating.

## Relationship to existing work

- P9 / #46 remains the owner of structural work and economic characterization.
- This PR adds readiness/currentness phase evidence rather than duplicating P9.
- #282 remains the owner of a real durable restart-safe runtime. This slice only proves that pending visibility obligations can serialize/reconstruct without inventing cross-restart timing.
- #280 remains the owner of component/profile configuration that declares which projections/currentness obligations are required.

## Productization compatibility

The installation direction discussed during this implementation has been recorded on #280: a future CLI/wizard should be a projection of the same declarative runtime/component contract, not a second hidden configuration system.

Refs #308.
Refs #282.
Refs #280.
Refs #46.