### PR TITLE
Add versioned capability behavior declaration contract

### DIFF
--- a/.github/workflows/capability-behavior-contract.yml
+++ b/.github/workflows/capability-behavior-contract.yml
@@ -1,0 +1,83 @@
+name: Capability Behavior Contract
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Execute targeted behavior-contract tests
+        run: python -m unittest discover -s reference/tests -t reference -p 'test_capability_behavior_contract.py'
+
+      - name: Execute full reference regression suite
+        run: python -m unittest discover -s reference/tests -t reference
+
+      - name: Emit exact-head behavior-contract evidence
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_capability_behavior_contract.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output capability-behavior-contract.json
+
+      - name: Validate emitted behavior evidence
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("capability-behavior-contract.json").read_text())
+          if len(report["agent_memory_commit"]) != 40:
+              raise SystemExit("behavior evidence is not exact-head bound")
+          invariants = report["structural_invariants"]
+          non_boolean = [name for name, value in invariants.items() if type(value) is not bool]
+          if non_boolean:
+              raise SystemExit(f"behavior invariants are not JSON booleans: {non_boolean}")
+          failed = [name for name, passed in invariants.items() if not passed]
+          if failed:
+              raise SystemExit(f"capability behavior invariants failed: {failed}")
+          if report["authority_effect"] != "none":
+              raise SystemExit("behavior metadata must not create authority")
+          if report["component_profile_contract"] != "component-capability-v2":
+              raise SystemExit("expected v2 capability behavior profile")
+          print(f"validated {len(invariants)} capability behavior invariants")
+          PY
+
+      - name: Upload capability behavior evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: capability-behavior-contract
+          path: capability-behavior-contract.json
+          if-no-files-found: error
+
+      - name: Publish behavior summary
+        if: always()
+        run: |
+          {
+            echo "## Capability behavior contract"
+            echo ""
+            echo "component-capability-v2 declares operation, currentness/invalidation, correction, deletion/residue, migration/rebuild, and structural-mutation requirements without granting authority."
+            echo ""
+            echo "Legacy component-capability-v1 remains readable but cannot satisfy an explicit v2 behavior requirement."
+            echo ""
+            echo '```'
+            echo "python -m unittest discover -s reference/tests -t reference -p 'test_capability_behavior_contract.py'"
+            echo "python reference/run_capability_behavior_contract.py --agent-memory-commit <exact-40-hex-commit> --output capability-behavior-contract.json"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/programs/memory-modules/capability-behavior-contract.md
+++ b/docs/programs/memory-modules/capability-behavior-contract.md
@@ -1,0 +1,289 @@
+# Capability behavior contract
+
+Status: implementation contract for #280 / ADR-033
+
+Agent Memory separates **what a capability is**, **how its state behaves**, and **what authority may act on its result**.
+
+Those are independent dimensions.
+
+```text
+capability identity
+  != lifecycle behavior
+  != maturity
+  != authority
+```
+
+## Why v2 exists
+
+`component-capability-v1` established independently matured capability declarations with explicit identity, version, maturity, state posture, scope posture, failure posture, evidence, limitations, and authority effect.
+
+That was sufficient to answer questions such as:
+
+- which implementation can provide `code_graph_traversal`;
+- whether its maturity is high enough;
+- whether it is canonical or derived;
+- whether it is scope-compatible;
+- whether failure must be explicit;
+- whether several eligible providers create ambiguity.
+
+It was not sufficient to answer a different class of questions:
+
+- does this capability write, read, or only nominate recall candidates;
+- how does it determine whether its output is current;
+- what makes its output stale or invalid;
+- what happens when canonical memory is corrected;
+- what happens when canonical memory is deleted;
+- can residue remain after deletion;
+- can the capability rebuild from canonical state;
+- does a structural mutation require PAMA or another authorization boundary.
+
+Those behaviors materially affect safe composition. `component-capability-v2` makes them machine-readable.
+
+## Backward compatibility
+
+Legacy declarations remain valid:
+
+```text
+component-capability-v1
+  -> behavior metadata optional / absent
+  -> valid when the consuming route does not require behavior semantics
+```
+
+New behavior-aware declarations use:
+
+```text
+component-capability-v2
+  -> behavior_contract required for every capability
+```
+
+A route that explicitly requires lifecycle behavior cannot be satisfied by a v1 provider that does not declare it.
+
+This is deliberate fail-closed behavior, not a claim that every v1 provider is unsafe. It means the runtime refuses to infer lifecycle guarantees the provider never declared.
+
+## Behavior fields
+
+Each v2 capability declares an operation surface:
+
+```text
+write
+read
+recall_candidate
+```
+
+These Booleans are descriptive. `write = true` means the capability exposes a write surface. It does **not** authorize a write.
+
+Each capability also declares one value for the following lifecycle dimensions.
+
+### Currentness model
+
+```text
+not_applicable
+canonical_version
+basis_versioned
+provider_revalidated
+external_asserted
+```
+
+Examples:
+
+- canonical retained memory may be current by canonical version;
+- a derived projection may be current only while its basis version matches canonical state;
+- an external provider may require revalidation.
+
+### Invalidation model
+
+```text
+not_applicable
+version_relation
+explicit_signal
+provider_revalidation
+```
+
+This describes how the implementation determines that prior state is no longer current. Invalidation remains a write-channel-sensitive operation under Agent Memory governance. Declaring an invalidation model does not authorize recomputation.
+
+### Correction model
+
+```text
+not_applicable
+canonical_supersession
+invalidate_derived
+candidate_only
+provider_revalidation
+```
+
+A canonical memory capability can declare that correction supersedes prior canonical state. A derived capability can declare that correction invalidates the derived basis without automatically rebuilding it.
+
+### Deletion model
+
+```text
+not_applicable
+canonical_delete
+derived_residue_then_purge
+candidate_drop
+provider_revalidation
+```
+
+Deletion semantics remain subordinate to deletion dominance. A derived component that declares `derived_residue_then_purge` explicitly admits that deleting canonical state does not prove physical derived residue disappeared at the same instant.
+
+### Residue model
+
+```text
+not_applicable
+none_expected
+scan_required
+derived_residual
+provider_managed
+```
+
+This describes the residual-state obligation after correction/deletion/removal. It does not weaken the existing must-not-surface and residue-verification contracts.
+
+### Migration / rebuild model
+
+```text
+not_applicable
+rebuild_from_canonical
+explicit_migration
+requires_requalification
+unsupported
+```
+
+`rebuild_from_canonical` is particularly important for disposable derived components. It permits the runtime to reason that a removed index can be reconstructed from canonical state without treating the index as canonical memory.
+
+### Structural mutation requirement
+
+```text
+none
+proposal_only
+pama_required
+external_authorization_required
+```
+
+This field describes which governance boundary a structural mutation would require.
+
+It is **not** an authority field.
+
+For example:
+
+```text
+structural_mutation_requirement = pama_required
+authority_effect = proposal_only
+```
+
+means the component may at most propose the structural change, while PAMA remains the independent authority boundary defined elsewhere.
+
+## Behavior-aware routing
+
+`CapabilityRequirement` may include a `CapabilityBehaviorRequirement`.
+
+The requirement can constrain any subset of the behavior dimensions. Providers with missing or incompatible behavior contracts are not eligible.
+
+This allows two implementations with the same nominal capability to remain distinguishable.
+
+Example:
+
+```text
+Provider A
+  capability = rebuild_projection
+  currentness = basis_versioned
+  rebuild = rebuild_from_canonical
+
+Provider B
+  capability = rebuild_projection
+  currentness = external_asserted
+  rebuild = rebuild_from_canonical
+```
+
+A route requiring `basis_versioned` currentness can deterministically select A without pretending A and B are behaviorally interchangeable.
+
+The portable runtime schema exposes the same constraints as `behavior_requirements` on a route. The v2 validation layer checks the resolved primary and any configured fallback against them.
+
+## Reference composed runtime
+
+`reference/fixtures/runtime-configuration/reference-composed-runtime.json` uses v2 behavior declarations for:
+
+### `semantic_fact_memory`
+
+```text
+write/read = true
+currentness = canonical_version
+correction = canonical_supersession
+deletion = canonical_delete
+residue = scan_required
+migration = explicit_migration
+```
+
+### `exact_identity_retrieval`
+
+```text
+write = false
+read = true
+recall_candidate = true
+currentness = canonical_version
+```
+
+### `rebuild_projection`
+
+```text
+write/read = true
+currentness = basis_versioned
+invalidation = version_relation
+correction = invalidate_derived
+deletion = derived_residue_then_purge
+residue = derived_residual
+migration/rebuild = rebuild_from_canonical
+```
+
+Those declarations match the executable composition evidence established by the reference runtime rather than inventing guarantees not present in the implementation.
+
+## No new logical state algebra
+
+The v2 vocabulary does not introduce new Agent Memory logical memory states.
+
+It describes implementation behavior using already-established lifecycle concepts:
+
+- canonical/current versioning;
+- derived basis currentness;
+- supersession;
+- deletion dominance;
+- residue verification;
+- rebuild/migration;
+- structural-mutation governance.
+
+The contract exists so configuration and routing can inspect those semantics before composing components.
+
+## Evidence
+
+Targeted tests:
+
+```bash
+python -m unittest discover -s reference/tests -t reference -p 'test_capability_behavior_contract.py'
+```
+
+Exact-head evidence:
+
+```bash
+python reference/run_capability_behavior_contract.py \
+  --agent-memory-commit <exact-40-character-commit> \
+  --output capability-behavior-contract.json
+```
+
+The `Capability Behavior Contract` workflow also runs the full reference regression suite and refuses non-Boolean structural invariants.
+
+## Authority boundary
+
+The invariant is intentionally boring:
+
+```text
+behavior metadata
+  -> may constrain eligibility / routing
+  -> may expose required governance boundaries
+  -> may describe lifecycle behavior
+
+behavior metadata
+  != mutation authority
+  != recall-admission authority
+  != structural authority
+  != action authority
+```
+
+That separation keeps configuration useful without allowing descriptive metadata to launder a component into a decision-maker.

--- a/reference/agentmem_ref/capabilities.py
+++ b/reference/agentmem_ref/capabilities.py
@@ -1,9 +1,13 @@
 """Capability declarations and deterministic component resolution.
 
-This module is the narrow executable surface for ADR-033 and issues #287/#290.
+This module is the narrow executable surface for ADR-033 and issues #287/#290/#280.
 It deliberately does not know about PAMA, recall admission, or memory mutation.
 Selecting a component says only which configured implementation may supply a
 capability. It never grants authority to use the resulting memory consequence.
+
+``component-capability-v2`` adds machine-readable behavior metadata for the
+lifecycle dimensions required by #280. Those fields describe what a capability
+supports and how its state relates to canonical memory; they are not authority.
 """
 
 from __future__ import annotations
@@ -20,6 +24,68 @@ MATURITY_ORDER = (
 )
 _MATURITY_RANK = {name: index for index, name in enumerate(MATURITY_ORDER)}
 
+CURRENTNESS_MODELS = frozenset(
+    {
+        "not_applicable",
+        "canonical_version",
+        "basis_versioned",
+        "provider_revalidated",
+        "external_asserted",
+    }
+)
+INVALIDATION_MODELS = frozenset(
+    {
+        "not_applicable",
+        "version_relation",
+        "explicit_signal",
+        "provider_revalidation",
+    }
+)
+CORRECTION_MODELS = frozenset(
+    {
+        "not_applicable",
+        "canonical_supersession",
+        "invalidate_derived",
+        "candidate_only",
+        "provider_revalidation",
+    }
+)
+DELETION_MODELS = frozenset(
+    {
+        "not_applicable",
+        "canonical_delete",
+        "derived_residue_then_purge",
+        "candidate_drop",
+        "provider_revalidation",
+    }
+)
+RESIDUE_MODELS = frozenset(
+    {
+        "not_applicable",
+        "none_expected",
+        "scan_required",
+        "derived_residual",
+        "provider_managed",
+    }
+)
+MIGRATION_REBUILD_MODELS = frozenset(
+    {
+        "not_applicable",
+        "rebuild_from_canonical",
+        "explicit_migration",
+        "requires_requalification",
+        "unsupported",
+    }
+)
+STRUCTURAL_MUTATION_REQUIREMENTS = frozenset(
+    {
+        "none",
+        "proposal_only",
+        "pama_required",
+        "external_authorization_required",
+    }
+)
+
 
 class CapabilityResolutionError(ValueError):
     """No configured provider can satisfy the exact requirement."""
@@ -27,6 +93,180 @@ class CapabilityResolutionError(ValueError):
 
 class AmbiguousCapabilityError(CapabilityResolutionError):
     """Several providers satisfy a requirement and configuration chooses none."""
+
+
+@dataclass(frozen=True)
+class CapabilityBehaviorContract:
+    """Machine-readable lifecycle behavior of one capability.
+
+    This contract is descriptive. For example, ``write=True`` says the
+    capability exposes a write surface; it does not authorize a write.
+    """
+
+    write: bool
+    read: bool
+    recall_candidate: bool
+    currentness_model: str
+    invalidation_model: str
+    correction_model: str
+    deletion_model: str
+    residue_model: str
+    migration_rebuild_model: str
+    structural_mutation_requirement: str
+
+    def __post_init__(self) -> None:
+        checks = (
+            ("currentness_model", self.currentness_model, CURRENTNESS_MODELS),
+            ("invalidation_model", self.invalidation_model, INVALIDATION_MODELS),
+            ("correction_model", self.correction_model, CORRECTION_MODELS),
+            ("deletion_model", self.deletion_model, DELETION_MODELS),
+            ("residue_model", self.residue_model, RESIDUE_MODELS),
+            ("migration_rebuild_model", self.migration_rebuild_model, MIGRATION_REBUILD_MODELS),
+            (
+                "structural_mutation_requirement",
+                self.structural_mutation_requirement,
+                STRUCTURAL_MUTATION_REQUIREMENTS,
+            ),
+        )
+        for name, value, allowed in checks:
+            if value not in allowed:
+                raise ValueError(f"unknown {name}: {value}")
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "CapabilityBehaviorContract":
+        operation = value.get("operation_support")
+        if not isinstance(operation, Mapping):
+            raise ValueError("capability behavior requires operation_support")
+        return cls(
+            write=bool(operation["write"]),
+            read=bool(operation["read"]),
+            recall_candidate=bool(operation["recall_candidate"]),
+            currentness_model=str(value["currentness_model"]),
+            invalidation_model=str(value["invalidation_model"]),
+            correction_model=str(value["correction_model"]),
+            deletion_model=str(value["deletion_model"]),
+            residue_model=str(value["residue_model"]),
+            migration_rebuild_model=str(value["migration_rebuild_model"]),
+            structural_mutation_requirement=str(value["structural_mutation_requirement"]),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "operation_support": {
+                "write": self.write,
+                "read": self.read,
+                "recall_candidate": self.recall_candidate,
+            },
+            "currentness_model": self.currentness_model,
+            "invalidation_model": self.invalidation_model,
+            "correction_model": self.correction_model,
+            "deletion_model": self.deletion_model,
+            "residue_model": self.residue_model,
+            "migration_rebuild_model": self.migration_rebuild_model,
+            "structural_mutation_requirement": self.structural_mutation_requirement,
+        }
+
+
+@dataclass(frozen=True)
+class CapabilityBehaviorRequirement:
+    """Optional routing constraints over declared behavior metadata."""
+
+    write: bool | None = None
+    read: bool | None = None
+    recall_candidate: bool | None = None
+    currentness_models: tuple[str, ...] = ()
+    invalidation_models: tuple[str, ...] = ()
+    correction_models: tuple[str, ...] = ()
+    deletion_models: tuple[str, ...] = ()
+    residue_models: tuple[str, ...] = ()
+    migration_rebuild_models: tuple[str, ...] = ()
+    structural_mutation_requirements: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        checks = (
+            ("currentness_models", self.currentness_models, CURRENTNESS_MODELS),
+            ("invalidation_models", self.invalidation_models, INVALIDATION_MODELS),
+            ("correction_models", self.correction_models, CORRECTION_MODELS),
+            ("deletion_models", self.deletion_models, DELETION_MODELS),
+            ("residue_models", self.residue_models, RESIDUE_MODELS),
+            ("migration_rebuild_models", self.migration_rebuild_models, MIGRATION_REBUILD_MODELS),
+            (
+                "structural_mutation_requirements",
+                self.structural_mutation_requirements,
+                STRUCTURAL_MUTATION_REQUIREMENTS,
+            ),
+        )
+        for name, values, allowed in checks:
+            unknown = sorted(set(values).difference(allowed))
+            if unknown:
+                raise ValueError(f"unknown {name}: {unknown}")
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "CapabilityBehaviorRequirement":
+        operation = value.get("operation_support", {})
+        if not isinstance(operation, Mapping):
+            raise ValueError("behavior requirement operation_support must be an object")
+        return cls(
+            write=bool(operation["write"]) if "write" in operation else None,
+            read=bool(operation["read"]) if "read" in operation else None,
+            recall_candidate=(
+                bool(operation["recall_candidate"])
+                if "recall_candidate" in operation
+                else None
+            ),
+            currentness_models=tuple(str(item) for item in value.get("currentness_models", ())),
+            invalidation_models=tuple(str(item) for item in value.get("invalidation_models", ())),
+            correction_models=tuple(str(item) for item in value.get("correction_models", ())),
+            deletion_models=tuple(str(item) for item in value.get("deletion_models", ())),
+            residue_models=tuple(str(item) for item in value.get("residue_models", ())),
+            migration_rebuild_models=tuple(
+                str(item) for item in value.get("migration_rebuild_models", ())
+            ),
+            structural_mutation_requirements=tuple(
+                str(item) for item in value.get("structural_mutation_requirements", ())
+            ),
+        )
+
+    def matches(self, contract: CapabilityBehaviorContract) -> bool:
+        operation_checks = (
+            (self.write, contract.write),
+            (self.read, contract.read),
+            (self.recall_candidate, contract.recall_candidate),
+        )
+        if any(required is not None and required != actual for required, actual in operation_checks):
+            return False
+        enum_checks = (
+            (self.currentness_models, contract.currentness_model),
+            (self.invalidation_models, contract.invalidation_model),
+            (self.correction_models, contract.correction_model),
+            (self.deletion_models, contract.deletion_model),
+            (self.residue_models, contract.residue_model),
+            (self.migration_rebuild_models, contract.migration_rebuild_model),
+            (
+                self.structural_mutation_requirements,
+                contract.structural_mutation_requirement,
+            ),
+        )
+        return all(not allowed or actual in allowed for allowed, actual in enum_checks)
+
+    def to_dict(self) -> dict:
+        operation: dict[str, bool] = {}
+        if self.write is not None:
+            operation["write"] = self.write
+        if self.read is not None:
+            operation["read"] = self.read
+        if self.recall_candidate is not None:
+            operation["recall_candidate"] = self.recall_candidate
+        return {
+            "operation_support": operation,
+            "currentness_models": list(self.currentness_models),
+            "invalidation_models": list(self.invalidation_models),
+            "correction_models": list(self.correction_models),
+            "deletion_models": list(self.deletion_models),
+            "residue_models": list(self.residue_models),
+            "migration_rebuild_models": list(self.migration_rebuild_models),
+            "structural_mutation_requirements": list(self.structural_mutation_requirements),
+        }
 
 
 @dataclass(frozen=True)
@@ -41,6 +281,7 @@ class CapabilityDeclaration:
     evidence_refs: tuple[str, ...] = ()
     limitations: tuple[str, ...] = ()
     enabled: bool = True
+    behavior_contract: CapabilityBehaviorContract | None = None
 
     def __post_init__(self) -> None:
         if not self.capability_id or not self.capability_version:
@@ -52,6 +293,12 @@ class CapabilityDeclaration:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, object]) -> "CapabilityDeclaration":
+        behavior_raw = value.get("behavior_contract")
+        behavior = None
+        if behavior_raw is not None:
+            if not isinstance(behavior_raw, Mapping):
+                raise ValueError("capability behavior_contract must be an object")
+            behavior = CapabilityBehaviorContract.from_dict(behavior_raw)
         return cls(
             capability_id=str(value["capability_id"]),
             capability_version=str(value["capability_version"]),
@@ -63,10 +310,11 @@ class CapabilityDeclaration:
             evidence_refs=tuple(str(item) for item in value.get("evidence_refs", ())),
             limitations=tuple(str(item) for item in value.get("limitations", ())),
             enabled=bool(value.get("enabled", True)),
+            behavior_contract=behavior,
         )
 
     def to_dict(self) -> dict:
-        return {
+        payload = {
             "capability_id": self.capability_id,
             "capability_version": self.capability_version,
             "maturity": self.maturity,
@@ -78,6 +326,9 @@ class CapabilityDeclaration:
             "limitations": list(self.limitations),
             "enabled": self.enabled,
         }
+        if self.behavior_contract is not None:
+            payload["behavior_contract"] = self.behavior_contract.to_dict()
+        return payload
 
 
 @dataclass(frozen=True)
@@ -100,6 +351,16 @@ class ComponentDeclaration:
             if identity in seen:
                 raise ValueError(f"duplicate capability declaration: {identity}")
             seen.add(identity)
+        if self.profile_version == "component-capability-v2":
+            missing = [
+                capability.capability_id
+                for capability in self.capabilities
+                if capability.behavior_contract is None
+            ]
+            if missing:
+                raise ValueError(
+                    f"component-capability-v2 requires behavior_contract for every capability: {missing}"
+                )
 
     @classmethod
     def from_dict(cls, value: Mapping[str, object]) -> "ComponentDeclaration":
@@ -139,6 +400,7 @@ class CapabilityRequirement:
     required_scope_postures: tuple[str, ...] = ()
     allowed_components: tuple[str, ...] = ()
     preferred_component: str = ""
+    behavior_requirement: CapabilityBehaviorRequirement | None = None
 
     def __post_init__(self) -> None:
         if self.minimum_maturity not in _MATURITY_RANK:
@@ -159,9 +421,10 @@ class ResolvedCapability:
     authority_effect: str
     evidence_refs: tuple[str, ...] = ()
     limitations: tuple[str, ...] = ()
+    behavior_contract: CapabilityBehaviorContract | None = None
 
     def to_dict(self) -> dict:
-        return {
+        payload = {
             "component_id": self.component_id,
             "component_version": self.component_version,
             "profile_version": self.profile_version,
@@ -175,6 +438,9 @@ class ResolvedCapability:
             "evidence_refs": list(self.evidence_refs),
             "limitations": list(self.limitations),
         }
+        if self.behavior_contract is not None:
+            payload["behavior_contract"] = self.behavior_contract.to_dict()
+        return payload
 
 
 @dataclass
@@ -220,6 +486,11 @@ class ComponentRegistry:
                     continue
                 if requirement.required_scope_postures and capability.scope_posture not in requirement.required_scope_postures:
                     continue
+                if requirement.behavior_requirement is not None:
+                    if capability.behavior_contract is None:
+                        continue
+                    if not requirement.behavior_requirement.matches(capability.behavior_contract):
+                        continue
                 eligible.append((component, capability))
 
         preferred = requirement.preferred_component or self.preferences.get(requirement.capability_id, "")
@@ -272,4 +543,5 @@ def _resolved(component: ComponentDeclaration, capability: CapabilityDeclaration
         authority_effect=capability.authority_effect,
         evidence_refs=capability.evidence_refs,
         limitations=capability.limitations,
+        behavior_contract=capability.behavior_contract,
     )

--- a/reference/agentmem_ref/runtime_behavior.py
+++ b/reference/agentmem_ref/runtime_behavior.py
@@ -1,0 +1,193 @@
+"""Behavior-aware extension of the portable Agent Memory runtime contract.
+
+The original runtime configuration validator remains the compatibility boundary
+for component-capability-v1 configurations. This module layers the v2 behavior
+contract on the same validated plan. It does not create a second routing model:
+component behavior matching uses the same ``CapabilityBehaviorRequirement``
+semantics implemented by ``ComponentRegistry``.
+
+A behavior declaration is descriptive evidence about an implementation surface.
+It never grants mutation, recall-admission, structural, or action authority.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from .capabilities import (
+    CapabilityBehaviorRequirement,
+    CapabilityDeclaration,
+    ComponentDeclaration,
+)
+from .runtime_config import (
+    QualificationBinding,
+    RuntimeConfigurationError,
+    RuntimeConfigurationPlan,
+    load_runtime_configuration,
+    validate_runtime_configuration,
+)
+
+
+class RuntimeBehaviorContractError(RuntimeConfigurationError):
+    """A resolved runtime route does not satisfy its declared behavior contract."""
+
+
+def _component_declarations(value: Mapping[str, object]) -> dict[str, ComponentDeclaration]:
+    rows = value.get("components", ())
+    if not isinstance(rows, list):
+        raise RuntimeBehaviorContractError("components must be an array")
+    declarations: dict[str, ComponentDeclaration] = {}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise RuntimeBehaviorContractError("component runtime row must be an object")
+        raw = row.get("declaration")
+        if not isinstance(raw, Mapping):
+            raise RuntimeBehaviorContractError("component declaration must be an object")
+        declaration = ComponentDeclaration.from_dict(raw)
+        declarations[declaration.component_id] = declaration
+    return declarations
+
+
+def _declared_capability(
+    declaration: ComponentDeclaration,
+    *,
+    capability_id: str,
+    capability_version: str,
+) -> CapabilityDeclaration:
+    matches = [
+        capability
+        for capability in declaration.capabilities
+        if capability.enabled
+        and capability.capability_id == capability_id
+        and capability.capability_version == capability_version
+    ]
+    if len(matches) != 1:
+        raise RuntimeBehaviorContractError(
+            f"resolved component {declaration.component_id!r} has missing/ambiguous capability "
+            f"{capability_id!r}@{capability_version}"
+        )
+    return matches[0]
+
+
+def _assert_behavior(
+    *,
+    route_id: str,
+    provider_role: str,
+    component: ComponentDeclaration,
+    capability_id: str,
+    capability_version: str,
+    requirement: CapabilityBehaviorRequirement,
+) -> None:
+    capability = _declared_capability(
+        component,
+        capability_id=capability_id,
+        capability_version=capability_version,
+    )
+    contract = capability.behavior_contract
+    if contract is None:
+        raise RuntimeBehaviorContractError(
+            f"route {route_id!r} requires behavior metadata but {provider_role} "
+            f"{component.component_id!r} uses a legacy/no-behavior capability declaration"
+        )
+    if not requirement.matches(contract):
+        raise RuntimeBehaviorContractError(
+            f"route {route_id!r} behavior requirements are not satisfied by {provider_role} "
+            f"{component.component_id!r}:{capability_id}"
+        )
+
+
+def validate_runtime_behavior_contract(
+    value: Mapping[str, object],
+    *,
+    qualification_bindings: Iterable[QualificationBinding] = (),
+) -> RuntimeConfigurationPlan:
+    """Validate the base runtime plan plus optional v2 route behavior requirements.
+
+    Legacy v1 configurations with no ``behavior_requirements`` remain valid.
+    When a route requests behavior semantics, both the resolved primary and any
+    configured resolved fallback must explicitly satisfy them.
+    """
+
+    plan = validate_runtime_configuration(
+        value,
+        qualification_bindings=qualification_bindings,
+    )
+    declarations = _component_declarations(value)
+
+    route_rows = value.get("routes", ())
+    if not isinstance(route_rows, list):
+        raise RuntimeBehaviorContractError("routes must be an array")
+    raw_by_id = {
+        str(row.get("route_id")): row
+        for row in route_rows
+        if isinstance(row, Mapping)
+    }
+
+    for resolved_route in plan.resolved_routes:
+        raw = raw_by_id.get(resolved_route.route_id)
+        if not isinstance(raw, Mapping):
+            raise RuntimeBehaviorContractError(
+                f"resolved route has no configuration row: {resolved_route.route_id}"
+            )
+        behavior_raw = raw.get("behavior_requirements")
+        if behavior_raw is None:
+            continue
+        if not isinstance(behavior_raw, Mapping):
+            raise RuntimeBehaviorContractError(
+                f"route behavior_requirements must be an object: {resolved_route.route_id}"
+            )
+        requirement = CapabilityBehaviorRequirement.from_dict(behavior_raw)
+        primary = declarations.get(resolved_route.primary.component_id)
+        if primary is None:
+            raise RuntimeBehaviorContractError(
+                f"resolved primary declaration is missing: {resolved_route.primary.component_id}"
+            )
+        _assert_behavior(
+            route_id=resolved_route.route_id,
+            provider_role="primary",
+            component=primary,
+            capability_id=resolved_route.primary.capability_id,
+            capability_version=resolved_route.primary.capability_version,
+            requirement=requirement,
+        )
+
+        if resolved_route.fallback_component_id:
+            fallback = declarations.get(resolved_route.fallback_component_id)
+            if fallback is None:
+                raise RuntimeBehaviorContractError(
+                    f"resolved fallback declaration is missing: {resolved_route.fallback_component_id}"
+                )
+            _assert_behavior(
+                route_id=resolved_route.route_id,
+                provider_role="fallback",
+                component=fallback,
+                capability_id=resolved_route.primary.capability_id,
+                capability_version=resolved_route.primary.capability_version,
+                requirement=requirement,
+            )
+
+    return plan
+
+
+def load_runtime_behavior_contract(
+    path: str | Path,
+    *,
+    qualification_bindings: Iterable[QualificationBinding] = (),
+) -> RuntimeConfigurationPlan:
+    """Load a JSON runtime configuration and apply the v1 + v2 behavior gates."""
+
+    # Reuse the base loader for file/JSON diagnostics, then parse once more for
+    # the behavior layer. The input is bounded reference configuration and this
+    # preserves one semantic contract rather than creating hidden state.
+    load_runtime_configuration(path, qualification_bindings=qualification_bindings)
+    import json
+
+    config_path = Path(path)
+    value = json.loads(config_path.read_text(encoding="utf-8"))
+    if not isinstance(value, Mapping):
+        raise RuntimeBehaviorContractError("runtime configuration must be a JSON object")
+    return validate_runtime_behavior_contract(
+        value,
+        qualification_bindings=qualification_bindings,
+    )

--- a/reference/fixtures/runtime-configuration/reference-composed-runtime.json
+++ b/reference/fixtures/runtime-configuration/reference-composed-runtime.json
@@ -22,7 +22,7 @@
       "declaration": {
         "component_id": "reference-governed-memory",
         "component_version": "1.0.0",
-        "profile_version": "component-capability-v1",
+        "profile_version": "component-capability-v2",
         "enabled": true,
         "runtime_ref": "reference/agentmem_ref/adapter.py",
         "failure_posture": "fail_closed",
@@ -38,7 +38,21 @@
             "authority_effect": "none",
             "enabled": true,
             "evidence_refs": ["reference:test-governed-adapter"],
-            "limitations": ["bounded_reference_runtime"]
+            "limitations": ["bounded_reference_runtime"],
+            "behavior_contract": {
+              "operation_support": {
+                "write": true,
+                "read": true,
+                "recall_candidate": false
+              },
+              "currentness_model": "canonical_version",
+              "invalidation_model": "version_relation",
+              "correction_model": "canonical_supersession",
+              "deletion_model": "canonical_delete",
+              "residue_model": "scan_required",
+              "migration_rebuild_model": "explicit_migration",
+              "structural_mutation_requirement": "none"
+            }
           },
           {
             "capability_id": "exact_identity_retrieval",
@@ -50,7 +64,21 @@
             "authority_effect": "none",
             "enabled": true,
             "evidence_refs": ["reference:test-governed-recall"],
-            "limitations": ["reference_query_path_uses_substrate_search_plus_governed_admission"]
+            "limitations": ["reference_query_path_uses_substrate_search_plus_governed_admission"],
+            "behavior_contract": {
+              "operation_support": {
+                "write": false,
+                "read": true,
+                "recall_candidate": true
+              },
+              "currentness_model": "canonical_version",
+              "invalidation_model": "version_relation",
+              "correction_model": "not_applicable",
+              "deletion_model": "not_applicable",
+              "residue_model": "not_applicable",
+              "migration_rebuild_model": "not_applicable",
+              "structural_mutation_requirement": "none"
+            }
           }
         ]
       },
@@ -61,7 +89,7 @@
       },
       "source_rights": {
         "license_id": "Apache-2.0",
-        "license_ref": "LICENSE@422138ab1fb3a9cf2735168f1d75404795afa83d",
+        "license_ref": "LICENSE@b1faeed936a32f3485a06a7b2f59557655872994",
         "use_posture": "runtime_allowed"
       }
     },
@@ -69,7 +97,7 @@
       "declaration": {
         "component_id": "reference-projection-sidecar",
         "component_version": "1.0.0",
-        "profile_version": "component-capability-v1",
+        "profile_version": "component-capability-v2",
         "enabled": true,
         "runtime_ref": "reference/agentmem_ref/projection_governance.py",
         "failure_posture": "explicit_unavailable",
@@ -85,7 +113,21 @@
             "authority_effect": "none",
             "enabled": true,
             "evidence_refs": ["reference:test-canonical-derived-state"],
-            "limitations": ["deterministic_reproducible_reference_projection"]
+            "limitations": ["deterministic_reproducible_reference_projection"],
+            "behavior_contract": {
+              "operation_support": {
+                "write": true,
+                "read": true,
+                "recall_candidate": false
+              },
+              "currentness_model": "basis_versioned",
+              "invalidation_model": "version_relation",
+              "correction_model": "invalidate_derived",
+              "deletion_model": "derived_residue_then_purge",
+              "residue_model": "derived_residual",
+              "migration_rebuild_model": "rebuild_from_canonical",
+              "structural_mutation_requirement": "none"
+            }
           }
         ]
       },
@@ -96,7 +138,7 @@
       },
       "source_rights": {
         "license_id": "Apache-2.0",
-        "license_ref": "LICENSE@422138ab1fb3a9cf2735168f1d75404795afa83d",
+        "license_ref": "LICENSE@b1faeed936a32f3485a06a7b2f59557655872994",
         "use_posture": "runtime_allowed"
       }
     }
@@ -112,6 +154,15 @@
       "fallback_components": [],
       "required_state_postures": ["canonical"],
       "required_scope_postures": ["enforces_agent_memory_scope"],
+      "behavior_requirements": {
+        "operation_support": {
+          "write": true,
+          "read": true
+        },
+        "currentness_models": ["canonical_version"],
+        "correction_models": ["canonical_supersession"],
+        "deletion_models": ["canonical_delete"]
+      },
       "qualification": {"required": false},
       "currentness": {"required": false}
     },
@@ -125,6 +176,13 @@
       "fallback_components": [],
       "required_state_postures": ["canonical"],
       "required_scope_postures": ["enforces_agent_memory_scope"],
+      "behavior_requirements": {
+        "operation_support": {
+          "read": true,
+          "recall_candidate": true
+        },
+        "currentness_models": ["canonical_version"]
+      },
       "qualification": {"required": false},
       "currentness": {"required": false}
     },
@@ -138,6 +196,19 @@
       "fallback_components": [],
       "required_state_postures": ["derived"],
       "required_scope_postures": ["inherits_agent_memory_scope"],
+      "behavior_requirements": {
+        "operation_support": {
+          "write": true,
+          "read": true
+        },
+        "currentness_models": ["basis_versioned"],
+        "invalidation_models": ["version_relation"],
+        "correction_models": ["invalidate_derived"],
+        "deletion_models": ["derived_residue_then_purge"],
+        "residue_models": ["derived_residual"],
+        "migration_rebuild_models": ["rebuild_from_canonical"],
+        "structural_mutation_requirements": ["none"]
+      },
       "qualification": {"required": false},
       "currentness": {
         "required": true,

--- a/reference/run_capability_behavior_contract.py
+++ b/reference/run_capability_behavior_contract.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Emit exact-head evidence for the #280 capability behavior declaration contract."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.capabilities import (  # noqa: E402
+    CapabilityBehaviorContract,
+    CapabilityBehaviorRequirement,
+    CapabilityDeclaration,
+    CapabilityRequirement,
+    ComponentDeclaration,
+    ComponentRegistry,
+)
+from agentmem_ref.runtime_behavior import (  # noqa: E402
+    RuntimeBehaviorContractError,
+    validate_runtime_behavior_contract,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "reference" / "fixtures"
+COMPOSED = FIXTURES / "runtime-configuration" / "reference-composed-runtime.json"
+LEGACY = FIXTURES / "component-capabilities" / "procedural-reference.json"
+
+
+def _provider(component_id: str, *, currentness: str) -> ComponentDeclaration:
+    return ComponentDeclaration(
+        component_id=component_id,
+        component_version="1.0.0",
+        profile_version="component-capability-v2",
+        failure_posture="explicit_unavailable",
+        capabilities=(
+            CapabilityDeclaration(
+                capability_id="rebuild_projection",
+                capability_version="1.0",
+                maturity="runtime_wired",
+                state_posture="derived",
+                scope_posture="inherits_agent_memory_scope",
+                failure_posture="explicit_unavailable",
+                authority_effect="none",
+                behavior_contract=CapabilityBehaviorContract(
+                    write=True,
+                    read=True,
+                    recall_candidate=False,
+                    currentness_model=currentness,
+                    invalidation_model="version_relation",
+                    correction_model="invalidate_derived",
+                    deletion_model="derived_residue_then_purge",
+                    residue_model="derived_residual",
+                    migration_rebuild_model="rebuild_from_canonical",
+                    structural_mutation_requirement="none",
+                ),
+            ),
+        ),
+    )
+
+
+def build_report(agent_memory_commit: str) -> dict:
+    if len(agent_memory_commit) != 40:
+        raise ValueError("agent-memory commit must be an exact 40-character SHA")
+
+    composed = json.loads(COMPOSED.read_text(encoding="utf-8"))
+    plan = validate_runtime_behavior_contract(composed)
+    routes = {route.route_id: route for route in plan.resolved_routes}
+    projection = routes["derived-projection-rebuild"].primary
+    semantic = routes["canonical-semantic-fact"].primary
+    retrieval = routes["governed-exact-retrieval"].primary
+
+    mismatch = copy.deepcopy(composed)
+    sidecar = next(
+        component for component in mismatch["components"]
+        if component["declaration"]["component_id"] == "reference-projection-sidecar"
+    )
+    sidecar["declaration"]["capabilities"][0]["behavior_contract"]["migration_rebuild_model"] = "unsupported"
+    mismatch_refused = False
+    try:
+        validate_runtime_behavior_contract(mismatch)
+    except RuntimeBehaviorContractError:
+        mismatch_refused = True
+
+    legacy = ComponentDeclaration.from_dict(json.loads(LEGACY.read_text(encoding="utf-8")))
+
+    registry = ComponentRegistry()
+    registry.register_many(
+        (
+            _provider("basis-provider", currentness="basis_versioned"),
+            _provider("external-provider", currentness="external_asserted"),
+        )
+    )
+    behavior_selected = registry.resolve(
+        CapabilityRequirement(
+            capability_id="rebuild_projection",
+            capability_version="1.0",
+            minimum_maturity="runtime_wired",
+            behavior_requirement=CapabilityBehaviorRequirement(
+                currentness_models=("basis_versioned",),
+                migration_rebuild_models=("rebuild_from_canonical",),
+            ),
+        )
+    )
+
+    structural_contract = CapabilityBehaviorContract(
+        write=False,
+        read=True,
+        recall_candidate=True,
+        currentness_model="provider_revalidated",
+        invalidation_model="provider_revalidation",
+        correction_model="candidate_only",
+        deletion_model="candidate_drop",
+        residue_model="provider_managed",
+        migration_rebuild_model="requires_requalification",
+        structural_mutation_requirement="pama_required",
+    )
+    structural_declaration = CapabilityDeclaration(
+        capability_id="schema_mutation_candidate",
+        capability_version="1.0",
+        maturity="runtime_wired",
+        state_posture="derived",
+        scope_posture="inherits_agent_memory_scope",
+        failure_posture="fail_closed",
+        authority_effect="proposal_only",
+        behavior_contract=structural_contract,
+    )
+
+    invariants = {
+        "legacy_v1_remains_readable": (
+            legacy.profile_version == "component-capability-v1"
+            and all(capability.behavior_contract is None for capability in legacy.capabilities)
+        ),
+        "v2_semantic_memory_behavior_explicit": (
+            semantic.behavior_contract is not None
+            and semantic.behavior_contract.write
+            and semantic.behavior_contract.currentness_model == "canonical_version"
+            and semantic.behavior_contract.correction_model == "canonical_supersession"
+            and semantic.behavior_contract.deletion_model == "canonical_delete"
+        ),
+        "v2_retrieval_behavior_explicit": (
+            retrieval.behavior_contract is not None
+            and retrieval.behavior_contract.read
+            and retrieval.behavior_contract.recall_candidate
+            and not retrieval.behavior_contract.write
+        ),
+        "v2_projection_lifecycle_explicit": (
+            projection.behavior_contract is not None
+            and projection.behavior_contract.currentness_model == "basis_versioned"
+            and projection.behavior_contract.invalidation_model == "version_relation"
+            and projection.behavior_contract.correction_model == "invalidate_derived"
+            and projection.behavior_contract.deletion_model == "derived_residue_then_purge"
+            and projection.behavior_contract.residue_model == "derived_residual"
+            and projection.behavior_contract.migration_rebuild_model == "rebuild_from_canonical"
+        ),
+        "runtime_route_behavior_mismatch_refused": mismatch_refused,
+        "behavior_requirement_can_disambiguate_provider": (
+            behavior_selected.component_id == "basis-provider"
+            and behavior_selected.behavior_contract is not None
+            and behavior_selected.behavior_contract.currentness_model == "basis_versioned"
+        ),
+        "behavior_metadata_does_not_grant_authority": (
+            behavior_selected.authority_effect == "none"
+            and structural_contract.structural_mutation_requirement == "pama_required"
+            and structural_declaration.authority_effect == "proposal_only"
+        ),
+        "composed_runtime_requires_behavior_v2": all(
+            route.primary.profile_version == "component-capability-v2"
+            for route in plan.resolved_routes
+        ),
+    }
+    invariants = {name: bool(value) for name, value in invariants.items()}
+    if not all(type(value) is bool for value in invariants.values()):
+        raise TypeError("every structural invariant must be a JSON boolean")
+
+    return {
+        "schema_version": "1.0.0",
+        "agent_memory_commit": agent_memory_commit,
+        "component_profile_contract": "component-capability-v2",
+        "legacy_profile_contract": "component-capability-v1",
+        "runtime_configuration_digest": plan.configuration_digest,
+        "resolved_behavior": {
+            route_id: route.primary.behavior_contract.to_dict()
+            for route_id, route in routes.items()
+        },
+        "structural_invariants": invariants,
+        "structural_invariants_passed": all(invariants.values()),
+        "authority_effect": "none",
+        "limitations": [
+            "Behavior metadata is descriptive and does not replace PAMA, recall admission, policy, or external authorization.",
+            "Legacy v1 declarations remain valid but cannot satisfy a route that explicitly requires v2 behavior semantics.",
+            "The behavior vocabulary is intentionally bounded to #280 lifecycle dimensions and does not introduce a new logical memory state algebra.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = build_report(args.agent_memory_commit)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report["structural_invariants_passed"]:
+        failed = [name for name, passed in report["structural_invariants"].items() if not passed]
+        print(f"capability behavior invariants failed: {failed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_capability_behavior_contract.py
+++ b/reference/tests/test_capability_behavior_contract.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+from agentmem_ref.capabilities import (
+    AmbiguousCapabilityError,
+    CapabilityBehaviorContract,
+    CapabilityBehaviorRequirement,
+    CapabilityDeclaration,
+    CapabilityRequirement,
+    ComponentDeclaration,
+    ComponentRegistry,
+)
+from agentmem_ref.runtime_behavior import (
+    RuntimeBehaviorContractError,
+    validate_runtime_behavior_contract,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPONENT_SCHEMA = ROOT / "schemas" / "component-capability-profile.schema.json"
+RUNTIME_COMPOSED = ROOT / "reference" / "fixtures" / "runtime-configuration" / "reference-composed-runtime.json"
+LEGACY_RUNTIME = ROOT / "reference" / "fixtures" / "runtime-configuration" / "attached-existing-stack.json"
+LEGACY_COMPONENT = ROOT / "reference" / "fixtures" / "component-capabilities" / "procedural-reference.json"
+
+
+def _behavior(*, currentness: str = "basis_versioned", correction: str = "invalidate_derived"):
+    return CapabilityBehaviorContract(
+        write=True,
+        read=True,
+        recall_candidate=False,
+        currentness_model=currentness,
+        invalidation_model="version_relation",
+        correction_model=correction,
+        deletion_model="derived_residue_then_purge",
+        residue_model="derived_residual",
+        migration_rebuild_model="rebuild_from_canonical",
+        structural_mutation_requirement="none",
+    )
+
+
+def _component(component_id: str, behavior: CapabilityBehaviorContract | None):
+    return ComponentDeclaration(
+        component_id=component_id,
+        component_version="1.0.0",
+        profile_version="component-capability-v2" if behavior else "component-capability-v1",
+        failure_posture="explicit_unavailable",
+        capabilities=(
+            CapabilityDeclaration(
+                capability_id="rebuild_projection",
+                capability_version="1.0",
+                maturity="runtime_wired",
+                state_posture="derived",
+                scope_posture="inherits_agent_memory_scope",
+                failure_posture="explicit_unavailable",
+                authority_effect="none",
+                behavior_contract=behavior,
+            ),
+        ),
+    )
+
+
+class CapabilityBehaviorContractTests(unittest.TestCase):
+    def test_legacy_v1_component_schema_remains_valid(self) -> None:
+        schema = json.loads(COMPONENT_SCHEMA.read_text(encoding="utf-8"))
+        legacy = json.loads(LEGACY_COMPONENT.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(legacy)
+        declaration = ComponentDeclaration.from_dict(legacy)
+        self.assertEqual(declaration.profile_version, "component-capability-v1")
+        self.assertTrue(all(capability.behavior_contract is None for capability in declaration.capabilities))
+
+    def test_v2_requires_behavior_contract_on_every_capability(self) -> None:
+        config = json.loads(RUNTIME_COMPOSED.read_text(encoding="utf-8"))
+        declaration = copy.deepcopy(config["components"][0]["declaration"])
+        declaration["capabilities"][0].pop("behavior_contract")
+        schema = json.loads(COMPONENT_SCHEMA.read_text(encoding="utf-8"))
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(declaration)
+        with self.assertRaisesRegex(ValueError, "requires behavior_contract"):
+            ComponentDeclaration.from_dict(declaration)
+
+    def test_behavior_requirement_can_disambiguate_providers(self) -> None:
+        registry = ComponentRegistry()
+        registry.register_many(
+            (
+                _component("basis-provider", _behavior()),
+                _component("external-provider", _behavior(currentness="external_asserted")),
+            )
+        )
+
+        with self.assertRaises(AmbiguousCapabilityError):
+            registry.resolve(
+                CapabilityRequirement(
+                    capability_id="rebuild_projection",
+                    capability_version="1.0",
+                    minimum_maturity="runtime_wired",
+                )
+            )
+
+        resolved = registry.resolve(
+            CapabilityRequirement(
+                capability_id="rebuild_projection",
+                capability_version="1.0",
+                minimum_maturity="runtime_wired",
+                behavior_requirement=CapabilityBehaviorRequirement(
+                    currentness_models=("basis_versioned",),
+                    migration_rebuild_models=("rebuild_from_canonical",),
+                ),
+            )
+        )
+        self.assertEqual(resolved.component_id, "basis-provider")
+        self.assertIsNotNone(resolved.behavior_contract)
+        self.assertEqual(resolved.behavior_contract.currentness_model, "basis_versioned")
+        self.assertEqual(resolved.authority_effect, "none")
+
+    def test_legacy_provider_is_ineligible_when_behavior_is_required(self) -> None:
+        registry = ComponentRegistry()
+        registry.register(_component("legacy-provider", None))
+        with self.assertRaisesRegex(ValueError, "no eligible provider"):
+            registry.resolve(
+                CapabilityRequirement(
+                    capability_id="rebuild_projection",
+                    capability_version="1.0",
+                    minimum_maturity="runtime_wired",
+                    behavior_requirement=CapabilityBehaviorRequirement(
+                        migration_rebuild_models=("rebuild_from_canonical",),
+                    ),
+                )
+            )
+
+    def test_v2_composed_runtime_satisfies_declared_behavior_routes(self) -> None:
+        config = json.loads(RUNTIME_COMPOSED.read_text(encoding="utf-8"))
+        plan = validate_runtime_behavior_contract(config)
+        self.assertEqual(plan.required_projection_ids, ("reference-derived-index",))
+        routes = {route.route_id: route for route in plan.resolved_routes}
+        projection = routes["derived-projection-rebuild"].primary
+        self.assertEqual(projection.profile_version, "component-capability-v2")
+        self.assertEqual(projection.behavior_contract.currentness_model, "basis_versioned")
+        self.assertEqual(projection.behavior_contract.correction_model, "invalidate_derived")
+        self.assertEqual(projection.behavior_contract.deletion_model, "derived_residue_then_purge")
+        self.assertEqual(projection.behavior_contract.residue_model, "derived_residual")
+        self.assertEqual(projection.behavior_contract.migration_rebuild_model, "rebuild_from_canonical")
+        self.assertEqual(projection.authority_effect, "none")
+
+    def test_runtime_route_refuses_behavior_mismatch(self) -> None:
+        config = json.loads(RUNTIME_COMPOSED.read_text(encoding="utf-8"))
+        projection = next(
+            component for component in config["components"]
+            if component["declaration"]["component_id"] == "reference-projection-sidecar"
+        )
+        projection["declaration"]["capabilities"][0]["behavior_contract"]["correction_model"] = "not_applicable"
+        with self.assertRaisesRegex(RuntimeBehaviorContractError, "behavior requirements are not satisfied"):
+            validate_runtime_behavior_contract(config)
+
+    def test_structural_mutation_requirement_is_metadata_not_authority(self) -> None:
+        contract = _behavior()
+        payload = contract.to_dict()
+        payload["structural_mutation_requirement"] = "pama_required"
+        parsed = CapabilityBehaviorContract.from_dict(payload)
+        declaration = CapabilityDeclaration(
+            capability_id="schema_mutation_candidate",
+            capability_version="1.0",
+            maturity="runtime_wired",
+            state_posture="derived",
+            scope_posture="inherits_agent_memory_scope",
+            failure_posture="fail_closed",
+            authority_effect="proposal_only",
+            behavior_contract=parsed,
+        )
+        self.assertEqual(parsed.structural_mutation_requirement, "pama_required")
+        self.assertEqual(declaration.authority_effect, "proposal_only")
+        self.assertNotEqual(declaration.authority_effect, "pama_required")
+
+    def test_legacy_runtime_without_behavior_requirements_remains_valid(self) -> None:
+        config = json.loads(LEGACY_RUNTIME.read_text(encoding="utf-8"))
+        # The legacy attach fixture requires external qualification evidence and
+        # is covered by its existing tests. Remove the evidence-level route here
+        # so this test isolates behavior-contract backward compatibility.
+        config["routes"] = [
+            route for route in config["routes"]
+            if route["route_id"] == "canonical-record-store"
+        ]
+        config["components"] = [
+            component for component in config["components"]
+            if component["declaration"]["component_id"] == "existing-canonical-store"
+        ]
+        plan = validate_runtime_behavior_contract(config)
+        self.assertEqual(plan.canonical_owner_component_id, "existing-canonical-store")
+        self.assertEqual(plan.resolved_routes[0].primary.profile_version, "component-capability-v1")
+        self.assertIsNone(plan.resolved_routes[0].primary.behavior_contract)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/component-capability-profile.schema.json
+++ b/schemas/component-capability-profile.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/component-capability-profile.schema.json",
   "title": "Agent Memory Component Capability Profile",
-  "description": "Machine-readable reference contract for independently matured component capabilities. Capability selection does not create memory authority.",
+  "description": "Machine-readable reference contract for independently matured component capabilities. component-capability-v2 requires explicit lifecycle behavior metadata. Capability selection and behavior declarations do not create memory authority.",
   "type": "object",
   "required": [
     "component_id",
@@ -33,8 +33,124 @@
       "items": { "$ref": "#/$defs/capability" }
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "profile_version": { "const": "component-capability-v2" }
+        },
+        "required": ["profile_version"]
+      },
+      "then": {
+        "properties": {
+          "capabilities": {
+            "items": {
+              "allOf": [
+                { "$ref": "#/$defs/capability" },
+                { "required": ["behavior_contract"] }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
   "additionalProperties": false,
   "$defs": {
+    "behaviorContract": {
+      "type": "object",
+      "required": [
+        "operation_support",
+        "currentness_model",
+        "invalidation_model",
+        "correction_model",
+        "deletion_model",
+        "residue_model",
+        "migration_rebuild_model",
+        "structural_mutation_requirement"
+      ],
+      "properties": {
+        "operation_support": {
+          "type": "object",
+          "required": ["write", "read", "recall_candidate"],
+          "properties": {
+            "write": { "type": "boolean" },
+            "read": { "type": "boolean" },
+            "recall_candidate": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        },
+        "currentness_model": {
+          "type": "string",
+          "enum": [
+            "not_applicable",
+            "canonical_version",
+            "basis_versioned",
+            "provider_revalidated",
+            "external_asserted"
+          ]
+        },
+        "invalidation_model": {
+          "type": "string",
+          "enum": [
+            "not_applicable",
+            "version_relation",
+            "explicit_signal",
+            "provider_revalidation"
+          ]
+        },
+        "correction_model": {
+          "type": "string",
+          "enum": [
+            "not_applicable",
+            "canonical_supersession",
+            "invalidate_derived",
+            "candidate_only",
+            "provider_revalidation"
+          ]
+        },
+        "deletion_model": {
+          "type": "string",
+          "enum": [
+            "not_applicable",
+            "canonical_delete",
+            "derived_residue_then_purge",
+            "candidate_drop",
+            "provider_revalidation"
+          ]
+        },
+        "residue_model": {
+          "type": "string",
+          "enum": [
+            "not_applicable",
+            "none_expected",
+            "scan_required",
+            "derived_residual",
+            "provider_managed"
+          ]
+        },
+        "migration_rebuild_model": {
+          "type": "string",
+          "enum": [
+            "not_applicable",
+            "rebuild_from_canonical",
+            "explicit_migration",
+            "requires_requalification",
+            "unsupported"
+          ]
+        },
+        "structural_mutation_requirement": {
+          "type": "string",
+          "enum": [
+            "none",
+            "proposal_only",
+            "pama_required",
+            "external_authorization_required"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "capability": {
       "type": "object",
       "required": [
@@ -90,7 +206,8 @@
           "type": "array",
           "items": { "type": "string", "minLength": 1 },
           "uniqueItems": true
-        }
+        },
+        "behavior_contract": { "$ref": "#/$defs/behaviorContract" }
       },
       "additionalProperties": false
     }

--- a/schemas/runtime-configuration.schema.json
+++ b/schemas/runtime-configuration.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/runtime-configuration.schema.json",
   "title": "Agent Memory Runtime Configuration",
-  "description": "Serialization-neutral runtime configuration contract for attaching Agent Memory to an existing stack or bootstrapping a bounded local profile. Configuration does not grant authority or prove qualification/currentness.",
+  "description": "Serialization-neutral runtime configuration contract for attaching Agent Memory to an existing stack or bootstrapping a bounded local profile. Configuration does not grant authority or prove qualification/currentness. component-capability-v2 declarations expose explicit lifecycle behavior metadata that routes may require.",
   "type": "object",
   "required": [
     "schema_version",
@@ -113,6 +113,112 @@
       },
       "additionalProperties": false
     },
+    "behaviorContract": {
+      "type": "object",
+      "required": [
+        "operation_support",
+        "currentness_model",
+        "invalidation_model",
+        "correction_model",
+        "deletion_model",
+        "residue_model",
+        "migration_rebuild_model",
+        "structural_mutation_requirement"
+      ],
+      "properties": {
+        "operation_support": {
+          "type": "object",
+          "required": ["write", "read", "recall_candidate"],
+          "properties": {
+            "write": { "type": "boolean" },
+            "read": { "type": "boolean" },
+            "recall_candidate": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        },
+        "currentness_model": {
+          "type": "string",
+          "enum": ["not_applicable", "canonical_version", "basis_versioned", "provider_revalidated", "external_asserted"]
+        },
+        "invalidation_model": {
+          "type": "string",
+          "enum": ["not_applicable", "version_relation", "explicit_signal", "provider_revalidation"]
+        },
+        "correction_model": {
+          "type": "string",
+          "enum": ["not_applicable", "canonical_supersession", "invalidate_derived", "candidate_only", "provider_revalidation"]
+        },
+        "deletion_model": {
+          "type": "string",
+          "enum": ["not_applicable", "canonical_delete", "derived_residue_then_purge", "candidate_drop", "provider_revalidation"]
+        },
+        "residue_model": {
+          "type": "string",
+          "enum": ["not_applicable", "none_expected", "scan_required", "derived_residual", "provider_managed"]
+        },
+        "migration_rebuild_model": {
+          "type": "string",
+          "enum": ["not_applicable", "rebuild_from_canonical", "explicit_migration", "requires_requalification", "unsupported"]
+        },
+        "structural_mutation_requirement": {
+          "type": "string",
+          "enum": ["none", "proposal_only", "pama_required", "external_authorization_required"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "behaviorRequirement": {
+      "type": "object",
+      "properties": {
+        "operation_support": {
+          "type": "object",
+          "properties": {
+            "write": { "type": "boolean" },
+            "read": { "type": "boolean" },
+            "recall_candidate": { "type": "boolean" }
+          },
+          "minProperties": 1,
+          "additionalProperties": false
+        },
+        "currentness_models": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["not_applicable", "canonical_version", "basis_versioned", "provider_revalidated", "external_asserted"] },
+          "uniqueItems": true
+        },
+        "invalidation_models": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["not_applicable", "version_relation", "explicit_signal", "provider_revalidation"] },
+          "uniqueItems": true
+        },
+        "correction_models": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["not_applicable", "canonical_supersession", "invalidate_derived", "candidate_only", "provider_revalidation"] },
+          "uniqueItems": true
+        },
+        "deletion_models": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["not_applicable", "canonical_delete", "derived_residue_then_purge", "candidate_drop", "provider_revalidation"] },
+          "uniqueItems": true
+        },
+        "residue_models": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["not_applicable", "none_expected", "scan_required", "derived_residual", "provider_managed"] },
+          "uniqueItems": true
+        },
+        "migration_rebuild_models": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["not_applicable", "rebuild_from_canonical", "explicit_migration", "requires_requalification", "unsupported"] },
+          "uniqueItems": true
+        },
+        "structural_mutation_requirements": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["none", "proposal_only", "pama_required", "external_authorization_required"] },
+          "uniqueItems": true
+        }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
     "capability": {
       "type": "object",
       "required": [
@@ -130,13 +236,7 @@
         "capability_version": { "$ref": "#/$defs/nonEmptyString" },
         "maturity": {
           "type": "string",
-          "enum": [
-            "declared",
-            "implemented",
-            "runtime_wired",
-            "evidence_proven",
-            "reference_qualified"
-          ]
+          "enum": ["declared", "implemented", "runtime_wired", "evidence_proven", "reference_qualified"]
         },
         "state_posture": {
           "type": "string",
@@ -144,11 +244,7 @@
         },
         "scope_posture": {
           "type": "string",
-          "enum": [
-            "enforces_agent_memory_scope",
-            "inherits_agent_memory_scope",
-            "external_scope_bridge"
-          ]
+          "enum": ["enforces_agent_memory_scope", "inherits_agent_memory_scope", "external_scope_bridge"]
         },
         "failure_posture": {
           "type": "string",
@@ -168,20 +264,14 @@
           "type": "array",
           "items": { "$ref": "#/$defs/nonEmptyString" },
           "uniqueItems": true
-        }
+        },
+        "behavior_contract": { "$ref": "#/$defs/behaviorContract" }
       },
       "additionalProperties": false
     },
     "componentDeclaration": {
       "type": "object",
-      "required": [
-        "component_id",
-        "component_version",
-        "profile_version",
-        "enabled",
-        "failure_posture",
-        "capabilities"
-      ],
+      "required": ["component_id", "component_version", "profile_version", "enabled", "failure_posture", "capabilities"],
       "properties": {
         "component_id": { "$ref": "#/$defs/nonEmptyString" },
         "component_version": { "$ref": "#/$defs/nonEmptyString" },
@@ -203,6 +293,26 @@
           "items": { "$ref": "#/$defs/capability" }
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "profile_version": { "const": "component-capability-v2" } },
+            "required": ["profile_version"]
+          },
+          "then": {
+            "properties": {
+              "capabilities": {
+                "items": {
+                  "allOf": [
+                    { "$ref": "#/$defs/capability" },
+                    { "required": ["behavior_contract"] }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ],
       "additionalProperties": false
     },
     "componentRuntime": {
@@ -226,13 +336,7 @@
         "profile_version": { "$ref": "#/$defs/nonEmptyString" },
         "minimum_earned_maturity": {
           "type": "string",
-          "enum": [
-            "declared",
-            "implemented",
-            "runtime_wired",
-            "evidence_proven",
-            "reference_qualified"
-          ]
+          "enum": ["declared", "implemented", "runtime_wired", "evidence_proven", "reference_qualified"]
         },
         "applicability_digest": {
           "type": "string",
@@ -246,14 +350,7 @@
             "required": ["required"]
           },
           "then": {
-            "required": [
-              "adapter_id",
-              "adapter_version",
-              "profile_id",
-              "profile_version",
-              "minimum_earned_maturity",
-              "applicability_digest"
-            ]
+            "required": ["adapter_id", "adapter_version", "profile_id", "profile_version", "minimum_earned_maturity", "applicability_digest"]
           }
         }
       ],
@@ -270,28 +367,14 @@
     },
     "route": {
       "type": "object",
-      "required": [
-        "route_id",
-        "capability_id",
-        "capability_version",
-        "minimum_maturity",
-        "allowed_components",
-        "qualification",
-        "currentness"
-      ],
+      "required": ["route_id", "capability_id", "capability_version", "minimum_maturity", "allowed_components", "qualification", "currentness"],
       "properties": {
         "route_id": { "$ref": "#/$defs/nonEmptyString" },
         "capability_id": { "$ref": "#/$defs/nonEmptyString" },
         "capability_version": { "$ref": "#/$defs/nonEmptyString" },
         "minimum_maturity": {
           "type": "string",
-          "enum": [
-            "declared",
-            "implemented",
-            "runtime_wired",
-            "evidence_proven",
-            "reference_qualified"
-          ]
+          "enum": ["declared", "implemented", "runtime_wired", "evidence_proven", "reference_qualified"]
         },
         "allowed_components": {
           "type": "array",
@@ -312,16 +395,10 @@
         },
         "required_scope_postures": {
           "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "enforces_agent_memory_scope",
-              "inherits_agent_memory_scope",
-              "external_scope_bridge"
-            ]
-          },
+          "items": { "type": "string", "enum": ["enforces_agent_memory_scope", "inherits_agent_memory_scope", "external_scope_bridge"] },
           "uniqueItems": true
         },
+        "behavior_requirements": { "$ref": "#/$defs/behaviorRequirement" },
         "qualification": { "$ref": "#/$defs/qualificationRequirement" },
         "currentness": { "$ref": "#/$defs/currentness" }
       },


### PR DESCRIPTION
## Summary

Implements the final machine-readable declaration gap identified in #280 after the runtime composition audit.

This PR adds `component-capability-v2`, preserving legacy v1 compatibility while requiring explicit lifecycle behavior metadata for v2 declarations.

### Behavior contract

Each v2 capability declares:

- operation support: write / read / recall-candidate;
- currentness model;
- invalidation model;
- correction/supersession model;
- deletion model;
- residue model;
- migration/rebuild model;
- structural-mutation requirement.

These fields are descriptive implementation metadata. They do not grant mutation, recall-admission, structural, or external action authority.

### Behavior-aware routing

`CapabilityRequirement` can now carry a `CapabilityBehaviorRequirement`. `ComponentRegistry.resolve()` treats providers with missing or mismatched behavior contracts as ineligible.

This allows behavior to disambiguate providers instead of relying only on a shared capability name.

The portable runtime schema now permits `behavior_requirements` on routes and requires every capability in a `component-capability-v2` declaration to expose a behavior contract.

A compatibility layer validates those requirements against the resolved runtime primary/fallback while leaving v1 configurations with no behavior requirements valid.

### Reference profile upgrade

`reference-composed-runtime.json` is upgraded to v2:

- `semantic_fact_memory` declares canonical-version currentness, canonical supersession, and canonical deletion;
- `exact_identity_retrieval` declares read + recall-candidate behavior;
- `rebuild_projection` declares basis-versioned currentness, version-relation invalidation, correction invalidation, derived residue/purge, and rebuild-from-canonical behavior.

Its routes explicitly require those semantics.

### Evidence

Adds:

- behavior contract and requirement types in `capabilities.py`;
- v2 component-profile schema support;
- runtime route behavior schema support;
- behavior-aware runtime validation layer;
- targeted legacy/v2/mismatch/disambiguation tests;
- exact-head behavior evidence runner/workflow.

## Compatibility boundary

```text
component-capability-v1
  -> remains valid when no behavior requirement is requested

component-capability-v2
  -> behavior_contract required for every capability

route with behavior_requirements
  -> legacy/no-behavior provider is ineligible/refused
```

No new logical memory state algebra is introduced.

## #280 closeout intent

If exact-head targeted/full regression and the repository-wide matrix remain green, this should satisfy the remaining full-issue-body requirement that capability declarations machine-readably state write/read/candidate, currentness/invalidation, correction, deletion/residue, migration/rebuild, and structural-mutation behavior.

At that point #280 can be closed only after a final acceptance-criteria crosswalk against all prior qualification/configuration/composition evidence.

Refs #280.
Refs ADR-033.
Refs #300.
Refs #308.