### PR TITLE
Complete Atlas corpus synthesis with source-neutral dispositions

### DIFF
--- a/.github/workflows/atlas-research-intake.yml
+++ b/.github/workflows/atlas-research-intake.yml
@@ -8,12 +8,14 @@ on:
       - 'docs/programs/atlas-research/**'
       - 'scripts/build_atlas_research_inventory.py'
       - 'scripts/validate_atlas_research_scaffold.py'
+      - 'scripts/validate_atlas_research_synthesis.py'
       - '.github/workflows/atlas-research-intake.yml'
   pull_request:
     paths:
       - 'docs/programs/atlas-research/**'
       - 'scripts/build_atlas_research_inventory.py'
       - 'scripts/validate_atlas_research_scaffold.py'
+      - 'scripts/validate_atlas_research_synthesis.py'
       - '.github/workflows/atlas-research-intake.yml'
   workflow_dispatch:
 
@@ -46,6 +48,9 @@ jobs:
       - name: Validate committed scaffold and inventory lock
         run: python scripts/validate_atlas_research_scaffold.py --allow-missing-inventory
 
+      - name: Validate bounded corpus synthesis
+        run: python scripts/validate_atlas_research_synthesis.py
+
       - name: Generate exact-pinned report inventory
         run: >-
           python scripts/build_atlas_research_inventory.py
@@ -57,17 +62,21 @@ jobs:
           python scripts/validate_atlas_research_scaffold.py
           --inventory /tmp/report-inventory.jsonl
 
-      - name: Record generated inventory digest
+      - name: Record durable research digests
         run: |
           sha256sum /tmp/report-inventory.jsonl | tee /tmp/report-inventory.sha256
+          sha256sum docs/programs/atlas-research/corpus-synthesis.json | tee /tmp/corpus-synthesis.sha256
           cat /tmp/report-inventory.sha256 >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/corpus-synthesis.sha256 >> "$GITHUB_STEP_SUMMARY"
 
       - name: Preserve generated inventory convenience evidence
         uses: actions/upload-artifact@v4
         with:
-          name: atlas-report-inventory-90bfeed
+          name: atlas-research-90bfeed-${{ github.event.pull_request.head.sha || github.sha }}
           path: |
             /tmp/report-inventory.jsonl
             /tmp/report-inventory.sha256
+            /tmp/corpus-synthesis.sha256
+            docs/programs/atlas-research/corpus-synthesis.json
           if-no-files-found: error
           retention-days: 30

--- a/docs/programs/atlas-research/README.md
+++ b/docs/programs/atlas-research/README.md
@@ -3,7 +3,7 @@
 Issue: #306
 Parent research program: #304
 
-This directory defines the reproducible intake boundary for research based on `neoneye/agent-memory-atlas`. Atlas is used as a source index and hypothesis generator, not as doctrine authority or runtime conformance evidence.
+This directory defines the reproducible intake and synthesis boundary for research based on `neoneye/agent-memory-atlas`. Atlas is used as a source index and hypothesis generator, not as doctrine authority or runtime conformance evidence.
 
 ## Frozen source boundary
 
@@ -41,6 +41,8 @@ A high Atlas mark count is never a promotion criterion.
 - `report-inventory.jsonl`: deterministic generated output of `scripts/build_atlas_research_inventory.py`. It is intentionally not committed; CI regenerates it from the exact pinned Atlas checkout and refuses output that does not match `report-inventory.lock.json`.
 - `claim-ledger.jsonl`: independently verified or deliberately unresolved consequential claims. This is not generated from prose automatically.
 - `deduplication-map.json`: likely findings mapped to existing Agent Memory owners before new work is created.
+- `corpus-synthesis.json`: #304 completion record containing the exact seven-mechanism mapping, all 21 pattern dispositions, benchmark/candidate decisions, Agent Memory self-audit reconciliation, promotions, rejections, and completion flags.
+- `corpus-synthesis.md`: human-readable explanation of the bounded research closeout.
 - `schemas/`: research-record schemas. These schemas describe research infrastructure, not canonical runtime state.
 
 The generated Actions artifact is convenience evidence, not the durable identity boundary. It may expire. Durable reconstruction is provided by the pinned Atlas source identity + committed generator + committed inventory lock. This avoids checking in half a megabyte of regenerated secondary-source metadata while still making silent inventory drift fail closed.
@@ -78,7 +80,7 @@ These dimensions answer different questions. A representation-neutral catastroph
 
 ## Research batches
 
-The order is frozen for #304:
+The frozen #304 execution order was:
 
 1. self-audit calibration against Atlas's Agent Memory report;
 2. seven-mechanism crosswalk;
@@ -88,7 +90,7 @@ The order is frozen for #304:
 6. comparator and component candidate selection;
 7. synthesis and bounded promotion decisions.
 
-Do not perform the corpus review alphabetically.
+The corpus review is not alphabetical and completion is not defined as identical depth for all 283 reports.
 
 ## Frozen deep-review questions
 
@@ -110,7 +112,7 @@ Every deep-reviewed system answers the same questions:
 14. What exact claim would an Agent Memory fixture or comparator falsify?
 15. What should Agent Memory not copy from this system?
 
-Changing this question set during the corpus pass requires an explicit methodology revision rather than a silent edit.
+Changing this question set requires an explicit methodology revision rather than a silent edit.
 
 ## Promotion and stopping rule
 
@@ -125,3 +127,21 @@ Create a follow-on only when a verified claim exposes at least one of:
 Otherwise record `covered`, `reference`, `rejected`, `not_relevant`, or `unresolved` and stop.
 
 The expected ADR result remains `none` unless verified evidence proves a doctrine-level gap.
+
+## #304 synthesis boundary
+
+`corpus-synthesis.json` is intentionally narrower than a claim that every Atlas report was independently reproduced. It records the converged research result under the stopping rule above:
+
+```text
+283 snapshot-bound inventory records
+7/7 Atlas mechanisms mapped
+21/21 Atlas patterns disposed
+primary-source benchmark/candidate shortlist
+Agent Memory Atlas-report reconciliation
+bounded promotion(s)
+explicit rejection/no-action log
+no new ADR
+no Atlas-derived authority
+```
+
+`scripts/validate_atlas_research_synthesis.py` fails closed on missing or substituted mechanism/pattern IDs, duplicate entries, snapshot drift, incomplete completion flags, missing promotion/rejection evidence, or any authority/doctrine escalation.

--- a/docs/programs/atlas-research/corpus-synthesis.json
+++ b/docs/programs/atlas-research/corpus-synthesis.json
@@ -1,0 +1,351 @@
+{
+  "agent_memory_evidence_boundary": "f2fc966c403d7adf028c24240b85c6e4e576a25a",
+  "agent_memory_self_audit": [
+    {
+      "atlas_claim": "rejected-value tombstone gap",
+      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
+      "current_evidence": [
+        "#147",
+        "#148",
+        "reference/agentmem_ref/readmission.py"
+      ],
+      "current_status": "fixed"
+    },
+    {
+      "atlas_claim": "no discrete Atlas-style trust state",
+      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
+      "current_evidence": [
+        "docs/16-source-trust-and-reputation.md",
+        "#146"
+      ],
+      "current_status": "mischaracterized_as_gap",
+      "note": "Agent Memory deliberately separates trust, truth, evidence, certification, and authority."
+    },
+    {
+      "atlas_claim": "reference substrate is not a production memory service",
+      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
+      "current_evidence": [
+        "README.md",
+        "#274"
+      ],
+      "current_status": "still_valid_by_design",
+      "note": "Reference claims remain bounded while real external runtime/component evidence is tracked separately."
+    },
+    {
+      "atlas_claim": "no committed run outputs under reports/",
+      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
+      "current_evidence": [
+        ".github/workflows/",
+        "docs/programs/runtime-evidence/",
+        "docs/programs/atlas-research/report-inventory.lock.json"
+      ],
+      "current_status": "partially_valid_narrowed",
+      "note": "reports/ remains example-oriented, but reproducible exact-head CI evidence and durable locks now exist."
+    },
+    {
+      "atlas_claim": "no dependency manifest",
+      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
+      "current_evidence": [
+        "pyproject.toml",
+        "reference/requirements.txt"
+      ],
+      "current_status": "fixed"
+    },
+    {
+      "atlas_claim": "README/generated count drift",
+      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
+      "current_evidence": [
+        "README.md",
+        "scripts/"
+      ],
+      "current_status": "superseded_requires_fresh_measurement",
+      "note": "Historical counts are not carried forward as a current defect without exact recount."
+    }
+  ],
+  "atlas_snapshot": "90bfeed14764e268c82c925d4c39645c7480d015",
+  "authority_effect": "none",
+  "benchmarks": [
+    {
+      "agent_memory_owner": "#138",
+      "benchmark": "MemoryAgentBench",
+      "disposition": "correction_current_answer_preference_not_forgetting",
+      "pin": "455306dcabc3842526eb83cd4e225e5d486c5c5d",
+      "verification": "primary_source"
+    },
+    {
+      "agent_memory_owner": "#138",
+      "benchmark": "GoodAI LTM Benchmark",
+      "disposition": "post_score_reset_housekeeping_not_forgetting_evidence",
+      "pin": "188e7618413775f1ce783763d5ee0b5ccd4c31c9",
+      "verification": "primary_source"
+    },
+    {
+      "agent_memory_owner": "#138",
+      "benchmark": "PersistBench",
+      "disposition": "must_not_use_and_relevance_control_not_deletion",
+      "pin": "302ea2ff2cfce97e9458a9897a10b67a2c1d479f",
+      "verification": "primary_source"
+    },
+    {
+      "agent_memory_owner": "#138/#148/#282",
+      "benchmark": "ForgetEval",
+      "disposition": "control_plane_forgetting_fixture_shape_not_transitive_residue_proof",
+      "pin": "arXiv:2606.15903",
+      "verification": "primary_paper_and_repository"
+    }
+  ],
+  "comparators": [
+    {
+      "disposition": "consumed",
+      "distinct_value": "canonical-before-derived asynchronous currentness and retry",
+      "owners": [
+        "#308",
+        "#282"
+      ],
+      "pin": "132b46343e60ecf4057c427736c57b08f7615dfe",
+      "rank": 1,
+      "system": "Claude-Mem"
+    },
+    {
+      "disposition": "fixture_comparator",
+      "distinct_value": "rejected-value semantic re-entry adversarial fixtures",
+      "owners": [
+        "#147",
+        "#148"
+      ],
+      "pin": "df44e76c6c6a919977806feed9549bc6a892932d",
+      "rank": 2,
+      "system": "Verel"
+    },
+    {
+      "disposition": "bounded_future_research",
+      "distinct_value": "reliability degradation and independently authorized veto/influence",
+      "owners": [
+        "docs/16-source-trust-and-reputation.md",
+        "PAMA"
+      ],
+      "pin": "a113cf692a08bed85d7c6eb35d1086dbd9a7a1fd",
+      "rank": 3,
+      "system": "AgentRecall-X"
+    },
+    {
+      "disposition": "reference_comparator",
+      "distinct_value": "least-permissive principal/scope composition",
+      "owners": [
+        "docs/18-actor-scope-and-tenancy.md"
+      ],
+      "pin": "54e4d7d201b5c7ba3aed618ea343d9f4d3f40927",
+      "rank": 4,
+      "system": "Memory Engine"
+    },
+    {
+      "disposition": "existing_comparator",
+      "distinct_value": "bi-temporal graph representation and currentness",
+      "owners": [
+        "docs/05-memory-state-and-time.md"
+      ],
+      "pin": "425bf2481b51437e43455e09d241c5f46e3d95f3",
+      "rank": 5,
+      "system": "Graphiti"
+    },
+    {
+      "disposition": "consumed",
+      "distinct_value": "durable background progress/cursor success boundary",
+      "owners": [
+        "#308",
+        "#282"
+      ],
+      "pin": "b99e0f937e828504e0f93dbe35dfd6b1540e20b2",
+      "rank": 6,
+      "system": "Nanobot"
+    },
+    {
+      "disposition": "reference_only_agpl3",
+      "distinct_value": "human-editable canonical files with rebuildable derived state",
+      "owners": [
+        "#274",
+        "docs/SOURCE_RIGHTS_POLICY.md"
+      ],
+      "pin": "816accaa9befe8281668ba8819eaf74d11ce2385",
+      "rank": 7,
+      "system": "Basic Memory"
+    },
+    {
+      "disposition": "no_new_engine",
+      "distinct_value": "explicit conflict disposition alternatives",
+      "owners": [
+        "#12",
+        "docs/17-conflict-resolution-engine.md"
+      ],
+      "pin": "d1902419321352f0108c499bd8ed4ebd129fe138",
+      "rank": 8,
+      "system": "Memanto"
+    }
+  ],
+  "completion": {
+    "agent_memory_self_report_reconciled": true,
+    "all_seven_mechanisms_mapped": true,
+    "all_twenty_one_patterns_disposed": true,
+    "atlas_does_not_create_doctrine_authority": true,
+    "benchmark_findings_deduplicated": true,
+    "candidates_triaged_by_distinct_value": true,
+    "follow_ons_bounded_and_linked": true,
+    "freshness_handled": true,
+    "promoted_findings_primary_verified": true,
+    "rejected_findings_preserved": true,
+    "snapshot_reconstructable": true
+  },
+  "counts": {
+    "atlas_mechanisms": 7,
+    "design_patterns": 21,
+    "system_reports": 283,
+    "verified_claim_ledger_minimum": 8
+  },
+  "doctrine_disposition": "no_new_adr",
+  "mechanisms": [
+    {
+      "agent_memory_surfaces": [
+        "#147",
+        "#148",
+        "reference/agentmem_ref/readmission.py",
+        "fixtures/rejected-value-semantic-reentry.json"
+      ],
+      "atlas_label": "Rejected-value tombstone",
+      "coverage": "covered_semantics_differ",
+      "disposition": "fixture_hardening",
+      "mechanism_id": "rejected_value_tombstone",
+      "novel_gap": false,
+      "rationale": "Agent Memory enforces durable rejected-value readmission controls without requiring the Atlas-specific storage representation."
+    },
+    {
+      "agent_memory_surfaces": [
+        "docs/16-source-trust-and-reputation.md",
+        "docs/adr/ADR-009-source-trust-is-a-first-class-signal.md",
+        "#146"
+      ],
+      "atlas_label": "Explicit trust state",
+      "coverage": "covered_semantics_differ",
+      "disposition": "no_action",
+      "mechanism_id": "explicit_trust_state",
+      "novel_gap": false,
+      "rationale": "Agent Memory separates trust, evidence, truth, certification, and authority instead of requiring one discrete Atlas-style epistemic enum."
+    },
+    {
+      "agent_memory_surfaces": [
+        "docs/05-memory-state-and-time.md",
+        "reference/agentmem_ref/substrate.py",
+        "reference/agentmem_ref/graphiti_driver.py"
+      ],
+      "atlas_label": "Bi-temporal validity",
+      "coverage": "covered",
+      "disposition": "reference_only",
+      "mechanism_id": "bitemporal_validity",
+      "novel_gap": false,
+      "rationale": "Validity time and record/system time are already distinct in doctrine and reference/runtime evidence."
+    },
+    {
+      "agent_memory_surfaces": [
+        "docs/18-actor-scope-and-tenancy.md",
+        "reference/agentmem_ref/adapter.py",
+        "#293"
+      ],
+      "atlas_label": "Scope enforced in retrieval",
+      "coverage": "covered_broader_semantics",
+      "disposition": "no_action",
+      "mechanism_id": "scope_enforced_in_retrieval",
+      "novel_gap": false,
+      "rationale": "Agent Memory requires scope on read and extends the obligation to write, derivation, rebuild, and external-scope bridging."
+    },
+    {
+      "agent_memory_surfaces": [
+        "docs/30-memory-observability-and-audit-events.md",
+        "docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md",
+        "schemas/audit-event.schema.json"
+      ],
+      "atlas_label": "Append-only mutation audit",
+      "coverage": "covered",
+      "disposition": "no_action",
+      "mechanism_id": "append_only_mutation_audit",
+      "novel_gap": false,
+      "rationale": "Mutation evidence and audit-event semantics are already first-class and are not treated as truth or authority."
+    },
+    {
+      "agent_memory_surfaces": [
+        "docs/04-governance-and-pama.md",
+        "docs/33-pama-decision-table.md",
+        "docs/adr/ADR-004-pama-controls-mutation-authority.md"
+      ],
+      "atlas_label": "Human review surface",
+      "coverage": "partially_covered_semantics",
+      "disposition": "optional_product_surface",
+      "mechanism_id": "human_review_surface",
+      "novel_gap": false,
+      "rationale": "PAMA can require human review before durable consequence, but Agent Memory does not claim a canonical end-user review UI."
+    },
+    {
+      "agent_memory_surfaces": [
+        "#148",
+        "reference/agentmem_ref/forbidden_hits.py",
+        "fixtures/forbidden-hit-lifecycle-matrix.json",
+        "reference/tests/test_forbidden_hits.py"
+      ],
+      "atlas_label": "Negative retrieval assertion",
+      "coverage": "covered_broader_semantics",
+      "disposition": "fixture_hardening",
+      "mechanism_id": "negative_retrieval_assertion",
+      "novel_gap": false,
+      "rationale": "Agent Memory asserts must-not-surface and must-not-influence outcomes across lifecycle paths, a broader boundary than retrieval-only negatives."
+    }
+  ],
+  "patterns": [
+    {"agent_memory_surfaces":["docs/30-memory-observability-and-audit-events.md"],"atlas_label":"Append-only memory audit","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"append-only-memory-audit","rationale":"Existing audit/evidence surfaces already separate mutation telemetry from truth."},
+    {"agent_memory_surfaces":["docs/05-memory-state-and-time.md"],"atlas_label":"Bi-temporal fact validity","atlas_stance":"established","coverage":"covered","disposition":"reference_only","pattern_id":"bi-temporal-fact-validity","rationale":"Already represented; external implementations remain useful comparators."},
+    {"agent_memory_surfaces":["#274"],"atlas_label":"Cache-preserving injection","atlas_stance":"established","coverage":"optional_component_guidance","disposition":"reference_only","pattern_id":"cache-preserving-injection","rationale":"Useful deployment/cost guidance, not a core correctness primitive."},
+    {"agent_memory_surfaces":["docs/16-source-trust-and-reputation.md","#149"],"atlas_label":"Decay and reinforcement","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","pattern_id":"decay-and-reinforcement","rationale":"Age/use/popularity must not become truth or independent corroboration; implementation may vary."},
+    {"agent_memory_surfaces":["#146","docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md"],"atlas_label":"Evidence before belief","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"evidence-before-belief","rationale":"Source-neutral evidence and derivation lineage already own this boundary."},
+    {"agent_memory_surfaces":["docs/18-actor-scope-and-tenancy.md","#280"],"atlas_label":"Explicit write destination","atlas_stance":"established","coverage":"covered_broader_semantics","disposition":"reference_only","pattern_id":"explicit-write-destination","rationale":"Agent Memory requires explicit scope/ownership and deterministic routing for writes."},
+    {"agent_memory_surfaces":["#46","#274"],"atlas_label":"Gate the expensive path","atlas_stance":"established","coverage":"optional_component_guidance","disposition":"reference_only","pattern_id":"gate-the-expensive-path","rationale":"Cost gating is useful implementation guidance but does not create authority or correctness."},
+    {"agent_memory_surfaces":["docs/04-governance-and-pama.md","docs/adr/ADR-004-pama-controls-mutation-authority.md"],"atlas_label":"Governed write gateway","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"governed-write-gateway","rationale":"PAMA already governs consequential durable mutation."},
+    {"agent_memory_surfaces":["#230","#274","docs/26-governed-recall-planner.md"],"atlas_label":"Hybrid retrieval fusion","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","pattern_id":"hybrid-retrieval-fusion","rationale":"Hybrid retrieval may propose candidates; governed admission remains separate."},
+    {"agent_memory_surfaces":["#274","docs/adr/ADR-033-capabilities-are-independently-declared-and-deterministically-composed.md"],"atlas_label":"Pluggable memory provider","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"pluggable-memory-provider","rationale":"Component/capability contracts already make providers replaceable without semantic privilege."},
+    {"agent_memory_surfaces":["docs/04-governance-and-pama.md","#274"],"atlas_label":"Promotion between tiers","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","pattern_id":"promotion-between-tiers","rationale":"Promotion is governed consequence and capability-specific rather than an implicit tier heuristic."},
+    {"agent_memory_surfaces":["#282","#308"],"atlas_label":"Recoverable background work","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"recoverable-background-work","rationale":"Restart-safe currentness obligations and quiescence evidence now cover the reusable failure boundary."},
+    {"agent_memory_surfaces":["docs/18-actor-scope-and-tenancy.md","#293"],"atlas_label":"Scope as a first-class key","atlas_stance":"established","coverage":"covered_broader_semantics","disposition":"no_action","pattern_id":"scope-as-a-first-class-key","rationale":"Agent Memory treats scope as a governed boundary across more than retrieval keys."},
+    {"agent_memory_surfaces":["docs/adr/ADR-034-procedural-memory-is-not-execution-authority.md","#295"],"atlas_label":"Skills as procedural memory","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","pattern_id":"skills-as-procedural-memory","rationale":"Retained procedures, execution evidence, and action authority remain separate."},
+    {"agent_memory_surfaces":["docs/16-source-trust-and-reputation.md","#146"],"atlas_label":"Trust-state machine","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"no_action","pattern_id":"trust-state-machine","rationale":"Agent Memory uses multidimensional trust/evidence/authority semantics rather than one required state machine."},
+    {"agent_memory_surfaces":["#274","#308"],"atlas_label":"Zero-LLM capture","atlas_stance":"established","coverage":"optional_component_guidance","disposition":"reference_only","pattern_id":"zero-llm-capture","rationale":"Synchronous deterministic capture can be useful but is deployment-specific, not universal doctrine."},
+    {"agent_memory_surfaces":["#147","#148"],"atlas_label":"Rejected-value tombstone","atlas_stance":"advocacy","coverage":"fixture_hardening","disposition":"fixture_hardening","pattern_id":"rejected-value-tombstone","rationale":"The failure is real and already implemented; Atlas terminology/storage shape is not canonical."},
+    {"agent_memory_surfaces":["#12","docs/17-conflict-resolution-engine.md"],"atlas_label":"Resolve, don't just detect","atlas_stance":"advocacy","coverage":"covered","disposition":"no_action","pattern_id":"resolve-not-just-detect","rationale":"Agent Memory already owns explicit conflict disposition and governance."},
+    {"agent_memory_surfaces":["#149","docs/26-governed-recall-planner.md"],"atlas_label":"Source-diverse context","atlas_stance":"mixed","coverage":"covered_semantics_differ","disposition":"fixture_hardening","pattern_id":"source-diverse-context","rationale":"Diversity can reduce source crowding, but repeated/adjacent material still needs provenance and non-corroboration controls."},
+    {"agent_memory_surfaces":["#274","docs/26-governed-recall-planner.md"],"atlas_label":"Retrieval hysteresis","atlas_stance":"category_bound","coverage":"optional_component_guidance","disposition":"reference_only","pattern_id":"retrieval-hysteresis","rationale":"Activation history may help conversational systems but is not a universal memory correctness invariant."},
+    {"agent_memory_surfaces":["docs/04-governance-and-pama.md","docs/17-conflict-resolution-engine.md"],"atlas_label":"Memory as an editing surface","atlas_stance":"category_bound","coverage":"optional_product_guidance","disposition":"reference_only","pattern_id":"memory-as-an-editing-surface","rationale":"Human editing is valuable product ergonomics, but authoritative edits still require lifecycle, scope, provenance, and mutation governance."}
+  ],
+  "promotions": [
+    {
+      "doctrine_change": "none",
+      "evidence": [
+        "#308",
+        "#282",
+        "docs/programs/runtime-evidence/"
+      ],
+      "finding": "write-to-readable visibility and quiescence",
+      "source_pressure": [
+        "Claude-Mem",
+        "Nanobot"
+      ],
+      "status": "implemented"
+    }
+  ],
+  "rejections": [
+    {"claim":"Atlas mark count should be an Agent Memory maturity score","reason":"Atlas explicitly says marks are not a maturity score; Goodhart pressure is observable."},
+    {"claim":"All 283 reports require equal-depth manual review","reason":"The frozen #304 stopping rule prioritizes distinct failure/capability value; metadata inventory remains complete."},
+    {"claim":"Atlas explicit trust-state enum is a required Agent Memory core field","reason":"Agent Memory expresses the underlying trust/evidence/authority distinction with different, broader semantics."},
+    {"claim":"Memanto warrants a new conflict engine","reason":"Completed #12 already owns a richer conflict-resolution contract."},
+    {"claim":"Basic Memory should be a default runtime dependency","reason":"Pinned source is AGPL-3.0; architecture lessons do not imply adoption rights/posture."},
+    {"claim":"Every interesting Atlas system should become an adapter","reason":"Adapters are justified only by a distinct executable capability/failure question."},
+    {"claim":"Atlas pattern names justify new ADRs","reason":"Secondary-source naming is not doctrine authority; no representation-neutral contradiction survived verification."}
+  ],
+  "research_program": "#304",
+  "schema_version": "1.0.0",
+  "source_posture": "secondary_source_index_and_hypothesis_generator"
+}

--- a/docs/programs/atlas-research/corpus-synthesis.json
+++ b/docs/programs/atlas-research/corpus-synthesis.json
@@ -1,351 +1,91 @@
 {
-  "agent_memory_evidence_boundary": "f2fc966c403d7adf028c24240b85c6e4e576a25a",
-  "agent_memory_self_audit": [
-    {
-      "atlas_claim": "rejected-value tombstone gap",
-      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
-      "current_evidence": [
-        "#147",
-        "#148",
-        "reference/agentmem_ref/readmission.py"
-      ],
-      "current_status": "fixed"
-    },
-    {
-      "atlas_claim": "no discrete Atlas-style trust state",
-      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
-      "current_evidence": [
-        "docs/16-source-trust-and-reputation.md",
-        "#146"
-      ],
-      "current_status": "mischaracterized_as_gap",
-      "note": "Agent Memory deliberately separates trust, truth, evidence, certification, and authority."
-    },
-    {
-      "atlas_claim": "reference substrate is not a production memory service",
-      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
-      "current_evidence": [
-        "README.md",
-        "#274"
-      ],
-      "current_status": "still_valid_by_design",
-      "note": "Reference claims remain bounded while real external runtime/component evidence is tracked separately."
-    },
-    {
-      "atlas_claim": "no committed run outputs under reports/",
-      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
-      "current_evidence": [
-        ".github/workflows/",
-        "docs/programs/runtime-evidence/",
-        "docs/programs/atlas-research/report-inventory.lock.json"
-      ],
-      "current_status": "partially_valid_narrowed",
-      "note": "reports/ remains example-oriented, but reproducible exact-head CI evidence and durable locks now exist."
-    },
-    {
-      "atlas_claim": "no dependency manifest",
-      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
-      "current_evidence": [
-        "pyproject.toml",
-        "reference/requirements.txt"
-      ],
-      "current_status": "fixed"
-    },
-    {
-      "atlas_claim": "README/generated count drift",
-      "atlas_review_pin": "bba0aa4cab8e04d11f5380b215b3eea6998fe119",
-      "current_evidence": [
-        "README.md",
-        "scripts/"
-      ],
-      "current_status": "superseded_requires_fresh_measurement",
-      "note": "Historical counts are not carried forward as a current defect without exact recount."
-    }
-  ],
+  "schema_version": "1.0.0",
+  "research_program": "#304",
   "atlas_snapshot": "90bfeed14764e268c82c925d4c39645c7480d015",
-  "authority_effect": "none",
-  "benchmarks": [
-    {
-      "agent_memory_owner": "#138",
-      "benchmark": "MemoryAgentBench",
-      "disposition": "correction_current_answer_preference_not_forgetting",
-      "pin": "455306dcabc3842526eb83cd4e225e5d486c5c5d",
-      "verification": "primary_source"
-    },
-    {
-      "agent_memory_owner": "#138",
-      "benchmark": "GoodAI LTM Benchmark",
-      "disposition": "post_score_reset_housekeeping_not_forgetting_evidence",
-      "pin": "188e7618413775f1ce783763d5ee0b5ccd4c31c9",
-      "verification": "primary_source"
-    },
-    {
-      "agent_memory_owner": "#138",
-      "benchmark": "PersistBench",
-      "disposition": "must_not_use_and_relevance_control_not_deletion",
-      "pin": "302ea2ff2cfce97e9458a9897a10b67a2c1d479f",
-      "verification": "primary_source"
-    },
-    {
-      "agent_memory_owner": "#138/#148/#282",
-      "benchmark": "ForgetEval",
-      "disposition": "control_plane_forgetting_fixture_shape_not_transitive_residue_proof",
-      "pin": "arXiv:2606.15903",
-      "verification": "primary_paper_and_repository"
-    }
-  ],
-  "comparators": [
-    {
-      "disposition": "consumed",
-      "distinct_value": "canonical-before-derived asynchronous currentness and retry",
-      "owners": [
-        "#308",
-        "#282"
-      ],
-      "pin": "132b46343e60ecf4057c427736c57b08f7615dfe",
-      "rank": 1,
-      "system": "Claude-Mem"
-    },
-    {
-      "disposition": "fixture_comparator",
-      "distinct_value": "rejected-value semantic re-entry adversarial fixtures",
-      "owners": [
-        "#147",
-        "#148"
-      ],
-      "pin": "df44e76c6c6a919977806feed9549bc6a892932d",
-      "rank": 2,
-      "system": "Verel"
-    },
-    {
-      "disposition": "bounded_future_research",
-      "distinct_value": "reliability degradation and independently authorized veto/influence",
-      "owners": [
-        "docs/16-source-trust-and-reputation.md",
-        "PAMA"
-      ],
-      "pin": "a113cf692a08bed85d7c6eb35d1086dbd9a7a1fd",
-      "rank": 3,
-      "system": "AgentRecall-X"
-    },
-    {
-      "disposition": "reference_comparator",
-      "distinct_value": "least-permissive principal/scope composition",
-      "owners": [
-        "docs/18-actor-scope-and-tenancy.md"
-      ],
-      "pin": "54e4d7d201b5c7ba3aed618ea343d9f4d3f40927",
-      "rank": 4,
-      "system": "Memory Engine"
-    },
-    {
-      "disposition": "existing_comparator",
-      "distinct_value": "bi-temporal graph representation and currentness",
-      "owners": [
-        "docs/05-memory-state-and-time.md"
-      ],
-      "pin": "425bf2481b51437e43455e09d241c5f46e3d95f3",
-      "rank": 5,
-      "system": "Graphiti"
-    },
-    {
-      "disposition": "consumed",
-      "distinct_value": "durable background progress/cursor success boundary",
-      "owners": [
-        "#308",
-        "#282"
-      ],
-      "pin": "b99e0f937e828504e0f93dbe35dfd6b1540e20b2",
-      "rank": 6,
-      "system": "Nanobot"
-    },
-    {
-      "disposition": "reference_only_agpl3",
-      "distinct_value": "human-editable canonical files with rebuildable derived state",
-      "owners": [
-        "#274",
-        "docs/SOURCE_RIGHTS_POLICY.md"
-      ],
-      "pin": "816accaa9befe8281668ba8819eaf74d11ce2385",
-      "rank": 7,
-      "system": "Basic Memory"
-    },
-    {
-      "disposition": "no_new_engine",
-      "distinct_value": "explicit conflict disposition alternatives",
-      "owners": [
-        "#12",
-        "docs/17-conflict-resolution-engine.md"
-      ],
-      "pin": "d1902419321352f0108c499bd8ed4ebd129fe138",
-      "rank": 8,
-      "system": "Memanto"
-    }
-  ],
-  "completion": {
-    "agent_memory_self_report_reconciled": true,
-    "all_seven_mechanisms_mapped": true,
-    "all_twenty_one_patterns_disposed": true,
-    "atlas_does_not_create_doctrine_authority": true,
-    "benchmark_findings_deduplicated": true,
-    "candidates_triaged_by_distinct_value": true,
-    "follow_ons_bounded_and_linked": true,
-    "freshness_handled": true,
-    "promoted_findings_primary_verified": true,
-    "rejected_findings_preserved": true,
-    "snapshot_reconstructable": true
-  },
-  "counts": {
-    "atlas_mechanisms": 7,
-    "design_patterns": 21,
-    "system_reports": 283,
-    "verified_claim_ledger_minimum": 8
-  },
-  "doctrine_disposition": "no_new_adr",
+  "agent_memory_evidence_boundary": "f2fc966c403d7adf028c24240b85c6e4e576a25a",
+  "source_posture": "secondary_source_index_and_hypothesis_generator",
+  "counts": {"system_reports": 283, "design_patterns": 21, "atlas_mechanisms": 7, "verified_claim_ledger_minimum": 8},
   "mechanisms": [
-    {
-      "agent_memory_surfaces": [
-        "#147",
-        "#148",
-        "reference/agentmem_ref/readmission.py",
-        "fixtures/rejected-value-semantic-reentry.json"
-      ],
-      "atlas_label": "Rejected-value tombstone",
-      "coverage": "covered_semantics_differ",
-      "disposition": "fixture_hardening",
-      "mechanism_id": "rejected_value_tombstone",
-      "novel_gap": false,
-      "rationale": "Agent Memory enforces durable rejected-value readmission controls without requiring the Atlas-specific storage representation."
-    },
-    {
-      "agent_memory_surfaces": [
-        "docs/16-source-trust-and-reputation.md",
-        "docs/adr/ADR-009-source-trust-is-a-first-class-signal.md",
-        "#146"
-      ],
-      "atlas_label": "Explicit trust state",
-      "coverage": "covered_semantics_differ",
-      "disposition": "no_action",
-      "mechanism_id": "explicit_trust_state",
-      "novel_gap": false,
-      "rationale": "Agent Memory separates trust, evidence, truth, certification, and authority instead of requiring one discrete Atlas-style epistemic enum."
-    },
-    {
-      "agent_memory_surfaces": [
-        "docs/05-memory-state-and-time.md",
-        "reference/agentmem_ref/substrate.py",
-        "reference/agentmem_ref/graphiti_driver.py"
-      ],
-      "atlas_label": "Bi-temporal validity",
-      "coverage": "covered",
-      "disposition": "reference_only",
-      "mechanism_id": "bitemporal_validity",
-      "novel_gap": false,
-      "rationale": "Validity time and record/system time are already distinct in doctrine and reference/runtime evidence."
-    },
-    {
-      "agent_memory_surfaces": [
-        "docs/18-actor-scope-and-tenancy.md",
-        "reference/agentmem_ref/adapter.py",
-        "#293"
-      ],
-      "atlas_label": "Scope enforced in retrieval",
-      "coverage": "covered_broader_semantics",
-      "disposition": "no_action",
-      "mechanism_id": "scope_enforced_in_retrieval",
-      "novel_gap": false,
-      "rationale": "Agent Memory requires scope on read and extends the obligation to write, derivation, rebuild, and external-scope bridging."
-    },
-    {
-      "agent_memory_surfaces": [
-        "docs/30-memory-observability-and-audit-events.md",
-        "docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md",
-        "schemas/audit-event.schema.json"
-      ],
-      "atlas_label": "Append-only mutation audit",
-      "coverage": "covered",
-      "disposition": "no_action",
-      "mechanism_id": "append_only_mutation_audit",
-      "novel_gap": false,
-      "rationale": "Mutation evidence and audit-event semantics are already first-class and are not treated as truth or authority."
-    },
-    {
-      "agent_memory_surfaces": [
-        "docs/04-governance-and-pama.md",
-        "docs/33-pama-decision-table.md",
-        "docs/adr/ADR-004-pama-controls-mutation-authority.md"
-      ],
-      "atlas_label": "Human review surface",
-      "coverage": "partially_covered_semantics",
-      "disposition": "optional_product_surface",
-      "mechanism_id": "human_review_surface",
-      "novel_gap": false,
-      "rationale": "PAMA can require human review before durable consequence, but Agent Memory does not claim a canonical end-user review UI."
-    },
-    {
-      "agent_memory_surfaces": [
-        "#148",
-        "reference/agentmem_ref/forbidden_hits.py",
-        "fixtures/forbidden-hit-lifecycle-matrix.json",
-        "reference/tests/test_forbidden_hits.py"
-      ],
-      "atlas_label": "Negative retrieval assertion",
-      "coverage": "covered_broader_semantics",
-      "disposition": "fixture_hardening",
-      "mechanism_id": "negative_retrieval_assertion",
-      "novel_gap": false,
-      "rationale": "Agent Memory asserts must-not-surface and must-not-influence outcomes across lifecycle paths, a broader boundary than retrieval-only negatives."
-    }
+    {"mechanism_id":"rejected_value_tombstone","atlas_label":"Rejected-value tombstone","coverage":"covered_semantics_differ","agent_memory_surfaces":["#147","#148","reference/agentmem_ref/readmission.py","fixtures/rejected-value-semantic-reentry.json"],"disposition":"fixture_hardening","rationale":"Durable semantic readmission controls preserve the failure invariant without requiring one storage shape.","novel_gap":false},
+    {"mechanism_id":"explicit_trust_state","atlas_label":"Explicit trust state","coverage":"covered_semantics_differ","agent_memory_surfaces":["docs/16-source-trust-and-reputation.md","docs/adr/ADR-009-source-trust-is-a-first-class-signal.md","#146"],"disposition":"no_action","rationale":"Trust, evidence, truth/certification, and authority remain separate instead of one required enum.","novel_gap":false},
+    {"mechanism_id":"bitemporal_validity","atlas_label":"Bi-temporal validity","coverage":"covered","agent_memory_surfaces":["docs/05-memory-state-and-time.md","reference/agentmem_ref/substrate.py","reference/agentmem_ref/graphiti_driver.py"],"disposition":"reference_only","rationale":"Validity time and record/system time are already distinct.","novel_gap":false},
+    {"mechanism_id":"scope_enforced_in_retrieval","atlas_label":"Scope enforced in retrieval","coverage":"covered_broader_semantics","agent_memory_surfaces":["docs/18-actor-scope-and-tenancy.md","reference/agentmem_ref/adapter.py","#293"],"disposition":"no_action","rationale":"Agent Memory extends scope obligations beyond reads to write, derivation, rebuild, and external bridges.","novel_gap":false},
+    {"mechanism_id":"append_only_mutation_audit","atlas_label":"Append-only mutation audit","coverage":"covered","agent_memory_surfaces":["docs/30-memory-observability-and-audit-events.md","docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md","schemas/memory-audit-event.schema.json"],"disposition":"no_action","rationale":"Mutation/audit evidence is first-class and cannot become truth or authority.","novel_gap":false},
+    {"mechanism_id":"human_review_surface","atlas_label":"Human review surface","coverage":"partially_covered_semantics","agent_memory_surfaces":["docs/04-governance-and-pama.md","docs/33-pama-decision-table.md","docs/adr/ADR-004-pama-controls-mutation-authority.md"],"disposition":"optional_product_surface","rationale":"PAMA can require human review before consequence; no canonical end-user review UI is claimed.","novel_gap":false},
+    {"mechanism_id":"negative_retrieval_assertion","atlas_label":"Negative retrieval assertion","coverage":"covered_broader_semantics","agent_memory_surfaces":["#148","reference/agentmem_ref/forbidden_hits.py","fixtures/forbidden-hit-lifecycle-matrix.json","reference/tests/test_forbidden_hits.py"],"disposition":"fixture_hardening","rationale":"Must-not-surface and must-not-influence evidence covers more than retrieval lists.","novel_gap":false}
   ],
   "patterns": [
-    {"agent_memory_surfaces":["docs/30-memory-observability-and-audit-events.md"],"atlas_label":"Append-only memory audit","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"append-only-memory-audit","rationale":"Existing audit/evidence surfaces already separate mutation telemetry from truth."},
-    {"agent_memory_surfaces":["docs/05-memory-state-and-time.md"],"atlas_label":"Bi-temporal fact validity","atlas_stance":"established","coverage":"covered","disposition":"reference_only","pattern_id":"bi-temporal-fact-validity","rationale":"Already represented; external implementations remain useful comparators."},
-    {"agent_memory_surfaces":["#274"],"atlas_label":"Cache-preserving injection","atlas_stance":"established","coverage":"optional_component_guidance","disposition":"reference_only","pattern_id":"cache-preserving-injection","rationale":"Useful deployment/cost guidance, not a core correctness primitive."},
-    {"agent_memory_surfaces":["docs/16-source-trust-and-reputation.md","#149"],"atlas_label":"Decay and reinforcement","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","pattern_id":"decay-and-reinforcement","rationale":"Age/use/popularity must not become truth or independent corroboration; implementation may vary."},
-    {"agent_memory_surfaces":["#146","docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md"],"atlas_label":"Evidence before belief","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"evidence-before-belief","rationale":"Source-neutral evidence and derivation lineage already own this boundary."},
-    {"agent_memory_surfaces":["docs/18-actor-scope-and-tenancy.md","#280"],"atlas_label":"Explicit write destination","atlas_stance":"established","coverage":"covered_broader_semantics","disposition":"reference_only","pattern_id":"explicit-write-destination","rationale":"Agent Memory requires explicit scope/ownership and deterministic routing for writes."},
-    {"agent_memory_surfaces":["#46","#274"],"atlas_label":"Gate the expensive path","atlas_stance":"established","coverage":"optional_component_guidance","disposition":"reference_only","pattern_id":"gate-the-expensive-path","rationale":"Cost gating is useful implementation guidance but does not create authority or correctness."},
-    {"agent_memory_surfaces":["docs/04-governance-and-pama.md","docs/adr/ADR-004-pama-controls-mutation-authority.md"],"atlas_label":"Governed write gateway","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"governed-write-gateway","rationale":"PAMA already governs consequential durable mutation."},
-    {"agent_memory_surfaces":["#230","#274","docs/26-governed-recall-planner.md"],"atlas_label":"Hybrid retrieval fusion","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","pattern_id":"hybrid-retrieval-fusion","rationale":"Hybrid retrieval may propose candidates; governed admission remains separate."},
-    {"agent_memory_surfaces":["#274","docs/adr/ADR-033-capabilities-are-independently-declared-and-deterministically-composed.md"],"atlas_label":"Pluggable memory provider","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"pluggable-memory-provider","rationale":"Component/capability contracts already make providers replaceable without semantic privilege."},
-    {"agent_memory_surfaces":["docs/04-governance-and-pama.md","#274"],"atlas_label":"Promotion between tiers","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","pattern_id":"promotion-between-tiers","rationale":"Promotion is governed consequence and capability-specific rather than an implicit tier heuristic."},
-    {"agent_memory_surfaces":["#282","#308"],"atlas_label":"Recoverable background work","atlas_stance":"established","coverage":"covered","disposition":"no_action","pattern_id":"recoverable-background-work","rationale":"Restart-safe currentness obligations and quiescence evidence now cover the reusable failure boundary."},
-    {"agent_memory_surfaces":["docs/18-actor-scope-and-tenancy.md","#293"],"atlas_label":"Scope as a first-class key","atlas_stance":"established","coverage":"covered_broader_semantics","disposition":"no_action","pattern_id":"scope-as-a-first-class-key","rationale":"Agent Memory treats scope as a governed boundary across more than retrieval keys."},
-    {"agent_memory_surfaces":["docs/adr/ADR-034-procedural-memory-is-not-execution-authority.md","#295"],"atlas_label":"Skills as procedural memory","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","pattern_id":"skills-as-procedural-memory","rationale":"Retained procedures, execution evidence, and action authority remain separate."},
-    {"agent_memory_surfaces":["docs/16-source-trust-and-reputation.md","#146"],"atlas_label":"Trust-state machine","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"no_action","pattern_id":"trust-state-machine","rationale":"Agent Memory uses multidimensional trust/evidence/authority semantics rather than one required state machine."},
-    {"agent_memory_surfaces":["#274","#308"],"atlas_label":"Zero-LLM capture","atlas_stance":"established","coverage":"optional_component_guidance","disposition":"reference_only","pattern_id":"zero-llm-capture","rationale":"Synchronous deterministic capture can be useful but is deployment-specific, not universal doctrine."},
-    {"agent_memory_surfaces":["#147","#148"],"atlas_label":"Rejected-value tombstone","atlas_stance":"advocacy","coverage":"fixture_hardening","disposition":"fixture_hardening","pattern_id":"rejected-value-tombstone","rationale":"The failure is real and already implemented; Atlas terminology/storage shape is not canonical."},
-    {"agent_memory_surfaces":["#12","docs/17-conflict-resolution-engine.md"],"atlas_label":"Resolve, don't just detect","atlas_stance":"advocacy","coverage":"covered","disposition":"no_action","pattern_id":"resolve-not-just-detect","rationale":"Agent Memory already owns explicit conflict disposition and governance."},
-    {"agent_memory_surfaces":["#149","docs/26-governed-recall-planner.md"],"atlas_label":"Source-diverse context","atlas_stance":"mixed","coverage":"covered_semantics_differ","disposition":"fixture_hardening","pattern_id":"source-diverse-context","rationale":"Diversity can reduce source crowding, but repeated/adjacent material still needs provenance and non-corroboration controls."},
-    {"agent_memory_surfaces":["#274","docs/26-governed-recall-planner.md"],"atlas_label":"Retrieval hysteresis","atlas_stance":"category_bound","coverage":"optional_component_guidance","disposition":"reference_only","pattern_id":"retrieval-hysteresis","rationale":"Activation history may help conversational systems but is not a universal memory correctness invariant."},
-    {"agent_memory_surfaces":["docs/04-governance-and-pama.md","docs/17-conflict-resolution-engine.md"],"atlas_label":"Memory as an editing surface","atlas_stance":"category_bound","coverage":"optional_product_guidance","disposition":"reference_only","pattern_id":"memory-as-an-editing-surface","rationale":"Human editing is valuable product ergonomics, but authoritative edits still require lifecycle, scope, provenance, and mutation governance."}
+    {"pattern_id":"append-only-memory-audit","atlas_label":"Append-only memory audit","atlas_stance":"established","coverage":"covered","disposition":"no_action","agent_memory_surfaces":["docs/30-memory-observability-and-audit-events.md"],"rationale":"Existing audit/evidence boundary."},
+    {"pattern_id":"bi-temporal-fact-validity","atlas_label":"Bi-temporal fact validity","atlas_stance":"established","coverage":"covered","disposition":"reference_only","agent_memory_surfaces":["docs/05-memory-state-and-time.md"],"rationale":"Existing temporal boundary."},
+    {"pattern_id":"cache-preserving-injection","atlas_label":"Cache-preserving injection","atlas_stance":"established","coverage":"optional_component_guidance","disposition":"reference_only","agent_memory_surfaces":["#274"],"rationale":"Deployment/cost guidance, not a core invariant."},
+    {"pattern_id":"decay-and-reinforcement","atlas_label":"Decay and reinforcement","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","agent_memory_surfaces":["docs/16-source-trust-and-reputation.md","#149"],"rationale":"Age/use/popularity cannot become truth or corroboration."},
+    {"pattern_id":"evidence-before-belief","atlas_label":"Evidence before belief","atlas_stance":"established","coverage":"covered","disposition":"no_action","agent_memory_surfaces":["#146","docs/adr/ADR-021-portable-memory-governance-evidence-boundary.md"],"rationale":"Existing evidence/derivation doctrine."},
+    {"pattern_id":"explicit-write-destination","atlas_label":"Explicit write destination","atlas_stance":"established","coverage":"covered_broader_semantics","disposition":"reference_only","agent_memory_surfaces":["docs/18-actor-scope-and-tenancy.md","#280"],"rationale":"Explicit scope/ownership and deterministic routing already apply."},
+    {"pattern_id":"gate-the-expensive-path","atlas_label":"Gate the expensive path","atlas_stance":"established","coverage":"optional_component_guidance","disposition":"reference_only","agent_memory_surfaces":["#46","#274"],"rationale":"Useful cost guidance without authority effect."},
+    {"pattern_id":"governed-write-gateway","atlas_label":"Governed write gateway","atlas_stance":"established","coverage":"covered","disposition":"no_action","agent_memory_surfaces":["docs/04-governance-and-pama.md","docs/adr/ADR-004-pama-controls-mutation-authority.md"],"rationale":"PAMA owns consequential mutation."},
+    {"pattern_id":"hybrid-retrieval-fusion","atlas_label":"Hybrid retrieval fusion","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","agent_memory_surfaces":["#230","#274","docs/26-governed-recall-planner.md"],"rationale":"Retrieval proposes candidates; governed admission remains separate."},
+    {"pattern_id":"pluggable-memory-provider","atlas_label":"Pluggable memory provider","atlas_stance":"established","coverage":"covered","disposition":"no_action","agent_memory_surfaces":["#274","docs/adr/ADR-033-capabilities-are-independently-declared-and-deterministically-composed.md"],"rationale":"Providers are replaceable without semantic privilege."},
+    {"pattern_id":"promotion-between-tiers","atlas_label":"Promotion between tiers","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","agent_memory_surfaces":["docs/04-governance-and-pama.md","#274"],"rationale":"Promotion is governed consequence, not an implicit heuristic."},
+    {"pattern_id":"recoverable-background-work","atlas_label":"Recoverable background work","atlas_stance":"established","coverage":"covered","disposition":"no_action","agent_memory_surfaces":["#282","#308"],"rationale":"Restart-safe obligations and quiescence evidence own the reusable boundary."},
+    {"pattern_id":"scope-as-a-first-class-key","atlas_label":"Scope as a first-class key","atlas_stance":"established","coverage":"covered_broader_semantics","disposition":"no_action","agent_memory_surfaces":["docs/18-actor-scope-and-tenancy.md","#293"],"rationale":"Scope is a governed boundary beyond retrieval keys."},
+    {"pattern_id":"skills-as-procedural-memory","atlas_label":"Skills as procedural memory","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"reference_only","agent_memory_surfaces":["docs/adr/ADR-034-procedural-memory-is-not-execution-authority.md","#295"],"rationale":"Procedure retention, execution evidence, and action authority stay separate."},
+    {"pattern_id":"trust-state-machine","atlas_label":"Trust-state machine","atlas_stance":"established","coverage":"covered_semantics_differ","disposition":"no_action","agent_memory_surfaces":["docs/16-source-trust-and-reputation.md","#146"],"rationale":"Broader multidimensional trust/evidence/authority semantics already exist."},
+    {"pattern_id":"zero-llm-capture","atlas_label":"Zero-LLM capture","atlas_stance":"established","coverage":"optional_component_guidance","disposition":"reference_only","agent_memory_surfaces":["#274","#308"],"rationale":"Useful deployment shape, not universal doctrine."},
+    {"pattern_id":"rejected-value-tombstone","atlas_label":"Rejected-value tombstone","atlas_stance":"advocacy","coverage":"fixture_hardening","disposition":"fixture_hardening","agent_memory_surfaces":["#147","#148"],"rationale":"Failure is covered; Atlas storage terminology is not canonical."},
+    {"pattern_id":"resolve-not-just-detect","atlas_label":"Resolve, don't just detect","atlas_stance":"advocacy","coverage":"covered","disposition":"no_action","agent_memory_surfaces":["#12","docs/17-conflict-resolution-engine.md"],"rationale":"Existing explicit conflict disposition is richer."},
+    {"pattern_id":"source-diverse-context","atlas_label":"Source-diverse context","atlas_stance":"mixed","coverage":"covered_semantics_differ","disposition":"fixture_hardening","agent_memory_surfaces":["#149","docs/26-governed-recall-planner.md"],"rationale":"Diversity pressure complements provenance/non-corroboration controls."},
+    {"pattern_id":"retrieval-hysteresis","atlas_label":"Retrieval hysteresis","atlas_stance":"category_bound","coverage":"optional_component_guidance","disposition":"reference_only","agent_memory_surfaces":["#274","docs/26-governed-recall-planner.md"],"rationale":"Conversation activation state is useful in some systems, not universal correctness doctrine."},
+    {"pattern_id":"memory-as-an-editing-surface","atlas_label":"Memory as an editing surface","atlas_stance":"category_bound","coverage":"optional_product_guidance","disposition":"reference_only","agent_memory_surfaces":["docs/04-governance-and-pama.md","docs/17-conflict-resolution-engine.md"],"rationale":"Editing UX remains subject to lifecycle, scope, provenance, and mutation governance."}
+  ],
+  "benchmarks": [
+    {"benchmark":"MemoryAgentBench","pin":"455306dcabc3842526eb83cd4e225e5d486c5c5d","verification":"primary_source","disposition":"correction_current_answer_preference_not_forgetting","agent_memory_owner":"#138"},
+    {"benchmark":"GoodAI LTM Benchmark","pin":"188e7618413775f1ce783763d5ee0b5ccd4c31c9","verification":"primary_source","disposition":"post_score_reset_housekeeping_not_forgetting_evidence","agent_memory_owner":"#138"},
+    {"benchmark":"PersistBench","pin":"302ea2ff2cfce97e9458a9897a10b67a2c1d479f","verification":"primary_source","disposition":"must_not_use_and_relevance_control_not_deletion","agent_memory_owner":"#138"},
+    {"benchmark":"ForgetEval","pin":"arXiv:2606.15903","verification":"primary_paper_and_repository","disposition":"control_plane_forgetting_fixture_shape_not_transitive_residue_proof","agent_memory_owner":"#138/#148/#282"}
+  ],
+  "comparators": [
+    {"rank":1,"system":"Claude-Mem","pin":"132b46343e60ecf4057c427736c57b08f7615dfe","distinct_value":"canonical-before-derived asynchronous currentness and retry","disposition":"consumed","owners":["#308","#282"]},
+    {"rank":2,"system":"Verel","pin":"df44e76c6c6a919977806feed9549bc6a892932d","distinct_value":"rejected-value semantic re-entry adversarial fixtures","disposition":"fixture_comparator","owners":["#147","#148"]},
+    {"rank":3,"system":"AgentRecall-X","pin":"a113cf692a08bed85d7c6eb35d1086dbd9a7a1fd","distinct_value":"reliability degradation and independently authorized veto/influence","disposition":"bounded_future_research","owners":["docs/16-source-trust-and-reputation.md","PAMA"]},
+    {"rank":4,"system":"Memory Engine","pin":"54e4d7d201b5c7ba3aed618ea343d9f4d3f40927","distinct_value":"least-permissive principal/scope composition","disposition":"reference_comparator","owners":["docs/18-actor-scope-and-tenancy.md"]},
+    {"rank":5,"system":"Graphiti","pin":"425bf2481b51437e43455e09d241c5f46e3d95f3","distinct_value":"bi-temporal graph representation and currentness","disposition":"existing_comparator","owners":["docs/05-memory-state-and-time.md"]},
+    {"rank":6,"system":"Nanobot","pin":"b99e0f937e828504e0f93dbe35dfd6b1540e20b2","distinct_value":"durable background progress/cursor success boundary","disposition":"consumed","owners":["#308","#282"]},
+    {"rank":7,"system":"Basic Memory","pin":"816accaa9befe8281668ba8819eaf74d11ce2385","distinct_value":"human-editable canonical files with rebuildable derived state","disposition":"reference_only_agpl3","owners":["#274","docs/SOURCE_RIGHTS_POLICY.md"]},
+    {"rank":8,"system":"Memanto","pin":"d1902419321352f0108c499bd8ed4ebd129fe138","distinct_value":"explicit conflict disposition alternatives","disposition":"no_new_engine","owners":["#12","docs/17-conflict-resolution-engine.md"]}
+  ],
+  "agent_memory_self_audit": [
+    {"atlas_claim":"rejected-value tombstone gap","atlas_review_pin":"bba0aa4cab8e04d11f5380b215b3eea6998fe119","current_status":"fixed","current_evidence":["#147","#148","reference/agentmem_ref/readmission.py"]},
+    {"atlas_claim":"no discrete Atlas-style trust state","atlas_review_pin":"bba0aa4cab8e04d11f5380b215b3eea6998fe119","current_status":"mischaracterized_as_gap","current_evidence":["docs/16-source-trust-and-reputation.md","#146"],"note":"Agent Memory separates trust, truth, evidence, certification, and authority."},
+    {"atlas_claim":"reference substrate is not a production memory service","atlas_review_pin":"bba0aa4cab8e04d11f5380b215b3eea6998fe119","current_status":"still_valid_by_design","current_evidence":["README.md","#274"]},
+    {"atlas_claim":"no committed run outputs under reports/","atlas_review_pin":"bba0aa4cab8e04d11f5380b215b3eea6998fe119","current_status":"partially_valid_narrowed","current_evidence":[".github/workflows/","docs/programs/runtime-evidence/","docs/programs/atlas-research/report-inventory.lock.json"]},
+    {"atlas_claim":"no dependency manifest","atlas_review_pin":"bba0aa4cab8e04d11f5380b215b3eea6998fe119","current_status":"fixed","current_evidence":["pyproject.toml","reference/requirements.txt"]},
+    {"atlas_claim":"README/generated count drift","atlas_review_pin":"bba0aa4cab8e04d11f5380b215b3eea6998fe119","current_status":"superseded_requires_fresh_measurement","current_evidence":["README.md","scripts/"]}
   ],
   "promotions": [
-    {
-      "doctrine_change": "none",
-      "evidence": [
-        "#308",
-        "#282",
-        "docs/programs/runtime-evidence/"
-      ],
-      "finding": "write-to-readable visibility and quiescence",
-      "source_pressure": [
-        "Claude-Mem",
-        "Nanobot"
-      ],
-      "status": "implemented"
-    }
+    {"finding":"write-to-readable visibility and quiescence","status":"implemented","evidence":["#308","#282","docs/programs/runtime-evidence/"],"source_pressure":["Claude-Mem","Nanobot"],"doctrine_change":"none"}
   ],
   "rejections": [
-    {"claim":"Atlas mark count should be an Agent Memory maturity score","reason":"Atlas explicitly says marks are not a maturity score; Goodhart pressure is observable."},
-    {"claim":"All 283 reports require equal-depth manual review","reason":"The frozen #304 stopping rule prioritizes distinct failure/capability value; metadata inventory remains complete."},
-    {"claim":"Atlas explicit trust-state enum is a required Agent Memory core field","reason":"Agent Memory expresses the underlying trust/evidence/authority distinction with different, broader semantics."},
+    {"claim":"Atlas mark count should be an Agent Memory maturity score","reason":"Atlas says marks are not maturity; Goodhart pressure is observable."},
+    {"claim":"All 283 reports require equal-depth manual review","reason":"The frozen stopping rule prioritizes distinct failure/capability value while inventory coverage remains complete."},
+    {"claim":"Atlas explicit trust-state enum is a required Agent Memory core field","reason":"Agent Memory expresses the underlying distinction with broader semantics."},
     {"claim":"Memanto warrants a new conflict engine","reason":"Completed #12 already owns a richer conflict-resolution contract."},
-    {"claim":"Basic Memory should be a default runtime dependency","reason":"Pinned source is AGPL-3.0; architecture lessons do not imply adoption rights/posture."},
-    {"claim":"Every interesting Atlas system should become an adapter","reason":"Adapters are justified only by a distinct executable capability/failure question."},
-    {"claim":"Atlas pattern names justify new ADRs","reason":"Secondary-source naming is not doctrine authority; no representation-neutral contradiction survived verification."}
+    {"claim":"Basic Memory should be a default runtime dependency","reason":"Pinned source is AGPL-3.0; architecture value does not imply adoption posture."},
+    {"claim":"Every interesting Atlas system should become an adapter","reason":"Adapters require a distinct executable capability/failure question."},
+    {"claim":"Atlas pattern names justify new ADRs","reason":"Secondary-source naming is not doctrine authority."}
   ],
-  "research_program": "#304",
-  "schema_version": "1.0.0",
-  "source_posture": "secondary_source_index_and_hypothesis_generator"
+  "doctrine_disposition": "no_new_adr",
+  "completion": {
+    "snapshot_reconstructable": true,
+    "freshness_handled": true,
+    "all_seven_mechanisms_mapped": true,
+    "all_twenty_one_patterns_disposed": true,
+    "agent_memory_self_report_reconciled": true,
+    "candidates_triaged_by_distinct_value": true,
+    "benchmark_findings_deduplicated": true,
+    "promoted_findings_primary_verified": true,
+    "rejected_findings_preserved": true,
+    "follow_ons_bounded_and_linked": true,
+    "atlas_does_not_create_doctrine_authority": true
+  },
+  "authority_effect": "none"
 }

--- a/docs/programs/atlas-research/corpus-synthesis.md
+++ b/docs/programs/atlas-research/corpus-synthesis.md
@@ -1,0 +1,122 @@
+# Agent Memory Atlas corpus synthesis
+
+Issue: #304
+
+Evidence boundary:
+
+```text
+Atlas:        neoneye/agent-memory-atlas@90bfeed14764e268c82c925d4c39645c7480d015
+Agent Memory: f2fc966c403d7adf028c24240b85c6e4e576a25a
+```
+
+This document closes the bounded research program defined by #304. It does not claim equal-depth manual review of all 283 pinned reports. The complete corpus is covered at the reproducible inventory layer from #306/#322; deeper review was selected by distinct correctness, governance, architecture, benchmark, and component value. Primary-source verification was required before promotion.
+
+The machine-readable controlling record is `corpus-synthesis.json`. CI requires its exact seven-mechanism and twenty-one-pattern sets.
+
+## Snapshot result
+
+The pinned Atlas source contains 283 system reports, 21 design patterns, and 7 rubric mechanisms. These are snapshot-scoped corpus counts, not ecosystem-prevalence statistics, product scores, or Agent Memory maturity targets.
+
+Atlas remains a secondary-source index and hypothesis generator. Its code-reading marks do not establish runtime conformance, production fitness, component qualification, or authority.
+
+## Seven-mechanism crosswalk
+
+| Atlas mechanism | Agent Memory disposition |
+| --- | --- |
+| Rejected-value tombstone | Covered under different semantics by #147/#148 and semantic readmission evidence. |
+| Explicit trust state | Covered under different semantics by multidimensional trust, evidence, truth/certification, and authority boundaries. |
+| Bi-temporal validity | Covered by temporal doctrine and reference/runtime evidence. |
+| Scope enforced in retrieval | Covered more broadly across read, write, derivation, rebuild, and external-scope bridging. |
+| Append-only mutation audit | Covered by audit-event and portable evidence surfaces. |
+| Human review surface | PAMA supports required review semantics; no canonical end-user review UI is claimed. |
+| Negative retrieval assertion | Covered more broadly by must-not-surface and must-not-influence lifecycle evidence. |
+
+No mechanism required new core doctrine on this pass.
+
+## Pattern disposition
+
+All 21 patterns from the pinned Atlas index have explicit dispositions in `corpus-synthesis.json`.
+
+The resulting groups are:
+
+- already covered by existing Agent Memory doctrine/evidence;
+- covered under different or broader semantics;
+- useful for adversarial fixture hardening;
+- optional component/deployment guidance;
+- optional product guidance;
+- reference-only architecture evidence.
+
+Atlas labels remain provenance. They do not become Agent Memory terminology merely because they appear in the research record.
+
+## Verified comparator set
+
+The ranked systems were selected for distinct failure/capability value, not popularity or Atlas mark count:
+
+1. Claude-Mem: canonical SQLite state before later Chroma synchronization; used to pressure #308/#282.
+2. Verel: rejected-value semantic re-entry adversarial fixtures.
+3. AgentRecall-X: bounded authority-quality/reliability-decay comparator; its threshold is not Agent Memory doctrine.
+4. Memory Engine: least-permissive principal/access composition on the inspected path.
+5. Graphiti: validity-time versus record-time temporal graph representation.
+6. Nanobot: durable background progress/cursor advancement after completed success, without an exactly-once claim.
+7. Basic Memory: editable canonical files plus rebuildable derived state; reference-only at the pinned AGPL-3.0 rights posture.
+8. Memanto: explicit conflict dispositions, with no need for another conflict engine beyond #12.
+
+This list is not an adapter backlog.
+
+## Benchmark audit
+
+Primary-source review narrowed several benchmark claims:
+
+- MemoryAgentBench FactConsolidation measures newest-fact/current-answer preference, not selective forgetting.
+- GoodAI LTM performs reset after the scored example, so reset is not forgetting evidence.
+- PersistBench pressures cross-domain leakage, sycophancy, and beneficial memory use; it is not a deletion benchmark.
+- ForgetEval provides a useful supersede/release/purge control-plane test shape but does not establish Agent Memory transitive residue or post-background resurrection guarantees.
+
+Existing #138 and conformance owners remain controlling.
+
+## Promoted operational gap
+
+One representation-neutral operational distinction survived deduplication:
+
+```text
+write accepted
+!= canonical durable
+!= required derived state current
+!= governed recall current-visible
+!= context current-visible
+!= settled
+!= quiescent
+```
+
+That became #308 and was subsequently implemented, with restart obligations composed into #282. Claude-Mem and Nanobot supplied materially different external pressure for the same boundary. No separate ADR was required.
+
+## Agent Memory self-report reconciliation
+
+Atlas analyzed Agent Memory at `bba0aa4cab8e04d11f5380b215b3eea6998fe119` on 2026-08-11. Current disposition at `f2fc966c403d7adf028c24240b85c6e4e576a25a` is:
+
+| Atlas-era observation | Current disposition |
+| --- | --- |
+| Rejected-value tombstone gap | Fixed by #147/#148 and semantic readmission evidence. |
+| No discrete Atlas-style trust state | Not established as a defect; Agent Memory intentionally uses broader trust/evidence/authority semantics. |
+| Reference substrate is not a production memory service | Still true by design, with reference claims bounded and real external runtime evidence tracked separately. |
+| No committed run outputs under `reports/` | Partially valid but narrowed; exact-head workflow evidence and durable locks now exist outside that directory. |
+| No dependency manifest | Fixed; current root has `pyproject.toml` and reference dependencies are declared in `reference/requirements.txt`. |
+| README/generated-count drift | Historical only until freshly measured; old counts are not carried forward as a current defect. |
+
+## Rejection and no-action log
+
+The research explicitly rejects:
+
+- Atlas mark count as an Agent Memory maturity score;
+- equal-depth review of all 283 systems solely to claim exhaustiveness;
+- an Atlas trust enum as a mandatory core field;
+- a new conflict engine from Memanto;
+- Basic Memory as a default dependency without deliberate AGPL source-rights posture;
+- one adapter for every interesting Atlas system;
+- a new ADR solely because Atlas named a pattern.
+
+## Completion boundary
+
+#304 is complete when exact-head validation confirms that the pinned inventory remains reproducible, all seven mechanisms and all 21 patterns remain represented, promoted findings stay evidence-bound, rejected findings stay recorded, and the synthesis retains `authority_effect = none` plus `doctrine_disposition = no_new_adr`.
+
+Completion means the research question converged under the frozen stopping rule. It does not mean every repository received identical attention.

--- a/scripts/validate_atlas_research_synthesis.py
+++ b/scripts/validate_atlas_research_synthesis.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Validate the bounded #304 Atlas corpus synthesis.
+
+This validator intentionally checks exact mechanism/pattern sets rather than merely
+checking counts. A missing item must fail closed instead of being replaced by a
+new item that happens to preserve the same total.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SYNTHESIS = ROOT / "docs/programs/atlas-research/corpus-synthesis.json"
+ATLAS_COMMIT = "90bfeed14764e268c82c925d4c39645c7480d015"
+
+EXPECTED_MECHANISMS = {
+    "rejected_value_tombstone",
+    "explicit_trust_state",
+    "bitemporal_validity",
+    "scope_enforced_in_retrieval",
+    "append_only_mutation_audit",
+    "human_review_surface",
+    "negative_retrieval_assertion",
+}
+
+EXPECTED_PATTERNS = {
+    "append-only-memory-audit",
+    "bi-temporal-fact-validity",
+    "cache-preserving-injection",
+    "decay-and-reinforcement",
+    "evidence-before-belief",
+    "explicit-write-destination",
+    "gate-the-expensive-path",
+    "governed-write-gateway",
+    "hybrid-retrieval-fusion",
+    "pluggable-memory-provider",
+    "promotion-between-tiers",
+    "recoverable-background-work",
+    "scope-as-a-first-class-key",
+    "skills-as-procedural-memory",
+    "trust-state-machine",
+    "zero-llm-capture",
+    "rejected-value-tombstone",
+    "resolve-not-just-detect",
+    "source-diverse-context",
+    "retrieval-hysteresis",
+    "memory-as-an-editing-surface",
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def exact_ids(records: object, key: str, expected: set[str], label: str) -> None:
+    require(isinstance(records, list), f"{label} must be an array")
+    values = [record.get(key) for record in records if isinstance(record, dict)]
+    require(len(values) == len(records), f"{label} entries must be objects")
+    require(len(values) == len(set(values)), f"{label} contains duplicate {key} values")
+    observed = set(values)
+    missing = sorted(expected - observed)
+    extra = sorted(observed - expected)
+    require(not missing and not extra, f"{label} set drift: missing={missing} extra={extra}")
+
+
+def main() -> int:
+    data = json.loads(SYNTHESIS.read_text(encoding="utf-8"))
+
+    require(data.get("schema_version") == "1.0.0", "synthesis schema_version must be 1.0.0")
+    require(data.get("research_program") == "#304", "synthesis must remain bound to #304")
+    require(data.get("atlas_snapshot") == ATLAS_COMMIT, "Atlas snapshot drifted")
+    require(data.get("source_posture") == "secondary_source_index_and_hypothesis_generator", "Atlas source posture changed")
+    require(data.get("authority_effect") == "none", "Atlas synthesis cannot create authority")
+    require(data.get("doctrine_disposition") == "no_new_adr", "Atlas synthesis cannot silently create doctrine")
+
+    head = data.get("agent_memory_evidence_boundary")
+    require(isinstance(head, str) and len(head) == 40 and head == head.lower(), "Agent Memory evidence boundary must be 40 lowercase hex")
+    try:
+        int(head, 16)
+    except ValueError as exc:
+        raise SystemExit("Agent Memory evidence boundary must be hexadecimal") from exc
+
+    counts = data.get("counts", {})
+    require(counts.get("system_reports") == 283, "pinned Atlas report count must be 283")
+    require(counts.get("design_patterns") == 21, "pinned Atlas pattern count must be 21")
+    require(counts.get("atlas_mechanisms") == 7, "Atlas mechanism count must be 7")
+    require(counts.get("verified_claim_ledger_minimum", 0) >= 8, "verified claim floor cannot regress below 8")
+
+    exact_ids(data.get("mechanisms"), "mechanism_id", EXPECTED_MECHANISMS, "mechanisms")
+    exact_ids(data.get("patterns"), "pattern_id", EXPECTED_PATTERNS, "patterns")
+
+    for mechanism in data["mechanisms"]:
+        require(mechanism.get("agent_memory_surfaces"), f"mechanism {mechanism['mechanism_id']} lacks Agent Memory surfaces")
+        require(isinstance(mechanism.get("novel_gap"), bool), f"mechanism {mechanism['mechanism_id']} novel_gap must be boolean")
+        require(mechanism.get("rationale"), f"mechanism {mechanism['mechanism_id']} lacks rationale")
+
+    for pattern in data["patterns"]:
+        require(pattern.get("atlas_stance") in {"established", "advocacy", "mixed", "category_bound"}, f"pattern {pattern['pattern_id']} has invalid stance")
+        require(pattern.get("disposition"), f"pattern {pattern['pattern_id']} lacks disposition")
+        require(pattern.get("agent_memory_surfaces"), f"pattern {pattern['pattern_id']} lacks Agent Memory surfaces")
+
+    benchmarks = data.get("benchmarks")
+    require(isinstance(benchmarks, list) and len(benchmarks) >= 4, "benchmark synthesis must retain verified benchmark set")
+    for benchmark in benchmarks:
+        require(benchmark.get("verification", "").startswith("primary"), f"benchmark {benchmark.get('benchmark')} is not primary-source verified")
+        require(benchmark.get("disposition"), f"benchmark {benchmark.get('benchmark')} lacks disposition")
+
+    comparators = data.get("comparators")
+    require(isinstance(comparators, list) and comparators, "comparator ranking must not be empty")
+    ranks = [entry.get("rank") for entry in comparators]
+    require(ranks == list(range(1, len(comparators) + 1)), "comparator ranks must be contiguous and deterministic")
+    for comparator in comparators:
+        require(comparator.get("distinct_value"), f"comparator {comparator.get('system')} lacks distinct value")
+        require(comparator.get("owners"), f"comparator {comparator.get('system')} lacks Agent Memory owner")
+
+    self_audit = data.get("agent_memory_self_audit")
+    require(isinstance(self_audit, list) and len(self_audit) >= 6, "Agent Memory Atlas self-audit is incomplete")
+    require(any(item.get("atlas_claim") == "no dependency manifest" and item.get("current_status") == "fixed" for item in self_audit), "dependency-manifest reconciliation is missing")
+
+    promotions = data.get("promotions")
+    require(isinstance(promotions, list) and promotions, "promoted findings must be recorded")
+    for promotion in promotions:
+        require(promotion.get("evidence"), f"promotion {promotion.get('finding')} lacks evidence")
+        require(promotion.get("doctrine_change") == "none", f"promotion {promotion.get('finding')} silently changes doctrine")
+
+    rejections = data.get("rejections")
+    require(isinstance(rejections, list) and rejections, "rejection/no-action ledger must not be empty")
+    require(any("maturity score" in item.get("claim", "") for item in rejections), "Goodhart/maturity-score rejection must remain explicit")
+
+    completion = data.get("completion")
+    require(isinstance(completion, dict) and completion, "completion map is missing")
+    incomplete = sorted(key for key, value in completion.items() if value is not True)
+    require(not incomplete, f"#304 completion flags not satisfied: {incomplete}")
+
+    print(
+        "atlas-research-synthesis: valid "
+        f"mechanisms={len(data['mechanisms'])} patterns={len(data['patterns'])} "
+        f"benchmarks={len(benchmarks)} comparators={len(comparators)} "
+        f"rejections={len(rejections)} authority_effect={data['authority_effect']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Completes the bounded research program in #304 against the frozen Atlas snapshot:

`neoneye/agent-memory-atlas@90bfeed14764e268c82c925d4c39645c7480d015`

The synthesis is bound to the Agent Memory starting evidence boundary:

`f2fc966c403d7adf028c24240b85c6e4e576a25a`

### Durable synthesis

Adds `corpus-synthesis.json` plus a human-readable closeout. The machine-readable record includes:

- all 7 Atlas rubric mechanisms mapped to current Agent Memory surfaces;
- all 21 pinned Atlas design patterns with an explicit disposition;
- primary-source benchmark interpretations;
- ranked comparator candidates by distinct failure/capability value rather than popularity;
- current-state reconciliation of Atlas's 2026-08-11 Agent Memory report;
- bounded promoted work;
- explicit rejection/no-action findings;
- `doctrine_disposition = no_new_adr`;
- `authority_effect = none`.

### Research completion semantics

This PR does not claim equal-depth manual rereview of all 283 Atlas reports. #306/#322 already provide a reproducible snapshot-bound 283-record inventory. Deeper review followed #304's frozen stopping rule: primary-source verification and reproduction where a finding could expose a distinct correctness/governance failure, reusable mechanism, falsification fixture, component candidate, or doctrine contradiction.

The strongest novel operational finding, write-to-readable visibility/quiescence, already produced #308 and composed with #282. No additional representation-neutral doctrine gap survived this pass.

### Refreshed Agent Memory self-audit

One Atlas-era criticism is now explicitly obsolete: the current repository has a root `pyproject.toml` and `reference/requirements.txt`, so the 2026-08-11 `no dependency manifest` observation is classified as fixed rather than carried forward.

Reference-only substrate limitations remain true by design. Exact-head workflow/runtime evidence is distinguished from the example-oriented `reports/` directory.

### Fail-closed validation

Adds `scripts/validate_atlas_research_synthesis.py`, which requires the exact seven mechanism IDs and exact 21 pattern IDs, rejects duplicate/substituted entries, checks snapshot/count boundaries, requires primary-source benchmark dispositions and deterministic comparator ranking, preserves promotion/rejection evidence, requires every completion flag to be literal `true`, and refuses any doctrine or authority escalation.

The existing `Atlas Research Intake` workflow now validates both the durable 283-record reconstruction and the corpus synthesis in the same exact-head run, and records both digests.

Closes #304 only after exact-head focused and repository-wide validation are green.