### PR TITLE
Add portable Agent Memory runtime configuration contract

### DIFF
--- a/.github/workflows/runtime-configuration.yml
+++ b/.github/workflows/runtime-configuration.yml
@@ -1,0 +1,85 @@
+name: Runtime Configuration Contract
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Execute targeted runtime configuration tests
+        run: python -m unittest discover -s reference/tests -t reference -p 'test_runtime_config.py'
+
+      - name: Execute full reference regression suite
+        run: python -m unittest discover -s reference/tests -t reference
+
+      - name: Emit exact-head runtime configuration evidence
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_runtime_configuration.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output runtime-configuration-evidence.json
+
+      - name: Validate emitted configuration evidence
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("runtime-configuration-evidence.json").read_text())
+          if len(report["agent_memory_commit"]) != 40:
+              raise SystemExit("configuration evidence is not exact-head bound")
+          failed = [
+              name for name, passed in report["structural_invariants"].items()
+              if not passed
+          ]
+          if failed:
+              raise SystemExit(f"runtime configuration invariants failed: {failed}")
+          plan = report["plan"]
+          if plan["authority_effect"] != "none":
+              raise SystemExit("configuration must not create authority")
+          if not plan["startable"]:
+              raise SystemExit("validated reference configuration should be startable")
+          if plan["entry_mode"] != "attach_existing_stack":
+              raise SystemExit("reference fixture must exercise attach_existing_stack")
+          print(f"validated {len(report['structural_invariants'])} runtime configuration invariants")
+          PY
+
+      - name: Upload runtime configuration evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-configuration-evidence
+          path: runtime-configuration-evidence.json
+          if-no-files-found: error
+
+      - name: Publish configuration summary
+        if: always()
+        run: |
+          {
+            echo "## Portable runtime configuration"
+            echo ""
+            echo "The reference fixture attaches Agent Memory to an operator-managed stack and validates canonical ownership, component routing, independent qualification, fallback topology, currentness obligations, source rights, governance peers, and secret references."
+            echo ""
+            echo "JSON is a reference serialization of the contract, not a mandated product syntax."
+            echo ""
+            echo '```'
+            echo "python -m unittest discover -s reference/tests -t reference -p 'test_runtime_config.py'"
+            echo "python reference/run_runtime_configuration.py --agent-memory-commit <exact-40-hex-commit> --output runtime-configuration-evidence.json"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,28 +1,257 @@
 # Configuration and Extension Surfaces
 
-Agent Memory is a reference architecture and evidence repository, not one monolithic runtime with one global configuration file.
+Agent Memory now has a versioned **runtime configuration contract**, but it still does not require one privileged filename, serialization syntax, installer, or product shell.
 
-That distinction matters. Configuration in this repository is intentionally split by responsibility so an implementation, comparator, policy consumer, or optional substrate cannot quietly become the canonical meaning of Agent Memory.
+That distinction matters. The semantic contract is canonical. JSON, a future YAML or TOML reader, a CLI, or an interactive setup wizard are presentation and transport layers over that contract.
 
-## Current configuration model
+Configuration selects and binds implementations. It does not redefine Agent Memory doctrine, prove a component qualified, create memory authority, or make a stale projection current.
 
-There is currently **no required global `.env` contract and no canonical `agent-memory.toml` / YAML runtime file** for the repository as a whole.
+## Current runtime configuration contract
 
-Instead, configuration is expressed through explicit, versioned surfaces:
+The portable runtime configuration schema is:
+
+`schemas/runtime-configuration.schema.json`
+
+Current schema version:
+
+`1.0.0`
+
+Reference validator:
+
+`reference/agentmem_ref/runtime_config.py`
+
+Reference attach-to-existing-stack fixture:
+
+`reference/fixtures/runtime-configuration/attached-existing-stack.json`
+
+Executable evidence runner:
+
+```bash
+python reference/run_runtime_configuration.py \
+  --agent-memory-commit <exact-40-character-commit> \
+  --output runtime-configuration-evidence.json
+```
+
+The first checked-in serialization is JSON because the repository already uses JSON Schema for machine-readable contracts. This does **not** establish a required `agent-memory.json`, `agent-memory.yaml`, `agent-memory.toml`, or `.env` convention.
+
+A future CLI or wizard must produce or edit an equivalent configuration and invoke the same validation semantics.
+
+```text
+serialization != semantics
+wizard != configuration authority
+installed != configured
+configured != qualified
+qualified != current
+current != quiescent
+```
+
+## Primary installation assumption
+
+The primary product assumption is that Agent Memory is usually attached to a stack that already exists.
+
+Typical flow:
+
+```text
+existing agent runtime
++ existing governance / policy layer
++ existing storage / retrieval / tools
+  -> declare or discover component identities
+  -> create Agent Memory runtime configuration
+  -> validate capabilities and source rights
+  -> bind required qualification evidence
+  -> resolve provider / fallback ambiguity
+  -> declare currentness obligations
+  -> start only from an explicit valid posture
+```
+
+`bootstrap_agent_memory_first` remains a supported entry-mode value for future Agent-Memory-first profiles, but it is not the primary assumption of this first implementation slice.
+
+## What the runtime contract configures
+
+The schema makes these boundaries explicit:
+
+| Surface | Purpose |
+|---|---|
+| Runtime identity | Binds runtime, profile, version, and entry mode |
+| Canonical-state owner | Declares which component/capability owns canonical retained state for the configured profile |
+| Durable governance | Binds the governance durability profile and state reference |
+| Components | Declares exact component/version/capability posture using the ADR-033 vocabulary |
+| Adapters | Binds adapter identity, version, runtime reference, and secret references |
+| Source rights | Records license/source reference and runtime/comparator/disallowed posture |
+| Routes | Declares capability/version/maturity requirements plus allowed/preferred providers |
+| Fallback | Declares explicit fallback candidates; no registration-order fallback is implied |
+| Qualification | Binds independently supplied qualification profile/applicability requirements |
+| Currentness | Declares which derived projections are correctness-required for the active profile |
+| Governance peers | References existing governance/policy peers without making them Agent Memory doctrine dependencies |
+| Evidence stores | References qualification, receipt, and runtime-evidence locations |
+
+An external product's native configuration format is never automatically an Agent Memory configuration format.
+
+## Configuration is not qualification
+
+Component declarations and runtime configuration are operator/runtime intent. Qualification is independent evidence.
+
+The validator therefore consumes qualification bindings separately from the configuration file for routes that require evidence-level maturity.
+
+The reference fixture uses normalized bindings derived from the independently validated #300 CodeGenome/Graphify qualification artifact. That checked-in fixture is a validation projection, not the source evidence authority.
+
+```text
+component declared
+  != component qualified
+
+component selected by configuration
+  != qualification current
+
+qualification current
+  != mutation authority
+```
+
+For a route requiring `evidence_proven` or `reference_qualified`, the reference validator refuses startup if independent qualification is not required and supplied.
+
+The validator also binds the configured primary qualification to exact equivalents of:
+
+```text
+component id/version
+capability id/version
+adapter id/version
+qualification profile id/version
+applicability digest
+qualification currentness
+earned maturity
+source-rights use posture
+```
+
+A changed component version does not silently inherit qualification.
+
+## Deterministic provider selection
+
+Runtime routing reuses the existing `ComponentRegistry` and ADR-033 capability declarations. There is no second installer-specific routing model.
+
+A route may specify:
+
+```text
+capability id/version
+minimum maturity
+allowed components
+preferred component
+required state posture
+required scope posture
+explicit fallback components
+qualification requirement
+currentness requirement
+```
+
+If more than one provider remains eligible and no explicit preference resolves the ambiguity, validation fails.
+
+If a configured fallback is weaker or incompatible in material posture, validation fails.
+
+The first configuration contract also rejects multiple equivalent fallback candidates because it does not yet define an ordering or composition rule. It will not invent first-match behavior from array order.
+
+Execution-time provider failure remains governed by the #300 fallback contract. Pre-start configuration validation does not replace runtime failure evidence.
+
+## Canonical state and durable governance
+
+The active profile must explicitly name its canonical-state owner component and capability.
+
+The referenced capability must:
+
+- exist at the configured version;
+- be enabled;
+- declare `state_posture = canonical`;
+- be permitted for runtime use under its source-rights posture.
+
+Durable governance state is configured separately from the canonical memory owner because these are distinct obligations.
+
+The current reference durability profile from #282 is:
+
+`reference_file_checkpoint_v1`
+
+That profile is bounded reference evidence, not a universal storage recommendation.
+
+```text
+canonical memory storage
+!= governance metadata durability
+!= provider qualification
+!= read-path currentness
+```
+
+## Currentness obligations
+
+The runtime configuration can declare a route as correctness-required for current visibility.
+
+For derived state, a required currentness route must name a projection identity. That projection identity can be consumed by the #308 write-to-readable visibility contract and later by #282 restart recovery.
+
+The reference attach fixture declares:
+
+`code-graph`
+
+as a required derived projection.
+
+A successful component invocation does not by itself satisfy that currentness obligation.
+
+## Secret handling
+
+Portable runtime configuration accepts **secret references**, not literal credentials.
+
+The first reference validator accepts these schemes:
+
+```text
+env://
+secret://
+vault://
+keyring://
+```
+
+Examples:
+
+```text
+env://EXISTING_MEMORY_DSN
+env://DASHCLAW_TOKEN
+vault://agent-memory/production/provider
+```
+
+Secret resolution is deliberately outside this slice. A future CLI or runtime integration may resolve these references through an appropriate credential provider, but the portable configuration must not become a credential dump.
+
+The validator additionally rejects common literal-secret field names even if a future schema edit accidentally becomes more permissive.
+
+## Source rights are runtime configuration
+
+Every configured component carries an explicit runtime source-rights posture:
+
+```text
+runtime_allowed
+comparator_only
+disallowed
+```
+
+A component selected for runtime use must be `runtime_allowed`.
+
+The configuration must also preserve its license/source reference. Agent Memory's Apache-2.0 license covers this repository's own licensed distribution. It does not relicense a component merely because the runtime can call it.
+
+Before adding a material external dependency, copied asset, comparator, source-derived fixture, or adapted implementation:
+
+1. identify the exact source;
+2. verify the applicable license or permission basis;
+3. choose citation, independent synthesis, licensed reuse, author-originated reuse, or explicit permission deliberately;
+4. add or update `sources/source-registry.json` when required by [`SOURCE_RIGHTS_POLICY.md`](SOURCE_RIGHTS_POLICY.md);
+5. preserve any required attribution, NOTICE, modification notice, trademark, or redistribution obligation.
+
+## Existing repository configuration surfaces
+
+The runtime configuration contract does not replace narrower repository surfaces that have different owners.
 
 | Surface | Canonical location | What it configures |
 |---|---|---|
+| Runtime composition | `schemas/runtime-configuration.schema.json` | Component topology, routing, qualification requirements, currentness and peer references |
 | Doctrine and lifecycle semantics | `docs/`, `docs/adr/` | Meaning, ownership, maturity, lifecycle and governance boundaries |
-| Machine-readable contracts | `schemas/` | Valid record and evidence shapes |
+| Other machine-readable contracts | `schemas/` | Valid record and evidence shapes |
 | Interoperability / implementation profiles | `docs/profiles/` and matching schemas | Optional cross-system behavior and evidence boundaries |
 | Reference validation dependencies | `reference/requirements.txt` | Pinned dependencies used by the main reference test environment |
-| Reference runner options | `reference/run_*.py` | Bounded experiment- or comparator-specific CLI configuration |
+| Reference runner options | `reference/run_*.py` | Bounded evidence-runner inputs |
 | Doctrine / adversarial scenarios | `fixtures/` | Structural and negative-path expectations |
 | Source-rights records | `sources/source-registry.json` | External source, license, provenance, and reuse posture |
 | Wiki publication | `wiki-src/` + `.github/workflows/publish-wiki.yml` | Reader-facing documentation source and publication |
 | CI behavior | `.github/workflows/` | Repository evidence and validation execution |
-
-An external product's configuration format is never automatically an Agent Memory configuration format.
 
 ## Reference environment
 
@@ -33,59 +262,15 @@ python -m pip install -r reference/requirements.txt
 python -m unittest discover -s reference/tests -t reference
 ```
 
-The reference environment is intentionally broader than the low-cost documentation/fixture validators because it exercises cryptographic, interoperability, and runtime evidence paths.
+The reference environment is intentionally broader than the low-cost documentation/fixture validators because it exercises cryptographic, interoperability, configuration, and runtime evidence paths.
 
-For the bounded conformance/evidence runner:
-
-```bash
-python reference/run_conformance.py --trials 500
-```
-
-`--trials` is an experiment input. It is not a governance or authority setting.
-
-See [`../reference/README.md`](../reference/README.md) for the current executable evidence boundary and exact comparator commands.
-
-## Optional real-substrate profile
-
-The current reference evidence includes an optional Graphiti/Kuzu temporal-graph path. It is not required for ordinary Agent Memory doctrine or schema use.
-
-```bash
-python -m pip install graphiti-core kuzu
-python -m unittest discover -s reference/tests -t reference
-python reference/run_conformance.py
-```
-
-The substrate is deliberately treated as an implementation surface:
-
-```text
-substrate capability
-!= Agent Memory doctrine
-!= recall permission
-!= mutation authority
-```
-
-A future graph, retrieval, relational, ledger, learned-state, or hybrid module must preserve the same separation.
-
-## Optional comparator environments
-
-Some external comparators intentionally use isolated dependency environments when their dependency graph should not become part of the core reference environment.
-
-The reference README records the exact commands and versions for those paths. Comparator configuration must preserve at least:
-
-- external project / specification identity;
-- exact release, package, source commit, or checkpoint where applicable;
-- adapter/profile version;
-- relevant policy, model, schema, or configuration identity;
-- explicit unavailable/unsupported behavior;
-- the claim the comparator proves and the claims it does not prove.
-
-A comparator being installed does not make it a required dependency.
+See [`../reference/README.md`](../reference/README.md) for the current executable evidence boundary and comparator commands.
 
 ## Profiles are configuration with semantics
 
-Files under `docs/profiles/` define optional implementation or interoperability contracts. A profile may describe, for example, governance context projection, portable evidence, external policy composition, runtime correlation, or other bounded behavior.
+Files under `docs/profiles/` define optional implementation or interoperability contracts. A profile may describe governance context projection, portable evidence, external policy composition, runtime correlation, or another bounded behavior.
 
-Profile configuration must remain subordinate to canonical doctrine:
+Profile configuration remains subordinate to canonical doctrine:
 
 ```text
 profile setting
@@ -99,69 +284,58 @@ Unknown or incompatible consequential profile versions should fail explicitly ra
 
 ## Schema and policy version binding
 
-When a runtime or evidence record depends on a schema, policy, projection, estimator, external consumer, or module configuration, bind the relevant version or stable identity into the evidence whenever the corresponding contract requires it.
+When a runtime or evidence record depends on a schema, policy, projection, estimator, external consumer, module, adapter, or qualification configuration, bind the relevant version or stable identity whenever the corresponding contract requires it.
 
-Do not collapse these independent version dimensions into one generic `version` string when their drift has different consequences.
+Do not collapse independent version dimensions into one generic `version` field when their drift has different consequences.
 
 Examples include:
 
 ```text
+runtime configuration schema version
+runtime profile version
+component/capability version
+adapter version
+qualification profile version
+qualification applicability digest
 memory schema version
 PAMA decision schema version
 policy version
-projection/profile version
+projection/currentness identity
 external peer version
 estimator/model version
-substrate/module version
 ```
 
 Version drift is evidence to evaluate, not permission to guess compatibility.
 
-## Source rights are part of dependency configuration
+## Future installer and setup UX
 
-Before adding a material external dependency, copied asset, comparator, source-derived fixture, or adapted implementation:
+A future installation experience should be a client of this contract.
 
-1. identify the exact source;
-2. verify the applicable license or permission basis;
-3. choose citation, independent synthesis, licensed reuse, author-originated reuse, or explicit permission deliberately;
-4. add or update `sources/source-registry.json` when required by [`SOURCE_RIGHTS_POLICY.md`](SOURCE_RIGHTS_POLICY.md);
-5. preserve any required attribution, NOTICE, modification notice, trademark, or redistribution obligation.
-
-Agent Memory's Apache-2.0 license covers this repository's own licensed distribution. It does not relicense external projects merely because they are linked, compared, or integrated.
-
-## Wiki configuration
-
-The GitHub Wiki is generated from `wiki-src/`; direct Wiki UI edits are not canonical.
-
-Validate Wiki source with:
-
-```bash
-python scripts/validate_wiki_links.py wiki-src
-```
-
-Publication behavior is defined in `.github/workflows/publish-wiki.yml` and documented in `wiki-src/README.md`.
-
-## Future modular memory configuration
-
-Implementation program #274 owns the transition from completed architecture-family research into optional first-class memory modules.
-
-The shared module configuration contract should eventually make these properties explicit without importing a vendor-specific schema into core:
+Likely command surfaces may include equivalents of:
 
 ```text
-module identity / type / version
-capabilities
-implementation/runtime reference
-configuration profile identity
-canonical-vs-derived posture
-scope/isolation behavior
-provenance/currentness bindings
-correction/deletion/rebuild semantics
-failure/unavailable posture
-migration/import/export posture
-optional dependency/license metadata
+agent-memory init
+agent-memory config validate
+agent-memory component list
+agent-memory component add
+agent-memory qualify
+agent-memory doctor
+agent-memory serve
 ```
 
-Graph, retrieval, ledger, relational, learned/latent, and hybrid modules may require different implementation settings. They must still expose enough common configuration evidence for Agent Memory to govern their consequences consistently.
+These commands are not implemented by this configuration slice and are not yet public CLI commitments.
+
+The intended UX boundary is nevertheless explicit:
+
+- inspect or ask about the user's existing runtime/governance/storage stack;
+- construct the portable configuration;
+- validate deterministic component routing and source rights;
+- resolve or surface qualification requirements;
+- refuse ambiguity instead of guessing;
+- keep credentials external through secret references;
+- report currentness/recovery posture separately from installation success.
+
+Suggested components may eventually be offered during setup, but a recommendation should expose exact qualified version, maturity, supported capability, limitations, source-rights posture, and evidence basis. Popularity is not qualification.
 
 ## Configuration review checklist
 
@@ -169,12 +343,18 @@ A configuration or extension change is not complete merely because it starts suc
 
 - preserves canonical doctrine ownership;
 - binds consequential versions and identities;
-- fails explicitly when required configuration is unknown or stale;
+- names canonical-state ownership explicitly;
+- separates component declaration from qualification evidence;
+- fails explicitly when required configuration or qualification is unknown or stale;
+- rejects ambiguous provider selection;
+- prevents fallback from silently weakening material posture;
 - keeps optional dependencies optional;
 - preserves scope and isolation boundaries;
+- records required derived currentness obligations;
+- keeps secrets out of portable configuration values;
 - does not turn estimator/backend capability into authority;
 - records source-rights and license posture;
 - updates README, canonical docs, Wiki, and visuals when the public architecture actually changes;
 - produces evidence appropriate to the claim being made.
 
-Configuration is an implementation surface. The repository's semantics remain governed by canonical doctrine, schemas, profiles, evidence, and accepted architecture decisions.
+Configuration is an implementation surface. Agent Memory semantics remain governed by canonical doctrine, schemas, profiles, evidence, and accepted architecture decisions.

--- a/docs/programs/runtime-evidence/runtime-configuration.md
+++ b/docs/programs/runtime-evidence/runtime-configuration.md
@@ -1,0 +1,156 @@
+# Portable runtime configuration evidence
+
+Status: implementation evidence for #280
+
+This slice establishes a machine-readable runtime composition contract for attaching Agent Memory to an existing stack without making the installer, serialization syntax, or component catalog authoritative.
+
+## Earned claim
+
+`runtime-configuration.schema.json@1.0.0` plus `reference/agentmem_ref/runtime_config.py` can deterministically validate and resolve a bounded Agent Memory runtime configuration that includes:
+
+- an operator-managed agent runtime identity;
+- an explicit canonical memory owner;
+- a durable-governance profile/state reference;
+- versioned component/capability declarations;
+- adapter identity/runtime bindings;
+- runtime source-rights posture;
+- allowed/preferred provider routing;
+- explicit fallback topology;
+- independent qualification requirements;
+- required derived-currentness projection identities;
+- governance peer references;
+- external secret references;
+- qualification, receipt, and runtime-evidence store references.
+
+The validated plan emits:
+
+`authority_effect = none`
+
+Configuration selects eligible implementation paths. It does not grant memory mutation, recall admission, structural, or external action authority.
+
+## Primary installation posture
+
+The reference fixture exercises:
+
+`entry_mode = attach_existing_stack`
+
+This reflects the expected dominant deployment sequence:
+
+```text
+existing runtime / governance / storage
+  -> attach Agent Memory
+  -> declare or discover components
+  -> validate exact capabilities and versions
+  -> bind independent qualification evidence where required
+  -> resolve ambiguity / fallback topology
+  -> declare currentness obligations
+  -> start only from a validated posture
+```
+
+The fixture intentionally includes an operator-supplied canonical store and a DashClaw governance-peer reference. Agent Memory does not claim to have selected or installed either system.
+
+## Qualified provider example
+
+The first fixture composes the #300 code-graph qualification evidence:
+
+```text
+CodeGenome
+  primary code_graph_traversal provider
+  exact component + adapter + qualification applicability
+
+Graphify
+  explicit equivalent fallback
+  independent current qualification
+```
+
+The checked-in `qualification-bindings.json` file is a normalized validation projection derived from the independently inspected #300 artifact.
+
+The source qualification artifact remains the evidence authority. Editing the runtime configuration cannot make a component qualified.
+
+## Fail-closed validation
+
+The reference tests currently exercise refusal of:
+
+- missing canonical-state owner;
+- non-canonical owner posture;
+- component-version drift with stale qualification;
+- maturity shortfall;
+- ambiguous provider selection;
+- incompatible fallback posture;
+- multiple equivalent fallbacks without an ordering/composition contract;
+- runtime-disallowed source rights;
+- non-current qualification;
+- wrong primary qualification applicability digest;
+- evidence-level maturity without independent qualification;
+- required derived currentness without projection identity;
+- literal credential material / invalid secret references.
+
+The validator reuses ADR-033 `ComponentRegistry` resolution. It does not create an installer-specific provider-selection algorithm.
+
+## Currentness and restart composition
+
+A configuration route can declare a derived projection as correctness-required.
+
+The reference fixture declares:
+
+`code-graph`
+
+This identity can be consumed by the #308 write-to-readable currentness contract and persisted/reconstructed by #282 restart-safe runtime work.
+
+```text
+configuration says projection is required
+  != projection is current
+
+projection observed current
+  != runtime quiescent if another required obligation remains
+```
+
+## Secret boundary
+
+Portable configuration records secret references only.
+
+Current accepted reference schemes:
+
+```text
+env://
+secret://
+vault://
+keyring://
+```
+
+Secret resolution is not implemented by this slice.
+
+## Evidence command
+
+```bash
+python reference/run_runtime_configuration.py \
+  --agent-memory-commit <exact-40-character-commit> \
+  --output runtime-configuration-evidence.json
+```
+
+The `Runtime Configuration Contract` workflow runs:
+
+1. targeted configuration tests;
+2. the complete reference regression suite;
+3. exact-head configuration resolution;
+4. structural invariant validation;
+5. evidence artifact upload.
+
+## Non-claims and remaining #280 work
+
+This slice does **not** complete #280.
+
+It does not yet provide:
+
+- interactive setup or setup wizard;
+- package/component installation;
+- automatic runtime/framework discovery;
+- secret resolution;
+- component marketplace/recommendation UX;
+- a mandated JSON/YAML/TOML filename;
+- general component removal/rebuild execution;
+- complete multi-capability end-to-end memory operations through this config;
+- restart-time migration between changed configurations;
+- a service/CLI process that consumes this configuration in production form.
+
+The next product-facing step can now build on a real contract rather than inventing configuration semantics inside a wizard.

--- a/reference/agentmem_ref/runtime_config.py
+++ b/reference/agentmem_ref/runtime_config.py
@@ -1,0 +1,707 @@
+"""Portable Agent Memory runtime configuration for issue #280.
+
+The configuration is intentionally serialization-neutral. JSON is used by the
+reference fixtures because the repository already validates JSON Schema, but a
+future CLI, wizard, YAML reader, or TOML reader must map to this same semantic
+contract rather than create a second configuration universe.
+
+Configuration is not qualification and never grants authority. The validator
+combines declared component capabilities with independently supplied,
+previously validated qualification evidence where a route requires it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import jsonschema
+
+from .capabilities import (
+    AmbiguousCapabilityError,
+    CapabilityDeclaration,
+    CapabilityRequirement,
+    CapabilityResolutionError,
+    ComponentDeclaration,
+    ComponentRegistry,
+    ResolvedCapability,
+    maturity_satisfies,
+)
+from .qualification import QualificationRecord
+
+
+RUNTIME_CONFIGURATION_SCHEMA_VERSION = "1.0.0"
+_ALLOWED_SECRET_SCHEMES = ("env://", "secret://", "vault://", "keyring://")
+_LITERAL_SECRET_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "token",
+        "access_token",
+        "refresh_token",
+        "api_key",
+        "apikey",
+        "secret",
+        "client_secret",
+        "private_key",
+        "access_key",
+        "secret_key",
+    }
+)
+
+
+class RuntimeConfigurationError(ValueError):
+    """Runtime configuration cannot be interpreted safely."""
+
+
+@dataclass(frozen=True)
+class SourceRights:
+    license_id: str
+    license_ref: str
+    use_posture: str
+
+
+@dataclass(frozen=True)
+class AdapterBinding:
+    adapter_id: str
+    adapter_version: str
+    runtime_ref: str
+    secret_refs: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class ComponentRuntime:
+    declaration: ComponentDeclaration
+    adapter: AdapterBinding
+    source_rights: SourceRights
+
+
+@dataclass(frozen=True)
+class QualificationRequirement:
+    required: bool
+    adapter_id: str = ""
+    adapter_version: str = ""
+    profile_id: str = ""
+    profile_version: str = ""
+    minimum_earned_maturity: str = ""
+    applicability_digest: str = ""
+
+
+@dataclass(frozen=True)
+class RouteConfiguration:
+    route_id: str
+    capability_id: str
+    capability_version: str
+    minimum_maturity: str
+    allowed_components: tuple[str, ...]
+    preferred_component: str
+    fallback_components: tuple[str, ...]
+    required_state_postures: tuple[str, ...]
+    required_scope_postures: tuple[str, ...]
+    qualification: QualificationRequirement
+    currentness_required: bool
+    projection_id: str
+
+
+@dataclass(frozen=True)
+class QualificationBinding:
+    """Runtime view derived from a validated #300 QualificationRecord.
+
+    It is supplied independently of configuration so an operator cannot make a
+    component qualified by editing the config file.
+    """
+
+    component_id: str
+    component_version: str
+    capability_id: str
+    capability_version: str
+    adapter_id: str
+    adapter_version: str
+    qualification_profile_id: str
+    qualification_profile_version: str
+    applicability_digest: str
+    qualification_current: bool
+    earned_maturity: str
+    source_rights_use_posture: str
+    record_ref: str
+
+    @classmethod
+    def from_record(cls, record: QualificationRecord, *, record_ref: str) -> "QualificationBinding":
+        subject = record.subject
+        return cls(
+            component_id=subject.component_id,
+            component_version=subject.component_version,
+            capability_id=subject.capability_id,
+            capability_version=subject.capability_version,
+            adapter_id=subject.adapter_id,
+            adapter_version=subject.adapter_version,
+            qualification_profile_id=subject.qualification_profile_id,
+            qualification_profile_version=subject.qualification_profile_version,
+            applicability_digest=record.applicability_digest,
+            qualification_current=record.qualification_current,
+            earned_maturity=record.earned_maturity,
+            source_rights_use_posture=record.use_posture,
+            record_ref=record_ref,
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedRoute:
+    route_id: str
+    primary: ResolvedCapability
+    fallback_component_id: str
+    qualification_record_ref: str
+    fallback_qualification_record_ref: str
+    currentness_required: bool
+    projection_id: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "route_id": self.route_id,
+            "primary": self.primary.to_dict(),
+            "fallback_component_id": self.fallback_component_id or None,
+            "qualification_record_ref": self.qualification_record_ref or None,
+            "fallback_qualification_record_ref": self.fallback_qualification_record_ref or None,
+            "currentness_required": self.currentness_required,
+            "projection_id": self.projection_id or None,
+            "authority_effect": "none",
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeConfigurationPlan:
+    schema_version: str
+    configuration_digest: str
+    entry_mode: str
+    runtime_id: str
+    runtime_version: str
+    profile_id: str
+    profile_version: str
+    canonical_owner_component_id: str
+    canonical_owner_capability_id: str
+    durable_governance_profile_id: str
+    resolved_routes: tuple[ResolvedRoute, ...]
+    required_projection_ids: tuple[str, ...]
+    governance_peer_ids: tuple[str, ...]
+
+    @property
+    def authority_effect(self) -> str:
+        return "none"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "configuration_digest": self.configuration_digest,
+            "entry_mode": self.entry_mode,
+            "runtime": {
+                "runtime_id": self.runtime_id,
+                "runtime_version": self.runtime_version,
+                "profile_id": self.profile_id,
+                "profile_version": self.profile_version,
+            },
+            "canonical_owner": {
+                "component_id": self.canonical_owner_component_id,
+                "capability_id": self.canonical_owner_capability_id,
+            },
+            "durable_governance_profile_id": self.durable_governance_profile_id,
+            "resolved_routes": [route.to_dict() for route in self.resolved_routes],
+            "required_projection_ids": list(self.required_projection_ids),
+            "governance_peer_ids": list(self.governance_peer_ids),
+            "authority_effect": "none",
+            "startable": True,
+        }
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _configuration_schema() -> dict:
+    return json.loads(
+        (_repo_root() / "schemas" / "runtime-configuration.schema.json").read_text(encoding="utf-8")
+    )
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def configuration_digest(value: Mapping[str, object]) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _reject_literal_secret_keys(value: object, *, path: tuple[str, ...] = ()) -> None:
+    if isinstance(value, Mapping):
+        for raw_key, child in value.items():
+            key = str(raw_key)
+            lowered = key.lower()
+            if lowered in _LITERAL_SECRET_KEYS or (
+                lowered.endswith("_secret") and not lowered.endswith("_secret_ref")
+            ):
+                dotted = ".".join((*path, key))
+                raise RuntimeConfigurationError(
+                    f"portable configuration may contain secret references, not literal secret material: {dotted}"
+                )
+            _reject_literal_secret_keys(child, path=(*path, key))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_literal_secret_keys(child, path=(*path, str(index)))
+
+
+def _validate_secret_refs(value: Mapping[str, object]) -> None:
+    refs: list[str] = []
+    for component in value.get("components", ()):  # type: ignore[union-attr]
+        if not isinstance(component, Mapping):
+            continue
+        adapter = component.get("adapter", {})
+        if isinstance(adapter, Mapping):
+            secret_refs = adapter.get("secret_refs", {})
+            if isinstance(secret_refs, Mapping):
+                refs.extend(str(item) for item in secret_refs.values())
+    for peer in value.get("governance_peers", ()):  # type: ignore[union-attr]
+        if not isinstance(peer, Mapping):
+            continue
+        secret_refs = peer.get("secret_refs", {})
+        if isinstance(secret_refs, Mapping):
+            refs.extend(str(item) for item in secret_refs.values())
+    for ref in refs:
+        if not ref.startswith(_ALLOWED_SECRET_SCHEMES):
+            raise RuntimeConfigurationError(f"unsupported secret reference scheme: {ref!r}")
+
+
+def _component_runtime(raw: Mapping[str, object]) -> ComponentRuntime:
+    declaration_raw = raw["declaration"]
+    adapter_raw = raw["adapter"]
+    rights_raw = raw["source_rights"]
+    if not isinstance(declaration_raw, Mapping) or not isinstance(adapter_raw, Mapping) or not isinstance(rights_raw, Mapping):
+        raise RuntimeConfigurationError("component declaration, adapter, and source_rights must be objects")
+    declaration = ComponentDeclaration.from_dict(declaration_raw)
+    secret_refs_raw = adapter_raw.get("secret_refs", {})
+    secret_refs = tuple(
+        sorted((str(key), str(value)) for key, value in secret_refs_raw.items())
+    ) if isinstance(secret_refs_raw, Mapping) else ()
+    return ComponentRuntime(
+        declaration=declaration,
+        adapter=AdapterBinding(
+            adapter_id=str(adapter_raw["adapter_id"]),
+            adapter_version=str(adapter_raw["adapter_version"]),
+            runtime_ref=str(adapter_raw["runtime_ref"]),
+            secret_refs=secret_refs,
+        ),
+        source_rights=SourceRights(
+            license_id=str(rights_raw["license_id"]),
+            license_ref=str(rights_raw["license_ref"]),
+            use_posture=str(rights_raw["use_posture"]),
+        ),
+    )
+
+
+def _qualification_requirement(raw: Mapping[str, object]) -> QualificationRequirement:
+    return QualificationRequirement(
+        required=bool(raw.get("required", False)),
+        adapter_id=str(raw.get("adapter_id", "")),
+        adapter_version=str(raw.get("adapter_version", "")),
+        profile_id=str(raw.get("profile_id", "")),
+        profile_version=str(raw.get("profile_version", "")),
+        minimum_earned_maturity=str(raw.get("minimum_earned_maturity", "")),
+        applicability_digest=str(raw.get("applicability_digest", "")),
+    )
+
+
+def _route(raw: Mapping[str, object]) -> RouteConfiguration:
+    qualification_raw = raw["qualification"]
+    currentness_raw = raw["currentness"]
+    if not isinstance(qualification_raw, Mapping) or not isinstance(currentness_raw, Mapping):
+        raise RuntimeConfigurationError("route qualification/currentness must be objects")
+    return RouteConfiguration(
+        route_id=str(raw["route_id"]),
+        capability_id=str(raw["capability_id"]),
+        capability_version=str(raw["capability_version"]),
+        minimum_maturity=str(raw["minimum_maturity"]),
+        allowed_components=tuple(str(item) for item in raw["allowed_components"]),
+        preferred_component=str(raw.get("preferred_component", "")),
+        fallback_components=tuple(str(item) for item in raw.get("fallback_components", ())),
+        required_state_postures=tuple(str(item) for item in raw.get("required_state_postures", ())),
+        required_scope_postures=tuple(str(item) for item in raw.get("required_scope_postures", ())),
+        qualification=_qualification_requirement(qualification_raw),
+        currentness_required=bool(currentness_raw.get("required", False)),
+        projection_id=str(currentness_raw.get("projection_id", "")),
+    )
+
+
+def _qualification_index(bindings: Iterable[QualificationBinding]) -> dict[tuple[str, str, str, str], list[QualificationBinding]]:
+    index: dict[tuple[str, str, str, str], list[QualificationBinding]] = {}
+    for binding in bindings:
+        key = (
+            binding.component_id,
+            binding.component_version,
+            binding.capability_id,
+            binding.capability_version,
+        )
+        index.setdefault(key, []).append(binding)
+    return index
+
+
+def _binding_for(
+    resolved: ResolvedCapability,
+    requirement: QualificationRequirement,
+    qualification_index: Mapping[tuple[str, str, str, str], list[QualificationBinding]],
+) -> QualificationBinding:
+    key = (
+        resolved.component_id,
+        resolved.component_version,
+        resolved.capability_id,
+        resolved.capability_version,
+    )
+    candidates = qualification_index.get(key, ())
+    matches = [
+        item
+        for item in candidates
+        if item.adapter_id == requirement.adapter_id
+        and item.adapter_version == requirement.adapter_version
+        and item.qualification_profile_id == requirement.profile_id
+        and item.qualification_profile_version == requirement.profile_version
+        and item.applicability_digest == requirement.applicability_digest
+    ]
+    if not matches:
+        raise RuntimeConfigurationError(
+            f"route qualification is missing/stale for {resolved.component_id}:{resolved.capability_id}"
+        )
+    if len(matches) > 1:
+        raise RuntimeConfigurationError(
+            f"ambiguous qualification records for {resolved.component_id}:{resolved.capability_id}"
+        )
+    binding = matches[0]
+    if not binding.qualification_current:
+        raise RuntimeConfigurationError(
+            f"qualification is non-current for {resolved.component_id}:{resolved.capability_id}"
+        )
+    if binding.source_rights_use_posture != "runtime_allowed":
+        raise RuntimeConfigurationError(
+            f"qualification source rights are not runtime_allowed for {resolved.component_id}:{resolved.capability_id}"
+        )
+    if not maturity_satisfies(binding.earned_maturity, requirement.minimum_earned_maturity):
+        raise RuntimeConfigurationError(
+            f"qualification maturity shortfall for {resolved.component_id}:{resolved.capability_id}"
+        )
+    return binding
+
+
+def _resolve_specific(
+    registry: ComponentRegistry,
+    route: RouteConfiguration,
+    component_id: str,
+) -> ResolvedCapability:
+    try:
+        return registry.resolve(
+            CapabilityRequirement(
+                capability_id=route.capability_id,
+                capability_version=route.capability_version,
+                minimum_maturity=route.minimum_maturity,
+                required_state_postures=route.required_state_postures,
+                required_scope_postures=route.required_scope_postures,
+                allowed_components=route.allowed_components,
+                preferred_component=component_id,
+            )
+        )
+    except CapabilityResolutionError as exc:
+        raise RuntimeConfigurationError(str(exc)) from exc
+
+
+def _static_fallback_reasons(primary: ResolvedCapability, candidate: ResolvedCapability) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if candidate.capability_id != primary.capability_id:
+        reasons.append("capability_id_mismatch")
+    if candidate.capability_version != primary.capability_version:
+        reasons.append("capability_version_mismatch")
+    if not maturity_satisfies(candidate.maturity, primary.maturity):
+        reasons.append("weaker_maturity")
+    if candidate.state_posture != primary.state_posture:
+        reasons.append("state_posture_mismatch")
+    if candidate.scope_posture != primary.scope_posture:
+        reasons.append("scope_posture_mismatch")
+    if candidate.failure_posture != primary.failure_posture:
+        reasons.append("failure_posture_mismatch")
+    if candidate.authority_effect != primary.authority_effect:
+        reasons.append("authority_effect_mismatch")
+    return tuple(reasons)
+
+
+def _assert_component_runtime_allowed(component: ComponentRuntime) -> None:
+    if component.source_rights.use_posture != "runtime_allowed":
+        raise RuntimeConfigurationError(
+            f"component {component.declaration.component_id!r} is not permitted for runtime use"
+        )
+
+
+def validate_runtime_configuration(
+    value: Mapping[str, object],
+    *,
+    qualification_bindings: Iterable[QualificationBinding] = (),
+) -> RuntimeConfigurationPlan:
+    """Validate and deterministically resolve one portable runtime configuration."""
+
+    try:
+        jsonschema.Draft202012Validator(_configuration_schema()).validate(value)
+    except jsonschema.ValidationError as exc:
+        path = ".".join(str(part) for part in exc.absolute_path)
+        location = f" at {path}" if path else ""
+        raise RuntimeConfigurationError(f"runtime configuration schema violation{location}: {exc.message}") from exc
+
+    _reject_literal_secret_keys(value)
+    _validate_secret_refs(value)
+
+    component_rows = value["components"]
+    route_rows = value["routes"]
+    if not isinstance(component_rows, list) or not isinstance(route_rows, list):
+        raise RuntimeConfigurationError("components and routes must be arrays")
+
+    components = tuple(_component_runtime(row) for row in component_rows)
+    component_ids = [item.declaration.component_id for item in components]
+    if len(component_ids) != len(set(component_ids)):
+        raise RuntimeConfigurationError("component ids must be unique within one runtime configuration")
+    components_by_id = {item.declaration.component_id: item for item in components}
+
+    registry = ComponentRegistry()
+    try:
+        registry.register_many(item.declaration for item in components)
+    except ValueError as exc:
+        raise RuntimeConfigurationError(str(exc)) from exc
+
+    canonical_raw = value["canonical_state"]
+    if not isinstance(canonical_raw, Mapping):
+        raise RuntimeConfigurationError("canonical_state must be an object")
+    owner_id = str(canonical_raw["owner_component_id"])
+    owner = components_by_id.get(owner_id)
+    if owner is None or not owner.declaration.enabled:
+        raise RuntimeConfigurationError("canonical-state owner is missing or disabled")
+    _assert_component_runtime_allowed(owner)
+    owner_capability_id = str(canonical_raw["owner_capability_id"])
+    owner_capability_version = str(canonical_raw["owner_capability_version"])
+    owner_matches = [
+        capability
+        for capability in owner.declaration.capabilities
+        if capability.enabled
+        and capability.capability_id == owner_capability_id
+        and capability.capability_version == owner_capability_version
+    ]
+    if len(owner_matches) != 1:
+        raise RuntimeConfigurationError("canonical-state owner capability is missing or ambiguous")
+    if owner_matches[0].state_posture != "canonical":
+        raise RuntimeConfigurationError("canonical-state owner capability must declare canonical state posture")
+
+    routes = tuple(_route(row) for row in route_rows)
+    route_ids = [route.route_id for route in routes]
+    if len(route_ids) != len(set(route_ids)):
+        raise RuntimeConfigurationError("route ids must be unique")
+
+    qindex = _qualification_index(qualification_bindings)
+    resolved_routes: list[ResolvedRoute] = []
+    required_projection_ids: list[str] = []
+
+    for route in routes:
+        allowed = set(route.allowed_components)
+        unknown_allowed = sorted(allowed.difference(components_by_id))
+        if unknown_allowed:
+            raise RuntimeConfigurationError(
+                f"route {route.route_id!r} names unknown allowed components: {unknown_allowed}"
+            )
+        if route.preferred_component and route.preferred_component not in allowed:
+            raise RuntimeConfigurationError(
+                f"route {route.route_id!r} preferred component is not in allowed_components"
+            )
+        if set(route.fallback_components).difference(allowed):
+            raise RuntimeConfigurationError(
+                f"route {route.route_id!r} fallback_components must be a subset of allowed_components"
+            )
+
+        if route.preferred_component:
+            primary = _resolve_specific(registry, route, route.preferred_component)
+        else:
+            try:
+                primary = registry.resolve(
+                    CapabilityRequirement(
+                        capability_id=route.capability_id,
+                        capability_version=route.capability_version,
+                        minimum_maturity=route.minimum_maturity,
+                        required_state_postures=route.required_state_postures,
+                        required_scope_postures=route.required_scope_postures,
+                        allowed_components=route.allowed_components,
+                    )
+                )
+            except AmbiguousCapabilityError as exc:
+                raise RuntimeConfigurationError(str(exc)) from exc
+            except CapabilityResolutionError as exc:
+                raise RuntimeConfigurationError(str(exc)) from exc
+
+        primary_runtime = components_by_id[primary.component_id]
+        _assert_component_runtime_allowed(primary_runtime)
+        if (
+            primary_runtime.adapter.adapter_id != route.qualification.adapter_id
+            or primary_runtime.adapter.adapter_version != route.qualification.adapter_version
+        ) and route.qualification.required:
+            raise RuntimeConfigurationError(
+                f"route {route.route_id!r} qualification adapter does not match configured primary adapter"
+            )
+
+        if route.minimum_maturity in {"evidence_proven", "reference_qualified"} and not route.qualification.required:
+            raise RuntimeConfigurationError(
+                f"route {route.route_id!r} requires evidence maturity but no independent qualification"
+            )
+
+        primary_binding: QualificationBinding | None = None
+        if route.qualification.required:
+            primary_binding = _binding_for(primary, route.qualification, qindex)
+
+        if route.currentness_required:
+            if primary.state_posture == "derived" and not route.projection_id:
+                raise RuntimeConfigurationError(
+                    f"route {route.route_id!r} requires current derived state but has no projection_id"
+                )
+            if route.projection_id:
+                required_projection_ids.append(route.projection_id)
+
+        fallback_component_id = ""
+        fallback_record_ref = ""
+        compatible_fallbacks: list[tuple[ResolvedCapability, QualificationBinding | None]] = []
+        for fallback_id in route.fallback_components:
+            if fallback_id == primary.component_id:
+                raise RuntimeConfigurationError(
+                    f"route {route.route_id!r} cannot list the primary as its own fallback"
+                )
+            candidate = _resolve_specific(registry, route, fallback_id)
+            candidate_runtime = components_by_id[candidate.component_id]
+            _assert_component_runtime_allowed(candidate_runtime)
+            reasons = _static_fallback_reasons(primary, candidate)
+            if reasons:
+                raise RuntimeConfigurationError(
+                    f"route {route.route_id!r} fallback {fallback_id!r} is weaker/incompatible: {list(reasons)}"
+                )
+            candidate_binding: QualificationBinding | None = None
+            if route.qualification.required:
+                if (
+                    candidate_runtime.adapter.adapter_id != route.qualification.adapter_id
+                    or candidate_runtime.adapter.adapter_version != route.qualification.adapter_version
+                ):
+                    # Different provider adapters are expected. Qualification
+                    # requirements bind profile/version, while each component's
+                    # exact adapter is matched by its evidence binding below.
+                    candidate_requirement = QualificationRequirement(
+                        required=True,
+                        adapter_id=candidate_runtime.adapter.adapter_id,
+                        adapter_version=candidate_runtime.adapter.adapter_version,
+                        profile_id=route.qualification.profile_id,
+                        profile_version=route.qualification.profile_version,
+                        minimum_earned_maturity=route.qualification.minimum_earned_maturity,
+                        applicability_digest="",
+                    )
+                    # Applicability is provider-specific. Find exactly one
+                    # current record for the configured adapter/profile.
+                    key = (
+                        candidate.component_id,
+                        candidate.component_version,
+                        candidate.capability_id,
+                        candidate.capability_version,
+                    )
+                    possible = [
+                        item
+                        for item in qindex.get(key, ())
+                        if item.adapter_id == candidate_requirement.adapter_id
+                        and item.adapter_version == candidate_requirement.adapter_version
+                        and item.qualification_profile_id == candidate_requirement.profile_id
+                        and item.qualification_profile_version == candidate_requirement.profile_version
+                    ]
+                    if len(possible) != 1:
+                        raise RuntimeConfigurationError(
+                            f"route {route.route_id!r} fallback qualification is missing/ambiguous for {fallback_id!r}"
+                        )
+                    candidate_binding = possible[0]
+                    if not candidate_binding.qualification_current:
+                        raise RuntimeConfigurationError(
+                            f"route {route.route_id!r} fallback qualification is non-current for {fallback_id!r}"
+                        )
+                    if candidate_binding.source_rights_use_posture != "runtime_allowed":
+                        raise RuntimeConfigurationError(
+                            f"route {route.route_id!r} fallback qualification source rights are not runtime_allowed"
+                        )
+                    if not maturity_satisfies(
+                        candidate_binding.earned_maturity,
+                        route.qualification.minimum_earned_maturity,
+                    ):
+                        raise RuntimeConfigurationError(
+                            f"route {route.route_id!r} fallback qualification maturity is too weak"
+                        )
+                else:
+                    candidate_binding = _binding_for(candidate, route.qualification, qindex)
+            compatible_fallbacks.append((candidate, candidate_binding))
+
+        if len(compatible_fallbacks) > 1:
+            raise RuntimeConfigurationError(
+                f"route {route.route_id!r} has ambiguous equivalent fallbacks; configure at most one until an explicit composition/order contract exists"
+            )
+        if compatible_fallbacks:
+            fallback, fallback_binding = compatible_fallbacks[0]
+            fallback_component_id = fallback.component_id
+            fallback_record_ref = fallback_binding.record_ref if fallback_binding else ""
+
+        resolved_routes.append(
+            ResolvedRoute(
+                route_id=route.route_id,
+                primary=primary,
+                fallback_component_id=fallback_component_id,
+                qualification_record_ref=primary_binding.record_ref if primary_binding else "",
+                fallback_qualification_record_ref=fallback_record_ref,
+                currentness_required=route.currentness_required,
+                projection_id=route.projection_id,
+            )
+        )
+
+    peer_rows = value.get("governance_peers", ())
+    if not isinstance(peer_rows, list):
+        raise RuntimeConfigurationError("governance_peers must be an array")
+    peer_ids = [str(peer["peer_id"]) for peer in peer_rows if isinstance(peer, Mapping)]
+    if len(peer_ids) != len(set(peer_ids)):
+        raise RuntimeConfigurationError("governance peer ids must be unique")
+
+    runtime_raw = value["runtime"]
+    governance_raw = value["durable_governance"]
+    if not isinstance(runtime_raw, Mapping) or not isinstance(governance_raw, Mapping):
+        raise RuntimeConfigurationError("runtime and durable_governance must be objects")
+
+    return RuntimeConfigurationPlan(
+        schema_version=RUNTIME_CONFIGURATION_SCHEMA_VERSION,
+        configuration_digest=configuration_digest(value),
+        entry_mode=str(runtime_raw["entry_mode"]),
+        runtime_id=str(runtime_raw["runtime_id"]),
+        runtime_version=str(runtime_raw["runtime_version"]),
+        profile_id=str(runtime_raw["profile_id"]),
+        profile_version=str(runtime_raw["profile_version"]),
+        canonical_owner_component_id=owner_id,
+        canonical_owner_capability_id=owner_capability_id,
+        durable_governance_profile_id=str(governance_raw["profile_id"]),
+        resolved_routes=tuple(resolved_routes),
+        required_projection_ids=tuple(dict.fromkeys(required_projection_ids)),
+        governance_peer_ids=tuple(peer_ids),
+    )
+
+
+def load_runtime_configuration(
+    path: str | Path,
+    *,
+    qualification_bindings: Iterable[QualificationBinding] = (),
+) -> RuntimeConfigurationPlan:
+    """Load a JSON serialization of the portable contract and validate it."""
+
+    config_path = Path(path)
+    try:
+        value = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RuntimeConfigurationError(f"runtime configuration not found: {config_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeConfigurationError(f"runtime configuration is not valid JSON: {config_path}") from exc
+    if not isinstance(value, Mapping):
+        raise RuntimeConfigurationError("runtime configuration must be a JSON object")
+    return validate_runtime_configuration(value, qualification_bindings=qualification_bindings)

--- a/reference/fixtures/runtime-configuration/attached-existing-stack.json
+++ b/reference/fixtures/runtime-configuration/attached-existing-stack.json
@@ -1,0 +1,190 @@
+{
+  "schema_version": "1.0.0",
+  "runtime": {
+    "runtime_id": "example-existing-agent-runtime",
+    "runtime_version": "operator-managed",
+    "profile_id": "attached-existing-stack",
+    "profile_version": "1.0.0",
+    "entry_mode": "attach_existing_stack"
+  },
+  "canonical_state": {
+    "owner_component_id": "existing-canonical-store",
+    "owner_capability_id": "memory_record_store",
+    "owner_capability_version": "1.0"
+  },
+  "durable_governance": {
+    "profile_id": "reference_file_checkpoint_v1",
+    "profile_version": "1.0.0",
+    "state_ref": "state://agent-memory/governance"
+  },
+  "components": [
+    {
+      "declaration": {
+        "component_id": "existing-canonical-store",
+        "component_version": "operator-managed-2026.08",
+        "profile_version": "component-capability-v1",
+        "enabled": true,
+        "runtime_ref": "connector://existing-canonical-store",
+        "failure_posture": "fail_closed",
+        "provenance_refs": ["operator:existing-stack"],
+        "capabilities": [
+          {
+            "capability_id": "memory_record_store",
+            "capability_version": "1.0",
+            "maturity": "runtime_wired",
+            "state_posture": "canonical",
+            "scope_posture": "enforces_agent_memory_scope",
+            "failure_posture": "fail_closed",
+            "authority_effect": "none",
+            "enabled": true,
+            "evidence_refs": ["operator:existing-store-runtime"],
+            "limitations": ["example_operator_supplied_component"]
+          }
+        ]
+      },
+      "adapter": {
+        "adapter_id": "existing-memory-store-adapter",
+        "adapter_version": "1.0.0",
+        "runtime_ref": "connector://existing-canonical-store",
+        "secret_refs": {
+          "connection": "env://EXISTING_MEMORY_DSN"
+        }
+      },
+      "source_rights": {
+        "license_id": "Proprietary",
+        "license_ref": "operator://existing-canonical-store/rights",
+        "use_posture": "runtime_allowed"
+      }
+    },
+    {
+      "declaration": {
+        "component_id": "codegenome",
+        "component_version": "43a6b7147ec78ec5c616723fa1dd30f342174860",
+        "profile_version": "component-capability-v1",
+        "enabled": true,
+        "runtime_ref": "MythologIQ-Labs-LLC/CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860",
+        "failure_posture": "explicit_unavailable",
+        "provenance_refs": ["qualification:#300"],
+        "capabilities": [
+          {
+            "capability_id": "code_graph_traversal",
+            "capability_version": "1.0",
+            "maturity": "evidence_proven",
+            "state_posture": "derived",
+            "scope_posture": "inherits_agent_memory_scope",
+            "failure_posture": "explicit_unavailable",
+            "authority_effect": "none",
+            "enabled": true,
+            "evidence_refs": ["qualification:#300:codegenome"],
+            "limitations": ["full_rebuild_currentness_only"]
+          }
+        ]
+      },
+      "adapter": {
+        "adapter_id": "codegenome-cli",
+        "adapter_version": "1.0.0",
+        "runtime_ref": "MythologIQ-Labs-LLC/CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860"
+      },
+      "source_rights": {
+        "license_id": "MIT",
+        "license_ref": "MythologIQ-Labs-LLC/CodeGenome/LICENSE@43a6b7147ec78ec5c616723fa1dd30f342174860",
+        "use_posture": "runtime_allowed"
+      }
+    },
+    {
+      "declaration": {
+        "component_id": "graphify",
+        "component_version": "v0.9.43",
+        "profile_version": "component-capability-v1",
+        "enabled": true,
+        "runtime_ref": "Graphify-Labs/graphify@7281f27eac568f77f50910f59f84543458f5dfd1",
+        "failure_posture": "explicit_unavailable",
+        "provenance_refs": ["qualification:#300"],
+        "capabilities": [
+          {
+            "capability_id": "code_graph_traversal",
+            "capability_version": "1.0",
+            "maturity": "evidence_proven",
+            "state_posture": "derived",
+            "scope_posture": "inherits_agent_memory_scope",
+            "failure_posture": "explicit_unavailable",
+            "authority_effect": "none",
+            "enabled": true,
+            "evidence_refs": ["qualification:#300:graphify"],
+            "limitations": ["full_rebuild_currentness_only"]
+          }
+        ]
+      },
+      "adapter": {
+        "adapter_id": "graphify-cli",
+        "adapter_version": "1.0.0",
+        "runtime_ref": "Graphify-Labs/graphify@7281f27eac568f77f50910f59f84543458f5dfd1"
+      },
+      "source_rights": {
+        "license_id": "Apache-2.0",
+        "license_ref": "Graphify-Labs/graphify/LICENSE@7281f27eac568f77f50910f59f84543458f5dfd1",
+        "use_posture": "runtime_allowed"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "route_id": "canonical-record-store",
+      "capability_id": "memory_record_store",
+      "capability_version": "1.0",
+      "minimum_maturity": "runtime_wired",
+      "allowed_components": ["existing-canonical-store"],
+      "preferred_component": "existing-canonical-store",
+      "fallback_components": [],
+      "required_state_postures": ["canonical"],
+      "required_scope_postures": ["enforces_agent_memory_scope"],
+      "qualification": {
+        "required": false
+      },
+      "currentness": {
+        "required": false
+      }
+    },
+    {
+      "route_id": "derived-code-graph",
+      "capability_id": "code_graph_traversal",
+      "capability_version": "1.0",
+      "minimum_maturity": "evidence_proven",
+      "allowed_components": ["codegenome", "graphify"],
+      "preferred_component": "codegenome",
+      "fallback_components": ["graphify"],
+      "required_state_postures": ["derived"],
+      "required_scope_postures": ["inherits_agent_memory_scope"],
+      "qualification": {
+        "required": true,
+        "adapter_id": "codegenome-cli",
+        "adapter_version": "1.0.0",
+        "profile_id": "code-graph-traversal-currentness",
+        "profile_version": "1.1.0",
+        "minimum_earned_maturity": "evidence_proven",
+        "applicability_digest": "sha256:915a093171623702ea39df6e37a5588b7fdf2fb7bd88f81f7d3d41445a41af2e"
+      },
+      "currentness": {
+        "required": true,
+        "projection_id": "code-graph"
+      }
+    }
+  ],
+  "governance_peers": [
+    {
+      "peer_id": "dashclaw",
+      "adapter_ref": "reference/agentmem_ref/dashclaw_external_verdict.py",
+      "required": false,
+      "secret_refs": {
+        "credential": "env://DASHCLAW_TOKEN"
+      }
+    }
+  ],
+  "evidence": {
+    "qualification_store_refs": [
+      "artifact://component-qualification-1db939deb903a6685830cfdcb43db0993e2f650f"
+    ],
+    "receipt_store_ref": "state://agent-memory/receipts",
+    "runtime_evidence_ref": "evidence://agent-memory/runtime"
+  }
+}

--- a/reference/fixtures/runtime-configuration/qualification-bindings.json
+++ b/reference/fixtures/runtime-configuration/qualification-bindings.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "1.0.0",
+  "source": {
+    "issue": 300,
+    "qualification_schema_version": "1.1.0",
+    "source_artifact": "component-qualification-1db939deb903a6685830cfdcb43db0993e2f650f",
+    "source_artifact_digest": "sha256:d82afbdb3ace6590af1b1f538ff15457b6062c3e4b5b9dd6ec8f68e5aaca53ad",
+    "note": "Normalized runtime-validation fixture derived from independently inspected #300 evidence; the source qualification artifact remains the evidence authority."
+  },
+  "bindings": [
+    {
+      "component_id": "codegenome",
+      "component_version": "43a6b7147ec78ec5c616723fa1dd30f342174860",
+      "capability_id": "code_graph_traversal",
+      "capability_version": "1.0",
+      "adapter_id": "codegenome-cli",
+      "adapter_version": "1.0.0",
+      "qualification_profile_id": "code-graph-traversal-currentness",
+      "qualification_profile_version": "1.1.0",
+      "applicability_digest": "sha256:915a093171623702ea39df6e37a5588b7fdf2fb7bd88f81f7d3d41445a41af2e",
+      "qualification_current": true,
+      "earned_maturity": "evidence_proven",
+      "source_rights_use_posture": "runtime_allowed",
+      "record_ref": "artifact://component-qualification-1db939deb903a6685830cfdcb43db0993e2f650f#providers.codegenome.qualification"
+    },
+    {
+      "component_id": "graphify",
+      "component_version": "v0.9.43",
+      "capability_id": "code_graph_traversal",
+      "capability_version": "1.0",
+      "adapter_id": "graphify-cli",
+      "adapter_version": "1.0.0",
+      "qualification_profile_id": "code-graph-traversal-currentness",
+      "qualification_profile_version": "1.1.0",
+      "applicability_digest": "sha256:5d7a051b579cc3bb914d664c2aff859426b48020d27c171fee6fe4930da14906",
+      "qualification_current": true,
+      "earned_maturity": "evidence_proven",
+      "source_rights_use_posture": "runtime_allowed",
+      "record_ref": "artifact://component-qualification-1db939deb903a6685830cfdcb43db0993e2f650f#providers.graphify.qualification"
+    }
+  ]
+}

--- a/reference/run_runtime_configuration.py
+++ b/reference/run_runtime_configuration.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Validate the portable #280 runtime configuration and emit exact-head evidence."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.runtime_config import (  # noqa: E402
+    QualificationBinding,
+    RuntimeConfigurationError,
+    validate_runtime_configuration,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = ROOT / "reference" / "fixtures" / "runtime-configuration"
+
+
+def _load_inputs() -> tuple[dict, tuple[QualificationBinding, ...], dict]:
+    config = json.loads((FIXTURE_ROOT / "attached-existing-stack.json").read_text(encoding="utf-8"))
+    binding_document = json.loads((FIXTURE_ROOT / "qualification-bindings.json").read_text(encoding="utf-8"))
+    bindings = tuple(QualificationBinding(**row) for row in binding_document["bindings"])
+    return config, bindings, binding_document["source"]
+
+
+def _refused(config: dict, bindings: tuple[QualificationBinding, ...]) -> bool:
+    try:
+        validate_runtime_configuration(config, qualification_bindings=bindings)
+    except RuntimeConfigurationError:
+        return True
+    return False
+
+
+def build_report(agent_memory_commit: str) -> dict:
+    if len(agent_memory_commit) != 40:
+        raise ValueError("agent-memory commit must be an exact 40-character SHA")
+
+    config, bindings, source = _load_inputs()
+    plan = validate_runtime_configuration(config, qualification_bindings=bindings)
+
+    stale = copy.deepcopy(config)
+    for component in stale["components"]:
+        if component["declaration"]["component_id"] == "codegenome":
+            component["declaration"]["component_version"] = "unverified-next-version"
+
+    ambiguous = copy.deepcopy(config)
+    for route in ambiguous["routes"]:
+        if route["route_id"] == "derived-code-graph":
+            route.pop("preferred_component", None)
+
+    literal_secret = copy.deepcopy(config)
+    literal_secret["governance_peers"][0]["secret_refs"]["credential"] = "literal-secret"
+
+    missing_owner = copy.deepcopy(config)
+    missing_owner["canonical_state"]["owner_component_id"] = "missing-store"
+
+    invariants = {
+        "attach_existing_stack": plan.entry_mode == "attach_existing_stack",
+        "canonical_owner_explicit": plan.canonical_owner_component_id == "existing-canonical-store",
+        "qualified_primary_selected": any(
+            route.route_id == "derived-code-graph"
+            and route.primary.component_id == "codegenome"
+            and bool(route.qualification_record_ref)
+            for route in plan.resolved_routes
+        ),
+        "explicit_equivalent_fallback_bound": any(
+            route.route_id == "derived-code-graph"
+            and route.fallback_component_id == "graphify"
+            and bool(route.fallback_qualification_record_ref)
+            for route in plan.resolved_routes
+        ),
+        "derived_currentness_obligation_declared": plan.required_projection_ids == ("code-graph",),
+        "governance_peer_declared": plan.governance_peer_ids == ("dashclaw",),
+        "configuration_grants_no_authority": plan.authority_effect == "none",
+        "stale_component_qualification_refused": _refused(stale, bindings),
+        "ambiguous_provider_refused": _refused(ambiguous, bindings),
+        "literal_secret_refused": _refused(literal_secret, bindings),
+        "missing_canonical_owner_refused": _refused(missing_owner, bindings),
+    }
+
+    return {
+        "schema_version": "1.0.0",
+        "agent_memory_commit": agent_memory_commit,
+        "configuration_contract": "schemas/runtime-configuration.schema.json@1.0.0",
+        "qualification_source": source,
+        "plan": plan.to_dict(),
+        "structural_invariants": invariants,
+        "structural_invariants_passed": all(invariants.values()),
+        "limitations": [
+            "JSON is the first reference serialization, not a mandated product configuration syntax.",
+            "The validator consumes independently supplied qualification bindings; it does not make configuration self-qualifying.",
+            "Component discovery, package installation, interactive wizard UX, and secret resolution are intentionally outside this slice.",
+            "Execution-time provider outage continues to use the #300 fallback contract; this slice validates configured topology before startup.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = build_report(args.agent_memory_commit)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report["structural_invariants_passed"]:
+        failed = [name for name, passed in report["structural_invariants"].items() if not passed]
+        print(f"runtime configuration invariant failed: {failed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_runtime_config.py
+++ b/reference/tests/test_runtime_config.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from agentmem_ref.runtime_config import (
+    QualificationBinding,
+    RuntimeConfigurationError,
+    configuration_digest,
+    validate_runtime_configuration,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "reference" / "fixtures" / "runtime-configuration" / "attached-existing-stack.json"
+
+
+def _config() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _bindings() -> tuple[QualificationBinding, ...]:
+    return (
+        QualificationBinding(
+            component_id="codegenome",
+            component_version="43a6b7147ec78ec5c616723fa1dd30f342174860",
+            capability_id="code_graph_traversal",
+            capability_version="1.0",
+            adapter_id="codegenome-cli",
+            adapter_version="1.0.0",
+            qualification_profile_id="code-graph-traversal-currentness",
+            qualification_profile_version="1.1.0",
+            applicability_digest="sha256:915a093171623702ea39df6e37a5588b7fdf2fb7bd88f81f7d3d41445a41af2e",
+            qualification_current=True,
+            earned_maturity="evidence_proven",
+            source_rights_use_posture="runtime_allowed",
+            record_ref="artifact:#300:codegenome",
+        ),
+        QualificationBinding(
+            component_id="graphify",
+            component_version="v0.9.43",
+            capability_id="code_graph_traversal",
+            capability_version="1.0",
+            adapter_id="graphify-cli",
+            adapter_version="1.0.0",
+            qualification_profile_id="code-graph-traversal-currentness",
+            qualification_profile_version="1.1.0",
+            applicability_digest="sha256:5d7a051b579cc3bb914d664c2aff859426b48020d27c171fee6fe4930da14906",
+            qualification_current=True,
+            earned_maturity="evidence_proven",
+            source_rights_use_posture="runtime_allowed",
+            record_ref="artifact:#300:graphify",
+        ),
+    )
+
+
+def _component(config: dict, component_id: str) -> dict:
+    return next(
+        item for item in config["components"]
+        if item["declaration"]["component_id"] == component_id
+    )
+
+
+def _route(config: dict, route_id: str) -> dict:
+    return next(item for item in config["routes"] if item["route_id"] == route_id)
+
+
+class RuntimeConfigurationTests(unittest.TestCase):
+    def test_attach_existing_stack_resolves_deterministically(self) -> None:
+        config = _config()
+        plan = validate_runtime_configuration(config, qualification_bindings=_bindings())
+        self.assertEqual(plan.entry_mode, "attach_existing_stack")
+        self.assertEqual(plan.canonical_owner_component_id, "existing-canonical-store")
+        self.assertEqual(plan.required_projection_ids, ("code-graph",))
+        self.assertEqual(plan.governance_peer_ids, ("dashclaw",))
+        self.assertEqual(plan.authority_effect, "none")
+        self.assertEqual(plan.configuration_digest, configuration_digest(config))
+
+        routes = {route.route_id: route for route in plan.resolved_routes}
+        self.assertEqual(routes["canonical-record-store"].primary.component_id, "existing-canonical-store")
+        self.assertEqual(routes["derived-code-graph"].primary.component_id, "codegenome")
+        self.assertEqual(routes["derived-code-graph"].fallback_component_id, "graphify")
+        self.assertEqual(routes["derived-code-graph"].qualification_record_ref, "artifact:#300:codegenome")
+        self.assertEqual(
+            routes["derived-code-graph"].fallback_qualification_record_ref,
+            "artifact:#300:graphify",
+        )
+
+    def test_configuration_digest_is_order_stable_for_object_keys(self) -> None:
+        config = _config()
+        reordered = {key: config[key] for key in reversed(list(config))}
+        self.assertEqual(configuration_digest(config), configuration_digest(reordered))
+
+    def test_missing_canonical_owner_fails_closed(self) -> None:
+        config = _config()
+        config["canonical_state"]["owner_component_id"] = "missing-store"
+        with self.assertRaisesRegex(RuntimeConfigurationError, "canonical-state owner is missing"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_noncanonical_owner_capability_fails_closed(self) -> None:
+        config = _config()
+        _component(config, "existing-canonical-store")["declaration"]["capabilities"][0]["state_posture"] = "derived"
+        with self.assertRaisesRegex(RuntimeConfigurationError, "must declare canonical state posture"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_stale_component_version_cannot_inherit_qualification(self) -> None:
+        config = _config()
+        _component(config, "codegenome")["declaration"]["component_version"] = "unverified-next-version"
+        with self.assertRaisesRegex(RuntimeConfigurationError, "qualification is missing/stale"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_maturity_shortfall_refuses_preferred_provider(self) -> None:
+        config = _config()
+        _component(config, "codegenome")["declaration"]["capabilities"][0]["maturity"] = "runtime_wired"
+        with self.assertRaisesRegex(RuntimeConfigurationError, "preferred provider"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_ambiguous_route_without_preference_fails(self) -> None:
+        config = _config()
+        _route(config, "derived-code-graph").pop("preferred_component")
+        with self.assertRaisesRegex(RuntimeConfigurationError, "ambiguous providers"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_incompatible_fallback_fails_configuration(self) -> None:
+        config = _config()
+        graphify = _component(config, "graphify")
+        graphify["declaration"]["capabilities"][0]["scope_posture"] = "external_scope_bridge"
+        with self.assertRaisesRegex(RuntimeConfigurationError, "preferred provider|weaker/incompatible"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_runtime_disallowed_source_rights_fail(self) -> None:
+        config = _config()
+        _component(config, "graphify")["source_rights"]["use_posture"] = "comparator_only"
+        with self.assertRaisesRegex(RuntimeConfigurationError, "not permitted for runtime use"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_noncurrent_qualification_fails(self) -> None:
+        config = _config()
+        bindings = list(_bindings())
+        current = bindings[0]
+        bindings[0] = QualificationBinding(
+            **{**current.__dict__, "qualification_current": False}
+        )
+        with self.assertRaisesRegex(RuntimeConfigurationError, "qualification is non-current"):
+            validate_runtime_configuration(config, qualification_bindings=bindings)
+
+    def test_wrong_primary_applicability_digest_fails(self) -> None:
+        config = _config()
+        _route(config, "derived-code-graph")["qualification"]["applicability_digest"] = "sha256:" + "0" * 64
+        with self.assertRaisesRegex(RuntimeConfigurationError, "qualification is missing/stale"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_evidence_maturity_requires_independent_qualification(self) -> None:
+        config = _config()
+        _route(config, "derived-code-graph")["qualification"] = {"required": False}
+        with self.assertRaisesRegex(RuntimeConfigurationError, "requires evidence maturity"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_current_derived_route_requires_projection_identity(self) -> None:
+        config = _config()
+        _route(config, "derived-code-graph")["currentness"].pop("projection_id")
+        with self.assertRaisesRegex(RuntimeConfigurationError, "has no projection_id"):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_literal_secret_material_is_not_a_portable_configuration_value(self) -> None:
+        config = _config()
+        _component(config, "existing-canonical-store")["adapter"]["secret_refs"]["connection"] = "postgres://user:literal-secret@db"
+        with self.assertRaises(RuntimeConfigurationError):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_literal_secret_key_is_rejected_even_if_schema_shape_changes_later(self) -> None:
+        config = _config()
+        config["governance_peers"][0]["token"] = "literal-token"
+        with self.assertRaises(RuntimeConfigurationError):
+            validate_runtime_configuration(config, qualification_bindings=_bindings())
+
+    def test_multiple_equivalent_fallbacks_are_ambiguous(self) -> None:
+        config = _config()
+        clone = copy.deepcopy(_component(config, "graphify"))
+        clone["declaration"]["component_id"] = "graphify-second"
+        clone["adapter"]["adapter_id"] = "graphify-second-cli"
+        config["components"].append(clone)
+        route = _route(config, "derived-code-graph")
+        route["allowed_components"].append("graphify-second")
+        route["fallback_components"].append("graphify-second")
+
+        graphify_binding = _bindings()[1]
+        second_binding = QualificationBinding(
+            **{
+                **graphify_binding.__dict__,
+                "component_id": "graphify-second",
+                "adapter_id": "graphify-second-cli",
+                "record_ref": "artifact:#300:graphify-second",
+            }
+        )
+        with self.assertRaisesRegex(RuntimeConfigurationError, "ambiguous equivalent fallbacks"):
+            validate_runtime_configuration(
+                config,
+                qualification_bindings=(*_bindings(), second_binding),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/runtime-configuration.schema.json
+++ b/schemas/runtime-configuration.schema.json
@@ -1,0 +1,359 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/runtime-configuration.schema.json",
+  "title": "Agent Memory Runtime Configuration",
+  "description": "Serialization-neutral runtime configuration contract for attaching Agent Memory to an existing stack or bootstrapping a bounded local profile. Configuration does not grant authority or prove qualification/currentness.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "runtime",
+    "canonical_state",
+    "durable_governance",
+    "components",
+    "routes",
+    "evidence"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "runtime": { "$ref": "#/$defs/runtime" },
+    "canonical_state": { "$ref": "#/$defs/canonicalState" },
+    "durable_governance": { "$ref": "#/$defs/durableGovernance" },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/componentRuntime" }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/route" }
+    },
+    "governance_peers": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/governancePeer" }
+    },
+    "evidence": { "$ref": "#/$defs/evidence" }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "nonEmptyString": { "type": "string", "minLength": 1 },
+    "secretRef": {
+      "type": "string",
+      "pattern": "^(env|secret|vault|keyring)://[^\\s]+$"
+    },
+    "runtime": {
+      "type": "object",
+      "required": [
+        "runtime_id",
+        "runtime_version",
+        "profile_id",
+        "profile_version",
+        "entry_mode"
+      ],
+      "properties": {
+        "runtime_id": { "$ref": "#/$defs/nonEmptyString" },
+        "runtime_version": { "$ref": "#/$defs/nonEmptyString" },
+        "profile_id": { "$ref": "#/$defs/nonEmptyString" },
+        "profile_version": { "$ref": "#/$defs/nonEmptyString" },
+        "entry_mode": {
+          "type": "string",
+          "enum": ["attach_existing_stack", "bootstrap_agent_memory_first"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "canonicalState": {
+      "type": "object",
+      "required": [
+        "owner_component_id",
+        "owner_capability_id",
+        "owner_capability_version"
+      ],
+      "properties": {
+        "owner_component_id": { "$ref": "#/$defs/nonEmptyString" },
+        "owner_capability_id": { "$ref": "#/$defs/nonEmptyString" },
+        "owner_capability_version": { "$ref": "#/$defs/nonEmptyString" }
+      },
+      "additionalProperties": false
+    },
+    "durableGovernance": {
+      "type": "object",
+      "required": ["profile_id", "profile_version", "state_ref"],
+      "properties": {
+        "profile_id": { "$ref": "#/$defs/nonEmptyString" },
+        "profile_version": { "$ref": "#/$defs/nonEmptyString" },
+        "state_ref": { "$ref": "#/$defs/nonEmptyString" }
+      },
+      "additionalProperties": false
+    },
+    "sourceRights": {
+      "type": "object",
+      "required": ["license_id", "license_ref", "use_posture"],
+      "properties": {
+        "license_id": { "$ref": "#/$defs/nonEmptyString" },
+        "license_ref": { "$ref": "#/$defs/nonEmptyString" },
+        "use_posture": {
+          "type": "string",
+          "enum": ["runtime_allowed", "comparator_only", "disallowed"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "adapter": {
+      "type": "object",
+      "required": ["adapter_id", "adapter_version", "runtime_ref"],
+      "properties": {
+        "adapter_id": { "$ref": "#/$defs/nonEmptyString" },
+        "adapter_version": { "$ref": "#/$defs/nonEmptyString" },
+        "runtime_ref": { "$ref": "#/$defs/nonEmptyString" },
+        "secret_refs": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/secretRef" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "capability": {
+      "type": "object",
+      "required": [
+        "capability_id",
+        "capability_version",
+        "maturity",
+        "state_posture",
+        "scope_posture",
+        "failure_posture",
+        "authority_effect",
+        "enabled"
+      ],
+      "properties": {
+        "capability_id": { "$ref": "#/$defs/nonEmptyString" },
+        "capability_version": { "$ref": "#/$defs/nonEmptyString" },
+        "maturity": {
+          "type": "string",
+          "enum": [
+            "declared",
+            "implemented",
+            "runtime_wired",
+            "evidence_proven",
+            "reference_qualified"
+          ]
+        },
+        "state_posture": {
+          "type": "string",
+          "enum": ["canonical", "historical", "derived", "learned", "external"]
+        },
+        "scope_posture": {
+          "type": "string",
+          "enum": [
+            "enforces_agent_memory_scope",
+            "inherits_agent_memory_scope",
+            "external_scope_bridge"
+          ]
+        },
+        "failure_posture": {
+          "type": "string",
+          "enum": ["fail_closed", "explicit_unavailable", "fail_open_candidate_only"]
+        },
+        "authority_effect": {
+          "type": "string",
+          "enum": ["none", "proposal_only"]
+        },
+        "enabled": { "type": "boolean" },
+        "evidence_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        },
+        "limitations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "componentDeclaration": {
+      "type": "object",
+      "required": [
+        "component_id",
+        "component_version",
+        "profile_version",
+        "enabled",
+        "failure_posture",
+        "capabilities"
+      ],
+      "properties": {
+        "component_id": { "$ref": "#/$defs/nonEmptyString" },
+        "component_version": { "$ref": "#/$defs/nonEmptyString" },
+        "profile_version": { "$ref": "#/$defs/nonEmptyString" },
+        "enabled": { "type": "boolean" },
+        "runtime_ref": { "type": "string" },
+        "failure_posture": {
+          "type": "string",
+          "enum": ["fail_closed", "explicit_unavailable", "fail_open_candidate_only"]
+        },
+        "provenance_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        },
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/capability" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "componentRuntime": {
+      "type": "object",
+      "required": ["declaration", "adapter", "source_rights"],
+      "properties": {
+        "declaration": { "$ref": "#/$defs/componentDeclaration" },
+        "adapter": { "$ref": "#/$defs/adapter" },
+        "source_rights": { "$ref": "#/$defs/sourceRights" }
+      },
+      "additionalProperties": false
+    },
+    "qualificationRequirement": {
+      "type": "object",
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "adapter_id": { "$ref": "#/$defs/nonEmptyString" },
+        "adapter_version": { "$ref": "#/$defs/nonEmptyString" },
+        "profile_id": { "$ref": "#/$defs/nonEmptyString" },
+        "profile_version": { "$ref": "#/$defs/nonEmptyString" },
+        "minimum_earned_maturity": {
+          "type": "string",
+          "enum": [
+            "declared",
+            "implemented",
+            "runtime_wired",
+            "evidence_proven",
+            "reference_qualified"
+          ]
+        },
+        "applicability_digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          },
+          "then": {
+            "required": [
+              "adapter_id",
+              "adapter_version",
+              "profile_id",
+              "profile_version",
+              "minimum_earned_maturity",
+              "applicability_digest"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "currentness": {
+      "type": "object",
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "projection_id": { "$ref": "#/$defs/nonEmptyString" }
+      },
+      "additionalProperties": false
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "route_id",
+        "capability_id",
+        "capability_version",
+        "minimum_maturity",
+        "allowed_components",
+        "qualification",
+        "currentness"
+      ],
+      "properties": {
+        "route_id": { "$ref": "#/$defs/nonEmptyString" },
+        "capability_id": { "$ref": "#/$defs/nonEmptyString" },
+        "capability_version": { "$ref": "#/$defs/nonEmptyString" },
+        "minimum_maturity": {
+          "type": "string",
+          "enum": [
+            "declared",
+            "implemented",
+            "runtime_wired",
+            "evidence_proven",
+            "reference_qualified"
+          ]
+        },
+        "allowed_components": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        },
+        "preferred_component": { "$ref": "#/$defs/nonEmptyString" },
+        "fallback_components": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        },
+        "required_state_postures": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["canonical", "historical", "derived", "learned", "external"] },
+          "uniqueItems": true
+        },
+        "required_scope_postures": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "enforces_agent_memory_scope",
+              "inherits_agent_memory_scope",
+              "external_scope_bridge"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "qualification": { "$ref": "#/$defs/qualificationRequirement" },
+        "currentness": { "$ref": "#/$defs/currentness" }
+      },
+      "additionalProperties": false
+    },
+    "governancePeer": {
+      "type": "object",
+      "required": ["peer_id", "adapter_ref", "required"],
+      "properties": {
+        "peer_id": { "$ref": "#/$defs/nonEmptyString" },
+        "adapter_ref": { "$ref": "#/$defs/nonEmptyString" },
+        "required": { "type": "boolean" },
+        "secret_refs": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/secretRef" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["qualification_store_refs", "receipt_store_ref", "runtime_evidence_ref"],
+      "properties": {
+        "qualification_store_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        },
+        "receipt_store_ref": { "$ref": "#/$defs/nonEmptyString" },
+        "runtime_evidence_ref": { "$ref": "#/$defs/nonEmptyString" }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the next bounded #280 slice from `main@11ddde653e0650f29a32463f2378d8965f146262`.

This PR establishes one public, serialization-neutral runtime configuration contract for the dominant installation case: **attach Agent Memory to an existing runtime/governance/storage stack**.

JSON is used only as the first reference serialization. The semantic authority is the schema + deterministic validator. A future CLI, wizard, YAML reader, or TOML reader must map to the same contract rather than create hidden configuration state.

### Configuration surface

Adds `schemas/runtime-configuration.schema.json@1.0.0` covering:

- runtime/profile identity and `attach_existing_stack | bootstrap_agent_memory_first` entry mode;
- explicit canonical-state owner;
- durable-governance profile/state reference;
- inline versioned component/capability declarations;
- adapter identity/runtime binding;
- runtime source-rights posture;
- preferred/allowed/fallback provider topology;
- independent qualification requirements;
- #308 currentness/projection obligations;
- governance-peer refs;
- secret **references** only;
- qualification/evidence/receipt store references.

### Deterministic validation

`reference/agentmem_ref/runtime_config.py` reuses the existing ADR-033 `ComponentRegistry` rather than creating a second router.

It fails closed on, among other things:

- missing/disabled/non-canonical canonical owner;
- unknown component IDs or stale component versions;
- maturity shortfall;
- ambiguous provider selection;
- preferred provider outside the allowed set;
- incompatible/weaker fallback posture;
- multiple equivalent fallbacks where no explicit composition/order contract exists;
- runtime-disallowed source rights;
- evidence-level maturity without independent qualification;
- stale/non-current/maturity-insufficient qualification;
- missing projection identity for required derived currentness;
- literal secret material or unsupported secret-reference schemes.

Configuration resolution emits `authority_effect = none`.

### Attach-to-existing-stack fixture

The reference fixture models:

- an operator-managed agent runtime;
- an operator-supplied canonical memory store;
- Agent Memory durable governance state;
- CodeGenome as a qualified derived `code_graph_traversal` primary;
- Graphify as an independently qualified equivalent fallback;
- DashClaw as an existing governance peer reference;
- `code-graph` as a required currentness projection.

The #300 qualification artifact remains the source evidence authority. The checked-in qualification binding fixture is explicitly a normalized validation projection derived from that independently inspected artifact, not a new self-qualification mechanism.

### Evidence

Adds targeted adversarial tests, a full reference regression gate, and `reference/run_runtime_configuration.py` exact-head evidence.

## Explicit non-goals

- setup wizard;
- package/component installation automation;
- auto-detection of every agent framework;
- secret resolution;
- universal backend selection;
- hidden configuration state;
- making Agent Memory the primary runtime;
- silently installing recommended components.

## Product invariant

```text
serialization != semantics
wizard != configuration authority
installed != configured
configured != qualified
qualified != current
current != quiescent
```

Refs #280.
Refs #300.
Refs #282.
Refs #308.
Refs PRD-001.
Refs ADR-033.