### PR TITLE
Bind runtime configuration to restart-safe recovery

### DIFF
--- a/.github/workflows/config-bound-recovery.yml
+++ b/.github/workflows/config-bound-recovery.yml
@@ -1,0 +1,84 @@
+name: Configuration-Bound Recovery
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Execute targeted configuration-bound recovery tests
+        run: python -m unittest discover -s reference/tests -t reference -p 'test_configured_restart.py'
+
+      - name: Execute full reference regression suite
+        run: python -m unittest discover -s reference/tests -t reference
+
+      - name: Emit exact-head configuration-bound recovery evidence
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_config_bound_recovery.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output config-bound-recovery.json
+
+      - name: Validate emitted recovery evidence
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("config-bound-recovery.json").read_text())
+          if len(report["agent_memory_commit"]) != 40:
+              raise SystemExit("recovery evidence is not exact-head bound")
+          failed = [
+              name for name, passed in report["structural_invariants"].items()
+              if not passed
+          ]
+          if failed:
+              raise SystemExit(f"configuration-bound recovery invariants failed: {failed}")
+          exact = report["exact_recovery"]
+          fallback = report["fallback_recovery"]
+          if exact["authority_effect"] != "none" or fallback["authority_effect"] != "none":
+              raise SystemExit("recovery/fallback cannot create authority")
+          if report["base_durability_profile"] == report["config_bound_durability_profile"]:
+              raise SystemExit("outer configuration-bound profile must not silently mutate v1")
+          print(f"validated {len(report['structural_invariants'])} configuration-bound recovery invariants")
+          PY
+
+      - name: Upload configuration-bound recovery evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: config-bound-recovery
+          path: config-bound-recovery.json
+          if-no-files-found: error
+
+      - name: Publish recovery summary
+        if: always()
+        run: |
+          {
+            echo "## Configuration-bound restart recovery"
+            echo ""
+            echo "The outer profile binds a validated #280 configuration plan to the immutable reference_file_checkpoint_v1 generation and preserves #308 projection obligations across restart."
+            echo ""
+            echo "Configured fallback activates only with explicit #300 ProviderFailure evidence."
+            echo ""
+            echo '```'
+            echo "python -m unittest discover -s reference/tests -t reference -p 'test_configured_restart.py'"
+            echo "python reference/run_config_bound_recovery.py --agent-memory-commit <exact-40-hex-commit> --output config-bound-recovery.json"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/programs/runtime-evidence/configuration-bound-recovery.md
+++ b/docs/programs/runtime-evidence/configuration-bound-recovery.md
@@ -1,0 +1,122 @@
+# Configuration-bound restart recovery
+
+Status: implementation evidence for #282, composed with #280, #300, and #308
+
+This slice binds the validated portable runtime configuration contract to restart-safe durable state without changing the already-earned `reference_file_checkpoint_v1` semantics.
+
+## Why a second profile exists
+
+The first restart profile proves that Agent Memory can reconstruct its reference substrate and governance envelope after restart.
+
+The runtime configuration work adds another interpretation boundary:
+
+```text
+same durable bytes
++ different component routing / qualification / currentness requirements
+= potentially different runtime meaning
+```
+
+Therefore configuration is not treated as startup-only convenience. A durable runtime must know which validated configuration interpretation produced and governs the state it is recovering.
+
+The outer durability profile is:
+
+`reference_config_bound_checkpoint_v1`
+
+It composes, rather than replaces:
+
+`reference_file_checkpoint_v1`
+
+## Bound state
+
+`configuration-binding.json` records:
+
+- runtime-configuration digest;
+- normalized resolved-plan digest and resolved plan;
+- exact base checkpoint generation;
+- base substrate digest;
+- base governance digest;
+- base interpretation digest;
+- required #308 projection identities.
+
+The outer binding is written after the inner checkpoint. If the inner checkpoint advances without a matching outer binding, recovery fails closed rather than pairing new durable memory with stale configuration interpretation.
+
+## Configuration drift
+
+Recovery requires both:
+
+```text
+configuration_digest == persisted configuration_digest
+plan_digest == persisted plan_digest
+```
+
+A changed evidence-store reference, runtime profile, provider resolution, qualification record interpretation, or required projection set does not silently migrate existing durable state.
+
+There is deliberately no automatic migration path in this slice.
+
+## Provider failure after restart
+
+A configured fallback is not activated from a boolean such as `provider_available = false`.
+
+Fallback requires an explicit #300 `ProviderFailure` record matching the configured primary component and capability.
+
+For the reference attach-to-existing-stack configuration:
+
+```text
+CodeGenome primary
+  + explicit provider failure evidence
+  + previously validated Graphify fallback binding
+  -> Graphify fallback_active
+```
+
+Without failure evidence, CodeGenome remains the active configured primary.
+
+A provider failure for a route with no configured fallback produces an explicit `unavailable` route activation and a degraded recovery posture. Durable-state recovery and operational readiness are therefore not collapsed.
+
+Fallback/recovery evidence retains:
+
+`authority_effect = none`
+
+## Currentness composition
+
+Persisted #308 visibility snapshots are checked against the recovered configuration's required projection identities.
+
+A visibility obligation for a projection that is no longer required by the exact recovered configuration is refused rather than silently reinterpreted.
+
+The reference fixture preserves the required:
+
+`code-graph`
+
+projection across restart.
+
+## Evidence
+
+Targeted tests:
+
+```bash
+python -m unittest discover -s reference/tests -t reference -p 'test_configured_restart.py'
+```
+
+Exact-head evidence:
+
+```bash
+python reference/run_config_bound_recovery.py \
+  --agent-memory-commit <exact-40-character-commit> \
+  --output config-bound-recovery.json
+```
+
+The workflow also runs the complete reference regression suite before preserving the evidence artifact.
+
+## Non-claims
+
+This slice does not provide:
+
+- production distributed transaction semantics;
+- automatic configuration migration;
+- component package installation;
+- interactive setup;
+- live secret resolution;
+- universal provider health monitoring;
+- an HTTP/service runtime;
+- a production CLI.
+
+It establishes the runtime invariant those later product surfaces must preserve: durable Agent Memory state cannot be safely recovered under a different configuration interpretation merely because the files still parse.

--- a/reference/agentmem_ref/configured_restart.py
+++ b/reference/agentmem_ref/configured_restart.py
@@ -1,0 +1,450 @@
+"""Configuration-bound restart recovery for Agent Memory issue #282.
+
+This module composes the already-earned #280 runtime configuration contract with
+the bounded ``reference_file_checkpoint_v1`` durability profile. It does not
+mutate that profile. Instead it adds an outer, versioned binding that fails
+closed when the validated runtime plan, qualification interpretation, required
+projection set, or underlying checkpoint generation changes unexpectedly.
+
+Provider fallback after restart additionally requires explicit #300
+``ProviderFailure`` evidence. Configuration may name a fallback, but a fallback
+is not activated merely because a boolean claims the primary is unavailable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from .component_fallback import ProviderFailure
+from .restart_runtime import (
+    CapabilityBinding,
+    RecoveryEvidence,
+    RestartSafeRuntime,
+    RuntimeProfile,
+    RuntimeRecoveryError,
+)
+from .runtime_config import ResolvedRoute, RuntimeConfigurationPlan
+
+
+CONFIG_BINDING_SCHEMA_VERSION = "1.0.0"
+CONFIG_BOUND_DURABILITY_PROFILE = "reference_config_bound_checkpoint_v1"
+
+
+@dataclass(frozen=True)
+class RouteActivation:
+    route_id: str
+    capability_id: str
+    primary_component_id: str
+    active_component_id: str
+    status: str
+    failure_result: str = "none"
+    failure_evidence_ref: str = ""
+    trace_ref: str = ""
+
+    @property
+    def authority_effect(self) -> str:
+        return "none"
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["authority_effect"] = "none"
+        return payload
+
+
+@dataclass(frozen=True)
+class ConfigBoundRecoveryEvidence:
+    durability_profile: str
+    configuration_digest: str
+    plan_digest: str
+    base_generation: int
+    base_substrate_digest: str
+    base_governance_digest: str
+    base_interpretation_digest: str
+    required_projection_ids: tuple[str, ...]
+    route_activations: tuple[RouteActivation, ...]
+    recovery_posture: str
+
+    @property
+    def authority_effect(self) -> str:
+        return "none"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "durability_profile": self.durability_profile,
+            "configuration_digest": self.configuration_digest,
+            "plan_digest": self.plan_digest,
+            "base_generation": self.base_generation,
+            "base_substrate_digest": self.base_substrate_digest,
+            "base_governance_digest": self.base_governance_digest,
+            "base_interpretation_digest": self.base_interpretation_digest,
+            "required_projection_ids": list(self.required_projection_ids),
+            "route_activations": [item.to_dict() for item in self.route_activations],
+            "recovery_posture": self.recovery_posture,
+            "authority_effect": "none",
+        }
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _digest(value: object) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _atomic_json_write(path: Path, value: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    payload = _canonical_bytes(value) + b"\n"
+    with temporary.open("wb") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError as exc:
+        raise RuntimeRecoveryError(f"required configuration-bound state missing: {path.name}") from exc
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeRecoveryError(f"configuration-bound state is corrupt: {path.name}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeRecoveryError("configuration-bound state must be a JSON object")
+    return value
+
+
+def plan_digest(plan: RuntimeConfigurationPlan) -> str:
+    return _digest(plan.to_dict())
+
+
+def _profile_from_plan(plan: RuntimeConfigurationPlan) -> RuntimeProfile:
+    bindings: dict[str, CapabilityBinding] = {}
+    for route in plan.resolved_routes:
+        resolved = route.primary
+        evidence_ref = route.qualification_record_ref or f"configuration:{plan.configuration_digest}"
+        binding = CapabilityBinding(
+            component_id=resolved.component_id,
+            component_version=resolved.component_version,
+            capability_id=resolved.capability_id,
+            capability_version=resolved.capability_version,
+            maturity=resolved.maturity,
+            evidence_ref=evidence_ref,
+            source_rights_posture="runtime_allowed",
+        )
+        existing = bindings.get(binding.key)
+        if existing is not None and existing != binding:
+            raise RuntimeRecoveryError(
+                f"configuration resolves one capability to multiple primary interpretations: {binding.key}"
+            )
+        bindings[binding.key] = binding
+    return RuntimeProfile(
+        runtime_version=plan.runtime_version,
+        profile_id=plan.profile_id,
+        profile_version=plan.profile_version,
+        bindings=tuple(bindings[key] for key in sorted(bindings)),
+    )
+
+
+def _route_by_primary(plan: RuntimeConfigurationPlan) -> dict[tuple[str, str], ResolvedRoute]:
+    result: dict[tuple[str, str], ResolvedRoute] = {}
+    for route in plan.resolved_routes:
+        key = (route.primary.component_id, route.primary.capability_id)
+        if key in result:
+            raise RuntimeRecoveryError(
+                f"provider failure mapping is ambiguous across configured routes: {key[0]}:{key[1]}"
+            )
+        result[key] = route
+    return result
+
+
+def _activate_routes(
+    plan: RuntimeConfigurationPlan,
+    failures: Iterable[ProviderFailure],
+) -> tuple[RouteActivation, ...]:
+    route_index = _route_by_primary(plan)
+    failures_by_key: dict[tuple[str, str], ProviderFailure] = {}
+    for failure in failures:
+        key = (failure.component_id, failure.capability_id)
+        if key not in route_index:
+            raise RuntimeRecoveryError(
+                f"provider failure does not match any configured primary route: {failure.component_id}:{failure.capability_id}"
+            )
+        if key in failures_by_key:
+            raise RuntimeRecoveryError(
+                f"multiple provider failure records are ambiguous for {failure.component_id}:{failure.capability_id}"
+            )
+        failures_by_key[key] = failure
+
+    activations: list[RouteActivation] = []
+    for route in plan.resolved_routes:
+        primary = route.primary
+        key = (primary.component_id, primary.capability_id)
+        failure = failures_by_key.get(key)
+        if failure is None:
+            activations.append(
+                RouteActivation(
+                    route_id=route.route_id,
+                    capability_id=primary.capability_id,
+                    primary_component_id=primary.component_id,
+                    active_component_id=primary.component_id,
+                    status="primary_active",
+                )
+            )
+            continue
+
+        if not failure.evidence_ref or not failure.trace_ref:
+            raise RuntimeRecoveryError(
+                f"fallback after restart requires provider failure evidence for route {route.route_id!r}"
+            )
+        if route.fallback_component_id:
+            if not route.fallback_qualification_record_ref:
+                raise RuntimeRecoveryError(
+                    f"configured fallback lacks independently bound qualification evidence: {route.route_id!r}"
+                )
+            activations.append(
+                RouteActivation(
+                    route_id=route.route_id,
+                    capability_id=primary.capability_id,
+                    primary_component_id=primary.component_id,
+                    active_component_id=route.fallback_component_id,
+                    status="fallback_active",
+                    failure_result=failure.failure_result,
+                    failure_evidence_ref=failure.evidence_ref,
+                    trace_ref=failure.trace_ref,
+                )
+            )
+        else:
+            activations.append(
+                RouteActivation(
+                    route_id=route.route_id,
+                    capability_id=primary.capability_id,
+                    primary_component_id=primary.component_id,
+                    active_component_id="",
+                    status="unavailable",
+                    failure_result=failure.failure_result,
+                    failure_evidence_ref=failure.evidence_ref,
+                    trace_ref=failure.trace_ref,
+                )
+            )
+    return tuple(activations)
+
+
+def _assert_visibility_matches_plan(
+    visibility_snapshots: Mapping[str, dict],
+    plan: RuntimeConfigurationPlan,
+) -> None:
+    allowed = set(plan.required_projection_ids)
+    for operation_id, snapshot in visibility_snapshots.items():
+        operation = snapshot.get("operation", {}) if isinstance(snapshot, Mapping) else {}
+        if not isinstance(operation, Mapping):
+            raise RuntimeRecoveryError(f"visibility snapshot operation is malformed: {operation_id}")
+        required = set(operation.get("required_projection_ids", ()))
+        unknown = sorted(required.difference(allowed))
+        if unknown:
+            raise RuntimeRecoveryError(
+                f"persisted visibility obligation is not required by the recovered configuration: {operation_id}: {unknown}"
+            )
+
+
+class ConfigBindingStore:
+    """Outer binding between a validated config plan and one v1 checkpoint generation."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.path = Path(root) / "configuration-binding.json"
+
+    def checkpoint(
+        self,
+        *,
+        plan: RuntimeConfigurationPlan,
+        base_evidence: RecoveryEvidence,
+    ) -> ConfigBoundRecoveryEvidence:
+        normalized_plan = plan.to_dict()
+        digest = plan_digest(plan)
+        record = {
+            "schema_version": CONFIG_BINDING_SCHEMA_VERSION,
+            "durability_profile": CONFIG_BOUND_DURABILITY_PROFILE,
+            "configuration_digest": plan.configuration_digest,
+            "plan_digest": digest,
+            "plan": normalized_plan,
+            "base": {
+                "generation": base_evidence.generation,
+                "substrate_digest": base_evidence.substrate_digest,
+                "governance_digest": base_evidence.governance_digest,
+                "interpretation_digest": base_evidence.interpretation_digest,
+            },
+            "required_projection_ids": list(plan.required_projection_ids),
+        }
+        _atomic_json_write(self.path, record)
+        activations = _activate_routes(plan, ())
+        return ConfigBoundRecoveryEvidence(
+            durability_profile=CONFIG_BOUND_DURABILITY_PROFILE,
+            configuration_digest=plan.configuration_digest,
+            plan_digest=digest,
+            base_generation=base_evidence.generation,
+            base_substrate_digest=base_evidence.substrate_digest,
+            base_governance_digest=base_evidence.governance_digest,
+            base_interpretation_digest=base_evidence.interpretation_digest,
+            required_projection_ids=plan.required_projection_ids,
+            route_activations=activations,
+            recovery_posture="checkpoint_bound_to_validated_configuration",
+        )
+
+    def recover(
+        self,
+        *,
+        plan: RuntimeConfigurationPlan,
+        base_evidence: RecoveryEvidence,
+        provider_failures: Iterable[ProviderFailure],
+    ) -> ConfigBoundRecoveryEvidence:
+        record = _read_json(self.path)
+        if record.get("schema_version") != CONFIG_BINDING_SCHEMA_VERSION:
+            raise RuntimeRecoveryError("unsupported configuration-binding schema")
+        if record.get("durability_profile") != CONFIG_BOUND_DURABILITY_PROFILE:
+            raise RuntimeRecoveryError("configuration-bound durability profile changed")
+        if record.get("configuration_digest") != plan.configuration_digest:
+            raise RuntimeRecoveryError(
+                "runtime configuration changed after durable state was written; explicit migration is required"
+            )
+        expected_plan_digest = plan_digest(plan)
+        if record.get("plan_digest") != expected_plan_digest:
+            raise RuntimeRecoveryError(
+                "resolved runtime plan or qualification interpretation changed; explicit migration is required"
+            )
+        persisted_plan = record.get("plan")
+        if not isinstance(persisted_plan, Mapping) or _digest(persisted_plan) != expected_plan_digest:
+            raise RuntimeRecoveryError("persisted runtime plan binding is corrupt or inconsistent")
+
+        base = record.get("base")
+        if not isinstance(base, Mapping):
+            raise RuntimeRecoveryError("configuration binding has no base checkpoint identity")
+        comparisons = {
+            "generation": base_evidence.generation,
+            "substrate_digest": base_evidence.substrate_digest,
+            "governance_digest": base_evidence.governance_digest,
+            "interpretation_digest": base_evidence.interpretation_digest,
+        }
+        for key, expected in comparisons.items():
+            if base.get(key) != expected:
+                raise RuntimeRecoveryError(
+                    f"configuration binding does not match recovered base checkpoint: {key}"
+                )
+
+        persisted_projections = tuple(record.get("required_projection_ids", ()))
+        if persisted_projections != plan.required_projection_ids:
+            raise RuntimeRecoveryError("required projection interpretation changed after restart")
+
+        activations = _activate_routes(plan, provider_failures)
+        degraded = any(item.status == "unavailable" for item in activations)
+        fallback = any(item.status == "fallback_active" for item in activations)
+        if degraded:
+            posture = "recovered_config_current_but_provider_unavailable"
+        elif fallback:
+            posture = "recovered_config_current_with_evidence_bound_fallback"
+        else:
+            posture = "recovered_exact_configuration"
+        return ConfigBoundRecoveryEvidence(
+            durability_profile=CONFIG_BOUND_DURABILITY_PROFILE,
+            configuration_digest=plan.configuration_digest,
+            plan_digest=expected_plan_digest,
+            base_generation=base_evidence.generation,
+            base_substrate_digest=base_evidence.substrate_digest,
+            base_governance_digest=base_evidence.governance_digest,
+            base_interpretation_digest=base_evidence.interpretation_digest,
+            required_projection_ids=plan.required_projection_ids,
+            route_activations=activations,
+            recovery_posture=posture,
+        )
+
+
+class ConfigBoundRestartRuntime:
+    """Validated runtime plan composed with the immutable v1 reference checkpoint."""
+
+    def __init__(
+        self,
+        *,
+        base: RestartSafeRuntime,
+        plan: RuntimeConfigurationPlan,
+        binding_store: ConfigBindingStore,
+        recovery_evidence: ConfigBoundRecoveryEvidence,
+    ) -> None:
+        self.base = base
+        self.plan = plan
+        self.binding_store = binding_store
+        self.recovery_evidence = recovery_evidence
+
+    @property
+    def adapter(self):
+        return self.base.adapter
+
+    @property
+    def visibility_snapshots(self) -> dict[str, dict]:
+        return self.base.visibility_snapshots
+
+    @classmethod
+    def create(
+        cls,
+        root: str | Path,
+        *,
+        tenant: str,
+        plan: RuntimeConfigurationPlan,
+    ) -> "ConfigBoundRestartRuntime":
+        profile = _profile_from_plan(plan)
+        base = RestartSafeRuntime.create(root, tenant=tenant, profile=profile)
+        binding_store = ConfigBindingStore(root)
+        evidence = binding_store.checkpoint(plan=plan, base_evidence=base.recovery_evidence)
+        return cls(base=base, plan=plan, binding_store=binding_store, recovery_evidence=evidence)
+
+    @classmethod
+    def recover(
+        cls,
+        root: str | Path,
+        *,
+        plan: RuntimeConfigurationPlan,
+        provider_failures: Iterable[ProviderFailure] = (),
+    ) -> "ConfigBoundRestartRuntime":
+        profile = _profile_from_plan(plan)
+        base = RestartSafeRuntime.recover(root, profile=profile)
+        _assert_visibility_matches_plan(base.visibility_snapshots, plan)
+        binding_store = ConfigBindingStore(root)
+        evidence = binding_store.recover(
+            plan=plan,
+            base_evidence=base.recovery_evidence,
+            provider_failures=provider_failures,
+        )
+        return cls(base=base, plan=plan, binding_store=binding_store, recovery_evidence=evidence)
+
+    def checkpoint(self) -> ConfigBoundRecoveryEvidence:
+        base_evidence = self.base.checkpoint()
+        self.recovery_evidence = self.binding_store.checkpoint(
+            plan=self.plan,
+            base_evidence=base_evidence,
+        )
+        return self.recovery_evidence
+
+    def commit_proposal(self, proposal, fact_text: str, episode=None):
+        result = self.base.adapter.commit_proposal(proposal, fact_text, episode)
+        self.checkpoint()
+        return result
+
+    def governed_delete(self, proposal, fact_uuid: str, derived_refs: tuple[str, ...] = ()):
+        result = self.base.adapter.governed_delete(proposal, fact_uuid, derived_refs)
+        self.checkpoint()
+        return result
+
+    def persist_visibility_snapshot(self, operation_id: str, snapshot: dict) -> ConfigBoundRecoveryEvidence:
+        _assert_visibility_matches_plan({operation_id: snapshot}, self.plan)
+        if not operation_id:
+            raise ValueError("visibility operation id is required")
+        if not isinstance(snapshot, dict):
+            raise ValueError("visibility snapshot must be a mapping")
+        self.base.visibility_snapshots[operation_id] = snapshot
+        return self.checkpoint()

--- a/reference/run_config_bound_recovery.py
+++ b/reference/run_config_bound_recovery.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Emit exact-head evidence for #280/#282 configuration-bound restart recovery."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.component_fallback import ProviderFailure  # noqa: E402
+from agentmem_ref.configured_restart import ConfigBoundRestartRuntime  # noqa: E402
+from agentmem_ref.restart_runtime import RuntimeRecoveryError  # noqa: E402
+from agentmem_ref.runtime_config import (  # noqa: E402
+    QualificationBinding,
+    validate_runtime_configuration,
+)
+from agentmem_ref.visibility import VisibilityOperation, VisibilityTracker  # noqa: E402
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = ROOT / "reference" / "fixtures" / "runtime-configuration"
+
+
+def _inputs() -> tuple[dict, tuple[QualificationBinding, ...]]:
+    config = json.loads((FIXTURE_ROOT / "attached-existing-stack.json").read_text(encoding="utf-8"))
+    binding_doc = json.loads((FIXTURE_ROOT / "qualification-bindings.json").read_text(encoding="utf-8"))
+    bindings = tuple(QualificationBinding(**row) for row in binding_doc["bindings"])
+    return config, bindings
+
+
+def _route(evidence, route_id: str):
+    return next(item for item in evidence.route_activations if item.route_id == route_id)
+
+
+def build_report(agent_memory_commit: str) -> dict:
+    if len(agent_memory_commit) != 40:
+        raise ValueError("agent-memory commit must be an exact 40-character SHA")
+
+    config, bindings = _inputs()
+    plan = validate_runtime_configuration(config, qualification_bindings=bindings)
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        created = ConfigBoundRestartRuntime.create(root, tenant="tenant-acme", plan=plan)
+
+        operation = VisibilityOperation(
+            operation_id="visibility:code-graph",
+            memory_id="memory:release-branch",
+            memory_version=1,
+            operation_type="promotion",
+            runtime_version=plan.runtime_version,
+            profile_version=plan.profile_version,
+            agent_memory_commit=agent_memory_commit,
+            required_projection_ids=("code-graph",),
+            component_versions=("codegenome@43a6b7147ec78ec5c616723fa1dd30f342174860",),
+            capability_versions=("code_graph_traversal@1.0",),
+        )
+        tracker = VisibilityTracker(operation)
+        tracker.policy_decided()
+        tracker.canonical_committed()
+        tracker.projection_refresh_started("code-graph")
+        created.persist_visibility_snapshot(operation.operation_id, tracker.snapshot_for_restart())
+
+        exact = ConfigBoundRestartRuntime.recover(root, plan=plan)
+        exact_route = _route(exact.recovery_evidence, "derived-code-graph")
+        restored_visibility = VisibilityTracker.restore_after_restart(
+            exact.visibility_snapshots[operation.operation_id]
+        ).evaluate()
+
+        failure = ProviderFailure(
+            component_id="codegenome",
+            capability_id="code_graph_traversal",
+            failure_result="provider_unavailable",
+            evidence_ref="artifact://failure/codegenome-missing-executable",
+            trace_ref="trace:restart-codegenome-unavailable",
+        )
+        fallback = ConfigBoundRestartRuntime.recover(
+            root,
+            plan=plan,
+            provider_failures=(failure,),
+        )
+        fallback_route = _route(fallback.recovery_evidence, "derived-code-graph")
+
+        changed_config = copy.deepcopy(config)
+        changed_config["evidence"]["receipt_store_ref"] = "state://agent-memory/changed-receipts"
+        changed_plan = validate_runtime_configuration(changed_config, qualification_bindings=bindings)
+        config_drift_refused = False
+        try:
+            ConfigBoundRestartRuntime.recover(root, plan=changed_plan)
+        except RuntimeRecoveryError:
+            config_drift_refused = True
+
+    with tempfile.TemporaryDirectory() as directory:
+        torn_root = Path(directory)
+        torn = ConfigBoundRestartRuntime.create(torn_root, tenant="tenant-acme", plan=plan)
+        torn.base.checkpoint()
+        torn_binding_refused = False
+        try:
+            ConfigBoundRestartRuntime.recover(torn_root, plan=plan)
+        except RuntimeRecoveryError:
+            torn_binding_refused = True
+
+    invariants = {
+        "configuration_digest_bound": created.recovery_evidence.configuration_digest == plan.configuration_digest,
+        "exact_restart_uses_primary": (
+            exact_route.status == "primary_active" and exact_route.active_component_id == "codegenome"
+        ),
+        "required_projection_survives_restart": (
+            exact.recovery_evidence.required_projection_ids == ("code-graph",)
+            and restored_visibility["quiescent"] is False
+            and "projection:code-graph" in restored_visibility["pending_required_obligations"]
+        ),
+        "provider_failure_evidence_selects_configured_fallback": (
+            fallback_route.status == "fallback_active"
+            and fallback_route.active_component_id == "graphify"
+            and fallback_route.failure_evidence_ref == failure.evidence_ref
+        ),
+        "fallback_grants_no_authority": fallback_route.authority_effect == "none",
+        "configuration_drift_requires_migration": config_drift_refused,
+        "torn_config_binding_fails_closed": torn_binding_refused,
+        "base_checkpoint_profile_remains_v1": exact.base.recovery_evidence.durability_profile == "reference_file_checkpoint_v1",
+        "outer_profile_is_versioned_separately": (
+            exact.recovery_evidence.durability_profile == "reference_config_bound_checkpoint_v1"
+        ),
+    }
+
+    return {
+        "schema_version": "1.0.0",
+        "agent_memory_commit": agent_memory_commit,
+        "configuration_digest": plan.configuration_digest,
+        "configuration_contract": "schemas/runtime-configuration.schema.json@1.0.0",
+        "base_durability_profile": "reference_file_checkpoint_v1",
+        "config_bound_durability_profile": "reference_config_bound_checkpoint_v1",
+        "exact_recovery": exact.recovery_evidence.to_dict(),
+        "fallback_recovery": fallback.recovery_evidence.to_dict(),
+        "structural_invariants": invariants,
+        "structural_invariants_passed": all(invariants.values()),
+        "limitations": [
+            "This slice composes validated configuration with the bounded reference file checkpoint; it is not a production HA claim.",
+            "Fallback activation requires explicit ProviderFailure evidence but this runner reuses a structurally valid failure record rather than reproducing the #300 missing-executable probe again.",
+            "Configuration migration is intentionally fail-closed and has no automatic migration path in this slice.",
+            "A process/service CLI and interactive setup remain future product surfaces over the same contract.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = build_report(args.agent_memory_commit)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report["structural_invariants_passed"]:
+        failed = [name for name, passed in report["structural_invariants"].items() if not passed]
+        print(f"configuration-bound recovery invariants failed: {failed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_configured_restart.py
+++ b/reference/tests/test_configured_restart.py
@@ -67,7 +67,10 @@ class ConfigBoundRestartTests(unittest.TestCase):
         changed = validate_runtime_configuration(config, qualification_bindings=bindings)
         self.assertNotEqual(changed.configuration_digest, self.plan.configuration_digest)
 
-        with self.assertRaisesRegex(RuntimeRecoveryError, "runtime configuration changed"):
+        with self.assertRaisesRegex(
+            RuntimeRecoveryError,
+            "runtime configuration changed|runtime profile/component interpretation changed",
+        ):
             ConfigBoundRestartRuntime.recover(self.root, plan=changed)
 
     def test_torn_outer_binding_is_detected_after_base_checkpoint_moves(self) -> None:

--- a/reference/tests/test_configured_restart.py
+++ b/reference/tests/test_configured_restart.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agentmem_ref.component_fallback import ProviderFailure
+from agentmem_ref.configured_restart import ConfigBoundRestartRuntime
+from agentmem_ref.restart_runtime import RuntimeRecoveryError
+from agentmem_ref.runtime_config import QualificationBinding, validate_runtime_configuration
+from agentmem_ref.visibility import VisibilityOperation, VisibilityTracker
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_ROOT = ROOT / "reference" / "fixtures" / "runtime-configuration"
+COMMIT = "192a9ebb15ac32ab89d50bb99857f3d53e452347"
+
+
+def _inputs() -> tuple[dict, tuple[QualificationBinding, ...]]:
+    config = json.loads((FIXTURE_ROOT / "attached-existing-stack.json").read_text(encoding="utf-8"))
+    binding_doc = json.loads((FIXTURE_ROOT / "qualification-bindings.json").read_text(encoding="utf-8"))
+    bindings = tuple(QualificationBinding(**row) for row in binding_doc["bindings"])
+    return config, bindings
+
+
+def _plan():
+    config, bindings = _inputs()
+    return validate_runtime_configuration(config, qualification_bindings=bindings)
+
+
+def _route(evidence, route_id: str):
+    return next(item for item in evidence.route_activations if item.route_id == route_id)
+
+
+class ConfigBoundRestartTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.plan = _plan()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_exact_validated_plan_survives_restart(self) -> None:
+        created = ConfigBoundRestartRuntime.create(
+            self.root,
+            tenant="tenant-acme",
+            plan=self.plan,
+        )
+        self.assertEqual(created.recovery_evidence.configuration_digest, self.plan.configuration_digest)
+        self.assertEqual(created.recovery_evidence.required_projection_ids, ("code-graph",))
+
+        recovered = ConfigBoundRestartRuntime.recover(self.root, plan=self.plan)
+        self.assertEqual(recovered.recovery_evidence.recovery_posture, "recovered_exact_configuration")
+        self.assertEqual(_route(recovered.recovery_evidence, "derived-code-graph").status, "primary_active")
+        self.assertEqual(
+            _route(recovered.recovery_evidence, "derived-code-graph").active_component_id,
+            "codegenome",
+        )
+
+    def test_configuration_digest_drift_requires_explicit_migration(self) -> None:
+        ConfigBoundRestartRuntime.create(self.root, tenant="tenant-acme", plan=self.plan)
+        config, bindings = _inputs()
+        config["evidence"]["receipt_store_ref"] = "state://agent-memory/changed-receipts"
+        changed = validate_runtime_configuration(config, qualification_bindings=bindings)
+        self.assertNotEqual(changed.configuration_digest, self.plan.configuration_digest)
+
+        with self.assertRaisesRegex(RuntimeRecoveryError, "runtime configuration changed"):
+            ConfigBoundRestartRuntime.recover(self.root, plan=changed)
+
+    def test_torn_outer_binding_is_detected_after_base_checkpoint_moves(self) -> None:
+        runtime = ConfigBoundRestartRuntime.create(self.root, tenant="tenant-acme", plan=self.plan)
+        old_generation = runtime.recovery_evidence.base_generation
+
+        # Simulate a crash/bug between the inner v1 checkpoint and the outer
+        # configuration binding update. Recovery must not silently pair a newer
+        # durable memory image with the older configuration binding.
+        runtime.base.checkpoint()
+        self.assertGreater(runtime.base.recovery_evidence.generation, old_generation)
+
+        with self.assertRaisesRegex(RuntimeRecoveryError, "configuration binding does not match"):
+            ConfigBoundRestartRuntime.recover(self.root, plan=self.plan)
+
+    def test_provider_failure_evidence_activates_only_configured_fallback(self) -> None:
+        ConfigBoundRestartRuntime.create(self.root, tenant="tenant-acme", plan=self.plan)
+        failure = ProviderFailure(
+            component_id="codegenome",
+            capability_id="code_graph_traversal",
+            failure_result="provider_unavailable",
+            evidence_ref="artifact://failure/codegenome-missing-executable",
+            trace_ref="trace:restart-codegenome-unavailable",
+        )
+        recovered = ConfigBoundRestartRuntime.recover(
+            self.root,
+            plan=self.plan,
+            provider_failures=(failure,),
+        )
+        route = _route(recovered.recovery_evidence, "derived-code-graph")
+        self.assertEqual(route.status, "fallback_active")
+        self.assertEqual(route.primary_component_id, "codegenome")
+        self.assertEqual(route.active_component_id, "graphify")
+        self.assertEqual(route.failure_result, "provider_unavailable")
+        self.assertEqual(route.failure_evidence_ref, failure.evidence_ref)
+        self.assertEqual(
+            recovered.recovery_evidence.recovery_posture,
+            "recovered_config_current_with_evidence_bound_fallback",
+        )
+        self.assertEqual(route.authority_effect, "none")
+
+    def test_unconfigured_failure_evidence_is_rejected(self) -> None:
+        ConfigBoundRestartRuntime.create(self.root, tenant="tenant-acme", plan=self.plan)
+        failure = ProviderFailure(
+            component_id="mystery-provider",
+            capability_id="code_graph_traversal",
+            failure_result="provider_unavailable",
+            evidence_ref="artifact://failure/mystery",
+            trace_ref="trace:mystery",
+        )
+        with self.assertRaisesRegex(RuntimeRecoveryError, "does not match any configured primary route"):
+            ConfigBoundRestartRuntime.recover(
+                self.root,
+                plan=self.plan,
+                provider_failures=(failure,),
+            )
+
+    def test_required_provider_without_fallback_recovers_as_explicitly_unavailable(self) -> None:
+        ConfigBoundRestartRuntime.create(self.root, tenant="tenant-acme", plan=self.plan)
+        failure = ProviderFailure(
+            component_id="existing-canonical-store",
+            capability_id="memory_record_store",
+            failure_result="provider_unavailable",
+            evidence_ref="artifact://failure/canonical-store-unavailable",
+            trace_ref="trace:canonical-store-unavailable",
+        )
+        recovered = ConfigBoundRestartRuntime.recover(
+            self.root,
+            plan=self.plan,
+            provider_failures=(failure,),
+        )
+        route = _route(recovered.recovery_evidence, "canonical-record-store")
+        self.assertEqual(route.status, "unavailable")
+        self.assertEqual(route.active_component_id, "")
+        self.assertEqual(
+            recovered.recovery_evidence.recovery_posture,
+            "recovered_config_current_but_provider_unavailable",
+        )
+
+    def test_currentness_snapshot_must_match_configured_required_projection(self) -> None:
+        runtime = ConfigBoundRestartRuntime.create(self.root, tenant="tenant-acme", plan=self.plan)
+        operation = VisibilityOperation(
+            operation_id="visibility:code-graph",
+            memory_id="memory:release-branch",
+            memory_version=1,
+            operation_type="promotion",
+            runtime_version=self.plan.runtime_version,
+            profile_version=self.plan.profile_version,
+            agent_memory_commit=COMMIT,
+            required_projection_ids=("code-graph",),
+            component_versions=("codegenome@43a6b7147ec78ec5c616723fa1dd30f342174860",),
+            capability_versions=("code_graph_traversal@1.0",),
+        )
+        tracker = VisibilityTracker(operation)
+        tracker.policy_decided()
+        tracker.canonical_committed()
+        tracker.projection_refresh_started("code-graph")
+        runtime.persist_visibility_snapshot(operation.operation_id, tracker.snapshot_for_restart())
+
+        recovered = ConfigBoundRestartRuntime.recover(self.root, plan=self.plan)
+        self.assertIn(operation.operation_id, recovered.visibility_snapshots)
+        self.assertFalse(
+            VisibilityTracker.restore_after_restart(
+                recovered.visibility_snapshots[operation.operation_id]
+            ).evaluate()["quiescent"]
+        )
+
+    def test_unconfigured_projection_obligation_is_refused_before_checkpoint(self) -> None:
+        runtime = ConfigBoundRestartRuntime.create(self.root, tenant="tenant-acme", plan=self.plan)
+        operation = VisibilityOperation(
+            operation_id="visibility:unknown",
+            memory_id="memory:release-branch",
+            memory_version=1,
+            operation_type="promotion",
+            runtime_version=self.plan.runtime_version,
+            profile_version=self.plan.profile_version,
+            agent_memory_commit=COMMIT,
+            required_projection_ids=("not-configured",),
+        )
+        tracker = VisibilityTracker(operation)
+        tracker.policy_decided()
+        tracker.canonical_committed()
+        tracker.projection_refresh_started("not-configured")
+
+        with self.assertRaisesRegex(RuntimeRecoveryError, "not required by the recovered configuration"):
+            runtime.persist_visibility_snapshot(operation.operation_id, tracker.snapshot_for_restart())
+
+    def test_changed_qualification_interpretation_cannot_rebind_same_configuration(self) -> None:
+        ConfigBoundRestartRuntime.create(self.root, tenant="tenant-acme", plan=self.plan)
+        config, bindings = _inputs()
+        changed_bindings = list(bindings)
+        original = changed_bindings[0]
+        changed_bindings[0] = QualificationBinding(
+            **{**original.__dict__, "record_ref": "artifact://replacement-qualification-record"}
+        )
+        changed_plan = validate_runtime_configuration(
+            copy.deepcopy(config),
+            qualification_bindings=changed_bindings,
+        )
+        self.assertEqual(changed_plan.configuration_digest, self.plan.configuration_digest)
+
+        with self.assertRaisesRegex(
+            RuntimeRecoveryError,
+            "runtime profile/component interpretation changed|resolved runtime plan",
+        ):
+            ConfigBoundRestartRuntime.recover(self.root, plan=changed_plan)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the next bounded #282 slice from `main@192a9ebb15ac32ab89d50bb99857f3d53e452347`, composing the newly merged #280 runtime-configuration contract with the existing restart-safe reference profile.

This PR deliberately does **not** mutate `reference_file_checkpoint_v1`. It adds an outer profile:

`reference_config_bound_checkpoint_v1`

that binds one validated runtime configuration/resolved plan to one exact inner checkpoint generation.

### Configuration-bound recovery

`reference/agentmem_ref/configured_restart.py` persists `configuration-binding.json` after the inner checkpoint and binds:

- exact runtime-configuration digest;
- normalized resolved-plan digest + plan;
- base checkpoint generation;
- base substrate/governance/interpretation digests;
- #308 required projection identities.

Recovery fails closed when configuration/plan interpretation changes or when the inner checkpoint advances without a matching outer binding.

### Provider failure/fallback after restart

A configured fallback is not activated from a boolean availability flag.

Fallback requires an explicit #300 `ProviderFailure` record matching the configured primary component/capability. The reference attach configuration therefore proves:

```text
CodeGenome primary
+ provider failure evidence
+ validated Graphify fallback binding
-> Graphify fallback_active
```

Without failure evidence, CodeGenome remains primary.

A required provider failure with no configured fallback remains explicitly `unavailable`; successful durable-state recovery is not mislabeled operational readiness.

All route activation/recovery evidence retains `authority_effect = none`.

### Currentness composition

Persisted #308 visibility snapshots must match projection identities required by the exact recovered #280 configuration. An unconfigured projection obligation is refused before checkpoint and after recovery.

### Evidence

Adds:

- `reference/agentmem_ref/configured_restart.py`;
- `reference/tests/test_configured_restart.py`;
- `reference/run_config_bound_recovery.py`;
- `Configuration-Bound Recovery` CI;
- `docs/programs/runtime-evidence/configuration-bound-recovery.md`.

Targeted acceptance includes:

- exact-plan recovery;
- config digest drift refusal;
- qualification interpretation drift refusal;
- torn outer binding after inner checkpoint advance;
- evidence-bound CodeGenome -> Graphify fallback;
- unconfigured failure evidence refusal;
- explicit unavailable posture where no fallback exists;
- required projection persistence;
- unconfigured projection refusal.

## Explicit non-claims

This is still bounded reference durability. It does not prove production distributed transactions, automatic config migration, package installation, secret resolution, universal provider health monitoring, an HTTP service, or a production CLI.

Refs #282.
Refs #280.
Refs #300.
Refs #308.