### PR TITLE
Qualify CodeGenome multi-capability profile without maturity leakage

### DIFF
--- a/.github/workflows/codegenome-multicapability-profile.yml
+++ b/.github/workflows/codegenome-multicapability-profile.yml
@@ -1,0 +1,133 @@
+name: CodeGenome Multi-Capability Profile
+
+on:
+  pull_request:
+    paths:
+      - "reference/fixtures/component-capabilities/codegenome.example.json"
+      - "reference/agentmem_ref/codegenome_profile.py"
+      - "reference/agentmem_ref/code_graph_qualification.py"
+      - "reference/run_codegenome_multicapability_profile.py"
+      - "reference/tests/test_codegenome_multicapability_profile.py"
+      - "reference/tests/test_component_capabilities.py"
+      - "reference/tests/test_code_graph_qualification.py"
+      - "schemas/component-capability-profile.schema.json"
+      - "docs/programs/memory-modules/codegenome-multicapability-profile.md"
+      - ".github/workflows/codegenome-multicapability-profile.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CODEGENOME_COMMIT: 43a6b7147ec78ec5c616723fa1dd30f342174860
+
+jobs:
+  validate-profile:
+    runs-on: ubuntu-latest
+    env:
+      AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+      EVIDENCE_ROOT: /tmp/codegenome-multicapability-profile
+    steps:
+      - name: Checkout Agent Memory
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Agent Memory reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Validate profile, declaration, and qualification regressions
+        env:
+          PYTHONPATH: reference
+        run: |
+          python -m unittest \
+            reference/tests/test_codegenome_multicapability_profile.py \
+            reference/tests/test_component_capabilities.py \
+            reference/tests/test_code_graph_qualification.py
+
+      - name: Fetch exact CodeGenome source
+        run: |
+          git clone --filter=blob:none --no-checkout https://github.com/MythologIQ-Labs-LLC/CodeGenome.git /tmp/codegenome
+          git -C /tmp/codegenome fetch --depth=1 origin "$CODEGENOME_COMMIT"
+          git -C /tmp/codegenome checkout --detach "$CODEGENOME_COMMIT"
+          test "$(git -C /tmp/codegenome rev-parse HEAD)" = "$CODEGENOME_COMMIT"
+
+      - name: Verify source rights and capability evidence paths
+        working-directory: /tmp/codegenome
+        run: |
+          grep -qi "MIT License" LICENSE
+          test -f codegenome-identity/src/identity/digest.rs
+          test -f codegenome-identity/src/index/resolver_multi.rs
+          test -f codegenome-identity/src/tests/fusion_tests.rs
+          test -f codegenome-substrate/src/embedding/store.rs
+          test -f codegenome-substrate/src/embedding/similarity.rs
+          test -f codegenome-substrate/src/tests/embedding_tests.rs
+          test -f codegenome-cli/src/commands/query.rs
+          test -f codegenome-cli/src/commands/status.rs
+          test -f codegenome-cli/src/commands/experiment.rs
+          test -f codegenome-cli/src/commands/serve.rs
+          test -f codegenome-mcp/Cargo.toml
+          mkdir -p "$EVIDENCE_ROOT/source-rights"
+          cp LICENSE "$EVIDENCE_ROOT/source-rights/CodeGenome-LICENSE"
+
+      - name: Execute pinned CodeGenome source regressions
+        working-directory: /tmp/codegenome
+        run: |
+          cargo test -p codegenome-identity duplicate_names_and_overlapping_spans_remain_file_scoped
+          cargo test -p codegenome-substrate --lib
+          cargo build -p codegenome-cli
+
+      - name: Emit exact-head multi-capability profile evidence
+        env:
+          PYTHONPATH: reference
+        run: |
+          mkdir -p "$EVIDENCE_ROOT"
+          python reference/run_codegenome_multicapability_profile.py \
+            --agent-memory-commit "$AGENT_MEMORY_COMMIT" \
+            --output "$EVIDENCE_ROOT/codegenome-multicapability-profile.json"
+
+      - name: Verify profile evidence boundaries
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(
+              (Path(os.environ["EVIDENCE_ROOT"]) / "codegenome-multicapability-profile.json").read_text()
+          )
+          assert report["agent_memory_commit"] == os.environ["AGENT_MEMORY_COMMIT"]
+          assert report["component"]["component_id"] == "codegenome"
+          assert report["component"]["component_version"] == os.environ["CODEGENOME_COMMIT"]
+          assert report["component"]["profile_version"] == "component-capability-v2"
+          assert report["maturity_counts"] == {
+              "declared": 2,
+              "implemented": 15,
+              "runtime_wired": 0,
+              "evidence_proven": 1,
+              "reference_qualified": 0,
+          }
+          assert report["qualification_binding"] == {
+              "capability_id": "code_graph_traversal",
+              "qualification_profile_id": "code-graph-traversal-currentness",
+              "qualification_profile_version": "1.1.0",
+              "evidence_ref": "qualification:codegenome:code-graph-traversal-currentness@1.1.0",
+          }
+          assert report["proposal_only_surfaces"] == ["experiment_evaluation", "impact_propagation"]
+          assert report["authority_effect"] == "none"
+          assert all(report["invariants"].values()), report["invariants"]
+          PY
+
+      - name: Upload exact-head profile evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codegenome-multicapability-profile-${{ env.AGENT_MEMORY_COMMIT }}
+          path: /tmp/codegenome-multicapability-profile
+          if-no-files-found: error

--- a/docs/programs/memory-modules/codegenome-multicapability-profile.md
+++ b/docs/programs/memory-modules/codegenome-multicapability-profile.md
@@ -1,0 +1,249 @@
+# CodeGenome Multi-Capability Agent Memory Profile
+
+Issue: #293
+
+Status: **evidence-bounded first-party component profile**
+
+## Exact source boundary
+
+This profile is bound to:
+
+```text
+MythologIQ-Labs-LLC/CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860
+```
+
+That revision includes the file-identity, traversal-direction, and cross-file semantic-resolution correctness repairs discovered during earlier Agent Memory qualification work.
+
+CodeGenome is MIT-licensed at this pin. The profile records CodeGenome as a runtime-allowed first-party implementation, but first-party ownership does not grant capability maturity, Agent Memory authority, or canonical doctrine status.
+
+## What this profile is
+
+`reference/fixtures/component-capabilities/codegenome.example.json` is the machine-readable `component-capability-v2` declaration for the tested CodeGenome revision.
+
+It intentionally separates:
+
+```text
+source implementation evidence
+  != supported runtime reachability
+  != executable qualification
+  != reference qualification
+```
+
+A CodeGenome capability may therefore be present in source while remaining only `implemented` in Agent Memory.
+
+The current profile contains eighteen independent capability rows. Maturity does not propagate between them.
+
+## Current earned maturity
+
+| Capability | Current profile maturity | Enabled | Boundary |
+|---|---|---:|---|
+| content-addressed code identity | `implemented` | yes | Code-domain content identity; not Agent Memory logical identity. |
+| multi-overlay graph state | `implemented` | yes | Provider-derived code reality; not canonical Agent Memory state. |
+| code graph traversal | **`evidence_proven`** | yes | Bounded matched-runtime qualification exists. |
+| graph candidate retrieval | `implemented` | yes | Not separately qualified from traversal. |
+| graph-augmented context assembly | `declared` | **no** | Graph traversal does not prove GraphRAG/context assembly. |
+| structural program analysis | `implemented` | yes | Domain evidence only. |
+| impact propagation | `implemented` | yes | Proposal/evidence surface only; no mutation or action authority. |
+| embedding persistence | `implemented` | yes | Source implementation exists; runtime qualification remains open. |
+| vector similarity | `implemented` | yes | Similarity is ranking evidence, not recall permission. |
+| vector candidate retrieval | `implemented` | yes | k-NN exists in source, but the supported product path has not been qualified. |
+| confidence/evidence fusion | `implemented` | yes | Fused confidence is evidence, not truth or authority. |
+| freshness/currentness | `implemented` | yes | Provider signals do not replace Agent Memory currentness. |
+| provenance/observer separation | `implemented` | yes | Provider provenance remains provider evidence. |
+| multi-language extraction | `implemented` | yes | CodeGenome IR remains domain state, not core Agent Memory schema. |
+| MCP/agent exposure | `implemented` | yes | MCP exposure is not Agent Memory conformance or permission. |
+| experiment/evaluation | `implemented` | yes | May propose changes; cannot promote its own capability or authority. |
+| LSP overlay | `declared` | **no** | The pinned implementation is still a stub that contributes no graph edges. |
+| deletion/rebuild | `implemented` | **no** | Disabled until Agent Memory-grade rebuild/residue evidence exists. |
+
+There are currently no `reference_qualified` CodeGenome capabilities.
+
+## Traversal qualification binding
+
+The only capability above source-level maturity in this profile is:
+
+```text
+code_graph_traversal@1.0
+  -> evidence_proven
+```
+
+Its evidence is owned by the provider-neutral qualification profile:
+
+```text
+code-graph-traversal-currentness@1.1.0
+```
+
+That exact runtime qualification uses:
+
+```text
+CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860
+Graphify v0.9.43@7281f27eac568f77f50910f59f84543458f5dfd1
+```
+
+The matched fixture proves requested file identity, upstream/downstream traversal fidelity, decoy isolation, full-rebuild currentness across source change, explicit provider-unavailable behavior, bounded deterministic fallback, raw provider evidence retention, and `authority_effect = none`.
+
+It does **not** prove vector retrieval, GraphRAG, deletion completeness, LSP behavior, or every CodeGenome overlay. Those rows remain at their independently earned maturity.
+
+Graphify is used as an Apache-2.0-compatible external comparator for the generic code-graph facts. It does not define Agent Memory ontology and is not declared the winner over CodeGenome.
+
+## Scope posture
+
+Every CodeGenome capability uses:
+
+```text
+scope_posture = external_scope_bridge
+```
+
+This is deliberate.
+
+CodeGenome has repository/code-domain identity and scoping of its own. Agent Memory must explicitly bind that provider scope to the active Agent Memory tenant/project/isolation context before provider output can participate in governed recall or consequence selection.
+
+The profile therefore refuses the stronger and misleading claim that CodeGenome natively `inherits_agent_memory_scope` or `enforces_agent_memory_scope`.
+
+```text
+provider repository scope
+!= Agent Memory tenant/project scope
+```
+
+## Currentness, correction, and rebuild posture
+
+Most source-level CodeGenome capabilities declare `provider_revalidated` currentness/correction/deletion behavior and `requires_requalification` for migration/rebuild changes.
+
+That is intentionally conservative. It means Agent Memory does not infer lifecycle completeness from the mere existence of CodeGenome storage, status, freshness, or rebuild mechanisms.
+
+The traversal qualification separately proves one bounded full-rebuild currentness scenario. It does not upgrade the generic `freshness_currentness` or `deletion_rebuild` rows.
+
+Deletion/rebuild remains disabled because:
+
+```text
+provider rebuild/delete mechanism
+!= Agent Memory deletion completeness
+!= proof derived residue is gone
+```
+
+A future qualification must explicitly exercise correction, deletion, rebuild, residue, and scoped currentness before that row may be activated or promoted.
+
+## Vector boundary
+
+CodeGenome contains embedding persistence, cosine similarity, and k-nearest-neighbor implementation at the pinned revision.
+
+Those facts establish source-level implementation only.
+
+The current profile therefore keeps:
+
+```text
+embedding_persistence      = implemented
+vector_similarity          = implemented
+vector_candidate_retrieval = implemented
+```
+
+No vector row is `runtime_wired`, `evidence_proven`, or `reference_qualified` until an Agent Memory adapter invokes a supported CodeGenome product/runtime path, preserves raw evidence, binds model/representation identity, and passes currentness/scope/correction/deletion/failure pressure.
+
+```text
+embedding exists
+!= vector retrieval is runtime-qualified
+!= recall admission
+```
+
+## GraphRAG boundary
+
+CodeGenome provides operational graph traversal and a substantial graph-derived structural context substrate.
+
+That does not establish a separate end-to-end graph-augmented context assembly contract.
+
+Accordingly:
+
+```text
+code_graph_traversal             = evidence_proven
+graph_augmented_context_assembly = declared + disabled
+```
+
+This prevents the common product-taxonomy error where every graph-backed retrieval path is silently renamed GraphRAG.
+
+## LSP boundary
+
+The pinned CodeGenome README describes the LSP overlay as a stub that can detect `rust-analyzer` but contributes no graph edges.
+
+The profile therefore requires:
+
+```text
+lsp_overlay.maturity = declared
+lsp_overlay.enabled  = false
+```
+
+A future implementation may change that, but a newer CodeGenome commit does not inherit this profile or any prior qualification automatically.
+
+## Confidence and evaluation are not authority
+
+CodeGenome confidence fusion, impact propagation, and experiment/evaluation surfaces are useful evidence producers.
+
+They do not mint Agent Memory truth, recall permission, structural authority, mutation authority, or action authority.
+
+The only current `proposal_only` profile surfaces are:
+
+```text
+impact_propagation
+experiment_evaluation
+```
+
+Everything else has `authority_effect = none`.
+
+The profile validator rejects direct authority escalation.
+
+## Fail-closed profile validator
+
+`reference/agentmem_ref/codegenome_profile.py` freezes the current evidence boundary.
+
+It rejects, among other things:
+
+- a CodeGenome source-version change without re-pinning;
+- an unreviewed capability-inventory change;
+- maturity above the per-capability evidence ceiling;
+- vector candidate retrieval promoted beyond `implemented`;
+- GraphRAG activation or promotion;
+- LSP stub activation;
+- deletion/rebuild activation without dedicated qualification;
+- loss of the exact traversal qualification binding;
+- provider scope being mislabeled as Agent Memory-native scope;
+- canonical Agent Memory state claims;
+- direct authority escalation;
+- any `reference_qualified` claim at this profile revision.
+
+The profile therefore fails closed instead of letting one successful component test become a permanent repository-wide halo.
+
+## Exact-head evidence
+
+The dedicated `CodeGenome Multi-Capability Profile` workflow:
+
+1. validates the v2 declaration and adversarial maturity tests;
+2. checks out the exact CodeGenome pin;
+3. verifies its MIT license and exact source-evidence paths;
+4. executes the cross-file resolver regression, CodeGenome substrate library tests, and CLI build;
+5. emits an Agent Memory exact-head profile report;
+6. verifies maturity counts and all fail-closed invariants;
+7. uploads the report and exact CodeGenome license as evidence.
+
+The heavy `Component Qualification Evidence` workflow remains the owner of the real CodeGenome/Graphify traversal qualification. The profile workflow does not duplicate that comparator or reinterpret its result as proof for unrelated capabilities.
+
+## Promotion rule
+
+A future CodeGenome capability promotion must be capability-specific and version-bound:
+
+```text
+exact CodeGenome revision
++ exact adapter version
++ exact qualification profile
++ exact runtime/dependency configuration
++ raw provider evidence
++ normalized Agent Memory evidence
++ relevant negative paths
+    -> earned maturity for that capability only
+```
+
+A repository release, test count, model score, repeated successful run, or neighboring capability's maturity cannot substitute for that chain.
+
+## Claim boundary
+
+This profile establishes a truthful, machine-readable CodeGenome capability inventory at an exact revision and binds the already-proven graph-traversal result into it.
+
+It does not claim that CodeGenome is production-ready, universally conformant, a canonical Agent Memory substrate, a universal code ontology, or reference-qualified across all capabilities.

--- a/reference/agentmem_ref/codegenome_profile.py
+++ b/reference/agentmem_ref/codegenome_profile.py
@@ -1,0 +1,251 @@
+"""Evidence-bounded CodeGenome multi-capability profile validation for #293.
+
+The profile is deliberately broader than the executable qualification surface.
+Each capability carries its own maturity ceiling. A stronger repository version,
+a useful model score, or success in another capability cannot promote it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Mapping
+
+from .capabilities import ComponentDeclaration, MATURITY_ORDER
+from .code_graph_qualification import CODEGENOME_COMMIT, PROFILE_ID, PROFILE_VERSION
+
+
+COMPONENT_ID = "codegenome"
+COMPONENT_PROFILE_VERSION = "component-capability-v2"
+QUALIFICATION_EVIDENCE_REF = (
+    f"qualification:codegenome:{PROFILE_ID}@{PROFILE_VERSION}"
+)
+SOURCE_REF = f"repo://MythologIQ-Labs-LLC/CodeGenome@{CODEGENOME_COMMIT}"
+
+CAPABILITY_CEILINGS: dict[str, str] = {
+    "content_addressed_code_identity": "implemented",
+    "multi_overlay_graph_state": "implemented",
+    "code_graph_traversal": "evidence_proven",
+    "graph_candidate_retrieval": "implemented",
+    "graph_augmented_context_assembly": "declared",
+    "structural_program_analysis": "implemented",
+    "impact_propagation": "implemented",
+    "embedding_persistence": "implemented",
+    "vector_similarity": "implemented",
+    "vector_candidate_retrieval": "implemented",
+    "confidence_evidence_fusion": "implemented",
+    "freshness_currentness": "implemented",
+    "provenance_observer_separation": "implemented",
+    "multi_language_extraction": "implemented",
+    "mcp_agent_exposure": "implemented",
+    "experiment_evaluation": "implemented",
+    "lsp_overlay": "declared",
+    "deletion_rebuild": "implemented",
+}
+
+REQUIRED_DISABLED = frozenset(
+    {
+        "graph_augmented_context_assembly",
+        "lsp_overlay",
+        "deletion_rebuild",
+    }
+)
+PROPOSAL_ONLY = frozenset({"impact_propagation", "experiment_evaluation"})
+
+
+class CodeGenomeProfileError(ValueError):
+    """The CodeGenome declaration exceeds the evidence available at its pin."""
+
+
+def _rank(maturity: str) -> int:
+    try:
+        return MATURITY_ORDER.index(maturity)
+    except ValueError as exc:
+        raise CodeGenomeProfileError(f"unknown capability maturity {maturity!r}") from exc
+
+
+def _capability_map(component: ComponentDeclaration) -> dict[str, object]:
+    return {capability.capability_id: capability for capability in component.capabilities}
+
+
+def profile_digest(value: Mapping[str, object]) -> str:
+    rendered = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(rendered).hexdigest()
+
+
+def load_profile(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    validate_profile(value)
+    return value
+
+
+def validate_profile(value: Mapping[str, object]) -> ComponentDeclaration:
+    component = ComponentDeclaration.from_dict(value)
+
+    if component.component_id != COMPONENT_ID:
+        raise CodeGenomeProfileError("CodeGenome profile component_id must be 'codegenome'")
+    if component.component_version != CODEGENOME_COMMIT:
+        raise CodeGenomeProfileError(
+            f"CodeGenome profile must bind exact tested commit {CODEGENOME_COMMIT}"
+        )
+    if component.profile_version != COMPONENT_PROFILE_VERSION:
+        raise CodeGenomeProfileError("CodeGenome profile must use component-capability-v2")
+    if component.runtime_ref != SOURCE_REF.removeprefix("repo://"):
+        raise CodeGenomeProfileError("CodeGenome runtime_ref must bind the exact source revision")
+    if component.failure_posture != "explicit_unavailable":
+        raise CodeGenomeProfileError("CodeGenome provider failure must remain explicitly unavailable")
+    if SOURCE_REF not in component.provenance_refs:
+        raise CodeGenomeProfileError("CodeGenome profile must preserve its exact source provenance ref")
+
+    capabilities = _capability_map(component)
+    if set(capabilities) != set(CAPABILITY_CEILINGS):
+        missing = sorted(set(CAPABILITY_CEILINGS).difference(capabilities))
+        extra = sorted(set(capabilities).difference(CAPABILITY_CEILINGS))
+        raise CodeGenomeProfileError(
+            f"CodeGenome capability inventory changed without profile review; missing={missing}, extra={extra}"
+        )
+
+    for capability_id, ceiling in CAPABILITY_CEILINGS.items():
+        capability = capabilities[capability_id]
+        if _rank(capability.maturity) > _rank(ceiling):
+            raise CodeGenomeProfileError(
+                f"{capability_id} maturity {capability.maturity} exceeds evidence ceiling {ceiling}"
+            )
+        if capability.scope_posture != "external_scope_bridge":
+            raise CodeGenomeProfileError(
+                f"{capability_id} must use explicit external_scope_bridge"
+            )
+        if capability.state_posture == "canonical":
+            raise CodeGenomeProfileError(
+                f"{capability_id} cannot become canonical Agent Memory state"
+            )
+        if capability.behavior_contract is None:
+            raise CodeGenomeProfileError(f"{capability_id} is missing v2 behavior metadata")
+        if not capability.evidence_refs:
+            raise CodeGenomeProfileError(f"{capability_id} requires bounded evidence refs")
+        if capability_id in REQUIRED_DISABLED and capability.enabled:
+            raise CodeGenomeProfileError(
+                f"{capability_id} must remain disabled until dedicated qualification exists"
+            )
+        if capability_id not in REQUIRED_DISABLED and not capability.enabled:
+            raise CodeGenomeProfileError(
+                f"{capability_id} unexpectedly disabled; change requires explicit profile review"
+            )
+        expected_authority = "proposal_only" if capability_id in PROPOSAL_ONLY else "none"
+        if capability.authority_effect != expected_authority:
+            raise CodeGenomeProfileError(
+                f"{capability_id} authority_effect must remain {expected_authority}"
+            )
+        if capability.maturity == "reference_qualified":
+            raise CodeGenomeProfileError(
+                f"{capability_id} has no reference-qualified evidence at this profile revision"
+            )
+
+    traversal = capabilities["code_graph_traversal"]
+    if traversal.maturity != "evidence_proven":
+        raise CodeGenomeProfileError("code_graph_traversal must preserve its earned evidence_proven maturity")
+    if QUALIFICATION_EVIDENCE_REF not in traversal.evidence_refs:
+        raise CodeGenomeProfileError(
+            "code_graph_traversal must bind the exact code-graph qualification profile"
+        )
+
+    vector = capabilities["vector_candidate_retrieval"]
+    if vector.maturity != "implemented":
+        raise CodeGenomeProfileError(
+            "vector_candidate_retrieval remains implemented until a supported product runtime path is qualified"
+        )
+    graph_rag = capabilities["graph_augmented_context_assembly"]
+    if graph_rag.maturity != "declared" or graph_rag.enabled:
+        raise CodeGenomeProfileError(
+            "graph_augmented_context_assembly remains declared and disabled until end-to-end qualification"
+        )
+    lsp = capabilities["lsp_overlay"]
+    if lsp.maturity != "declared" or lsp.enabled:
+        raise CodeGenomeProfileError("LSP overlay remains a disabled declared stub")
+    deletion = capabilities["deletion_rebuild"]
+    if deletion.enabled:
+        raise CodeGenomeProfileError(
+            "deletion_rebuild remains disabled until residue/rebuild qualification exists"
+        )
+
+    return component
+
+
+def build_profile_report(value: Mapping[str, object], *, agent_memory_commit: str) -> dict:
+    if len(agent_memory_commit) != 40 or any(ch not in "0123456789abcdef" for ch in agent_memory_commit):
+        raise CodeGenomeProfileError("agent_memory_commit must be 40 lowercase hex characters")
+    component = validate_profile(value)
+    capabilities = _capability_map(component)
+    maturity_counts = {name: 0 for name in MATURITY_ORDER}
+    for capability in component.capabilities:
+        maturity_counts[capability.maturity] += 1
+
+    direct_authority = [
+        capability.capability_id
+        for capability in component.capabilities
+        if capability.authority_effect not in {"none", "proposal_only"}
+    ]
+    proposal_surfaces = sorted(
+        capability.capability_id
+        for capability in component.capabilities
+        if capability.authority_effect == "proposal_only"
+    )
+
+    invariants = {
+        "exact_codegenome_pin": component.component_version == CODEGENOME_COMMIT,
+        "profile_v2_behavior_complete": all(
+            capability.behavior_contract is not None for capability in component.capabilities
+        ),
+        "code_graph_traversal_evidence_proven": capabilities["code_graph_traversal"].maturity
+        == "evidence_proven",
+        "qualification_profile_bound": QUALIFICATION_EVIDENCE_REF
+        in capabilities["code_graph_traversal"].evidence_refs,
+        "vector_runtime_not_overstated": capabilities["vector_candidate_retrieval"].maturity
+        == "implemented",
+        "graph_rag_not_overstated": capabilities["graph_augmented_context_assembly"].maturity
+        == "declared"
+        and not capabilities["graph_augmented_context_assembly"].enabled,
+        "lsp_stub_not_promoted": capabilities["lsp_overlay"].maturity == "declared"
+        and not capabilities["lsp_overlay"].enabled,
+        "deletion_residue_not_overstated": not capabilities["deletion_rebuild"].enabled,
+        "scope_bridge_explicit": all(
+            capability.scope_posture == "external_scope_bridge"
+            for capability in component.capabilities
+        ),
+        "no_canonical_state_claims": all(
+            capability.state_posture != "canonical" for capability in component.capabilities
+        ),
+        "no_reference_qualified_claims": all(
+            capability.maturity != "reference_qualified" for capability in component.capabilities
+        ),
+        "no_direct_authority": not direct_authority,
+    }
+
+    return {
+        "schema_version": "1.0.0",
+        "agent_memory_commit": agent_memory_commit,
+        "component": {
+            "component_id": component.component_id,
+            "component_version": component.component_version,
+            "runtime_ref": component.runtime_ref,
+            "profile_version": component.profile_version,
+            "profile_digest": profile_digest(value),
+        },
+        "source_rights": {
+            "license_id": "MIT",
+            "license_ref": f"MythologIQ-Labs-LLC/CodeGenome/LICENSE@{CODEGENOME_COMMIT}",
+            "use_posture": "runtime_allowed",
+        },
+        "qualification_binding": {
+            "capability_id": "code_graph_traversal",
+            "qualification_profile_id": PROFILE_ID,
+            "qualification_profile_version": PROFILE_VERSION,
+            "evidence_ref": QUALIFICATION_EVIDENCE_REF,
+        },
+        "maturity_counts": maturity_counts,
+        "proposal_only_surfaces": proposal_surfaces,
+        "capabilities": [capability.to_dict() for capability in component.capabilities],
+        "invariants": invariants,
+        "authority_effect": "none",
+    }

--- a/reference/fixtures/component-capabilities/codegenome.example.json
+++ b/reference/fixtures/component-capabilities/codegenome.example.json
@@ -1,47 +1,504 @@
 {
-  "component_id": "codegenome-example",
-  "component_version": "d2578729",
-  "profile_version": "component-capability-v1",
+  "component_id": "codegenome",
+  "component_version": "43a6b7147ec78ec5c616723fa1dd30f342174860",
+  "profile_version": "component-capability-v2",
   "enabled": true,
-  "runtime_ref": "MythologIQ-Labs-LLC/CodeGenome@d2578729a46d495369bd7613845002d50cf20f4c",
-  "failure_posture": "fail_closed",
-  "provenance_refs": ["docs/programs/memory-modules/first-party-capability-inventory.md"],
+  "runtime_ref": "MythologIQ-Labs-LLC/CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860",
+  "failure_posture": "explicit_unavailable",
+  "provenance_refs": [
+    "repo://MythologIQ-Labs-LLC/CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860",
+    "issue://MythologIQ-Labs-LLC/agent-memory/293",
+    "qualification://code-graph-traversal-currentness@1.1.0"
+  ],
   "capabilities": [
     {
-      "capability_id": "graph_traversal",
+      "capability_id": "content_addressed_code_identity",
       "capability_version": "1.0",
-      "maturity": "runtime_wired",
+      "maturity": "implemented",
       "state_posture": "derived",
-      "scope_posture": "inherits_agent_memory_scope",
+      "scope_posture": "external_scope_bridge",
       "failure_posture": "explicit_unavailable",
       "authority_effect": "none",
       "enabled": true,
-      "evidence_refs": ["inventory:codegenome:graph-traversal"],
-      "limitations": ["code_domain_ontology_is_not_agent_memory_core"]
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-identity/src/identity/digest.rs"
+      ],
+      "limitations": [
+        "code_domain_content_identity_is_not_agent_memory_logical_identity",
+        "runtime_behavior_not_independently_qualified"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "multi_overlay_graph_state",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:README.md#graph-composition",
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-identity/src/index/resolver_multi.rs"
+      ],
+      "limitations": [
+        "codegenome_graph_ontology_is_external_domain_state",
+        "provider_state_does_not_become_agent_memory_canonical_state"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "code_graph_traversal",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:codegenome:code-graph-traversal-currentness@1.1.0",
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-cli/src/commands/query.rs"
+      ],
+      "limitations": [
+        "qualification_covers_bounded_code_graph_fixture_and_full_rebuild_currentness",
+        "repository_scope_requires_explicit_agent_memory_binding",
+        "graph_reachability_is_candidate_evidence_not_recall_permission"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "graph_candidate_retrieval",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-cli/src/commands/query.rs"
+      ],
+      "limitations": [
+        "candidate_retrieval_not_separately_qualified_from_traversal",
+        "retrieval_does_not_create_recall_admission"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "graph_augmented_context_assembly",
+      "capability_version": "1.0",
+      "maturity": "declared",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": false,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:README.md"
+      ],
+      "limitations": [
+        "end_to_end_graph_augmented_context_assembly_not_runtime_qualified",
+        "graph_traversal_is_not_graph_rag_conformance"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "structural_program_analysis",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:README.md#graph-composition"
+      ],
+      "limitations": [
+        "overlay_outputs_are_domain_evidence_not_agent_memory_truth"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "proposal_only"
+      }
+    },
+    {
+      "capability_id": "impact_propagation",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "proposal_only",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-cli/src/commands/query.rs"
+      ],
+      "limitations": [
+        "impact_evidence_does_not_create_mutation_or_action_authority",
+        "capability_not_separately_qualified_from_graph_traversal"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "proposal_only"
+      }
+    },
+    {
+      "capability_id": "embedding_persistence",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-substrate/src/embedding/store.rs"
+      ],
+      "limitations": [
+        "embedding_storage_not_independently_runtime_qualified"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
     },
     {
       "capability_id": "vector_similarity",
       "capability_version": "1.0",
       "maturity": "implemented",
       "state_posture": "derived",
-      "scope_posture": "inherits_agent_memory_scope",
+      "scope_posture": "external_scope_bridge",
       "failure_posture": "explicit_unavailable",
       "authority_effect": "none",
       "enabled": true,
-      "evidence_refs": ["inventory:codegenome:vector-similarity"],
-      "limitations": ["primary_product_runtime_path_not_yet_qualified"]
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-substrate/src/embedding/similarity.rs",
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-substrate/src/tests/embedding_tests.rs"
+      ],
+      "limitations": [
+        "similarity_is_ranking_evidence_not_recall_permission",
+        "supported_product_runtime_path_not_yet_qualified"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
     },
     {
-      "capability_id": "impact_propagation",
+      "capability_id": "vector_candidate_retrieval",
       "capability_version": "1.0",
-      "maturity": "runtime_wired",
+      "maturity": "implemented",
       "state_posture": "derived",
-      "scope_posture": "inherits_agent_memory_scope",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-substrate/src/embedding/store.rs",
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-substrate/src/embedding/similarity.rs"
+      ],
+      "limitations": [
+        "k_nearest_implementation_exists_but_supported_product_runtime_path_is_not_qualified",
+        "vector_candidate_retrieval_does_not_create_recall_admission"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "confidence_evidence_fusion",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-identity/src/tests/fusion_tests.rs"
+      ],
+      "limitations": [
+        "fusion_score_is_evidence_not_truth",
+        "correlated_observations_must_not_be_treated_as_independent_authority"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "freshness_currentness",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-cli/src/commands/status.rs",
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:README.md"
+      ],
+      "limitations": [
+        "provider_freshness_signal_does_not_replace_agent_memory_currentness",
+        "only_code_graph_full_rebuild_currentness_is_currently_evidence_proven"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "provenance_observer_separation",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:README.md#core-concepts"
+      ],
+      "limitations": [
+        "provider_provenance_is_normalized_without_becoming_agent_memory_evidentiary_privilege"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "multi_language_extraction",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-identity/src/index/resolver_multi.rs",
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:README.md#multi-language-support"
+      ],
+      "limitations": [
+        "language_neutral_ir_is_codegenome_domain_state_not_agent_memory_core_schema"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "proposal_only"
+      }
+    },
+    {
+      "capability_id": "mcp_agent_exposure",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "external",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-mcp/Cargo.toml",
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-cli/src/commands/serve.rs"
+      ],
+      "limitations": [
+        "mcp_exposure_is_not_agent_memory_conformance",
+        "provider_write_tools_create_no_agent_memory_authority"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "not_applicable",
+        "invalidation_model": "not_applicable",
+        "correction_model": "not_applicable",
+        "deletion_model": "not_applicable",
+        "residue_model": "not_applicable",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "external_authorization_required"
+      }
+    },
+    {
+      "capability_id": "experiment_evaluation",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "external",
+      "scope_posture": "external_scope_bridge",
       "failure_posture": "explicit_unavailable",
       "authority_effect": "proposal_only",
       "enabled": true,
-      "evidence_refs": ["inventory:codegenome:impact-propagation"],
-      "limitations": ["impact_evidence_does_not_create_mutation_authority"]
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:codegenome-cli/src/commands/experiment.rs"
+      ],
+      "limitations": [
+        "self_evaluation_may_propose_changes_but_cannot_promote_agent_memory_capability_or_authority"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "not_applicable",
+        "invalidation_model": "not_applicable",
+        "correction_model": "not_applicable",
+        "deletion_model": "not_applicable",
+        "residue_model": "not_applicable",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "proposal_only"
+      }
+    },
+    {
+      "capability_id": "lsp_overlay",
+      "capability_version": "1.0",
+      "maturity": "declared",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": false,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:README.md#graph-composition"
+      ],
+      "limitations": [
+        "rust_analyzer_detection_stub_contributes_no_edges_at_pinned_revision",
+        "must_not_count_as_active_overlay_capability"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": false, "recall_candidate": false},
+        "currentness_model": "not_applicable",
+        "invalidation_model": "not_applicable",
+        "correction_model": "not_applicable",
+        "deletion_model": "not_applicable",
+        "residue_model": "not_applicable",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "deletion_rebuild",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": false,
+      "evidence_refs": [
+        "source:CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860:README.md"
+      ],
+      "limitations": [
+        "agent_memory_deletion_residue_conformance_not_established",
+        "disabled_until_dedicated_rebuild_and_residue_qualification_exists"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
     }
   ]
 }

--- a/reference/run_codegenome_multicapability_profile.py
+++ b/reference/run_codegenome_multicapability_profile.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Emit exact-head CodeGenome multi-capability profile evidence for #293."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import jsonschema
+
+from agentmem_ref.codegenome_profile import build_profile_report
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PROFILE = ROOT / "reference" / "fixtures" / "component-capabilities" / "codegenome.example.json"
+PROFILE_SCHEMA = ROOT / "schemas" / "component-capability-profile.schema.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--profile", type=Path, default=DEFAULT_PROFILE)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    value = json.loads(args.profile.read_text(encoding="utf-8"))
+    schema = json.loads(PROFILE_SCHEMA.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator(schema).validate(value)
+
+    report = build_profile_report(value, agent_memory_commit=args.agent_memory_commit)
+    failed = sorted(name for name, passed in report["invariants"].items() if not passed)
+    if failed:
+        raise SystemExit(f"CodeGenome profile invariants failed: {failed}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "component": report["component"],
+        "maturity_counts": report["maturity_counts"],
+        "invariants": report["invariants"],
+        "authority_effect": report["authority_effect"],
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_codegenome_multicapability_profile.py
+++ b/reference/tests/test_codegenome_multicapability_profile.py
@@ -1,0 +1,125 @@
+"""CodeGenome multi-capability profile boundaries for #293."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.codegenome_profile import (  # noqa: E402
+    CODEGENOME_COMMIT,
+    CodeGenomeProfileError,
+    build_profile_report,
+    validate_profile,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE_PATH = ROOT / "reference" / "fixtures" / "component-capabilities" / "codegenome.example.json"
+SCHEMA_PATH = ROOT / "schemas" / "component-capability-profile.schema.json"
+
+
+def profile() -> dict:
+    return json.loads(PROFILE_PATH.read_text(encoding="utf-8"))
+
+
+def capability(value: dict, capability_id: str) -> dict:
+    return next(item for item in value["capabilities"] if item["capability_id"] == capability_id)
+
+
+class CodeGenomeMultiCapabilityProfileTests(unittest.TestCase):
+    def test_profile_is_schema_valid_and_evidence_bounded(self):
+        value = profile()
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        errors = list(jsonschema.Draft202012Validator(schema).iter_errors(value))
+        self.assertEqual(errors, [], [error.message for error in errors])
+
+        component = validate_profile(value)
+        self.assertEqual(component.component_version, CODEGENOME_COMMIT)
+        self.assertEqual(len(component.capabilities), 18)
+
+        report = build_profile_report(value, agent_memory_commit="a" * 40)
+        self.assertTrue(all(report["invariants"].values()), report["invariants"])
+        self.assertEqual(report["maturity_counts"]["declared"], 2)
+        self.assertEqual(report["maturity_counts"]["implemented"], 15)
+        self.assertEqual(report["maturity_counts"]["evidence_proven"], 1)
+        self.assertEqual(report["maturity_counts"]["reference_qualified"], 0)
+        self.assertEqual(
+            report["proposal_only_surfaces"],
+            ["experiment_evaluation", "impact_propagation"],
+        )
+        self.assertEqual(report["authority_effect"], "none")
+
+    def test_vector_runtime_cannot_be_promoted_from_source_implementation(self):
+        value = profile()
+        capability(value, "vector_candidate_retrieval")["maturity"] = "runtime_wired"
+        with self.assertRaisesRegex(CodeGenomeProfileError, "exceeds evidence ceiling"):
+            validate_profile(value)
+
+    def test_graph_rag_cannot_hitchhike_on_graph_traversal(self):
+        value = profile()
+        graph_rag = capability(value, "graph_augmented_context_assembly")
+        graph_rag["maturity"] = "implemented"
+        graph_rag["enabled"] = True
+        with self.assertRaises(CodeGenomeProfileError):
+            validate_profile(value)
+
+    def test_lsp_stub_cannot_be_activated(self):
+        value = profile()
+        capability(value, "lsp_overlay")["enabled"] = True
+        with self.assertRaisesRegex(CodeGenomeProfileError, "must remain disabled"):
+            validate_profile(value)
+
+    def test_deletion_rebuild_stays_disabled_without_residue_qualification(self):
+        value = profile()
+        capability(value, "deletion_rebuild")["enabled"] = True
+        with self.assertRaisesRegex(CodeGenomeProfileError, "must remain disabled"):
+            validate_profile(value)
+
+    def test_source_version_change_invalidates_profile(self):
+        value = profile()
+        value["component_version"] = "b" * 40
+        value["runtime_ref"] = f"MythologIQ-Labs-LLC/CodeGenome@{'b' * 40}"
+        with self.assertRaisesRegex(CodeGenomeProfileError, "exact tested commit"):
+            validate_profile(value)
+
+    def test_traversal_must_preserve_exact_qualification_binding(self):
+        value = profile()
+        traversal = capability(value, "code_graph_traversal")
+        traversal["evidence_refs"] = [
+            item for item in traversal["evidence_refs"] if not item.startswith("qualification:")
+        ]
+        with self.assertRaisesRegex(CodeGenomeProfileError, "exact code-graph qualification profile"):
+            validate_profile(value)
+
+    def test_provider_scope_cannot_be_laundered_into_agent_memory_scope(self):
+        value = profile()
+        capability(value, "code_graph_traversal")["scope_posture"] = "inherits_agent_memory_scope"
+        with self.assertRaisesRegex(CodeGenomeProfileError, "external_scope_bridge"):
+            validate_profile(value)
+
+    def test_component_output_cannot_gain_direct_authority(self):
+        value = profile()
+        capability(value, "code_graph_traversal")["authority_effect"] = "proposal_only"
+        with self.assertRaisesRegex(CodeGenomeProfileError, "authority_effect must remain none"):
+            validate_profile(value)
+
+    def test_capability_inventory_drift_requires_explicit_review(self):
+        value = profile()
+        value["capabilities"] = deepcopy(value["capabilities"][:-1])
+        with self.assertRaisesRegex(CodeGenomeProfileError, "capability inventory changed"):
+            validate_profile(value)
+
+    def test_agent_memory_evidence_requires_exact_commit_identity(self):
+        value = profile()
+        with self.assertRaisesRegex(CodeGenomeProfileError, "40 lowercase hex"):
+            build_profile_report(value, agent_memory_commit="main")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Delivers the bounded multi-capability profile slice of #293 at the exact CodeGenome revision:

`MythologIQ-Labs-LLC/CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860`

### Profile migration

Replaces the stale three-row `component-capability-v1` CodeGenome example with a `component-capability-v2` profile containing eighteen independently graded capability rows.

Only `code_graph_traversal` is currently `evidence_proven`, bound to the existing provider-neutral `code-graph-traversal-currentness@1.1.0` qualification and its exact CodeGenome/Graphify runtime evidence.

All other capabilities remain capped at what exact source evidence supports. In particular:

- vector storage/similarity/k-NN remain `implemented`, not runtime-qualified;
- graph-augmented context assembly remains `declared` and disabled;
- the LSP overlay remains `declared` and disabled because the pinned implementation is still a stub;
- deletion/rebuild remains `implemented` but disabled pending dedicated residue/rebuild qualification;
- no capability is `reference_qualified`.

### Scope and authority

All CodeGenome capabilities declare `external_scope_bridge`, not Agent Memory-native scope enforcement. CodeGenome repository/domain scope must be explicitly bound to Agent Memory tenant/project/isolation context.

CodeGenome content identity and graph ontology remain provider/domain state, not Agent Memory canonical identity or ontology.

No component output directly creates Agent Memory authority. `impact_propagation` and `experiment_evaluation` are proposal-only surfaces; all other rows have `authority_effect = none`.

### Fail-closed validator

Adds `reference/agentmem_ref/codegenome_profile.py`, which rejects source-version drift, inventory drift, maturity above per-capability ceilings, vector/GraphRAG/LSP/deletion over-promotion, loss of the exact traversal qualification binding, scope laundering, canonical-state claims, direct authority escalation, and any current `reference_qualified` claim.

### Evidence

Adds targeted adversarial tests, an exact-head profile evidence runner, a dedicated CI workflow, and a claim-boundary document. The workflow verifies the exact CodeGenome pin and MIT source rights, exercises the cross-file resolver regression and CodeGenome substrate library tests, builds the CLI, and emits the exact Agent Memory head profile report.

The existing `Component Qualification Evidence` workflow remains the owner of the real matched CodeGenome/Graphify traversal qualification. This PR does not duplicate that comparator or use one passing graph fixture to certify unrelated capabilities.

### Remaining #293 boundary

This merge intentionally does **not** close #293. The remaining work is the #293-specific negative-path pressure for the capability already above source-level maturity, especially explicit external-scope binding/refusal and source-deletion/rebuild/residue behavior. Lower-maturity vector, GraphRAG, and LSP rows do not need to be promoted merely to close the issue.

Refs #293.
Refs #300.
Refs ADR-033.