### PR TITLE
Close CodeGenome traversal scope and residue qualification gaps

### DIFF
--- a/.github/workflows/codegenome-scope-residue-closeout.yml
+++ b/.github/workflows/codegenome-scope-residue-closeout.yml
@@ -1,0 +1,152 @@
+name: CodeGenome Scope and Residue Closeout
+
+on:
+  pull_request:
+    paths:
+      - "reference/agentmem_ref/codegenome_scope_residue.py"
+      - "reference/run_codegenome_scope_residue.py"
+      - "reference/tests/test_codegenome_scope_residue.py"
+      - "reference/fixtures/component-capabilities/codegenome.example.json"
+      - "reference/fixtures/component-qualification/**"
+      - "docs/programs/memory-modules/codegenome-scope-residue-closeout.md"
+      - ".github/workflows/codegenome-scope-residue-closeout.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CODEGENOME_COMMIT: 43a6b7147ec78ec5c616723fa1dd30f342174860
+
+jobs:
+  closeout:
+    runs-on: ubuntu-latest
+    env:
+      AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+      FIXTURE_ROOT: ${{ github.workspace }}/reference/fixtures/component-qualification
+      EVIDENCE_ROOT: /tmp/codegenome-scope-residue
+    steps:
+      - name: Checkout Agent Memory
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Execute scope and residue unit tests
+        env:
+          PYTHONPATH: reference
+        run: |
+          python -m unittest \
+            reference/tests/test_codegenome_scope_residue.py \
+            reference/tests/test_codegenome_multicapability_profile.py \
+            reference/tests/test_code_graph_qualification.py
+
+      - name: Prepare evidence directories
+        run: mkdir -p "$EVIDENCE_ROOT/raw" "$EVIDENCE_ROOT/source-rights"
+
+      - name: Fetch exact CodeGenome source
+        run: |
+          git clone --filter=blob:none --no-checkout https://github.com/MythologIQ-Labs-LLC/CodeGenome.git /tmp/codegenome
+          git -C /tmp/codegenome fetch --depth=1 origin "$CODEGENOME_COMMIT"
+          git -C /tmp/codegenome checkout --detach "$CODEGENOME_COMMIT"
+          test "$(git -C /tmp/codegenome rev-parse HEAD)" = "$CODEGENOME_COMMIT"
+          grep -qi "MIT License" /tmp/codegenome/LICENSE
+          cp /tmp/codegenome/LICENSE "$EVIDENCE_ROOT/source-rights/CodeGenome-LICENSE"
+
+      - name: Build exact CodeGenome CLI
+        working-directory: /tmp/codegenome
+        run: cargo build -p codegenome-cli
+
+      - name: Execute v1 historical graph
+        run: |
+          /tmp/codegenome/target/debug/codegenome index \
+            --source-dir "$FIXTURE_ROOT/v1" \
+            --store-dir /tmp/codegenome-closeout-v1 \
+            > "$EVIDENCE_ROOT/raw/v1-index.txt"
+          /tmp/codegenome/target/debug/codegenome query \
+            --store-dir /tmp/codegenome-closeout-v1 \
+            --file main.rs --line 6 --direction downstream --json \
+            > "$EVIDENCE_ROOT/raw/v1-main-downstream.json"
+          find /tmp/codegenome-closeout-v1 -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            > "$EVIDENCE_ROOT/raw/v1-store-manifest.txt"
+          test -s "$EVIDENCE_ROOT/raw/v1-store-manifest.txt"
+
+      - name: Execute v2 source-deletion full rebuild
+        run: |
+          /tmp/codegenome/target/debug/codegenome index \
+            --source-dir "$FIXTURE_ROOT/v2" \
+            --store-dir /tmp/codegenome-closeout-v2 \
+            > "$EVIDENCE_ROOT/raw/v2-index.txt"
+          /tmp/codegenome/target/debug/codegenome query \
+            --store-dir /tmp/codegenome-closeout-v2 \
+            --file main.rs --line 6 --direction downstream --json \
+            > "$EVIDENCE_ROOT/raw/v2-main-downstream.json"
+          find /tmp/codegenome-closeout-v2 -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            > "$EVIDENCE_ROOT/raw/v2-store-manifest.txt"
+          test -s "$EVIDENCE_ROOT/raw/v2-store-manifest.txt"
+
+      - name: Emit exact-head scope and residue evidence
+        env:
+          PYTHONPATH: reference
+        run: |
+          python reference/run_codegenome_scope_residue.py \
+            --agent-memory-commit "$AGENT_MEMORY_COMMIT" \
+            --v1-main-downstream "$EVIDENCE_ROOT/raw/v1-main-downstream.json" \
+            --v2-main-downstream "$EVIDENCE_ROOT/raw/v2-main-downstream.json" \
+            --v1-store-manifest "$EVIDENCE_ROOT/raw/v1-store-manifest.txt" \
+            --v2-store-manifest "$EVIDENCE_ROOT/raw/v2-store-manifest.txt" \
+            --output "$EVIDENCE_ROOT/codegenome-scope-residue.json"
+
+      - name: Verify closeout semantics
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(
+              (Path(os.environ["EVIDENCE_ROOT"]) / "codegenome-scope-residue.json").read_text()
+          )
+          assert report["agent_memory_commit"] == os.environ["AGENT_MEMORY_COMMIT"]
+          assert report["component"]["component_version"] == os.environ["CODEGENOME_COMMIT"]
+          assert report["base_qualification"] == {
+              "profile_id": "code-graph-traversal-currentness",
+              "profile_version": "1.1.0",
+              "evidence_ref": "qualification:codegenome:code-graph-traversal-currentness@1.1.0",
+          }
+          scope = report["scope_bridge"]
+          assert scope["exact"]["admitted"] is True
+          assert scope["missing_binding"]["admitted"] is False
+          assert scope["foreign_provider"]["admitted"] is False
+          assert scope["foreign_agent_memory_scope"]["admitted"] is False
+          deletion = report["deletion_rebuild"]
+          assert deletion["currentness_result"] == "deleted_source_not_current"
+          assert deletion["old_source_current_after_rebuild"] is False
+          assert deletion["replacement_source_current_after_rebuild"] is True
+          assert deletion["historical_provider_artifact_retained"] is True
+          assert deletion["historical_provider_artifact_current"] is False
+          assert deletion["physical_erasure_proven"] is False
+          assert deletion["residue_posture"] == "historical_provider_artifact_disclosed_not_current"
+          assert all(report["invariants"].values()), report["invariants"]
+          assert report["authority_effect"] == "none"
+          PY
+
+      - name: Upload exact-head closeout evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codegenome-scope-residue-${{ env.AGENT_MEMORY_COMMIT }}
+          path: /tmp/codegenome-scope-residue
+          if-no-files-found: error

--- a/docs/programs/memory-modules/codegenome-scope-residue-closeout.md
+++ b/docs/programs/memory-modules/codegenome-scope-residue-closeout.md
@@ -30,7 +30,7 @@ That is stronger and more precise than treating provider repository scope as if 
 
 The closeout therefore adds two explicit obligations for the only CodeGenome capability currently above source-level maturity:
 
-1. provider output is admitted only through an exact provider-scope → Agent Memory-scope binding;
+1. provider output is admitted only through an exact, version-bound provider-scope → Agent Memory-scope binding;
 2. source deletion after full rebuild proves old material is not current without pretending historical provider artifacts were physically erased.
 
 ## External scope binding
@@ -39,6 +39,8 @@ The reference closeout uses an explicit binding containing:
 
 ```text
 component_id
+component_version
+component_profile_digest
 provider_scope_ref
 agent_memory_scope_ref
 tenant_ref
@@ -47,20 +49,28 @@ binding_ref
 binding_version
 ```
 
+The component revision and component-profile digest are part of the binding. An upgrade or material profile change therefore invalidates the old scope admission rather than silently inheriting it.
+
 Admission is deterministic:
 
 ```text
-exact provider scope + exact Agent Memory scope + explicit binding
+exact component revision
++ exact component-profile digest
++ exact provider scope
++ exact Agent Memory scope
++ explicit binding
   -> candidate may cross the scope bridge
 
 missing binding
+stale component revision
+stale component-profile digest
 foreign provider scope
 foreign Agent Memory scope
 missing scope identity
   -> refuse
 ```
 
-The binding is not authority. It only proves which external provider scope is allowed to contribute candidate evidence to which Agent Memory scope.
+The binding is not authority. It only proves which exact external provider/profile scope is allowed to contribute candidate evidence to which Agent Memory scope.
 
 ```text
 scope binding
@@ -123,7 +133,8 @@ Lower-maturity capability rows remain lower maturity by design.
 
 `CodeGenome Scope and Residue Closeout`:
 
-- runs the scope/refusal unit cases;
+- runs exact/missing/stale/foreign scope-refusal cases;
+- binds scope admission to the exact CodeGenome revision and component-profile digest;
 - checks out the exact CodeGenome pin and verifies MIT source rights;
 - builds the exact CodeGenome CLI;
 - indexes the v1 and v2 fixtures into separate provider stores;

--- a/docs/programs/memory-modules/codegenome-scope-residue-closeout.md
+++ b/docs/programs/memory-modules/codegenome-scope-residue-closeout.md
@@ -1,0 +1,142 @@
+# CodeGenome Traversal Scope and Residue Closeout
+
+Issue: #293
+
+This evidence supplements, rather than replaces, the existing provider-neutral CodeGenome/Graphify traversal qualification.
+
+## Base qualification
+
+The existing runtime qualification remains:
+
+```text
+code-graph-traversal-currentness@1.1.0
+CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860
+Graphify v0.9.43@7281f27eac568f77f50910f59f84543458f5dfd1
+```
+
+It already proves requested-file identity, traversal direction, decoy isolation, v1→v2 full-rebuild currentness, explicit provider unavailability, raw evidence retention, bounded fallback, and no authority effect.
+
+The v1→v2 fixture is also a source-deletion case: v1 contains `leaf`; v2 removes it and replaces the active downstream relation with `replacement_leaf`.
+
+## Why this closeout exists
+
+The bounded CodeGenome profile now truthfully declares:
+
+```text
+scope_posture = external_scope_bridge
+```
+
+That is stronger and more precise than treating provider repository scope as if it were automatically Agent Memory tenant/project scope.
+
+The closeout therefore adds two explicit obligations for the only CodeGenome capability currently above source-level maturity:
+
+1. provider output is admitted only through an exact provider-scope → Agent Memory-scope binding;
+2. source deletion after full rebuild proves old material is not current without pretending historical provider artifacts were physically erased.
+
+## External scope binding
+
+The reference closeout uses an explicit binding containing:
+
+```text
+component_id
+provider_scope_ref
+agent_memory_scope_ref
+tenant_ref
+project_ref
+binding_ref
+binding_version
+```
+
+Admission is deterministic:
+
+```text
+exact provider scope + exact Agent Memory scope + explicit binding
+  -> candidate may cross the scope bridge
+
+missing binding
+foreign provider scope
+foreign Agent Memory scope
+missing scope identity
+  -> refuse
+```
+
+The binding is not authority. It only proves which external provider scope is allowed to contribute candidate evidence to which Agent Memory scope.
+
+```text
+scope binding
+!= recall permission
+!= mutation authority
+!= action authority
+```
+
+This closeout is the controlling Agent Memory posture for the CodeGenome profile. Historical comparator/fallback metadata from earlier qualification work does not convert CodeGenome into a component that natively enforces or inherits Agent Memory tenancy.
+
+## Source deletion and residue
+
+The runtime fixture is intentionally interpreted as:
+
+```text
+v1: middle -> leaf
+v2: middle -> replacement_leaf
+```
+
+After a fresh v2 full rebuild, the active v2 CodeGenome query must no longer return the deleted v1 `leaf` line and must return the replacement line.
+
+The workflow also records manifests for both the historical v1 provider store and current v2 provider store.
+
+That proves the narrower currentness statement:
+
+```text
+deleted v1 source
+-> not admitted as current from the v2 rebuilt store
+```
+
+It does **not** prove:
+
+```text
+all historical provider bytes erased
+all backups erased
+all derived systems erased
+transitive Agent Memory forgetting complete
+```
+
+Instead the evidence records:
+
+```text
+historical_provider_artifact_retained = true
+historical_provider_artifact_current = false
+physical_erasure_proven = false
+residue_posture = historical_provider_artifact_disclosed_not_current
+```
+
+This is deliberate. Historical qualification evidence may remain retained while being non-current. Physical retention and governed currentness are different properties.
+
+## Relationship to the CodeGenome profile
+
+`docs/programs/memory-modules/codegenome-multicapability-profile.md` remains the capability inventory.
+
+The closeout does not promote vector retrieval, GraphRAG, LSP, or deletion/rebuild to a stronger maturity. It only completes #293-specific negative-path evidence for `code_graph_traversal`, the capability already carrying `evidence_proven` maturity.
+
+Lower-maturity capability rows remain lower maturity by design.
+
+## Exact-head evidence
+
+`CodeGenome Scope and Residue Closeout`:
+
+- runs the scope/refusal unit cases;
+- checks out the exact CodeGenome pin and verifies MIT source rights;
+- builds the exact CodeGenome CLI;
+- indexes the v1 and v2 fixtures into separate provider stores;
+- captures the historical and current downstream query outputs;
+- preserves manifests for both provider stores;
+- emits an exact-head closeout report;
+- requires every scope/currentness/residue invariant to pass;
+- keeps `authority_effect = none`.
+
+## Claim boundary
+
+This evidence supports a bounded statement:
+
+> CodeGenome graph traversal may contribute evidence-proven candidates for the qualified fixture when the exact provider revision/profile remains current, the provider repository scope is explicitly bridged to the active Agent Memory scope, and a full rebuild after source deletion no longer admits the deleted source as current. Historical provider artifacts may remain retained as disclosed non-current evidence.
+
+It does not make CodeGenome a canonical Agent Memory graph, scope authority, deletion authority, or universal memory substrate.

--- a/reference/agentmem_ref/codegenome_scope_residue.py
+++ b/reference/agentmem_ref/codegenome_scope_residue.py
@@ -1,0 +1,250 @@
+"""#293 closeout pressure for CodeGenome traversal scope and deletion residue.
+
+This module supplements the existing provider-neutral traversal qualification.
+It does not grant a stronger capability maturity. It proves that CodeGenome's
+external repository scope must be explicitly bound before Agent Memory may use
+provider output, and that source deletion after full rebuild changes current
+admissibility without fabricating a physical-erasure claim for historical
+provider artifacts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Mapping
+
+from .code_graph_qualification import CODEGENOME_COMMIT, PROFILE_ID, PROFILE_VERSION
+from .codegenome_profile import profile_digest, validate_profile
+
+
+CLOSEOUT_PROFILE_ID = "codegenome-traversal-scope-residue"
+CLOSEOUT_PROFILE_VERSION = "1.0.0"
+_LINE = re.compile(r"^line (\d+):(\d+)$")
+
+
+class CodeGenomeScopeResidueError(ValueError):
+    """The external scope or deletion/currentness evidence is unsafe or incomplete."""
+
+
+@dataclass(frozen=True)
+class ExternalScopeBinding:
+    binding_ref: str
+    component_id: str
+    provider_scope_ref: str
+    agent_memory_scope_ref: str
+    tenant_ref: str
+    project_ref: str
+    binding_version: str = "1.0.0"
+
+    def __post_init__(self) -> None:
+        for name in (
+            "binding_ref",
+            "component_id",
+            "provider_scope_ref",
+            "agent_memory_scope_ref",
+            "tenant_ref",
+            "project_ref",
+            "binding_version",
+        ):
+            if not getattr(self, name):
+                raise CodeGenomeScopeResidueError(f"{name} is required")
+        if self.component_id != "codegenome":
+            raise CodeGenomeScopeResidueError("scope binding must target codegenome")
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ScopeAdmission:
+    admitted: bool
+    reason: str
+    binding_ref: str | None
+    provider_scope_ref: str
+    agent_memory_scope_ref: str
+    authority_effect: str = "none"
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def evaluate_scope_bridge(
+    *,
+    binding: ExternalScopeBinding | None,
+    provider_scope_ref: str,
+    agent_memory_scope_ref: str,
+) -> ScopeAdmission:
+    """Admit provider output only through an exact external-scope binding."""
+    if not provider_scope_ref or not agent_memory_scope_ref:
+        return ScopeAdmission(
+            admitted=False,
+            reason="scope_identity_missing",
+            binding_ref=binding.binding_ref if binding else None,
+            provider_scope_ref=provider_scope_ref,
+            agent_memory_scope_ref=agent_memory_scope_ref,
+        )
+    if binding is None:
+        return ScopeAdmission(
+            admitted=False,
+            reason="external_scope_binding_missing",
+            binding_ref=None,
+            provider_scope_ref=provider_scope_ref,
+            agent_memory_scope_ref=agent_memory_scope_ref,
+        )
+    if provider_scope_ref != binding.provider_scope_ref:
+        return ScopeAdmission(
+            admitted=False,
+            reason="provider_scope_mismatch",
+            binding_ref=binding.binding_ref,
+            provider_scope_ref=provider_scope_ref,
+            agent_memory_scope_ref=agent_memory_scope_ref,
+        )
+    if agent_memory_scope_ref != binding.agent_memory_scope_ref:
+        return ScopeAdmission(
+            admitted=False,
+            reason="agent_memory_scope_mismatch",
+            binding_ref=binding.binding_ref,
+            provider_scope_ref=provider_scope_ref,
+            agent_memory_scope_ref=agent_memory_scope_ref,
+        )
+    return ScopeAdmission(
+        admitted=True,
+        reason="exact_external_scope_binding",
+        binding_ref=binding.binding_ref,
+        provider_scope_ref=provider_scope_ref,
+        agent_memory_scope_ref=agent_memory_scope_ref,
+    )
+
+
+def _codegenome_start_lines(path: Path) -> set[int]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise CodeGenomeScopeResidueError("CodeGenome query output must be a list")
+    lines: set[int] = set()
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        node = item.get("node")
+        if not isinstance(node, str):
+            continue
+        match = _LINE.fullmatch(node)
+        if match:
+            lines.add(int(match.group(1)))
+    return lines
+
+
+def sha256_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def build_closeout_report(
+    *,
+    agent_memory_commit: str,
+    component_profile: Mapping[str, object],
+    binding: ExternalScopeBinding,
+    v1_main_downstream: Path,
+    v2_main_downstream: Path,
+    v1_store_manifest: Path,
+    v2_store_manifest: Path,
+) -> dict[str, object]:
+    if len(agent_memory_commit) != 40 or any(ch not in "0123456789abcdef" for ch in agent_memory_commit):
+        raise CodeGenomeScopeResidueError("agent_memory_commit must be 40 lowercase hex")
+
+    component = validate_profile(component_profile)
+    traversal = next(
+        capability for capability in component.capabilities if capability.capability_id == "code_graph_traversal"
+    )
+    if traversal.maturity != "evidence_proven":
+        raise CodeGenomeScopeResidueError("closeout requires the existing evidence-proven traversal qualification")
+    if traversal.scope_posture != "external_scope_bridge":
+        raise CodeGenomeScopeResidueError("CodeGenome traversal must use external_scope_bridge")
+
+    v1_lines = _codegenome_start_lines(v1_main_downstream)
+    v2_lines = _codegenome_start_lines(v2_main_downstream)
+    source_deletion_current = 1 in v1_lines and 1 not in v2_lines and 13 in v2_lines
+
+    admitted = evaluate_scope_bridge(
+        binding=binding,
+        provider_scope_ref=binding.provider_scope_ref,
+        agent_memory_scope_ref=binding.agent_memory_scope_ref,
+    )
+    missing_binding = evaluate_scope_bridge(
+        binding=None,
+        provider_scope_ref=binding.provider_scope_ref,
+        agent_memory_scope_ref=binding.agent_memory_scope_ref,
+    )
+    foreign_provider = evaluate_scope_bridge(
+        binding=binding,
+        provider_scope_ref=binding.provider_scope_ref + "/foreign",
+        agent_memory_scope_ref=binding.agent_memory_scope_ref,
+    )
+    foreign_agent_scope = evaluate_scope_bridge(
+        binding=binding,
+        provider_scope_ref=binding.provider_scope_ref,
+        agent_memory_scope_ref=binding.agent_memory_scope_ref + "/foreign",
+    )
+
+    invariants = {
+        "exact_codegenome_pin": component.component_version == CODEGENOME_COMMIT,
+        "base_traversal_qualification_bound": any(
+            ref == f"qualification:codegenome:{PROFILE_ID}@{PROFILE_VERSION}"
+            for ref in traversal.evidence_refs
+        ),
+        "external_scope_bridge_declared": traversal.scope_posture == "external_scope_bridge",
+        "exact_scope_binding_admitted": admitted.admitted,
+        "missing_scope_binding_refused": not missing_binding.admitted,
+        "foreign_provider_scope_refused": not foreign_provider.admitted,
+        "foreign_agent_memory_scope_refused": not foreign_agent_scope.admitted,
+        "source_deleted_old_leaf_not_current_after_rebuild": source_deletion_current,
+        "historical_v1_store_disclosed": v1_store_manifest.exists() and v1_store_manifest.stat().st_size > 0,
+        "current_v2_store_disclosed": v2_store_manifest.exists() and v2_store_manifest.stat().st_size > 0,
+        "physical_erasure_not_claimed": True,
+        "no_authority_effect": all(
+            result.authority_effect == "none"
+            for result in (admitted, missing_binding, foreign_provider, foreign_agent_scope)
+        ),
+    }
+
+    return {
+        "schema_version": "1.0.0",
+        "profile": {"id": CLOSEOUT_PROFILE_ID, "version": CLOSEOUT_PROFILE_VERSION},
+        "agent_memory_commit": agent_memory_commit,
+        "component": {
+            "component_id": component.component_id,
+            "component_version": component.component_version,
+            "component_profile_version": component.profile_version,
+            "component_profile_digest": profile_digest(component_profile),
+        },
+        "base_qualification": {
+            "profile_id": PROFILE_ID,
+            "profile_version": PROFILE_VERSION,
+            "evidence_ref": f"qualification:codegenome:{PROFILE_ID}@{PROFILE_VERSION}",
+        },
+        "scope_bridge": {
+            "binding": binding.to_dict(),
+            "exact": admitted.to_dict(),
+            "missing_binding": missing_binding.to_dict(),
+            "foreign_provider": foreign_provider.to_dict(),
+            "foreign_agent_memory_scope": foreign_agent_scope.to_dict(),
+        },
+        "deletion_rebuild": {
+            "source_change": "v1_leaf_removed_v2_replacement_leaf",
+            "historical_v1_start_lines": sorted(v1_lines),
+            "current_v2_start_lines": sorted(v2_lines),
+            "old_source_current_after_rebuild": 1 in v2_lines,
+            "replacement_source_current_after_rebuild": 13 in v2_lines,
+            "currentness_result": "deleted_source_not_current" if source_deletion_current else "unproven",
+            "historical_provider_artifact_retained": True,
+            "historical_provider_artifact_current": False,
+            "physical_erasure_proven": False,
+            "residue_posture": "historical_provider_artifact_disclosed_not_current",
+            "v1_store_manifest_sha256": sha256_file(v1_store_manifest),
+            "v2_store_manifest_sha256": sha256_file(v2_store_manifest),
+        },
+        "invariants": invariants,
+        "authority_effect": "none",
+    }

--- a/reference/agentmem_ref/codegenome_scope_residue.py
+++ b/reference/agentmem_ref/codegenome_scope_residue.py
@@ -34,6 +34,8 @@ class CodeGenomeScopeResidueError(ValueError):
 class ExternalScopeBinding:
     binding_ref: str
     component_id: str
+    component_version: str
+    component_profile_digest: str
     provider_scope_ref: str
     agent_memory_scope_ref: str
     tenant_ref: str
@@ -44,6 +46,8 @@ class ExternalScopeBinding:
         for name in (
             "binding_ref",
             "component_id",
+            "component_version",
+            "component_profile_digest",
             "provider_scope_ref",
             "agent_memory_scope_ref",
             "tenant_ref",
@@ -54,6 +58,20 @@ class ExternalScopeBinding:
                 raise CodeGenomeScopeResidueError(f"{name} is required")
         if self.component_id != "codegenome":
             raise CodeGenomeScopeResidueError("scope binding must target codegenome")
+        if len(self.component_version) != 40 or any(
+            ch not in "0123456789abcdef" for ch in self.component_version
+        ):
+            raise CodeGenomeScopeResidueError("component_version must be 40 lowercase hex")
+        if not self.component_profile_digest.startswith("sha256:") or len(self.component_profile_digest) != 71:
+            raise CodeGenomeScopeResidueError("component_profile_digest must be sha256:<64 lowercase hex>")
+        try:
+            int(self.component_profile_digest.removeprefix("sha256:"), 16)
+        except ValueError as exc:
+            raise CodeGenomeScopeResidueError(
+                "component_profile_digest must be sha256:<64 lowercase hex>"
+            ) from exc
+        if self.component_profile_digest != self.component_profile_digest.lower():
+            raise CodeGenomeScopeResidueError("component_profile_digest must be lowercase")
 
     def to_dict(self) -> dict[str, str]:
         return asdict(self)
@@ -75,10 +93,12 @@ class ScopeAdmission:
 def evaluate_scope_bridge(
     *,
     binding: ExternalScopeBinding | None,
+    component_version: str,
+    component_profile_digest: str,
     provider_scope_ref: str,
     agent_memory_scope_ref: str,
 ) -> ScopeAdmission:
-    """Admit provider output only through an exact external-scope binding."""
+    """Admit provider output only through an exact version-bound external-scope binding."""
     if not provider_scope_ref or not agent_memory_scope_ref:
         return ScopeAdmission(
             admitted=False,
@@ -92,6 +112,22 @@ def evaluate_scope_bridge(
             admitted=False,
             reason="external_scope_binding_missing",
             binding_ref=None,
+            provider_scope_ref=provider_scope_ref,
+            agent_memory_scope_ref=agent_memory_scope_ref,
+        )
+    if component_version != binding.component_version:
+        return ScopeAdmission(
+            admitted=False,
+            reason="component_version_mismatch",
+            binding_ref=binding.binding_ref,
+            provider_scope_ref=provider_scope_ref,
+            agent_memory_scope_ref=agent_memory_scope_ref,
+        )
+    if component_profile_digest != binding.component_profile_digest:
+        return ScopeAdmission(
+            admitted=False,
+            reason="component_profile_mismatch",
+            binding_ref=binding.binding_ref,
             provider_scope_ref=provider_scope_ref,
             agent_memory_scope_ref=agent_memory_scope_ref,
         )
@@ -155,6 +191,7 @@ def build_closeout_report(
         raise CodeGenomeScopeResidueError("agent_memory_commit must be 40 lowercase hex")
 
     component = validate_profile(component_profile)
+    current_profile_digest = profile_digest(component_profile)
     traversal = next(
         capability for capability in component.capabilities if capability.capability_id == "code_graph_traversal"
     )
@@ -167,13 +204,33 @@ def build_closeout_report(
     v2_lines = _codegenome_start_lines(v2_main_downstream)
     source_deletion_current = 1 in v1_lines and 1 not in v2_lines and 13 in v2_lines
 
+    common_scope_args = {
+        "component_version": component.component_version,
+        "component_profile_digest": current_profile_digest,
+    }
     admitted = evaluate_scope_bridge(
         binding=binding,
         provider_scope_ref=binding.provider_scope_ref,
         agent_memory_scope_ref=binding.agent_memory_scope_ref,
+        **common_scope_args,
     )
     missing_binding = evaluate_scope_bridge(
         binding=None,
+        provider_scope_ref=binding.provider_scope_ref,
+        agent_memory_scope_ref=binding.agent_memory_scope_ref,
+        **common_scope_args,
+    )
+    stale_component = evaluate_scope_bridge(
+        binding=binding,
+        component_version="0" * 40,
+        component_profile_digest=current_profile_digest,
+        provider_scope_ref=binding.provider_scope_ref,
+        agent_memory_scope_ref=binding.agent_memory_scope_ref,
+    )
+    stale_profile = evaluate_scope_bridge(
+        binding=binding,
+        component_version=component.component_version,
+        component_profile_digest="sha256:" + "0" * 64,
         provider_scope_ref=binding.provider_scope_ref,
         agent_memory_scope_ref=binding.agent_memory_scope_ref,
     )
@@ -181,11 +238,13 @@ def build_closeout_report(
         binding=binding,
         provider_scope_ref=binding.provider_scope_ref + "/foreign",
         agent_memory_scope_ref=binding.agent_memory_scope_ref,
+        **common_scope_args,
     )
     foreign_agent_scope = evaluate_scope_bridge(
         binding=binding,
         provider_scope_ref=binding.provider_scope_ref,
         agent_memory_scope_ref=binding.agent_memory_scope_ref + "/foreign",
+        **common_scope_args,
     )
 
     invariants = {
@@ -195,8 +254,12 @@ def build_closeout_report(
             for ref in traversal.evidence_refs
         ),
         "external_scope_bridge_declared": traversal.scope_posture == "external_scope_bridge",
+        "scope_binding_version_bound": binding.component_version == component.component_version,
+        "scope_binding_profile_bound": binding.component_profile_digest == current_profile_digest,
         "exact_scope_binding_admitted": admitted.admitted,
         "missing_scope_binding_refused": not missing_binding.admitted,
+        "stale_component_scope_binding_refused": not stale_component.admitted,
+        "stale_profile_scope_binding_refused": not stale_profile.admitted,
         "foreign_provider_scope_refused": not foreign_provider.admitted,
         "foreign_agent_memory_scope_refused": not foreign_agent_scope.admitted,
         "source_deleted_old_leaf_not_current_after_rebuild": source_deletion_current,
@@ -205,7 +268,14 @@ def build_closeout_report(
         "physical_erasure_not_claimed": True,
         "no_authority_effect": all(
             result.authority_effect == "none"
-            for result in (admitted, missing_binding, foreign_provider, foreign_agent_scope)
+            for result in (
+                admitted,
+                missing_binding,
+                stale_component,
+                stale_profile,
+                foreign_provider,
+                foreign_agent_scope,
+            )
         ),
     }
 
@@ -217,7 +287,7 @@ def build_closeout_report(
             "component_id": component.component_id,
             "component_version": component.component_version,
             "component_profile_version": component.profile_version,
-            "component_profile_digest": profile_digest(component_profile),
+            "component_profile_digest": current_profile_digest,
         },
         "base_qualification": {
             "profile_id": PROFILE_ID,
@@ -228,6 +298,8 @@ def build_closeout_report(
             "binding": binding.to_dict(),
             "exact": admitted.to_dict(),
             "missing_binding": missing_binding.to_dict(),
+            "stale_component": stale_component.to_dict(),
+            "stale_profile": stale_profile.to_dict(),
             "foreign_provider": foreign_provider.to_dict(),
             "foreign_agent_memory_scope": foreign_agent_scope.to_dict(),
         },

--- a/reference/run_codegenome_scope_residue.py
+++ b/reference/run_codegenome_scope_residue.py
@@ -7,6 +7,8 @@ import argparse
 import json
 from pathlib import Path
 
+from agentmem_ref.code_graph_qualification import CODEGENOME_COMMIT
+from agentmem_ref.codegenome_profile import profile_digest
 from agentmem_ref.codegenome_scope_residue import ExternalScopeBinding, build_closeout_report
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -28,6 +30,8 @@ def main() -> int:
     binding = ExternalScopeBinding(
         binding_ref="scope-binding:codegenome:qualification-fixture:tenant-a-project-a",
         component_id="codegenome",
+        component_version=CODEGENOME_COMMIT,
+        component_profile_digest=profile_digest(profile),
         provider_scope_ref="repo://qualification-fixture/codegenome-main",
         agent_memory_scope_ref="tenant://tenant-a/project/project-a",
         tenant_ref="tenant-a",

--- a/reference/run_codegenome_scope_residue.py
+++ b/reference/run_codegenome_scope_residue.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Emit exact-head #293 CodeGenome scope/deletion closeout evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref.codegenome_scope_residue import ExternalScopeBinding, build_closeout_report
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PROFILE = ROOT / "reference" / "fixtures" / "component-capabilities" / "codegenome.example.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--component-profile", type=Path, default=DEFAULT_PROFILE)
+    parser.add_argument("--v1-main-downstream", type=Path, required=True)
+    parser.add_argument("--v2-main-downstream", type=Path, required=True)
+    parser.add_argument("--v1-store-manifest", type=Path, required=True)
+    parser.add_argument("--v2-store-manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    profile = json.loads(args.component_profile.read_text(encoding="utf-8"))
+    binding = ExternalScopeBinding(
+        binding_ref="scope-binding:codegenome:qualification-fixture:tenant-a-project-a",
+        component_id="codegenome",
+        provider_scope_ref="repo://qualification-fixture/codegenome-main",
+        agent_memory_scope_ref="tenant://tenant-a/project/project-a",
+        tenant_ref="tenant-a",
+        project_ref="project-a",
+    )
+    report = build_closeout_report(
+        agent_memory_commit=args.agent_memory_commit,
+        component_profile=profile,
+        binding=binding,
+        v1_main_downstream=args.v1_main_downstream,
+        v2_main_downstream=args.v2_main_downstream,
+        v1_store_manifest=args.v1_store_manifest,
+        v2_store_manifest=args.v2_store_manifest,
+    )
+    failed = sorted(name for name, passed in report["invariants"].items() if not passed)
+    if failed:
+        raise SystemExit(f"CodeGenome scope/residue invariants failed: {failed}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "profile": report["profile"],
+        "base_qualification": report["base_qualification"],
+        "scope_bridge": report["scope_bridge"],
+        "deletion_rebuild": report["deletion_rebuild"],
+        "invariants": report["invariants"],
+        "authority_effect": report["authority_effect"],
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_codegenome_scope_residue.py
+++ b/reference/tests/test_codegenome_scope_residue.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from agentmem_ref.code_graph_qualification import CODEGENOME_COMMIT  # noqa: E402
+from agentmem_ref.codegenome_profile import profile_digest  # noqa: E402
 from agentmem_ref.codegenome_scope_residue import (  # noqa: E402
     CodeGenomeScopeResidueError,
     ExternalScopeBinding,
@@ -21,10 +23,17 @@ ROOT = Path(__file__).resolve().parents[2]
 PROFILE = ROOT / "reference" / "fixtures" / "component-capabilities" / "codegenome.example.json"
 
 
-def binding() -> ExternalScopeBinding:
+def profile_value() -> dict:
+    return json.loads(PROFILE.read_text(encoding="utf-8"))
+
+
+def binding(profile: dict | None = None) -> ExternalScopeBinding:
+    value = profile if profile is not None else profile_value()
     return ExternalScopeBinding(
         binding_ref="scope-binding:codegenome:fixture-main:tenant-a-project-a",
         component_id="codegenome",
+        component_version=CODEGENOME_COMMIT,
+        component_profile_digest=profile_digest(value),
         provider_scope_ref="repo://fixture/codegenome-main",
         agent_memory_scope_ref="tenant://tenant-a/project/project-a",
         tenant_ref="tenant-a",
@@ -32,13 +41,21 @@ def binding() -> ExternalScopeBinding:
     )
 
 
+def admission_args(item: ExternalScopeBinding) -> dict[str, str]:
+    return {
+        "component_version": item.component_version,
+        "component_profile_digest": item.component_profile_digest,
+    }
+
+
 class CodeGenomeScopeResidueTests(unittest.TestCase):
-    def test_exact_external_scope_binding_is_required(self):
+    def test_exact_external_scope_binding_is_required_and_version_bound(self):
         item = binding()
         exact = evaluate_scope_bridge(
             binding=item,
             provider_scope_ref=item.provider_scope_ref,
             agent_memory_scope_ref=item.agent_memory_scope_ref,
+            **admission_args(item),
         )
         self.assertTrue(exact.admitted)
         self.assertEqual(exact.reason, "exact_external_scope_binding")
@@ -48,14 +65,36 @@ class CodeGenomeScopeResidueTests(unittest.TestCase):
             binding=None,
             provider_scope_ref=item.provider_scope_ref,
             agent_memory_scope_ref=item.agent_memory_scope_ref,
+            **admission_args(item),
         )
         self.assertFalse(missing.admitted)
         self.assertEqual(missing.reason, "external_scope_binding_missing")
+
+        stale_version = evaluate_scope_bridge(
+            binding=item,
+            component_version="0" * 40,
+            component_profile_digest=item.component_profile_digest,
+            provider_scope_ref=item.provider_scope_ref,
+            agent_memory_scope_ref=item.agent_memory_scope_ref,
+        )
+        self.assertFalse(stale_version.admitted)
+        self.assertEqual(stale_version.reason, "component_version_mismatch")
+
+        stale_profile = evaluate_scope_bridge(
+            binding=item,
+            component_version=item.component_version,
+            component_profile_digest="sha256:" + "0" * 64,
+            provider_scope_ref=item.provider_scope_ref,
+            agent_memory_scope_ref=item.agent_memory_scope_ref,
+        )
+        self.assertFalse(stale_profile.admitted)
+        self.assertEqual(stale_profile.reason, "component_profile_mismatch")
 
         provider_mismatch = evaluate_scope_bridge(
             binding=item,
             provider_scope_ref="repo://foreign/codegenome-main",
             agent_memory_scope_ref=item.agent_memory_scope_ref,
+            **admission_args(item),
         )
         self.assertFalse(provider_mismatch.admitted)
         self.assertEqual(provider_mismatch.reason, "provider_scope_mismatch")
@@ -64,15 +103,19 @@ class CodeGenomeScopeResidueTests(unittest.TestCase):
             binding=item,
             provider_scope_ref=item.provider_scope_ref,
             agent_memory_scope_ref="tenant://tenant-b/project/project-a",
+            **admission_args(item),
         )
         self.assertFalse(scope_mismatch.admitted)
         self.assertEqual(scope_mismatch.reason, "agent_memory_scope_mismatch")
 
     def test_binding_cannot_target_another_component(self):
+        value = profile_value()
         with self.assertRaisesRegex(CodeGenomeScopeResidueError, "must target codegenome"):
             ExternalScopeBinding(
                 binding_ref="binding:bad",
                 component_id="graphify",
+                component_version=CODEGENOME_COMMIT,
+                component_profile_digest=profile_digest(value),
                 provider_scope_ref="repo://fixture/codegenome-main",
                 agent_memory_scope_ref="tenant://tenant-a/project/project-a",
                 tenant_ref="tenant-a",
@@ -80,7 +123,7 @@ class CodeGenomeScopeResidueTests(unittest.TestCase):
             )
 
     def test_v1_to_v2_source_deletion_is_currentness_not_erasure_claim(self):
-        profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+        profile = profile_value()
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             v1 = root / "v1.json"
@@ -95,7 +138,7 @@ class CodeGenomeScopeResidueTests(unittest.TestCase):
             report = build_closeout_report(
                 agent_memory_commit="a" * 40,
                 component_profile=profile,
-                binding=binding(),
+                binding=binding(profile),
                 v1_main_downstream=v1,
                 v2_main_downstream=v2,
                 v1_store_manifest=v1_manifest,
@@ -103,6 +146,8 @@ class CodeGenomeScopeResidueTests(unittest.TestCase):
             )
 
         self.assertTrue(all(report["invariants"].values()), report["invariants"])
+        self.assertFalse(report["scope_bridge"]["stale_component"]["admitted"])
+        self.assertFalse(report["scope_bridge"]["stale_profile"]["admitted"])
         deletion = report["deletion_rebuild"]
         self.assertEqual(deletion["currentness_result"], "deleted_source_not_current")
         self.assertFalse(deletion["old_source_current_after_rebuild"])
@@ -116,8 +161,25 @@ class CodeGenomeScopeResidueTests(unittest.TestCase):
         )
         self.assertEqual(report["authority_effect"], "none")
 
+    def test_profile_drift_invalidates_existing_scope_binding(self):
+        profile = profile_value()
+        item = binding(profile)
+        changed = json.loads(json.dumps(profile))
+        next(cap for cap in changed["capabilities"] if cap["capability_id"] == "vector_similarity")[
+            "limitations"
+        ].append("new_unverified_profile_state")
+        result = evaluate_scope_bridge(
+            binding=item,
+            component_version=CODEGENOME_COMMIT,
+            component_profile_digest=profile_digest(changed),
+            provider_scope_ref=item.provider_scope_ref,
+            agent_memory_scope_ref=item.agent_memory_scope_ref,
+        )
+        self.assertFalse(result.admitted)
+        self.assertEqual(result.reason, "component_profile_mismatch")
+
     def test_deleted_source_remaining_current_fails_closeout_invariant(self):
-        profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+        profile = profile_value()
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             v1 = root / "v1.json"
@@ -131,7 +193,7 @@ class CodeGenomeScopeResidueTests(unittest.TestCase):
             report = build_closeout_report(
                 agent_memory_commit="b" * 40,
                 component_profile=profile,
-                binding=binding(),
+                binding=binding(profile),
                 v1_main_downstream=v1,
                 v2_main_downstream=v2,
                 v1_store_manifest=v1_manifest,

--- a/reference/tests/test_codegenome_scope_residue.py
+++ b/reference/tests/test_codegenome_scope_residue.py
@@ -1,0 +1,144 @@
+"""#293 CodeGenome traversal scope and deletion/residue closeout tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.codegenome_scope_residue import (  # noqa: E402
+    CodeGenomeScopeResidueError,
+    ExternalScopeBinding,
+    build_closeout_report,
+    evaluate_scope_bridge,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE = ROOT / "reference" / "fixtures" / "component-capabilities" / "codegenome.example.json"
+
+
+def binding() -> ExternalScopeBinding:
+    return ExternalScopeBinding(
+        binding_ref="scope-binding:codegenome:fixture-main:tenant-a-project-a",
+        component_id="codegenome",
+        provider_scope_ref="repo://fixture/codegenome-main",
+        agent_memory_scope_ref="tenant://tenant-a/project/project-a",
+        tenant_ref="tenant-a",
+        project_ref="project-a",
+    )
+
+
+class CodeGenomeScopeResidueTests(unittest.TestCase):
+    def test_exact_external_scope_binding_is_required(self):
+        item = binding()
+        exact = evaluate_scope_bridge(
+            binding=item,
+            provider_scope_ref=item.provider_scope_ref,
+            agent_memory_scope_ref=item.agent_memory_scope_ref,
+        )
+        self.assertTrue(exact.admitted)
+        self.assertEqual(exact.reason, "exact_external_scope_binding")
+        self.assertEqual(exact.authority_effect, "none")
+
+        missing = evaluate_scope_bridge(
+            binding=None,
+            provider_scope_ref=item.provider_scope_ref,
+            agent_memory_scope_ref=item.agent_memory_scope_ref,
+        )
+        self.assertFalse(missing.admitted)
+        self.assertEqual(missing.reason, "external_scope_binding_missing")
+
+        provider_mismatch = evaluate_scope_bridge(
+            binding=item,
+            provider_scope_ref="repo://foreign/codegenome-main",
+            agent_memory_scope_ref=item.agent_memory_scope_ref,
+        )
+        self.assertFalse(provider_mismatch.admitted)
+        self.assertEqual(provider_mismatch.reason, "provider_scope_mismatch")
+
+        scope_mismatch = evaluate_scope_bridge(
+            binding=item,
+            provider_scope_ref=item.provider_scope_ref,
+            agent_memory_scope_ref="tenant://tenant-b/project/project-a",
+        )
+        self.assertFalse(scope_mismatch.admitted)
+        self.assertEqual(scope_mismatch.reason, "agent_memory_scope_mismatch")
+
+    def test_binding_cannot_target_another_component(self):
+        with self.assertRaisesRegex(CodeGenomeScopeResidueError, "must target codegenome"):
+            ExternalScopeBinding(
+                binding_ref="binding:bad",
+                component_id="graphify",
+                provider_scope_ref="repo://fixture/codegenome-main",
+                agent_memory_scope_ref="tenant://tenant-a/project/project-a",
+                tenant_ref="tenant-a",
+                project_ref="project-a",
+            )
+
+    def test_v1_to_v2_source_deletion_is_currentness_not_erasure_claim(self):
+        profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            v1 = root / "v1.json"
+            v2 = root / "v2.json"
+            v1_manifest = root / "v1-store-manifest.txt"
+            v2_manifest = root / "v2-store-manifest.txt"
+            v1.write_text(json.dumps([{"node": "line 1:1"}, {"node": "line 5:1"}]), encoding="utf-8")
+            v2.write_text(json.dumps([{"node": "line 5:1"}, {"node": "line 13:1"}]), encoding="utf-8")
+            v1_manifest.write_text("v1-store/file.bin sha256:aaa\n", encoding="utf-8")
+            v2_manifest.write_text("v2-store/file.bin sha256:bbb\n", encoding="utf-8")
+
+            report = build_closeout_report(
+                agent_memory_commit="a" * 40,
+                component_profile=profile,
+                binding=binding(),
+                v1_main_downstream=v1,
+                v2_main_downstream=v2,
+                v1_store_manifest=v1_manifest,
+                v2_store_manifest=v2_manifest,
+            )
+
+        self.assertTrue(all(report["invariants"].values()), report["invariants"])
+        deletion = report["deletion_rebuild"]
+        self.assertEqual(deletion["currentness_result"], "deleted_source_not_current")
+        self.assertFalse(deletion["old_source_current_after_rebuild"])
+        self.assertTrue(deletion["replacement_source_current_after_rebuild"])
+        self.assertTrue(deletion["historical_provider_artifact_retained"])
+        self.assertFalse(deletion["historical_provider_artifact_current"])
+        self.assertFalse(deletion["physical_erasure_proven"])
+        self.assertEqual(
+            deletion["residue_posture"],
+            "historical_provider_artifact_disclosed_not_current",
+        )
+        self.assertEqual(report["authority_effect"], "none")
+
+    def test_deleted_source_remaining_current_fails_closeout_invariant(self):
+        profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            v1 = root / "v1.json"
+            v2 = root / "v2.json"
+            v1_manifest = root / "v1.txt"
+            v2_manifest = root / "v2.txt"
+            v1.write_text(json.dumps([{"node": "line 1:1"}]), encoding="utf-8")
+            v2.write_text(json.dumps([{"node": "line 1:1"}, {"node": "line 13:1"}]), encoding="utf-8")
+            v1_manifest.write_text("old", encoding="utf-8")
+            v2_manifest.write_text("new", encoding="utf-8")
+            report = build_closeout_report(
+                agent_memory_commit="b" * 40,
+                component_profile=profile,
+                binding=binding(),
+                v1_main_downstream=v1,
+                v2_main_downstream=v2,
+                v1_store_manifest=v1_manifest,
+                v2_store_manifest=v2_manifest,
+            )
+        self.assertFalse(report["invariants"]["source_deleted_old_leaf_not_current_after_rebuild"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the remaining #293 negative-path gap for the only CodeGenome capability currently above source-level maturity: `code_graph_traversal`.

This PR supplements the existing `code-graph-traversal-currentness@1.1.0` CodeGenome/Graphify runtime qualification. It does not promote any additional CodeGenome capability.

### Version-bound external scope bridge

Adds a deterministic provider-scope → Agent Memory-scope binding for CodeGenome traversal candidates.

The binding is tied to:

- exact CodeGenome revision;
- exact CodeGenome component-profile digest;
- exact provider scope;
- exact Agent Memory scope;
- tenant/project identity and a versioned binding ref.

The closeout proves:

- exact revision/profile/provider scope/Agent Memory scope + explicit binding may cross the bridge as candidate evidence;
- missing binding fails closed;
- stale CodeGenome revision fails closed;
- stale component-profile digest fails closed;
- foreign provider scope fails closed;
- foreign Agent Memory scope fails closed;
- scope binding creates no recall, mutation, structural, or action authority.

This makes `external_scope_bridge` executable and prevents yesterday's scope admission from silently surviving a provider/profile change.

### Source deletion and residue

Reuses the existing v1→v2 adversarial fixture as the deletion/currentness case:

```text
v1: middle -> leaf
v2: middle -> replacement_leaf
```

The exact CodeGenome runtime is rebuilt into a fresh v2 provider store. The old v1 leaf must no longer be admitted as current, while the replacement must be present.

The workflow deliberately retains manifests for both the historical v1 and current v2 provider stores and records:

```text
historical_provider_artifact_retained = true
historical_provider_artifact_current = false
physical_erasure_proven = false
residue_posture = historical_provider_artifact_disclosed_not_current
```

This proves currentness after source deletion without laundering it into a transitive physical-erasure claim.

### Relationship to #293 profile

The merged CodeGenome v2 profile remains unchanged:

- traversal: `evidence_proven`;
- vector rows: `implemented`;
- GraphRAG: `declared` + disabled;
- LSP: `declared` + disabled;
- deletion/rebuild capability: `implemented` + disabled;
- no `reference_qualified` rows.

The lower-maturity rows do not need artificial promotion to complete #293.

### Exact pin

```text
CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860
```

Source rights remain MIT. No provider output gains Agent Memory authority.

Refs #293.
Refs #300.
Refs #324.