### PR TITLE
Add attach-mode discovery and provider availability probes

### DIFF
--- a/.github/workflows/provider-discovery.yml
+++ b/.github/workflows/provider-discovery.yml
@@ -62,8 +62,10 @@ jobs:
           import json
           from pathlib import Path
           report = json.loads(Path("installed-doctor-probed.json").read_text())
-          if report["provider_availability"]["status"] != "available":
-              raise SystemExit("doctor did not expose observed provider availability")
+          if report["provider_availability"]["status"] != "partial":
+              raise SystemExit("doctor did not preserve mixed provider availability as partial")
+          if report["provider_availability"]["status_counts"]["unavailable"] != 1:
+              raise SystemExit("doctor hid optional unavailable provider evidence")
           if report["provider_availability"]["startability"] != "proven_for_declared_probes":
               raise SystemExit("doctor lost declared probe startability")
           if report["operational_readiness"] != "provider_probe_observed_state_not_checked":
@@ -130,5 +132,5 @@ jobs:
             echo "agent-memory doctor --config <config.json> --probe --probes <probes.json>"
             echo '```'
             echo ""
-            echo "Probe success establishes only the declared availability signal. It does not grant qualification, currentness, health, fallback authority, or mutation permission."
+            echo "Mixed optional availability is reported as partial while required-probe startability remains separate. Probe success does not grant qualification, currentness, health, fallback authority, or mutation permission."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/provider-discovery.yml
+++ b/.github/workflows/provider-discovery.yml
@@ -1,0 +1,128 @@
+name: Provider Discovery Evidence
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Install Agent Memory distribution from repository
+        run: python -m pip install --disable-pip-version-check .
+
+      - name: Smoke-test installed discovery command
+        run: |
+          agent-memory discover \
+            --config reference/fixtures/runtime-configuration/reference-composed-runtime.json \
+            --probes reference/fixtures/runtime-configuration/reference-provider-probes.json \
+            --json > installed-provider-discovery.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path("installed-provider-discovery.json").read_text())
+          if report["startability"] != "proven_for_declared_probes":
+              raise SystemExit("installed discovery did not prove declared required probes")
+          if report["status_counts"]["unavailable"] != 1:
+              raise SystemExit("installed discovery did not preserve optional unavailable evidence")
+          if report["mutated_configuration"] is not False:
+              raise SystemExit("discovery must remain read-only")
+          if report["authority_effect"] != "none":
+              raise SystemExit("discovery cannot create authority")
+          PY
+
+      - name: Smoke-test installed doctor probe path
+        run: |
+          agent-memory doctor \
+            --config reference/fixtures/runtime-configuration/reference-composed-runtime.json \
+            --probe \
+            --probes reference/fixtures/runtime-configuration/reference-provider-probes.json \
+            --json > installed-doctor-probed.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path("installed-doctor-probed.json").read_text())
+          if report["provider_availability"]["status"] != "available":
+              raise SystemExit("doctor did not expose observed provider availability")
+          if report["provider_availability"]["startability"] != "proven_for_declared_probes":
+              raise SystemExit("doctor lost declared probe startability")
+          if report["operational_readiness"] != "provider_probe_observed_state_not_checked":
+              raise SystemExit("doctor must not turn availability into full health")
+          if report["authority_effect"] != "none":
+              raise SystemExit("doctor probe path cannot create authority")
+          PY
+
+      - name: Execute targeted provider discovery tests
+        run: python -m unittest discover -s reference/tests -t reference -p 'test_provider_discovery.py'
+
+      - name: Execute full reference regression suite
+        run: python -m unittest discover -s reference/tests -t reference
+
+      - name: Emit exact-head provider discovery evidence
+        env:
+          AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python reference/run_provider_discovery.py
+          --agent-memory-commit "$AGENT_MEMORY_COMMIT"
+          --output provider-discovery-evidence.json
+
+      - name: Validate emitted provider discovery evidence
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("provider-discovery-evidence.json").read_text())
+          if len(report["agent_memory_commit"]) != 40:
+              raise SystemExit("provider discovery evidence is not exact-head bound")
+          invariants = report["structural_invariants"]
+          non_boolean = [name for name, value in invariants.items() if type(value) is not bool]
+          if non_boolean:
+              raise SystemExit(f"provider discovery invariants are not JSON booleans: {non_boolean}")
+          failed = [name for name, passed in invariants.items() if not passed]
+          if failed:
+              raise SystemExit(f"provider discovery invariants failed: {failed}")
+          if report["authority_effect"] != "none":
+              raise SystemExit("provider discovery evidence cannot create authority")
+          print(f"validated {len(invariants)} provider discovery invariants")
+          PY
+
+      - name: Upload provider discovery evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: provider-discovery-evidence
+          path: |
+            provider-discovery-evidence.json
+            installed-provider-discovery.json
+            installed-doctor-probed.json
+          if-no-files-found: error
+
+      - name: Publish provider discovery summary
+        if: always()
+        run: |
+          {
+            echo "## Attach-mode discovery and provider probes"
+            echo ""
+            echo "Discovery is read-only and bound to explicit configured subjects plus explicit probe descriptors."
+            echo ""
+            echo '```'
+            echo "agent-memory discover --config <config.json> --probes <probes.json>"
+            echo "agent-memory doctor --config <config.json> --probe --probes <probes.json>"
+            echo '```'
+            echo ""
+            echo "Probe success establishes only the declared availability signal. It does not grant qualification, currentness, health, fallback authority, or mutation permission."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/provider-discovery.yml
+++ b/.github/workflows/provider-discovery.yml
@@ -27,10 +27,13 @@ jobs:
 
       - name: Smoke-test installed discovery command
         run: |
-          agent-memory discover \
+          if ! agent-memory discover \
             --config reference/fixtures/runtime-configuration/reference-composed-runtime.json \
             --probes reference/fixtures/runtime-configuration/reference-provider-probes.json \
-            --json > installed-provider-discovery.json
+            --json > installed-provider-discovery.json; then
+            cat installed-provider-discovery.json
+            exit 1
+          fi
           python - <<'PY'
           import json
           from pathlib import Path
@@ -47,11 +50,14 @@ jobs:
 
       - name: Smoke-test installed doctor probe path
         run: |
-          agent-memory doctor \
+          if ! agent-memory doctor \
             --config reference/fixtures/runtime-configuration/reference-composed-runtime.json \
             --probe \
             --probes reference/fixtures/runtime-configuration/reference-provider-probes.json \
-            --json > installed-doctor-probed.json
+            --json > installed-doctor-probed.json; then
+            cat installed-doctor-probed.json
+            exit 1
+          fi
           python - <<'PY'
           import json
           from pathlib import Path

--- a/docs/programs/runtime-evidence/provider-discovery.md
+++ b/docs/programs/runtime-evidence/provider-discovery.md
@@ -1,0 +1,107 @@
+# Attach-mode discovery and provider availability probes
+
+Issue: #318
+
+## Purpose
+
+Agent Memory is normally attached to an architecture that already exists. The discovery boundary therefore observes **explicit, bounded signals** about configured components rather than scanning the host and silently constructing configuration.
+
+```text
+existing runtime/configuration
+  -> explicit probe manifest
+  -> read-only observation
+  -> availability evidence
+  -> doctor reports availability separately
+```
+
+The following remain distinct:
+
+```text
+detected != configured
+configured != qualified
+qualified != available now
+available now != healthy for every operation
+available now != current/quiescent
+probe success != authority
+```
+
+## Installed commands
+
+```text
+agent-memory discover \
+  --config <runtime-config.json> \
+  --probes <provider-probes.json>
+
+agent-memory doctor \
+  --config <runtime-config.json> \
+  --probe \
+  --probes <provider-probes.json>
+```
+
+`doctor` remains non-probing by default. Passing a probe manifest without `--probe` is refused rather than silently executing observations.
+
+## Probe manifest
+
+The manifest is separate from the portable runtime configuration in this first version. Each descriptor must bind to an already configured component or governance peer.
+
+Supported bounded probe kinds:
+
+- `executable`: resolve an explicit executable through the platform PATH/explicit executable lookup;
+- `python_import`: resolve an explicit Python import specification;
+- `filesystem_path`: test existence/type of an explicit filesystem path without reading its contents.
+
+The schema is `schemas/provider-probes.schema.json` and is packaged with the installable distribution.
+
+Probe targets cannot be `env://`, `secret://`, `vault://`, or `keyring://` references. Discovery does not resolve credentials and does not emit secret values.
+
+## Evidence posture
+
+Every probe result records:
+
+- probe identity;
+- configured subject identity;
+- probe kind and explicit non-secret target;
+- observation time;
+- bounded lookup evidence;
+- `available`, `unavailable`, `probe_failed`, or `unsupported` posture;
+- whether the result satisfies a declared startability requirement;
+- `authority_effect = none`.
+
+A required unavailable probe blocks **declared provider startability**. It does not rewrite the runtime configuration or select a fallback.
+
+An optional unavailable probe remains visible evidence but does not fabricate a required failure.
+
+## Discovery is not installation
+
+This implementation intentionally does not:
+
+- enumerate all installed packages;
+- inspect process tables, shell history, browser state, or home-directory contents;
+- discover network services broadly;
+- install or replace components;
+- mutate the runtime configuration;
+- resolve secrets;
+- promote capability maturity;
+- mark a provider healthy for every operation;
+- change fallback selection;
+- create PAMA, recall, structural, or execution authority.
+
+The configuration remains operator-reviewable and declarative. Discovery can inform a future `init`/attach workflow, but observed state does not silently become durable configuration.
+
+## Evidence
+
+Exact-head CI runs:
+
+```text
+python -m unittest discover -s reference/tests -t reference -p 'test_provider_discovery.py'
+python -m unittest discover -s reference/tests -t reference
+python reference/run_provider_discovery.py \
+  --agent-memory-commit <40-char-sha> \
+  --output provider-discovery-evidence.json
+```
+
+The workflow also installs the repository distribution and invokes `agent-memory discover` and `agent-memory doctor --probe` through the installed console command, proving that packaged schema/resource resolution works outside source-tree imports.
+
+## Current limitation
+
+This slice establishes **availability signals**, not full service health. HTTP/network health probing is deliberately deferred until a bounded, source-rights-safe, credential-safe contract is justified. A successful executable or import probe means exactly what it says and nothing more.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,5 @@ include = ["agentmem_ref*"]
 [tool.setuptools.data-files]
 "agent_memory_reference/schemas" = [
   "schemas/runtime-configuration.schema.json",
+  "schemas/provider-probes.schema.json",
 ]

--- a/reference/agentmem_ref/cli.py
+++ b/reference/agentmem_ref/cli.py
@@ -6,7 +6,13 @@ import argparse
 import json
 import sys
 
-from .doctor import DiagnosticInputError, diagnose, validate_configuration_file
+from .discovery import DiscoveryInputError
+from .doctor import (
+    DiagnosticInputError,
+    diagnose,
+    discover_configuration_file,
+    validate_configuration_file,
+)
 from .runtime_config import RuntimeConfigurationError
 
 
@@ -24,6 +30,20 @@ def _emit(value: dict, *, json_output: bool) -> None:
         )
         print(f"Routes: {value['route_count']}")
         print(f"Required projections: {', '.join(value['required_projection_ids']) or 'none'}")
+        print("Authority effect: none")
+        return
+    if value.get("command") == "discover":
+        print(f"Entry mode: {value['entry_mode']}")
+        print(f"Configured components: {len(value['configured_subjects']['components'])}")
+        print(f"Configured governance peers: {len(value['configured_subjects']['governance_peers'])}")
+        print(f"Declared probes: {value['probe_count']}")
+        print(f"Startability from declared probes: {value['startability']}")
+        for result in value["results"]:
+            print(
+                f"- {result['probe_id']}: {result['subject_id']} "
+                f"{result['probe_kind']} -> {result['status']}"
+            )
+        print("Configuration mutated: false")
         print("Authority effect: none")
         return
     print(f"Configuration: {value['configuration']['status']}")
@@ -55,7 +75,7 @@ def _failure(command: str, exc: Exception, *, json_output: bool) -> int:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="agent-memory",
-        description="Validate and diagnose the Agent Memory reference runtime.",
+        description="Validate, discover, and diagnose the Agent Memory reference runtime.",
     )
     subcommands = parser.add_subparsers(dest="command", required=True)
 
@@ -66,10 +86,21 @@ def _parser() -> argparse.ArgumentParser:
     validate.add_argument("--qualifications", help="path to normalized independent qualification bindings")
     validate.add_argument("--json", action="store_true", help="emit machine-readable JSON")
 
+    discover = subcommands.add_parser(
+        "discover",
+        help="observe explicitly declared existing-stack signals without mutating configuration",
+    )
+    discover.add_argument("--config", required=True, help="path to a JSON serialization of the runtime contract")
+    discover.add_argument("--probes", required=True, help="path to an explicit read-only provider probe manifest")
+    discover.add_argument("--qualifications", help="path to normalized independent qualification bindings")
+    discover.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+
     doctor = subcommands.add_parser("doctor", help="diagnose configuration and bounded durable-state recovery")
     doctor.add_argument("--config", required=True, help="path to a JSON serialization of the runtime contract")
     doctor.add_argument("--qualifications", help="path to normalized independent qualification bindings")
     doctor.add_argument("--state-dir", help="Agent Memory bounded reference state directory to inspect/recover")
+    doctor.add_argument("--probe", action="store_true", help="execute explicitly declared read-only provider probes")
+    doctor.add_argument("--probes", help="path to an explicit read-only provider probe manifest")
     doctor.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     return parser
 
@@ -85,19 +116,42 @@ def main(argv: list[str] | None = None) -> int:
             )
             _emit(value, json_output=json_output)
             return 0
+        if args.command == "discover":
+            value = discover_configuration_file(
+                args.config,
+                probe_path=args.probes,
+                qualification_path=args.qualifications,
+            )
+            _emit(value, json_output=json_output)
+            if value["startability"] == "blocked_by_required_probe":
+                return 1
+            return 0
         if args.command == "doctor":
+            if args.probes and not args.probe:
+                raise DiagnosticInputError("doctor --probes requires --probe")
             value = diagnose(
                 args.config,
                 qualification_path=args.qualifications,
                 state_dir=args.state_dir,
+                probe_path=args.probes,
+                probe=args.probe,
             )
             _emit(value, json_output=json_output)
             if value["recovery"].get("status") == "failed_closed":
                 return 1
             if value["currentness"].get("status") == "degraded":
                 return 1
+            if value["provider_availability"].get("startability") == "blocked_by_required_probe":
+                return 1
             return 0
-    except (DiagnosticInputError, RuntimeConfigurationError, KeyError, TypeError, ValueError) as exc:
+    except (
+        DiagnosticInputError,
+        DiscoveryInputError,
+        RuntimeConfigurationError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
         return _failure(args.command, exc, json_output=json_output)
     raise AssertionError("unreachable command")
 

--- a/reference/agentmem_ref/discovery.py
+++ b/reference/agentmem_ref/discovery.py
@@ -1,0 +1,268 @@
+"""Read-only attach-mode discovery and provider availability probes.
+
+Discovery is evidence only. It does not mutate configuration, install or replace
+components, grant capability maturity, prove currentness, or create authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import metadata, util
+import json
+from pathlib import Path
+import shutil
+from typing import Mapping
+
+import jsonschema
+
+
+PROBE_SCHEMA_VERSION = "1.0.0"
+_DISTRIBUTION_NAME = "agent-memory-reference"
+_PROBE_SCHEMA_DATA_SUFFIX = "agent_memory_reference/schemas/provider-probes.schema.json"
+_SECRET_SCHEMES = ("env://", "secret://", "vault://", "keyring://")
+_SUPPORTED_PROBE_KINDS = frozenset({"executable", "python_import", "filesystem_path"})
+
+
+class DiscoveryInputError(ValueError):
+    """A discovery/probe input cannot be interpreted safely."""
+
+
+@dataclass(frozen=True)
+class ProbeDescriptor:
+    probe_id: str
+    subject_kind: str
+    subject_id: str
+    probe_kind: str
+    target: str
+    required_for_startability: bool
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    descriptor: ProbeDescriptor
+    status: str
+    observed_at: str
+    evidence: Mapping[str, object]
+
+    @property
+    def startability_satisfied(self) -> bool:
+        if not self.descriptor.required_for_startability:
+            return True
+        return self.status == "available"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "probe_id": self.descriptor.probe_id,
+            "subject_kind": self.descriptor.subject_kind,
+            "subject_id": self.descriptor.subject_id,
+            "probe_kind": self.descriptor.probe_kind,
+            "target": self.descriptor.target,
+            "required_for_startability": self.descriptor.required_for_startability,
+            "status": self.status,
+            "observed_at": self.observed_at,
+            "evidence": dict(self.evidence),
+            "startability_satisfied": self.startability_satisfied,
+            "authority_effect": "none",
+        }
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _probe_schema_path() -> Path:
+    source_path = _repo_root() / "schemas" / "provider-probes.schema.json"
+    if source_path.is_file():
+        return source_path
+
+    try:
+        distribution_files = metadata.files(_DISTRIBUTION_NAME) or ()
+    except metadata.PackageNotFoundError:
+        distribution_files = ()
+
+    for entry in distribution_files:
+        normalized = str(entry).replace("\\", "/")
+        if normalized.endswith(_PROBE_SCHEMA_DATA_SUFFIX):
+            installed_path = Path(entry.locate())
+            if installed_path.is_file():
+                return installed_path
+
+    raise DiscoveryInputError(
+        "provider probe schema is unavailable; install the distribution with its packaged schema data"
+    )
+
+
+def _probe_schema() -> dict:
+    return json.loads(_probe_schema_path().read_text(encoding="utf-8"))
+
+
+def _configured_subjects(config_value: Mapping[str, object]) -> dict[str, set[str]]:
+    component_ids: set[str] = set()
+    for raw in config_value.get("components", ()):  # type: ignore[union-attr]
+        if not isinstance(raw, Mapping):
+            continue
+        declaration = raw.get("declaration")
+        if isinstance(declaration, Mapping) and declaration.get("component_id"):
+            component_ids.add(str(declaration["component_id"]))
+
+    peer_ids: set[str] = set()
+    for raw in config_value.get("governance_peers", ()):  # type: ignore[union-attr]
+        if isinstance(raw, Mapping) and raw.get("peer_id"):
+            peer_ids.add(str(raw["peer_id"]))
+
+    return {"component": component_ids, "governance_peer": peer_ids}
+
+
+def load_probe_manifest(
+    path: str | Path,
+    *,
+    config_value: Mapping[str, object],
+) -> tuple[ProbeDescriptor, ...]:
+    source = Path(path)
+    try:
+        value = json.loads(source.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise DiscoveryInputError(f"provider probe manifest not found: {source}") from exc
+    except json.JSONDecodeError as exc:
+        raise DiscoveryInputError(f"provider probe manifest is not valid JSON: {source}") from exc
+
+    try:
+        jsonschema.Draft202012Validator(_probe_schema()).validate(value)
+    except jsonschema.ValidationError as exc:
+        location = ".".join(str(part) for part in exc.absolute_path)
+        suffix = f" at {location}" if location else ""
+        raise DiscoveryInputError(f"provider probe schema violation{suffix}: {exc.message}") from exc
+
+    subjects = _configured_subjects(config_value)
+    descriptors: list[ProbeDescriptor] = []
+    probe_ids: set[str] = set()
+    for raw in value["probes"]:
+        descriptor = ProbeDescriptor(
+            probe_id=str(raw["probe_id"]),
+            subject_kind=str(raw["subject_kind"]),
+            subject_id=str(raw["subject_id"]),
+            probe_kind=str(raw["probe_kind"]),
+            target=str(raw["target"]),
+            required_for_startability=bool(raw["required_for_startability"]),
+        )
+        if descriptor.probe_id in probe_ids:
+            raise DiscoveryInputError(f"duplicate provider probe id: {descriptor.probe_id!r}")
+        probe_ids.add(descriptor.probe_id)
+        if descriptor.subject_id not in subjects.get(descriptor.subject_kind, set()):
+            raise DiscoveryInputError(
+                f"provider probe {descriptor.probe_id!r} references unconfigured "
+                f"{descriptor.subject_kind} {descriptor.subject_id!r}"
+            )
+        if descriptor.target.startswith(_SECRET_SCHEMES):
+            raise DiscoveryInputError(
+                f"provider probe {descriptor.probe_id!r} must not resolve or emit secret references"
+            )
+        descriptors.append(descriptor)
+    return tuple(descriptors)
+
+
+def _probe_executable(target: str) -> tuple[str, dict[str, object]]:
+    resolved = shutil.which(target)
+    if resolved is None:
+        return "unavailable", {"lookup": "PATH_or_explicit_executable", "resolved": False}
+    return "available", {
+        "lookup": "PATH_or_explicit_executable",
+        "resolved": True,
+        "resolved_path": resolved,
+    }
+
+
+def _probe_python_import(target: str) -> tuple[str, dict[str, object]]:
+    try:
+        spec = util.find_spec(target)
+    except (ImportError, AttributeError, ValueError) as exc:
+        return "probe_failed", {"lookup": "python_import_spec", "error_type": type(exc).__name__}
+    if spec is None:
+        return "unavailable", {"lookup": "python_import_spec", "resolved": False}
+    return "available", {
+        "lookup": "python_import_spec",
+        "resolved": True,
+        "origin": spec.origin or "namespace_or_builtin",
+    }
+
+
+def _probe_filesystem_path(target: str) -> tuple[str, dict[str, object]]:
+    path = Path(target).expanduser()
+    try:
+        exists = path.exists()
+    except OSError as exc:
+        return "probe_failed", {"lookup": "filesystem_exists", "error_type": type(exc).__name__}
+    if not exists:
+        return "unavailable", {"lookup": "filesystem_exists", "resolved": False}
+    if path.is_file():
+        path_type = "file"
+    elif path.is_dir():
+        path_type = "directory"
+    else:
+        path_type = "other"
+    return "available", {
+        "lookup": "filesystem_exists",
+        "resolved": True,
+        "path_type": path_type,
+    }
+
+
+def run_probe(descriptor: ProbeDescriptor, *, observed_at: str) -> ProbeResult:
+    try:
+        if descriptor.probe_kind == "executable":
+            status, evidence = _probe_executable(descriptor.target)
+        elif descriptor.probe_kind == "python_import":
+            status, evidence = _probe_python_import(descriptor.target)
+        elif descriptor.probe_kind == "filesystem_path":
+            status, evidence = _probe_filesystem_path(descriptor.target)
+        else:
+            status, evidence = "unsupported", {"supported_probe_kinds": sorted(_SUPPORTED_PROBE_KINDS)}
+    except OSError as exc:
+        status, evidence = "probe_failed", {"error_type": type(exc).__name__}
+    return ProbeResult(
+        descriptor=descriptor,
+        status=status,
+        observed_at=observed_at,
+        evidence=evidence,
+    )
+
+
+def discover_configuration(
+    config_value: Mapping[str, object],
+    *,
+    probe_path: str | Path,
+) -> dict[str, object]:
+    descriptors = load_probe_manifest(probe_path, config_value=config_value)
+    observed_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    results = tuple(run_probe(item, observed_at=observed_at) for item in descriptors)
+
+    counts = {name: 0 for name in ("available", "unavailable", "probe_failed", "unsupported")}
+    for result in results:
+        counts[result.status] = counts.get(result.status, 0) + 1
+
+    required = tuple(result for result in results if result.descriptor.required_for_startability)
+    failed_required = tuple(result for result in required if not result.startability_satisfied)
+    if failed_required:
+        startability = "blocked_by_required_probe"
+    elif required:
+        startability = "proven_for_declared_probes"
+    else:
+        startability = "not_proven_no_required_probes"
+
+    subjects = _configured_subjects(config_value)
+    return {
+        "schema_version": PROBE_SCHEMA_VERSION,
+        "command": "discover",
+        "observation_posture": "explicit_declared_signals_only",
+        "configured_subjects": {
+            "components": sorted(subjects["component"]),
+            "governance_peers": sorted(subjects["governance_peer"]),
+        },
+        "probe_count": len(results),
+        "status_counts": counts,
+        "startability": startability,
+        "results": [result.to_dict() for result in results],
+        "mutated_configuration": False,
+        "authority_effect": "none",
+    }

--- a/reference/agentmem_ref/doctor.py
+++ b/reference/agentmem_ref/doctor.py
@@ -174,6 +174,8 @@ def _provider_availability(discovery: Mapping[str, object]) -> dict[str, object]
         counts = {}
     probe_count = int(discovery.get("probe_count", 0))
     startability = str(discovery.get("startability", "not_proven"))
+    available_count = int(counts.get("available", 0))
+    unavailable_count = int(counts.get("unavailable", 0))
 
     if probe_count == 0:
         status = "not_configured"
@@ -183,7 +185,9 @@ def _provider_availability(discovery: Mapping[str, object]) -> dict[str, object]
         status = "probe_failed"
     elif int(counts.get("unsupported", 0)):
         status = "unsupported"
-    elif int(counts.get("available", 0)):
+    elif available_count and unavailable_count:
+        status = "partial"
+    elif available_count:
         status = "available"
     else:
         status = "unavailable"

--- a/reference/agentmem_ref/doctor.py
+++ b/reference/agentmem_ref/doctor.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Mapping
 
 from .configured_restart import ConfigBoundRestartRuntime
+from .discovery import DiscoveryInputError, discover_configuration
 from .restart_runtime import RuntimeRecoveryError
 from .runtime_behavior import validate_runtime_behavior_contract
 from .runtime_config import QualificationBinding
@@ -94,6 +95,26 @@ def validate_configuration_file(
     }
 
 
+def discover_configuration_file(
+    config_path: str | Path,
+    *,
+    probe_path: str | Path,
+    qualification_path: str | Path | None = None,
+) -> dict:
+    """Validate configuration, then observe only explicitly declared probe signals."""
+
+    value = load_configuration_value(config_path)
+    bindings = load_qualification_bindings(qualification_path)
+    plan = validate_runtime_behavior_contract(value, qualification_bindings=bindings)
+    report = discover_configuration(value, probe_path=probe_path)
+    report["configuration_digest"] = plan.configuration_digest
+    report["entry_mode"] = plan.entry_mode
+    report["runtime_id"] = plan.runtime_id
+    report["profile_id"] = plan.profile_id
+    report["qualification_binding_count"] = len(bindings)
+    return report
+
+
 def _currentness_summary(snapshots: Mapping[str, dict]) -> dict:
     if not snapshots:
         return {
@@ -147,11 +168,44 @@ def _currentness_summary(snapshots: Mapping[str, dict]) -> dict:
     }
 
 
+def _provider_availability(discovery: Mapping[str, object]) -> dict[str, object]:
+    counts = discovery.get("status_counts", {})
+    if not isinstance(counts, Mapping):
+        counts = {}
+    probe_count = int(discovery.get("probe_count", 0))
+    startability = str(discovery.get("startability", "not_proven"))
+
+    if probe_count == 0:
+        status = "not_configured"
+    elif startability == "blocked_by_required_probe":
+        status = "unavailable"
+    elif int(counts.get("probe_failed", 0)):
+        status = "probe_failed"
+    elif int(counts.get("unsupported", 0)):
+        status = "unsupported"
+    elif int(counts.get("available", 0)):
+        status = "available"
+    else:
+        status = "unavailable"
+
+    return {
+        "status": status,
+        "scope": "explicit_declared_probes_only",
+        "startability": startability,
+        "probe_count": probe_count,
+        "status_counts": dict(counts),
+        "results": discovery.get("results", []),
+        "authority_effect": "none",
+    }
+
+
 def diagnose(
     config_path: str | Path,
     *,
     qualification_path: str | Path | None = None,
     state_dir: str | Path | None = None,
+    probe_path: str | Path | None = None,
+    probe: bool = False,
 ) -> dict:
     value = load_configuration_value(config_path)
     bindings = load_qualification_bindings(qualification_path)
@@ -187,7 +241,24 @@ def diagnose(
         "authority_effect": "none",
     }
 
+    provider_blocked = False
+    provider_observed = False
+    if probe:
+        if probe_path is None:
+            raise DiagnosticInputError("doctor --probe requires an explicit provider probe manifest")
+        try:
+            discovery = discover_configuration(value, probe_path=probe_path)
+        except DiscoveryInputError as exc:
+            raise DiagnosticInputError(str(exc)) from exc
+        report["provider_availability"] = _provider_availability(discovery)
+        provider_observed = True
+        provider_blocked = report["provider_availability"]["startability"] == "blocked_by_required_probe"
+
     if state_dir is None:
+        if provider_blocked:
+            report["operational_readiness"] = "blocked_by_required_provider_probe"
+        elif provider_observed:
+            report["operational_readiness"] = "provider_probe_observed_state_not_checked"
         return report
 
     root = Path(state_dir)
@@ -199,7 +270,10 @@ def diagnose(
             "state_dir": str(root),
         }
         report["currentness"] = {"status": "not_observed"}
-        report["operational_readiness"] = "configuration_valid_state_not_initialized"
+        if provider_blocked:
+            report["operational_readiness"] = "blocked_by_required_provider_probe"
+        else:
+            report["operational_readiness"] = "configuration_valid_state_not_initialized"
         return report
 
     report["durable_state"] = {
@@ -235,6 +309,10 @@ def diagnose(
         report["operational_readiness"] = "degraded_currentness"
     elif report["currentness"]["status"] == "pending":
         report["operational_readiness"] = "pending_currentness"
+    elif provider_blocked:
+        report["operational_readiness"] = "blocked_by_required_provider_probe"
+    elif provider_observed:
+        report["operational_readiness"] = "declared_provider_probes_satisfied_current_state_recovered"
     else:
         report["operational_readiness"] = "provider_availability_not_probed"
     return report

--- a/reference/fixtures/runtime-configuration/reference-provider-probes.json
+++ b/reference/fixtures/runtime-configuration/reference-provider-probes.json
@@ -12,7 +12,7 @@
     {
       "probe_id": "reference-json-import",
       "subject_kind": "component",
-      "subject_id": "reference-derived-index",
+      "subject_id": "reference-projection-sidecar",
       "probe_kind": "python_import",
       "target": "json",
       "required_for_startability": false
@@ -20,7 +20,7 @@
     {
       "probe_id": "reference-unavailable-optional",
       "subject_kind": "component",
-      "subject_id": "reference-derived-index",
+      "subject_id": "reference-projection-sidecar",
       "probe_kind": "executable",
       "target": "agent-memory-definitely-not-a-real-provider-executable",
       "required_for_startability": false

--- a/reference/fixtures/runtime-configuration/reference-provider-probes.json
+++ b/reference/fixtures/runtime-configuration/reference-provider-probes.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "probes": [
+    {
+      "probe_id": "reference-python-runtime",
+      "subject_kind": "component",
+      "subject_id": "reference-governed-memory",
+      "probe_kind": "executable",
+      "target": "python",
+      "required_for_startability": true
+    },
+    {
+      "probe_id": "reference-json-import",
+      "subject_kind": "component",
+      "subject_id": "reference-derived-index",
+      "probe_kind": "python_import",
+      "target": "json",
+      "required_for_startability": false
+    },
+    {
+      "probe_id": "reference-unavailable-optional",
+      "subject_kind": "component",
+      "subject_id": "reference-derived-index",
+      "probe_kind": "executable",
+      "target": "agent-memory-definitely-not-a-real-provider-executable",
+      "required_for_startability": false
+    }
+  ]
+}

--- a/reference/run_provider_discovery.py
+++ b/reference/run_provider_discovery.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Emit exact-head evidence for attach-mode discovery and provider availability probes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agentmem_ref.doctor import diagnose, discover_configuration_file  # noqa: E402
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "reference" / "fixtures" / "runtime-configuration"
+COMPOSED = FIXTURES / "reference-composed-runtime.json"
+PROBES = FIXTURES / "reference-provider-probes.json"
+
+
+def _required_missing_manifest(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0.0",
+                "probes": [
+                    {
+                        "probe_id": "required-missing-provider",
+                        "subject_kind": "component",
+                        "subject_id": "reference-governed-memory",
+                        "probe_kind": "executable",
+                        "target": "agent-memory-definitely-not-a-real-required-provider",
+                        "required_for_startability": True,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def build_report(agent_memory_commit: str) -> dict:
+    if len(agent_memory_commit) != 40:
+        raise ValueError("agent-memory commit must be an exact 40-character SHA")
+
+    before = COMPOSED.read_bytes()
+    discovery = discover_configuration_file(COMPOSED, probe_path=PROBES)
+    after = COMPOSED.read_bytes()
+    doctor_unprobed = diagnose(COMPOSED)
+    doctor_probed = diagnose(COMPOSED, probe=True, probe_path=PROBES)
+
+    with tempfile.TemporaryDirectory() as directory:
+        required_missing = Path(directory) / "required-missing.json"
+        _required_missing_manifest(required_missing)
+        blocked_discovery = discover_configuration_file(COMPOSED, probe_path=required_missing)
+        blocked_doctor = diagnose(COMPOSED, probe=True, probe_path=required_missing)
+
+    by_id = {item["probe_id"]: item for item in discovery["results"]}
+    invariants = {
+        "discovery_observes_only_explicit_declared_signals": (
+            discovery["observation_posture"] == "explicit_declared_signals_only"
+        ),
+        "discovery_does_not_mutate_configuration": (
+            before == after and discovery["mutated_configuration"] is False
+        ),
+        "real_executable_lookup_proves_available_runtime": (
+            by_id["reference-python-runtime"]["status"] == "available"
+            and by_id["reference-python-runtime"]["evidence"]["resolved"] is True
+        ),
+        "real_python_import_probe_is_observed": (
+            by_id["reference-json-import"]["status"] == "available"
+            and by_id["reference-json-import"]["evidence"]["resolved"] is True
+        ),
+        "missing_optional_provider_is_reported_unavailable": (
+            by_id["reference-unavailable-optional"]["status"] == "unavailable"
+        ),
+        "optional_unavailability_does_not_fabricate_required_failure": (
+            discovery["startability"] == "proven_for_declared_probes"
+        ),
+        "required_missing_provider_blocks_declared_startability": (
+            blocked_discovery["startability"] == "blocked_by_required_probe"
+            and blocked_doctor["provider_availability"]["status"] == "unavailable"
+            and blocked_doctor["operational_readiness"] == "blocked_by_required_provider_probe"
+        ),
+        "doctor_remains_opt_in_for_live_probes": (
+            doctor_unprobed["provider_availability"]["status"] == "not_probed"
+            and doctor_probed["provider_availability"]["status"] == "available"
+        ),
+        "probe_success_does_not_claim_full_health": (
+            doctor_probed["operational_readiness"] == "provider_probe_observed_state_not_checked"
+        ),
+        "discovery_and_doctor_grant_no_authority": (
+            discovery["authority_effect"] == "none"
+            and blocked_discovery["authority_effect"] == "none"
+            and doctor_probed["authority_effect"] == "none"
+            and blocked_doctor["authority_effect"] == "none"
+        ),
+    }
+    invariants = {name: bool(value) for name, value in invariants.items()}
+    if not all(type(value) is bool for value in invariants.values()):
+        raise TypeError("every provider-discovery structural invariant must be a JSON boolean")
+
+    return {
+        "schema_version": "1.0.0",
+        "agent_memory_commit": agent_memory_commit,
+        "commands": ["discover", "doctor --probe"],
+        "probe_kinds": ["executable", "python_import", "filesystem_path"],
+        "discovery": discovery,
+        "doctor_examples": {
+            "unprobed": doctor_unprobed,
+            "probed": doctor_probed,
+            "required_provider_missing": blocked_doctor,
+        },
+        "required_provider_missing_discovery": blocked_discovery,
+        "structural_invariants": invariants,
+        "structural_invariants_passed": all(invariants.values()),
+        "authority_effect": "none",
+        "limitations": [
+            "This slice only probes explicit descriptors bound to already configured subjects; it does not broadly scan the machine.",
+            "Executable, Python import, and filesystem-path availability do not prove full provider health or capability correctness.",
+            "HTTP/network probing, automatic component installation, secret resolution, and configuration mutation are intentionally excluded.",
+            "Discovery evidence does not change qualification maturity, currentness, fallback selection, or authority.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    report = build_report(args.agent_memory_commit)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report["structural_invariants_passed"]:
+        failed = [name for name, passed in report["structural_invariants"].items() if not passed]
+        print(f"provider discovery invariants failed: {failed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/run_provider_discovery.py
+++ b/reference/run_provider_discovery.py
@@ -84,9 +84,11 @@ def build_report(agent_memory_commit: str) -> dict:
             and blocked_doctor["provider_availability"]["status"] == "unavailable"
             and blocked_doctor["operational_readiness"] == "blocked_by_required_provider_probe"
         ),
-        "doctor_remains_opt_in_for_live_probes": (
+        "doctor_reports_partial_availability_without_hiding_optional_failure": (
             doctor_unprobed["provider_availability"]["status"] == "not_probed"
-            and doctor_probed["provider_availability"]["status"] == "available"
+            and doctor_probed["provider_availability"]["status"] == "partial"
+            and doctor_probed["provider_availability"]["status_counts"]["unavailable"] == 1
+            and doctor_probed["provider_availability"]["startability"] == "proven_for_declared_probes"
         ),
         "probe_success_does_not_claim_full_health": (
             doctor_probed["operational_readiness"] == "provider_probe_observed_state_not_checked"

--- a/reference/tests/test_provider_discovery.py
+++ b/reference/tests/test_provider_discovery.py
@@ -108,11 +108,12 @@ class ProviderDiscoveryTests(unittest.TestCase):
         observed = diagnose(COMPOSED, probe=True, probe_path=PROBES)
 
         self.assertEqual(baseline["provider_availability"]["status"], "not_probed")
-        self.assertEqual(observed["provider_availability"]["status"], "available")
+        self.assertEqual(observed["provider_availability"]["status"], "partial")
         self.assertEqual(
             observed["provider_availability"]["startability"],
             "proven_for_declared_probes",
         )
+        self.assertEqual(observed["provider_availability"]["status_counts"]["unavailable"], 1)
         self.assertEqual(observed["operational_readiness"], "provider_probe_observed_state_not_checked")
         self.assertEqual(observed["authority_effect"], "none")
 

--- a/reference/tests/test_provider_discovery.py
+++ b/reference/tests/test_provider_discovery.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agentmem_ref.cli import main
+from agentmem_ref.discovery import DiscoveryInputError, discover_configuration, load_probe_manifest
+from agentmem_ref.doctor import diagnose, discover_configuration_file, load_configuration_value
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "reference" / "fixtures" / "runtime-configuration"
+COMPOSED = FIXTURES / "reference-composed-runtime.json"
+PROBES = FIXTURES / "reference-provider-probes.json"
+
+
+class ProviderDiscoveryTests(unittest.TestCase):
+    def test_discovery_uses_real_declared_signals_without_mutating_configuration(self) -> None:
+        before = COMPOSED.read_bytes()
+        report = discover_configuration_file(COMPOSED, probe_path=PROBES)
+        after = COMPOSED.read_bytes()
+
+        self.assertEqual(before, after)
+        self.assertEqual(report["probe_count"], 3)
+        self.assertEqual(report["status_counts"]["available"], 2)
+        self.assertEqual(report["status_counts"]["unavailable"], 1)
+        self.assertEqual(report["startability"], "proven_for_declared_probes")
+        self.assertFalse(report["mutated_configuration"])
+        self.assertEqual(report["authority_effect"], "none")
+
+        by_id = {item["probe_id"]: item for item in report["results"]}
+        self.assertEqual(by_id["reference-python-runtime"]["status"], "available")
+        self.assertTrue(by_id["reference-python-runtime"]["evidence"]["resolved"])
+        self.assertEqual(by_id["reference-json-import"]["status"], "available")
+        self.assertEqual(by_id["reference-unavailable-optional"]["status"], "unavailable")
+
+    def test_required_unavailable_probe_blocks_declared_startability(self) -> None:
+        value = load_configuration_value(COMPOSED)
+        manifest = {
+            "schema_version": "1.0.0",
+            "probes": [
+                {
+                    "probe_id": "required-missing-provider",
+                    "subject_kind": "component",
+                    "subject_id": "reference-governed-memory",
+                    "probe_kind": "executable",
+                    "target": "agent-memory-definitely-not-a-real-required-provider",
+                    "required_for_startability": True,
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "probes.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            report = discover_configuration(value, probe_path=path)
+        self.assertEqual(report["startability"], "blocked_by_required_probe")
+        self.assertEqual(report["results"][0]["status"], "unavailable")
+        self.assertFalse(report["results"][0]["startability_satisfied"])
+
+    def test_probe_manifest_cannot_reference_unconfigured_subject(self) -> None:
+        value = load_configuration_value(COMPOSED)
+        manifest = {
+            "schema_version": "1.0.0",
+            "probes": [
+                {
+                    "probe_id": "unknown-component",
+                    "subject_kind": "component",
+                    "subject_id": "not-configured",
+                    "probe_kind": "executable",
+                    "target": "python",
+                    "required_for_startability": False,
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "probes.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaises(DiscoveryInputError):
+                load_probe_manifest(path, config_value=value)
+
+    def test_probe_manifest_rejects_secret_reference_targets(self) -> None:
+        value = load_configuration_value(COMPOSED)
+        manifest = {
+            "schema_version": "1.0.0",
+            "probes": [
+                {
+                    "probe_id": "secret-target",
+                    "subject_kind": "component",
+                    "subject_id": "reference-governed-memory",
+                    "probe_kind": "filesystem_path",
+                    "target": "env://MEMORY_DSN",
+                    "required_for_startability": False,
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "probes.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaises(DiscoveryInputError):
+                load_probe_manifest(path, config_value=value)
+
+    def test_doctor_only_probes_when_explicitly_requested(self) -> None:
+        baseline = diagnose(COMPOSED)
+        observed = diagnose(COMPOSED, probe=True, probe_path=PROBES)
+
+        self.assertEqual(baseline["provider_availability"]["status"], "not_probed")
+        self.assertEqual(observed["provider_availability"]["status"], "available")
+        self.assertEqual(
+            observed["provider_availability"]["startability"],
+            "proven_for_declared_probes",
+        )
+        self.assertEqual(observed["operational_readiness"], "provider_probe_observed_state_not_checked")
+        self.assertEqual(observed["authority_effect"], "none")
+
+    def test_cli_discover_is_machine_readable(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            code = main([
+                "discover",
+                "--config",
+                str(COMPOSED),
+                "--probes",
+                str(PROBES),
+                "--json",
+            ])
+        self.assertEqual(code, 0)
+        report = json.loads(output.getvalue())
+        self.assertEqual(report["command"], "discover")
+        self.assertEqual(report["startability"], "proven_for_declared_probes")
+        self.assertEqual(report["authority_effect"], "none")
+
+    def test_cli_doctor_rejects_probe_manifest_without_probe_flag(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            code = main([
+                "doctor",
+                "--config",
+                str(COMPOSED),
+                "--probes",
+                str(PROBES),
+                "--json",
+            ])
+        self.assertEqual(code, 2)
+        report = json.loads(output.getvalue())
+        self.assertEqual(report["status"], "refused")
+        self.assertEqual(report["authority_effect"], "none")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/provider-probes.schema.json
+++ b/schemas/provider-probes.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/provider-probes.schema.json",
+  "title": "Agent Memory Provider Probe Manifest",
+  "description": "Read-only provider discovery/probe descriptors. Probe evidence does not grant configuration, qualification, maturity, currentness, or authority.",
+  "type": "object",
+  "required": ["schema_version", "probes"],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "probes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/probe" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "nonEmptyString": { "type": "string", "minLength": 1 },
+    "probe": {
+      "type": "object",
+      "required": ["probe_id", "subject_kind", "subject_id", "probe_kind", "target", "required_for_startability"],
+      "properties": {
+        "probe_id": { "$ref": "#/$defs/nonEmptyString" },
+        "subject_kind": {
+          "type": "string",
+          "enum": ["component", "governance_peer"]
+        },
+        "subject_id": { "$ref": "#/$defs/nonEmptyString" },
+        "probe_kind": {
+          "type": "string",
+          "enum": ["executable", "python_import", "filesystem_path"]
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1,
+          "not": { "pattern": "^(env|secret|vault|keyring)://" }
+        },
+        "required_for_startability": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the first bounded #318 attach-mode discovery/provider-probe slice on top of the installed CLI from #316.

### Surface

- packaged `provider-probes.schema.json`
- read-only explicit probe descriptors bound to already configured components/governance peers
- bounded probe kinds: `executable`, `python_import`, `filesystem_path`
- `agent-memory discover --config ... --probes ...`
- `agent-memory doctor --probe --probes ...`
- real executable/import availability evidence
- required-provider unavailable path blocks declared startability
- optional unavailability remains visible without fabricating a required failure
- exact-head evidence + installed-console-command CI

### Safety / product posture

Discovery does not scan the host broadly, mutate configuration, install/replace components, resolve secrets, change fallback selection, promote qualification, or create authority.

`doctor` remains non-probing by default. Availability remains separate from configuration, qualification, recovery, currentness, and full operational health.

### Explicit non-goals

No setup wizard, broad package/process/network discovery, HTTP health probe, secret/credential validation, automatic component installation, or configuration mutation.

Refs #318.
Refs #274.
Refs #308.