### PR TITLE
Add installable config validation and truthful doctor CLI

### DIFF
--- a/.github/workflows/cli-doctor.yml
+++ b/.github/workflows/cli-doctor.yml
@@ -1,0 +1,122 @@
+name: CLI Doctor Boundary
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install full reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Install Agent Memory distribution from repository
+        run: python -m pip install --disable-pip-version-check .
+
+      - name: Smoke-test installed console command
+        run: |
+          agent-memory --help
+          agent-memory config validate \
+            --config reference/fixtures/runtime-configuration/reference-composed-runtime.json \
+            --json > installed-config-validation.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path("installed-config-validation.json").read_text())
+          if report["valid"] is not True:
+              raise SystemExit("installed console command did not validate reference configuration")
+          if report["authority_effect"] != "none":
+              raise SystemExit("installed configuration command cannot create authority")
+          PY
+
+      - name: Smoke-test attach-to-existing-stack configuration
+        run: |
+          agent-memory config validate \
+            --config reference/fixtures/runtime-configuration/attached-existing-stack.json \
+            --qualifications reference/fixtures/runtime-configuration/qualification-bindings.json \
+            --json > attached-config-validation.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path("attached-config-validation.json").read_text())
+          if report["entry_mode"] != "attach_existing_stack":
+              raise SystemExit("expected attach_existing_stack reference validation")
+          if report["qualification_binding_count"] != 2:
+              raise SystemExit("independent qualification bindings were not consumed")
+          PY
+
+      - name: Execute targeted CLI/doctor tests
+        run: python -m unittest discover -s reference/tests -t reference -p 'test_cli_doctor.py'
+
+      - name: Execute full reference regression suite
+        run: python -m unittest discover -s reference/tests -t reference
+
+      - name: Emit exact-head CLI/doctor evidence
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_cli_doctor.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output cli-doctor-evidence.json
+
+      - name: Validate emitted CLI/doctor evidence
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("cli-doctor-evidence.json").read_text())
+          if len(report["agent_memory_commit"]) != 40:
+              raise SystemExit("CLI/doctor evidence is not exact-head bound")
+          invariants = report["structural_invariants"]
+          non_boolean = [name for name, value in invariants.items() if type(value) is not bool]
+          if non_boolean:
+              raise SystemExit(f"CLI/doctor invariants are not JSON booleans: {non_boolean}")
+          failed = [name for name, passed in invariants.items() if not passed]
+          if failed:
+              raise SystemExit(f"CLI/doctor invariants failed: {failed}")
+          if report["authority_effect"] != "none":
+              raise SystemExit("CLI/doctor boundary cannot create authority")
+          if report["doctor_examples"]["state_recovered"]["provider_availability"]["status"] != "not_probed":
+              raise SystemExit("doctor must not fabricate live provider health")
+          print(f"validated {len(invariants)} CLI/doctor invariants")
+          PY
+
+      - name: Upload CLI/doctor evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-doctor-evidence
+          path: |
+            cli-doctor-evidence.json
+            installed-config-validation.json
+            attached-config-validation.json
+          if-no-files-found: error
+
+      - name: Publish CLI/doctor summary
+        if: always()
+        run: |
+          {
+            echo "## Installed Agent Memory command boundary"
+            echo ""
+            echo "Repository installation exposes agent-memory config validate and agent-memory doctor over the same portable configuration/recovery contracts."
+            echo ""
+            echo "doctor distinguishes configuration, durable recovery, currentness, and unprobed provider availability rather than emitting a generic healthy flag."
+            echo ""
+            echo '```'
+            echo "python -m pip install ."
+            echo "agent-memory config validate --config <config.json>"
+            echo "agent-memory doctor --config <config.json> --state-dir <state-dir>"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/programs/runtime-evidence/cli-doctor-boundary.md
+++ b/docs/programs/runtime-evidence/cli-doctor-boundary.md
@@ -1,0 +1,200 @@
+# Installed CLI and truthful doctor boundary
+
+Status: implementation evidence for #282, consuming #280/#300/#308 contracts
+
+This slice creates the first installed process boundary for the Agent Memory reference runtime.
+
+It deliberately starts with diagnostics rather than a setup wizard. The goal is to make the existing configuration, qualification, currentness, and restart contracts usable from an installed command without inventing another configuration model.
+
+## Installation boundary
+
+The repository now contains Python package metadata and installs a console script:
+
+```bash
+python -m pip install .
+agent-memory --help
+```
+
+The distribution name for this bounded reference slice is:
+
+`agent-memory-reference`
+
+The installed command is:
+
+`agent-memory`
+
+This does not claim a published PyPI release. It proves repository installation and console-script execution.
+
+## Configuration validation
+
+```bash
+agent-memory config validate \
+  --config path/to/runtime-config.json
+```
+
+For configurations that require independent qualification evidence:
+
+```bash
+agent-memory config validate \
+  --config path/to/runtime-config.json \
+  --qualifications path/to/qualification-bindings.json
+```
+
+The command consumes the same portable runtime schema, capability behavior contract, `ComponentRegistry`, source-rights checks, and qualification requirements used by the reference runtime.
+
+It does not create a second installer-specific routing model.
+
+Successful validation reports a configuration as startable under the bounded configuration contract. It does not claim the runtime is operationally healthy.
+
+## Doctor
+
+```bash
+agent-memory doctor \
+  --config path/to/runtime-config.json \
+  --state-dir path/to/agent-memory-state
+```
+
+The diagnostic surface separates:
+
+```text
+configuration validity
+durable-state presence
+restart recovery
+currentness / quiescence
+live provider availability
+operational readiness
+```
+
+These are intentionally not collapsed into one `healthy` Boolean.
+
+### No durable state yet
+
+A valid configuration with no initialized state reports:
+
+```text
+configuration = valid
+durable_state = not_initialized
+recovery = not_attempted
+provider_availability = not_probed
+operational_readiness = configuration_valid_state_not_initialized
+```
+
+This is a useful pre-start posture, not a recovery success.
+
+### Exact bounded recovery
+
+When `reference_config_bound_checkpoint_v1` state exists and matches the validated configuration/plan, doctor invokes the existing bounded recovery contract.
+
+Successful recovery reports the exact durability profile, configuration/plan binding, checkpoint generation, and configured route activations.
+
+It still reports:
+
+`provider_availability = not_probed`
+
+because successful file recovery does not prove a provider executable, network service, credential, or dependency is live now.
+
+### Currentness
+
+Persisted #308 visibility snapshots are reconstructed and summarized independently.
+
+Possible aggregate statuses include:
+
+```text
+not_observed
+pending
+quiescent
+degraded
+not_proven
+```
+
+A pending required projection therefore remains visible as pending after restart instead of being hidden behind a generic process-up result.
+
+### Recovery corruption
+
+If the durable configuration/checkpoint binding fails the existing #282 recovery contract, doctor reports:
+
+```text
+recovery = failed_closed
+configuration_startable = false
+operational_readiness = blocked_by_recovery_failure
+```
+
+The CLI does not repair or migrate the state automatically.
+
+## JSON output
+
+Both commands support machine-readable output:
+
+```bash
+agent-memory config validate --config config.json --json
+agent-memory doctor --config config.json --state-dir state --json
+```
+
+This allows the installed CLI to serve as a future automation/UX boundary without requiring a wizard to scrape human-formatted output.
+
+## Exit behavior
+
+The bounded command surface uses distinct refusal/error behavior:
+
+- configuration/input refusal returns a nonzero refusal exit code;
+- failed durable recovery or degraded currentness returns nonzero from doctor;
+- pending currentness remains explicit in output instead of being converted into a fabricated failure or success;
+- live provider availability remains unproven until an actual provider probe exists.
+
+## Evidence
+
+Targeted tests:
+
+```bash
+python -m unittest discover -s reference/tests -t reference -p 'test_cli_doctor.py'
+```
+
+Exact-head evidence:
+
+```bash
+python reference/run_cli_doctor.py \
+  --agent-memory-commit <exact-40-character-commit> \
+  --output cli-doctor-evidence.json
+```
+
+The `CLI Doctor Boundary` workflow additionally:
+
+1. installs the distribution from the repository;
+2. executes the installed `agent-memory` console script;
+3. validates both the composed first-party and attach-to-existing-stack configurations;
+4. runs targeted CLI/doctor tests;
+5. runs the complete reference regression suite;
+6. emits exact-head evidence;
+7. refuses non-Boolean structural invariants;
+8. preserves the diagnostic artifacts.
+
+## Non-claims
+
+This slice does not provide:
+
+- a published PyPI package;
+- setup wizard;
+- automatic discovery of arbitrary runtimes/frameworks;
+- component package installation;
+- live secret resolution;
+- universal provider health probes;
+- HTTP/server API;
+- production distributed durability;
+- automatic configuration migration.
+
+Those surfaces can now build on an installed command that already understands the canonical configuration/recovery contracts.
+
+## Product direction
+
+The intended sequence remains:
+
+```text
+existing runtime / governance / storage
+  -> install Agent Memory
+  -> validate/construct portable configuration
+  -> qualify required components
+  -> inspect durable/currentness posture
+  -> start runtime
+```
+
+An eventual setup wizard should call these same validation/diagnostic APIs. It should not become the only place configuration semantics exist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,8 @@ package-dir = {"" = "reference"}
 [tool.setuptools.packages.find]
 where = ["reference"]
 include = ["agentmem_ref*"]
+
+[tool.setuptools.data-files]
+"agent_memory_reference/schemas" = [
+  "schemas/runtime-configuration.schema.json",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agent-memory-reference"
+version = "0.1.0"
+description = "Reference runtime and diagnostic CLI for the Agent Memory project"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "Apache-2.0"}
+dependencies = [
+  "jsonschema>=4.20,<5",
+]
+
+[project.scripts]
+agent-memory = "agentmem_ref.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "reference"}
+
+[tool.setuptools.packages.find]
+where = ["reference"]
+include = ["agentmem_ref*"]

--- a/reference/agentmem_ref/__main__.py
+++ b/reference/agentmem_ref/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/reference/agentmem_ref/cli.py
+++ b/reference/agentmem_ref/cli.py
@@ -1,0 +1,106 @@
+"""Installed command surface for the Agent Memory reference runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from .doctor import DiagnosticInputError, diagnose, validate_configuration_file
+from .runtime_config import RuntimeConfigurationError
+
+
+def _emit(value: dict, *, json_output: bool) -> None:
+    if json_output:
+        print(json.dumps(value, indent=2, sort_keys=True))
+        return
+    if value.get("command") == "config_validate":
+        print("Configuration: valid")
+        print(f"Digest: {value['configuration_digest']}")
+        print(f"Entry mode: {value['entry_mode']}")
+        print(
+            "Canonical owner: "
+            f"{value['canonical_owner_component_id']} / {value['canonical_owner_capability_id']}"
+        )
+        print(f"Routes: {value['route_count']}")
+        print(f"Required projections: {', '.join(value['required_projection_ids']) or 'none'}")
+        print("Authority effect: none")
+        return
+    print(f"Configuration: {value['configuration']['status']}")
+    print(f"Durable state: {value['durable_state']['status']}")
+    print(f"Recovery: {value['recovery']['status']}")
+    print(f"Currentness: {value['currentness']['status']}")
+    print(f"Provider availability: {value['provider_availability']['status']}")
+    print(f"Configuration startable: {str(value['configuration_startable']).lower()}")
+    print(f"Operational readiness: {value['operational_readiness']}")
+    print("Authority effect: none")
+
+
+def _failure(command: str, exc: Exception, *, json_output: bool) -> int:
+    value = {
+        "schema_version": "1.0.0",
+        "command": command,
+        "valid": False,
+        "status": "refused",
+        "error": str(exc),
+        "authority_effect": "none",
+    }
+    if json_output:
+        print(json.dumps(value, indent=2, sort_keys=True))
+    else:
+        print(f"Refused: {exc}", file=sys.stderr)
+    return 2
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agent-memory",
+        description="Validate and diagnose the Agent Memory reference runtime.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    config = subcommands.add_parser("config", help="runtime configuration operations")
+    config_sub = config.add_subparsers(dest="config_command", required=True)
+    validate = config_sub.add_parser("validate", help="validate one portable runtime configuration")
+    validate.add_argument("--config", required=True, help="path to a JSON serialization of the runtime contract")
+    validate.add_argument("--qualifications", help="path to normalized independent qualification bindings")
+    validate.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+
+    doctor = subcommands.add_parser("doctor", help="diagnose configuration and bounded durable-state recovery")
+    doctor.add_argument("--config", required=True, help="path to a JSON serialization of the runtime contract")
+    doctor.add_argument("--qualifications", help="path to normalized independent qualification bindings")
+    doctor.add_argument("--state-dir", help="Agent Memory bounded reference state directory to inspect/recover")
+    doctor.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    json_output = bool(getattr(args, "json", False))
+    try:
+        if args.command == "config" and args.config_command == "validate":
+            value = validate_configuration_file(
+                args.config,
+                qualification_path=args.qualifications,
+            )
+            _emit(value, json_output=json_output)
+            return 0
+        if args.command == "doctor":
+            value = diagnose(
+                args.config,
+                qualification_path=args.qualifications,
+                state_dir=args.state_dir,
+            )
+            _emit(value, json_output=json_output)
+            if value["recovery"].get("status") == "failed_closed":
+                return 1
+            if value["currentness"].get("status") == "degraded":
+                return 1
+            return 0
+    except (DiagnosticInputError, RuntimeConfigurationError, KeyError, TypeError, ValueError) as exc:
+        return _failure(args.command, exc, json_output=json_output)
+    raise AssertionError("unreachable command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/agentmem_ref/doctor.py
+++ b/reference/agentmem_ref/doctor.py
@@ -1,0 +1,240 @@
+"""Truthful diagnostics for an Agent Memory runtime configuration.
+
+The doctor surface distinguishes configuration validity, durable-state
+recovery, currentness, and live provider availability. It intentionally does
+not reduce those independent claims to a generic ``healthy`` boolean.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping
+
+from .configured_restart import ConfigBoundRestartRuntime
+from .restart_runtime import RuntimeRecoveryError
+from .runtime_behavior import validate_runtime_behavior_contract
+from .runtime_config import QualificationBinding
+from .visibility import VisibilityTracker
+
+
+class DiagnosticInputError(ValueError):
+    """A CLI diagnostic input cannot be interpreted safely."""
+
+
+def load_qualification_bindings(path: str | Path | None) -> tuple[QualificationBinding, ...]:
+    if path is None:
+        return ()
+    source = Path(path)
+    try:
+        value = json.loads(source.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise DiagnosticInputError(f"qualification binding file not found: {source}") from exc
+    except json.JSONDecodeError as exc:
+        raise DiagnosticInputError(f"qualification binding file is not valid JSON: {source}") from exc
+    if isinstance(value, Mapping):
+        rows = value.get("bindings")
+    else:
+        rows = value
+    if not isinstance(rows, list):
+        raise DiagnosticInputError("qualification binding document must be an array or contain a bindings array")
+    try:
+        return tuple(QualificationBinding(**row) for row in rows)
+    except (TypeError, KeyError, ValueError) as exc:
+        raise DiagnosticInputError(f"qualification binding row is invalid: {exc}") from exc
+
+
+def load_configuration_value(path: str | Path) -> dict:
+    source = Path(path)
+    try:
+        value = json.loads(source.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise DiagnosticInputError(f"runtime configuration not found: {source}") from exc
+    except json.JSONDecodeError as exc:
+        raise DiagnosticInputError(f"runtime configuration is not valid JSON: {source}") from exc
+    if not isinstance(value, dict):
+        raise DiagnosticInputError("runtime configuration must be a JSON object")
+    return value
+
+
+def validate_configuration_file(
+    config_path: str | Path,
+    *,
+    qualification_path: str | Path | None = None,
+) -> dict:
+    value = load_configuration_value(config_path)
+    bindings = load_qualification_bindings(qualification_path)
+    plan = validate_runtime_behavior_contract(value, qualification_bindings=bindings)
+    required_qualification_routes = [
+        str(route.get("route_id"))
+        for route in value.get("routes", ())
+        if isinstance(route, Mapping)
+        and isinstance(route.get("qualification"), Mapping)
+        and bool(route["qualification"].get("required", False))
+    ]
+    return {
+        "schema_version": "1.0.0",
+        "command": "config_validate",
+        "valid": True,
+        "configuration_digest": plan.configuration_digest,
+        "entry_mode": plan.entry_mode,
+        "runtime_id": plan.runtime_id,
+        "runtime_version": plan.runtime_version,
+        "profile_id": plan.profile_id,
+        "profile_version": plan.profile_version,
+        "canonical_owner_component_id": plan.canonical_owner_component_id,
+        "canonical_owner_capability_id": plan.canonical_owner_capability_id,
+        "route_count": len(plan.resolved_routes),
+        "required_projection_ids": list(plan.required_projection_ids),
+        "required_qualification_routes": required_qualification_routes,
+        "qualification_binding_count": len(bindings),
+        "authority_effect": "none",
+        "startable_configuration": True,
+        "plan": plan.to_dict(),
+    }
+
+
+def _currentness_summary(snapshots: Mapping[str, dict]) -> dict:
+    if not snapshots:
+        return {
+            "status": "not_observed",
+            "operation_count": 0,
+            "quiescent_operations": 0,
+            "pending_operations": 0,
+            "degraded_operations": 0,
+        }
+    quiescent = pending = degraded = 0
+    operations: list[dict] = []
+    for operation_id, snapshot in sorted(snapshots.items()):
+        try:
+            disposition = VisibilityTracker.restore_after_restart(snapshot).evaluate()
+        except (KeyError, TypeError, ValueError) as exc:
+            degraded += 1
+            operations.append({
+                "operation_id": operation_id,
+                "status": "invalid_snapshot",
+                "detail": str(exc),
+            })
+            continue
+        if disposition["quiescent"]:
+            quiescent += 1
+            status = "quiescent"
+        elif disposition["settled"]:
+            degraded += 1
+            status = "degraded"
+        else:
+            pending += 1
+            status = "pending"
+        operations.append({
+            "operation_id": operation_id,
+            "status": status,
+            "pending_required_obligations": disposition["pending_required_obligations"],
+            "failed_required_obligations": disposition["failed_required_obligations"],
+        })
+    if degraded:
+        status = "degraded"
+    elif pending:
+        status = "pending"
+    else:
+        status = "quiescent"
+    return {
+        "status": status,
+        "operation_count": len(snapshots),
+        "quiescent_operations": quiescent,
+        "pending_operations": pending,
+        "degraded_operations": degraded,
+        "operations": operations,
+    }
+
+
+def diagnose(
+    config_path: str | Path,
+    *,
+    qualification_path: str | Path | None = None,
+    state_dir: str | Path | None = None,
+) -> dict:
+    value = load_configuration_value(config_path)
+    bindings = load_qualification_bindings(qualification_path)
+    plan = validate_runtime_behavior_contract(value, qualification_bindings=bindings)
+
+    report = {
+        "schema_version": "1.0.0",
+        "command": "doctor",
+        "configuration": {
+            "status": "valid",
+            "digest": plan.configuration_digest,
+            "entry_mode": plan.entry_mode,
+            "profile_id": plan.profile_id,
+            "profile_version": plan.profile_version,
+            "route_count": len(plan.resolved_routes),
+            "required_projection_ids": list(plan.required_projection_ids),
+            "authority_effect": "none",
+        },
+        "qualification": {
+            "status": "valid_for_configured_routes",
+            "binding_count": len(bindings),
+            "scope": "configured_routes_only",
+        },
+        "durable_state": {"status": "not_checked"},
+        "recovery": {"status": "not_attempted"},
+        "currentness": {"status": "not_checked"},
+        "provider_availability": {
+            "status": "not_probed",
+            "detail": "configuration and recovery evidence do not prove live provider availability",
+        },
+        "configuration_startable": True,
+        "operational_readiness": "not_proven",
+        "authority_effect": "none",
+    }
+
+    if state_dir is None:
+        return report
+
+    root = Path(state_dir)
+    manifest = root / "runtime-manifest.json"
+    config_binding = root / "configuration-binding.json"
+    if not root.exists() or not manifest.exists():
+        report["durable_state"] = {
+            "status": "not_initialized",
+            "state_dir": str(root),
+        }
+        report["currentness"] = {"status": "not_observed"}
+        report["operational_readiness"] = "configuration_valid_state_not_initialized"
+        return report
+
+    report["durable_state"] = {
+        "status": "checkpoint_present",
+        "state_dir": str(root),
+        "configuration_binding_present": config_binding.exists(),
+    }
+    try:
+        runtime = ConfigBoundRestartRuntime.recover(root, plan=plan)
+    except RuntimeRecoveryError as exc:
+        report["recovery"] = {
+            "status": "failed_closed",
+            "detail": str(exc),
+        }
+        report["currentness"] = {"status": "not_proven"}
+        report["configuration_startable"] = False
+        report["operational_readiness"] = "blocked_by_recovery_failure"
+        return report
+
+    evidence = runtime.recovery_evidence
+    report["recovery"] = {
+        "status": "recovered",
+        "durability_profile": evidence.durability_profile,
+        "recovery_posture": evidence.recovery_posture,
+        "base_generation": evidence.base_generation,
+        "configuration_digest": evidence.configuration_digest,
+        "plan_digest": evidence.plan_digest,
+        "route_activations": [item.to_dict() for item in evidence.route_activations],
+    }
+    report["durable_state"]["status"] = "recovered"
+    report["currentness"] = _currentness_summary(runtime.visibility_snapshots)
+    if report["currentness"]["status"] == "degraded":
+        report["operational_readiness"] = "degraded_currentness"
+    elif report["currentness"]["status"] == "pending":
+        report["operational_readiness"] = "pending_currentness"
+    else:
+        report["operational_readiness"] = "provider_availability_not_probed"
+    return report

--- a/reference/agentmem_ref/runtime_config.py
+++ b/reference/agentmem_ref/runtime_config.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 import hashlib
+from importlib import metadata
 import json
 from pathlib import Path
 from typing import Iterable, Mapping
@@ -34,6 +35,8 @@ from .qualification import QualificationRecord
 
 
 RUNTIME_CONFIGURATION_SCHEMA_VERSION = "1.0.0"
+_DISTRIBUTION_NAME = "agent-memory-reference"
+_RUNTIME_SCHEMA_DATA_SUFFIX = "agent_memory_reference/schemas/runtime-configuration.schema.json"
 _ALLOWED_SECRET_SCHEMES = ("env://", "secret://", "vault://", "keyring://")
 _LITERAL_SECRET_KEYS = frozenset(
     {
@@ -219,10 +222,32 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _configuration_schema() -> dict:
-    return json.loads(
-        (_repo_root() / "schemas" / "runtime-configuration.schema.json").read_text(encoding="utf-8")
+def _configuration_schema_path() -> Path:
+    """Locate the canonical runtime schema in source or an installed wheel."""
+
+    source_path = _repo_root() / "schemas" / "runtime-configuration.schema.json"
+    if source_path.is_file():
+        return source_path
+
+    try:
+        distribution_files = metadata.files(_DISTRIBUTION_NAME) or ()
+    except metadata.PackageNotFoundError:
+        distribution_files = ()
+
+    for entry in distribution_files:
+        normalized = str(entry).replace("\\", "/")
+        if normalized.endswith(_RUNTIME_SCHEMA_DATA_SUFFIX):
+            installed_path = Path(entry.locate())
+            if installed_path.is_file():
+                return installed_path
+
+    raise RuntimeConfigurationError(
+        "runtime configuration schema is unavailable; install the distribution with its packaged schema data"
     )
+
+
+def _configuration_schema() -> dict:
+    return json.loads(_configuration_schema_path().read_text(encoding="utf-8"))
 
 
 def _canonical_bytes(value: object) -> bytes:

--- a/reference/run_cli_doctor.py
+++ b/reference/run_cli_doctor.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Emit exact-head evidence for the installed Agent Memory CLI/doctor boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.configured_restart import ConfigBoundRestartRuntime  # noqa: E402
+from agentmem_ref.doctor import diagnose, validate_configuration_file  # noqa: E402
+from agentmem_ref.runtime_behavior import validate_runtime_behavior_contract  # noqa: E402
+from agentmem_ref.visibility import VisibilityOperation, VisibilityTracker  # noqa: E402
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "reference" / "fixtures" / "runtime-configuration"
+COMPOSED = FIXTURES / "reference-composed-runtime.json"
+ATTACHED = FIXTURES / "attached-existing-stack.json"
+QUALIFICATIONS = FIXTURES / "qualification-bindings.json"
+
+
+def build_report(agent_memory_commit: str) -> dict:
+    if len(agent_memory_commit) != 40:
+        raise ValueError("agent-memory commit must be an exact 40-character SHA")
+
+    composed_validation = validate_configuration_file(COMPOSED)
+    attached_validation = validate_configuration_file(
+        ATTACHED,
+        qualification_path=QUALIFICATIONS,
+    )
+    composed_value = json.loads(COMPOSED.read_text(encoding="utf-8"))
+    plan = validate_runtime_behavior_contract(composed_value)
+
+    with tempfile.TemporaryDirectory() as directory:
+        runtime = ConfigBoundRestartRuntime.create(directory, tenant="tenant-acme", plan=plan)
+        recovered = diagnose(COMPOSED, state_dir=directory)
+
+        operation = VisibilityOperation(
+            operation_id="visibility:doctor-evidence",
+            memory_id="memory:doctor-evidence",
+            memory_version=1,
+            operation_type="promotion",
+            runtime_version=plan.runtime_version,
+            profile_version=plan.profile_version,
+            agent_memory_commit=agent_memory_commit,
+            required_projection_ids=("reference-derived-index",),
+        )
+        tracker = VisibilityTracker(operation)
+        tracker.policy_decided()
+        tracker.canonical_committed()
+        tracker.projection_refresh_started("reference-derived-index")
+        runtime.persist_visibility_snapshot(operation.operation_id, tracker.snapshot_for_restart())
+        pending = diagnose(COMPOSED, state_dir=directory)
+
+        binding_path = Path(directory) / "configuration-binding.json"
+        binding = json.loads(binding_path.read_text(encoding="utf-8"))
+        binding["configuration_digest"] = "sha256:" + "0" * 64
+        binding_path.write_text(json.dumps(binding), encoding="utf-8")
+        failed = diagnose(COMPOSED, state_dir=directory)
+
+    with tempfile.TemporaryDirectory() as directory:
+        absent = diagnose(COMPOSED, state_dir=Path(directory) / "not-created")
+
+    invariants = {
+        "composed_configuration_valid": composed_validation["valid"] is True,
+        "attach_existing_stack_configuration_valid_with_independent_qualification": (
+            attached_validation["valid"] is True
+            and attached_validation["entry_mode"] == "attach_existing_stack"
+            and attached_validation["qualification_binding_count"] == 2
+        ),
+        "configuration_validation_grants_no_authority": (
+            composed_validation["authority_effect"] == "none"
+            and attached_validation["authority_effect"] == "none"
+        ),
+        "doctor_reports_uninitialized_state_without_fabricating_recovery": (
+            absent["durable_state"]["status"] == "not_initialized"
+            and absent["recovery"]["status"] == "not_attempted"
+        ),
+        "doctor_recovers_exact_configuration": (
+            recovered["recovery"]["status"] == "recovered"
+            and recovered["durable_state"]["status"] == "recovered"
+        ),
+        "doctor_never_equates_recovery_with_live_provider_health": (
+            recovered["provider_availability"]["status"] == "not_probed"
+            and recovered["operational_readiness"] == "provider_availability_not_probed"
+        ),
+        "doctor_surfaces_pending_currentness": (
+            pending["currentness"]["status"] == "pending"
+            and pending["currentness"]["pending_operations"] == 1
+            and pending["operational_readiness"] == "pending_currentness"
+        ),
+        "doctor_fails_closed_on_durable_binding_corruption": (
+            failed["recovery"]["status"] == "failed_closed"
+            and failed["configuration_startable"] is False
+            and failed["operational_readiness"] == "blocked_by_recovery_failure"
+        ),
+        "doctor_grants_no_authority": all(
+            report["authority_effect"] == "none"
+            for report in (absent, recovered, pending, failed)
+        ),
+    }
+    invariants = {name: bool(value) for name, value in invariants.items()}
+    if not all(type(value) is bool for value in invariants.values()):
+        raise TypeError("every CLI/doctor structural invariant must be a JSON boolean")
+
+    return {
+        "schema_version": "1.0.0",
+        "agent_memory_commit": agent_memory_commit,
+        "distribution_name": "agent-memory-reference",
+        "console_script": "agent-memory",
+        "commands": ["config validate", "doctor"],
+        "composed_configuration": composed_validation,
+        "attached_configuration": attached_validation,
+        "doctor_examples": {
+            "state_absent": absent,
+            "state_recovered": recovered,
+            "currentness_pending": pending,
+            "corrupt_binding": failed,
+        },
+        "structural_invariants": invariants,
+        "structural_invariants_passed": all(invariants.values()),
+        "authority_effect": "none",
+        "limitations": [
+            "The distribution is installable from the repository but is not claimed to be published to PyPI by this slice.",
+            "doctor does not probe live provider health yet and therefore never reports operational readiness as proven from configuration/recovery alone.",
+            "No setup wizard, automatic component discovery, package installation, secret resolution, or HTTP service is implemented here.",
+            "Durable-state diagnostics are bounded to the existing reference_config_bound_checkpoint_v1 profile.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = build_report(args.agent_memory_commit)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report["structural_invariants_passed"]:
+        failed = [name for name, passed in report["structural_invariants"].items() if not passed]
+        print(f"CLI/doctor invariants failed: {failed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_cli_doctor.py
+++ b/reference/tests/test_cli_doctor.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agentmem_ref.cli import main
+from agentmem_ref.configured_restart import ConfigBoundRestartRuntime
+from agentmem_ref.doctor import diagnose, validate_configuration_file
+from agentmem_ref.runtime_behavior import validate_runtime_behavior_contract
+from agentmem_ref.runtime_config import RuntimeConfigurationError
+from agentmem_ref.visibility import VisibilityOperation, VisibilityTracker
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "reference" / "fixtures" / "runtime-configuration"
+COMPOSED = FIXTURES / "reference-composed-runtime.json"
+ATTACHED = FIXTURES / "attached-existing-stack.json"
+QUALIFICATIONS = FIXTURES / "qualification-bindings.json"
+
+
+def _composed_plan():
+    return validate_runtime_behavior_contract(json.loads(COMPOSED.read_text(encoding="utf-8")))
+
+
+class CliDoctorTests(unittest.TestCase):
+    def test_config_validate_reports_composed_runtime_without_overclaiming_authority(self) -> None:
+        report = validate_configuration_file(COMPOSED)
+        self.assertTrue(report["valid"])
+        self.assertTrue(report["startable_configuration"])
+        self.assertEqual(report["authority_effect"], "none")
+        self.assertEqual(report["entry_mode"], "bootstrap_agent_memory_first")
+        self.assertIn("reference-derived-index", report["required_projection_ids"])
+
+    def test_attached_stack_requires_and_accepts_independent_qualification_bindings(self) -> None:
+        with self.assertRaises(RuntimeConfigurationError):
+            validate_configuration_file(ATTACHED)
+        report = validate_configuration_file(ATTACHED, qualification_path=QUALIFICATIONS)
+        self.assertTrue(report["valid"])
+        self.assertEqual(report["entry_mode"], "attach_existing_stack")
+        self.assertEqual(report["required_qualification_routes"], ["derived-code-graph"])
+        self.assertEqual(report["qualification_binding_count"], 2)
+
+    def test_doctor_without_state_is_truthful_about_initialization_and_provider_probe(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory) / "not-created"
+            report = diagnose(COMPOSED, state_dir=state)
+        self.assertEqual(report["configuration"]["status"], "valid")
+        self.assertEqual(report["durable_state"]["status"], "not_initialized")
+        self.assertEqual(report["recovery"]["status"], "not_attempted")
+        self.assertEqual(report["provider_availability"]["status"], "not_probed")
+        self.assertEqual(report["operational_readiness"], "configuration_valid_state_not_initialized")
+        self.assertTrue(report["configuration_startable"])
+        self.assertEqual(report["authority_effect"], "none")
+
+    def test_doctor_recovers_exact_configuration_but_does_not_claim_provider_health(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plan = _composed_plan()
+            ConfigBoundRestartRuntime.create(directory, tenant="tenant-acme", plan=plan)
+            report = diagnose(COMPOSED, state_dir=directory)
+        self.assertEqual(report["durable_state"]["status"], "recovered")
+        self.assertEqual(report["recovery"]["status"], "recovered")
+        self.assertEqual(report["currentness"]["status"], "not_observed")
+        self.assertEqual(report["provider_availability"]["status"], "not_probed")
+        self.assertEqual(report["operational_readiness"], "provider_availability_not_probed")
+
+    def test_doctor_surfaces_pending_currentness_after_recovery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plan = _composed_plan()
+            runtime = ConfigBoundRestartRuntime.create(directory, tenant="tenant-acme", plan=plan)
+            operation = VisibilityOperation(
+                operation_id="visibility:cli-doctor",
+                memory_id="memory:doctor",
+                memory_version=1,
+                operation_type="promotion",
+                runtime_version=plan.runtime_version,
+                profile_version=plan.profile_version,
+                agent_memory_commit="a" * 40,
+                required_projection_ids=("reference-derived-index",),
+            )
+            tracker = VisibilityTracker(operation)
+            tracker.policy_decided()
+            tracker.canonical_committed()
+            tracker.projection_refresh_started("reference-derived-index")
+            runtime.persist_visibility_snapshot(operation.operation_id, tracker.snapshot_for_restart())
+            report = diagnose(COMPOSED, state_dir=directory)
+        self.assertEqual(report["recovery"]["status"], "recovered")
+        self.assertEqual(report["currentness"]["status"], "pending")
+        self.assertEqual(report["currentness"]["pending_operations"], 1)
+        self.assertEqual(report["operational_readiness"], "pending_currentness")
+
+    def test_doctor_fails_closed_on_corrupt_configuration_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plan = _composed_plan()
+            ConfigBoundRestartRuntime.create(directory, tenant="tenant-acme", plan=plan)
+            binding = Path(directory) / "configuration-binding.json"
+            value = json.loads(binding.read_text(encoding="utf-8"))
+            value["configuration_digest"] = "sha256:" + "0" * 64
+            binding.write_text(json.dumps(value), encoding="utf-8")
+            report = diagnose(COMPOSED, state_dir=directory)
+        self.assertEqual(report["recovery"]["status"], "failed_closed")
+        self.assertFalse(report["configuration_startable"])
+        self.assertEqual(report["operational_readiness"], "blocked_by_recovery_failure")
+
+    def test_cli_json_output_is_machine_readable(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            code = main(["config", "validate", "--config", str(COMPOSED), "--json"])
+        self.assertEqual(code, 0)
+        report = json.loads(output.getvalue())
+        self.assertTrue(report["valid"])
+        self.assertEqual(report["authority_effect"], "none")
+
+    def test_cli_invalid_configuration_returns_refusal_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "bad.json"
+            path.write_text("{}", encoding="utf-8")
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                code = main(["config", "validate", "--config", str(path), "--json"])
+        self.assertEqual(code, 2)
+        report = json.loads(output.getvalue())
+        self.assertFalse(report["valid"])
+        self.assertEqual(report["status"], "refused")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the next bounded #282 product/process slice after #280 completion.

This PR creates the first installable command boundary over the existing Agent Memory configuration, qualification, currentness, and restart contracts.

### Installed surface

- root `pyproject.toml`
- distribution: `agent-memory-reference`
- console command: `agent-memory`
- `agent-memory config validate`
- `agent-memory doctor`
- machine-readable `--json` output

### Truthful diagnostics

`doctor` keeps configuration validity, durable-state presence, restart recovery, #308 currentness/quiescence, live provider availability, and operational readiness separate.

Successful checkpoint recovery does not become a generic health claim. Until a real provider probe exists, doctor reports `provider_availability = not_probed`.

### Evidence

Adds targeted CLI/doctor tests, full reference regression, repository-install smoke tests, exact-head evidence, and artifact validation.

### Explicit non-goals

No setup wizard, automatic runtime discovery, component installation, secret resolution, HTTP service, published PyPI release, or fabricated provider-health claim.

Refs #282.
Refs #280.
Refs #300.
Refs #308.