### PR TITLE
Qualify repaired EvolveAI multi-capability profile

### DIFF
--- a/.github/workflows/evolveai-multicapability-qualification.yml
+++ b/.github/workflows/evolveai-multicapability-qualification.yml
@@ -1,0 +1,170 @@
+name: EvolveAI Multi-Capability Qualification
+
+on:
+  pull_request:
+    paths:
+      - 'reference/agentmem_ref/evolveai_profile.py'
+      - 'reference/fixtures/component-capabilities/evolveai.example.json'
+      - 'reference/fixtures/evolveai-qualification.json'
+      - 'reference/fixtures/evolveai-qualification-driver/**'
+      - 'reference/run_evolveai_multicapability_qualification.py'
+      - 'reference/run_evolveai_failure_probe.py'
+      - 'reference/tests/test_evolveai_profile.py'
+      - 'docs/programs/memory-modules/evolveai-multicapability-profile.md'
+      - '.github/workflows/evolveai-multicapability-qualification.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'reference/agentmem_ref/evolveai_profile.py'
+      - 'reference/fixtures/component-capabilities/evolveai.example.json'
+      - 'reference/fixtures/evolveai-qualification.json'
+      - 'reference/fixtures/evolveai-qualification-driver/**'
+      - 'reference/run_evolveai_multicapability_qualification.py'
+      - 'reference/run_evolveai_failure_probe.py'
+      - 'reference/tests/test_evolveai_profile.py'
+      - 'docs/programs/memory-modules/evolveai-multicapability-profile.md'
+      - '.github/workflows/evolveai-multicapability-qualification.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  qualify-evolveai:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Agent Memory
+        uses: actions/checkout@v4
+
+      - name: Checkout exact repaired EvolveAI
+        uses: actions/checkout@v4
+        with:
+          repository: MythologIQ-Labs-LLC/EvolveAI
+          ref: 21161ce7b88dbffeb7ed59757b4d02d24a9c2acd
+          path: _evolveai
+          persist-credentials: false
+
+      - name: Verify exact provider and source rights
+        run: |
+          test "$(git -C _evolveai rev-parse HEAD)" = "21161ce7b88dbffeb7ed59757b4d02d24a9c2acd"
+          grep -q "Apache License" _evolveai/LICENSE
+          grep -q "Version 2.0" _evolveai/LICENSE
+          grep -q 'const OP_DELETE: &str = "delete"' _evolveai/crates/evolve-core/src/tiers/l3_vault.rs
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reference dependencies
+        run: python -m pip install -r reference/requirements.txt
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Validate EvolveAI profile regressions
+        env:
+          PYTHONPATH: reference
+        run: python -m pytest -q reference/tests/test_evolveai_profile.py
+
+      - name: Reproduce EvolveAI native deletion regression suite
+        run: cargo test --manifest-path _evolveai/Cargo.toml -p evolve-core delete_tests
+
+      - name: Build public-facade qualification driver
+        run: cargo build --manifest-path reference/fixtures/evolveai-qualification-driver/Cargo.toml
+
+      - name: Execute public-facade workload
+        run: |
+          mkdir -p /tmp/evolveai-qualification
+          reference/fixtures/evolveai-qualification-driver/target/debug/agent-memory-evolveai-qualification-driver \
+            > /tmp/evolveai-qualification/evolveai-native-observation.json
+          cat /tmp/evolveai-qualification/evolveai-native-observation.json
+
+      - name: Normalize and qualify capabilities through common contract
+        env:
+          PYTHONPATH: reference
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          python reference/run_evolveai_multicapability_qualification.py \
+            --profile reference/fixtures/component-capabilities/evolveai.example.json \
+            --fixture reference/fixtures/evolveai-qualification.json \
+            --raw /tmp/evolveai-qualification/evolveai-native-observation.json \
+            --output-dir /tmp/evolveai-qualification/evidence \
+            --agent-memory-commit "$HEAD_SHA"
+
+      - name: Reproduce real adapter-unavailable evidence
+        env:
+          PYTHONPATH: reference
+        run: |
+          driver=reference/fixtures/evolveai-qualification-driver/target/debug/agent-memory-evolveai-qualification-driver
+          mv "$driver" "${driver}.available"
+          python reference/run_evolveai_failure_probe.py \
+            --executable "$driver" \
+            --raw-output /tmp/evolveai-qualification/evolveai-unavailable-raw.json \
+            --normalized-output /tmp/evolveai-qualification/evolveai-unavailable-normalized.json \
+            --trace-ref trace://evolveai/provider-unavailable/1.0.0
+          mv "${driver}.available" "$driver"
+
+      - name: Validate qualification records and exact-head evidence
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from jsonschema import Draft202012Validator
+          import os
+
+          root = Path('/tmp/evolveai-qualification/evidence')
+          schema = json.loads(Path('schemas/component-capability-qualification.schema.json').read_text())
+          validator = Draft202012Validator(schema)
+          records = sorted(root.glob('qualification-*.json'))
+          assert len(records) == 13, len(records)
+          for path in records:
+              value = json.loads(path.read_text())
+              errors = sorted(validator.iter_errors(value), key=lambda error: list(error.path))
+              assert not errors, (path, [error.message for error in errors])
+              assert value['subject']['component_version'] == '21161ce7b88dbffeb7ed59757b4d02d24a9c2acd'
+              assert value['result']['qualification_current'] is True
+              assert value['result']['authority_effect'] == 'none'
+
+          summary = json.loads((root / 'evolveai-qualification-summary.json').read_text())
+          assert summary['agent_memory_commit'] == os.environ['HEAD_SHA']
+          assert summary['provider_commit'] == '21161ce7b88dbffeb7ed59757b4d02d24a9c2acd'
+          assert all(type(value) is bool and value for value in summary['invariants'].values())
+          assert summary['authority_effect'] == 'none'
+
+          unavailable = json.loads(Path('/tmp/evolveai-qualification/evolveai-unavailable-normalized.json').read_text())
+          assert unavailable['failure_result'] == 'provider_unavailable'
+          assert unavailable['currentness'] == 'unavailable'
+          assert unavailable['authority_effect'] == 'none'
+          PY
+
+      - name: Run full Agent Memory reference regression
+        env:
+          PYTHONPATH: reference
+        run: python -m pytest -q reference/tests
+
+      - name: Record evidence digests
+        run: |
+          sha256sum /tmp/evolveai-qualification/evolveai-native-observation.json \
+            | tee /tmp/evolveai-qualification/evolveai-native-observation.sha256
+          find /tmp/evolveai-qualification/evidence -type f -name '*.json' -print0 \
+            | sort -z | xargs -0 sha256sum \
+            | tee /tmp/evolveai-qualification/evidence.sha256
+          cat /tmp/evolveai-qualification/evolveai-native-observation.sha256 >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/evolveai-qualification/evidence.sha256 >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload exact-head EvolveAI qualification evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: evolveai-multicapability-${{ github.event.pull_request.head.sha || github.sha }}
+          path: |
+            /tmp/evolveai-qualification/evolveai-native-observation.json
+            /tmp/evolveai-qualification/evolveai-native-observation.sha256
+            /tmp/evolveai-qualification/evolveai-unavailable-raw.json
+            /tmp/evolveai-qualification/evolveai-unavailable-normalized.json
+            /tmp/evolveai-qualification/evidence/
+            /tmp/evolveai-qualification/evidence.sha256
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/evolveai-multicapability-qualification.yml
+++ b/.github/workflows/evolveai-multicapability-qualification.yml
@@ -43,10 +43,12 @@ jobs:
           ref: 21161ce7b88dbffeb7ed59757b4d02d24a9c2acd
           path: _evolveai
           persist-credentials: false
+          submodules: recursive
 
       - name: Verify exact provider and source rights
         run: |
           test "$(git -C _evolveai rev-parse HEAD)" = "21161ce7b88dbffeb7ed59757b4d02d24a9c2acd"
+          test -f _evolveai/vendor/GG-CORE/core-runtime/Cargo.toml
           grep -q "Apache License" _evolveai/LICENSE
           grep -q "Version 2.0" _evolveai/LICENSE
           grep -q 'const OP_DELETE: &str = "delete"' _evolveai/crates/evolve-core/src/tiers/l3_vault.rs

--- a/.github/workflows/evolveai-multicapability-qualification.yml
+++ b/.github/workflows/evolveai-multicapability-qualification.yml
@@ -57,7 +57,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install reference dependencies
-        run: python -m pip install -r reference/requirements.txt
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -65,7 +65,7 @@ jobs:
       - name: Validate EvolveAI profile regressions
         env:
           PYTHONPATH: reference
-        run: python -m pytest -q reference/tests/test_evolveai_profile.py
+        run: python -m unittest reference/tests/test_evolveai_profile.py
 
       - name: Reproduce EvolveAI native deletion regression suite
         run: cargo test --manifest-path _evolveai/Cargo.toml -p evolve-core delete_tests
@@ -143,7 +143,7 @@ jobs:
       - name: Run full Agent Memory reference regression
         env:
           PYTHONPATH: reference
-        run: python -m pytest -q reference/tests
+        run: python -m unittest discover -s reference/tests -p 'test_*.py'
 
       - name: Record evidence digests
         run: |

--- a/docs/programs/memory-modules/evolveai-multicapability-profile.md
+++ b/docs/programs/memory-modules/evolveai-multicapability-profile.md
@@ -1,0 +1,175 @@
+# EvolveAI multi-capability qualification profile
+
+Status: **executable qualification evidence for #292**
+
+Exact provider revision:
+
+`MythologIQ-Labs-LLC/EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd`
+
+That revision contains EvolveAI PR #21, which repairs #19 by recording L3 deletion in the hash-chain ledger and reconciling live vault state against replayed store/update/delete history.
+
+## Qualification posture
+
+EvolveAI is treated as one multi-capability component, not as one monolithic maturity label.
+
+The component profile is:
+
+`reference/fixtures/component-capabilities/evolveai.example.json`
+
+It uses `component-capability-v2` and declares fifteen independently graded capability surfaces. Every surface uses `external_scope_bridge`; EvolveAI provider scope is not silently equated with Agent Memory actor/tenant/project scope.
+
+The executable profile is:
+
+`evolveai-public-facade-behavior@1.0.0`
+
+Adapter:
+
+`evolveai-public-facade-adapter@1.0.0`
+
+The common #298 qualification record/schema remains the authority for evidence shape. EvolveAI does not get a private certification vocabulary.
+
+## Public-facade workload
+
+The qualification driver compiles against the exact checked-out EvolveAI `evolve-core` crate and exercises public `MemoryProcessor` behavior.
+
+It proves a bounded sequence:
+
+1. ordinary 384-dimensional mock-engine inputs route to L2;
+2. session co-capture creates temporal graph associations;
+3. the supported query path performs vector candidate scan;
+4. lifecycle traces reach `detach()` and execute the current REM-synthesis path;
+5. a public Shadow Genome failure record can produce EvolveAI's native `Block` verdict;
+6. a sensitive input routes to L3;
+7. content-addressed L3 exact retrieval returns the live unit;
+8. explicit save/load preserves the current L3 value and chain health;
+9. explicit forget removes the live L3 unit and appends the repaired `delete:<address>:<last-content-hash>` ledger event;
+10. the deleted value is not current after deletion;
+11. save/load after deletion preserves the delete history and continued absence.
+
+The raw provider observation is preserved before normalization.
+
+## Independent maturity result
+
+The profile intentionally does not promote every row equally.
+
+`reference_qualified` is bounded to:
+
+- `content_addressed_exact_retrieval`;
+- `persistent_snapshot_restart`;
+- `audited_deletion`;
+- `l3_provenance_audit`.
+
+`evidence_proven` is bounded to:
+
+- mock-backed `vector_representation`;
+- mock-backed `vector_candidate_retrieval`;
+- `temporal_graph`;
+- direct-neighbor `graph_traversal`;
+- `tier_routing`;
+- `lifecycle_orchestration`;
+- current `rem_synthesis_consolidation` behavior;
+- `negative_failure_memory`.
+
+`lifecycle_decay` remains `runtime_wired`: the workload proves the supported invocation path through synthesis but does not claim exhaustive threshold/decay behavior.
+
+`transient_cache_storage` remains `implemented` in this profile because the 1.0.0 workload does not independently exercise the ephemeral L1 boundary.
+
+`graph_augmented_context_assembly` remains `declared` and disabled. Temporal graph state plus vector retrieval is not an end-to-end GraphRAG/context-assembly qualification.
+
+## Mock versus real representation
+
+The exact supported CLI and qualification workload use EvolveAI `MockEngine` at 384 dimensions.
+
+EvolveAI also contains a GG-CORE-backed ONNX `GgCoreEngine` behind its `ggcore` feature. That implementation existence is preserved as source evidence, but this profile does not execute it and does not transfer mock-path evidence to real embedding quality.
+
+Therefore:
+
+```text
+mock vector runtime behavior proven
+!= real embedding quality proven
+!= production semantic retrieval quality proven
+```
+
+## Shadow Genome authority boundary
+
+The provider-native workload deliberately produces an EvolveAI `Verdict::Block` from a matching negative/failure memory.
+
+Agent Memory normalizes that result as:
+
+`risk_candidate_only`
+
+It does not become Agent Memory PASS/BLOCK, mutation authority, recall-admission authority, or action authority.
+
+Trigger count, similarity, severity, and repeated encounters remain provider evidence. Repetition is not independent corroboration.
+
+## Deletion and residue boundary
+
+The repaired EvolveAI revision now earns the narrower native claim that was previously blocked:
+
+```text
+live L3 state
+-> explicit forget
+-> delete record bound to prior content hash
+-> live state absent
+-> chain verifies
+-> delete history survives explicit restart
+```
+
+It does **not** earn:
+
+```text
+native L3 delete
+!= Agent Memory transitive forgetting completeness
+!= proof every external/derived representation is absent
+!= authority to perform a governed deletion
+```
+
+The profile therefore records provider-managed residue and preserves `external_derived_residue_absence_proven = false`.
+
+## Scope and applicability
+
+Qualification applicability binds:
+
+- exact EvolveAI commit;
+- exact component profile digest;
+- adapter identity/version;
+- qualification profile identity/version;
+- runtime configuration;
+- fixture digest;
+- Agent Memory scope binding;
+- provider scope binding;
+- dependency/runtime refs.
+
+Foreign Agent Memory scope, stale EvolveAI version, or stale component-profile digest fails closed. A changed version does not inherit qualification by resemblance.
+
+## Failure posture
+
+The component declares `explicit_unavailable`.
+
+CI additionally builds the exact qualification adapter, removes its executable from the configured path, and uses the common provider-unavailable probe to preserve the real `FileNotFoundError` evidence. The normalized result is `provider_unavailable`, `currentness = unavailable`, and `authority_effect = none`.
+
+An ordinary provider error or timeout is not silently relabeled as unavailable.
+
+## Evidence outputs
+
+Focused CI:
+
+`.github/workflows/evolveai-multicapability-qualification.yml`
+
+The workflow preserves:
+
+- raw EvolveAI public-facade observation;
+- raw and normalized unavailable-provider evidence;
+- provider-neutral normalized evidence;
+- one schema-valid #298 qualification record per advanced capability;
+- exact applicability digests;
+- exact-head profile report and summary;
+- SHA-256 evidence digests.
+
+The workflow also reruns EvolveAI's native delete regression suite and the full Agent Memory reference suite.
+
+## Claim boundary
+
+This qualification makes EvolveAI a stronger first-party component candidate. It does not make EvolveAI the Agent Memory architecture, import EvolveAI tier names as doctrine, or grant its learned signals governance authority.
+
+Component identity remains provenance. Capability behavior remains evidence. Consequence remains governed by Agent Memory's existing authority boundaries.

--- a/reference/agentmem_ref/evolveai_profile.py
+++ b/reference/agentmem_ref/evolveai_profile.py
@@ -1,0 +1,277 @@
+"""Evidence-bounded EvolveAI multi-capability profile validation for #292."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Mapping
+
+from .capabilities import ComponentDeclaration, MATURITY_ORDER
+
+EVOLVEAI_COMMIT = "21161ce7b88dbffeb7ed59757b4d02d24a9c2acd"
+COMPONENT_ID = "evolveai"
+COMPONENT_PROFILE_VERSION = "component-capability-v2"
+ADAPTER_ID = "evolveai-public-facade-adapter"
+ADAPTER_VERSION = "1.0.0"
+QUALIFICATION_PROFILE_ID = "evolveai-public-facade-behavior"
+QUALIFICATION_PROFILE_VERSION = "1.0.0"
+SOURCE_REF = f"repo://MythologIQ-Labs-LLC/EvolveAI@{EVOLVEAI_COMMIT}"
+IMPLEMENTATION_REF = SOURCE_REF.removeprefix("repo://")
+
+EXPECTED_MATURITY: dict[str, str] = {
+    "transient_cache_storage": "implemented",
+    "vector_representation": "evidence_proven",
+    "vector_candidate_retrieval": "evidence_proven",
+    "temporal_graph": "evidence_proven",
+    "graph_traversal": "evidence_proven",
+    "graph_augmented_context_assembly": "declared",
+    "content_addressed_exact_retrieval": "reference_qualified",
+    "tier_routing": "evidence_proven",
+    "lifecycle_decay": "runtime_wired",
+    "lifecycle_orchestration": "evidence_proven",
+    "rem_synthesis_consolidation": "evidence_proven",
+    "negative_failure_memory": "evidence_proven",
+    "persistent_snapshot_restart": "reference_qualified",
+    "audited_deletion": "reference_qualified",
+    "l3_provenance_audit": "reference_qualified",
+}
+
+REQUIRED_DISABLED = frozenset({"graph_augmented_context_assembly"})
+PROPOSAL_ONLY = frozenset(
+    {
+        "tier_routing",
+        "lifecycle_decay",
+        "lifecycle_orchestration",
+        "rem_synthesis_consolidation",
+        "negative_failure_memory",
+    }
+)
+REFERENCE_QUALIFIED = frozenset(
+    {
+        "content_addressed_exact_retrieval",
+        "persistent_snapshot_restart",
+        "audited_deletion",
+        "l3_provenance_audit",
+    }
+)
+QUALIFIED_CAPABILITIES = frozenset(
+    capability_id
+    for capability_id, maturity in EXPECTED_MATURITY.items()
+    if maturity not in {"declared", "implemented"}
+)
+
+
+class EvolveAIProfileError(ValueError):
+    """The EvolveAI declaration exceeds or drifts from its evidence boundary."""
+
+
+def qualification_evidence_ref(capability_id: str) -> str:
+    return (
+        f"qualification:evolveai:{capability_id}@"
+        f"{QUALIFICATION_PROFILE_ID}/{QUALIFICATION_PROFILE_VERSION}"
+    )
+
+
+def _rank(maturity: str) -> int:
+    try:
+        return MATURITY_ORDER.index(maturity)
+    except ValueError as exc:
+        raise EvolveAIProfileError(f"unknown capability maturity {maturity!r}") from exc
+
+
+def _capability_map(component: ComponentDeclaration) -> dict[str, object]:
+    return {capability.capability_id: capability for capability in component.capabilities}
+
+
+def profile_digest(value: Mapping[str, object]) -> str:
+    rendered = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(rendered).hexdigest()
+
+
+def load_profile(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    validate_profile(value)
+    return value
+
+
+def validate_profile(value: Mapping[str, object]) -> ComponentDeclaration:
+    component = ComponentDeclaration.from_dict(value)
+    if component.component_id != COMPONENT_ID:
+        raise EvolveAIProfileError("EvolveAI profile component_id must be 'evolveai'")
+    if component.component_version != EVOLVEAI_COMMIT:
+        raise EvolveAIProfileError(f"EvolveAI profile must bind repaired commit {EVOLVEAI_COMMIT}")
+    if component.profile_version != COMPONENT_PROFILE_VERSION:
+        raise EvolveAIProfileError("EvolveAI profile must use component-capability-v2")
+    if component.runtime_ref != IMPLEMENTATION_REF:
+        raise EvolveAIProfileError("EvolveAI runtime_ref must bind the exact source revision")
+    if component.failure_posture != "explicit_unavailable":
+        raise EvolveAIProfileError("EvolveAI provider failure must remain explicitly unavailable")
+    if SOURCE_REF not in component.provenance_refs:
+        raise EvolveAIProfileError("EvolveAI profile must preserve exact source provenance")
+    if "issue://MythologIQ-Labs-LLC/EvolveAI/19" not in component.provenance_refs:
+        raise EvolveAIProfileError("repaired deletion profile must preserve EvolveAI #19 provenance")
+
+    capabilities = _capability_map(component)
+    if set(capabilities) != set(EXPECTED_MATURITY):
+        missing = sorted(set(EXPECTED_MATURITY).difference(capabilities))
+        extra = sorted(set(capabilities).difference(EXPECTED_MATURITY))
+        raise EvolveAIProfileError(
+            f"EvolveAI capability inventory changed without review; missing={missing}, extra={extra}"
+        )
+
+    for capability_id, expected_maturity in EXPECTED_MATURITY.items():
+        capability = capabilities[capability_id]
+        if capability.maturity != expected_maturity:
+            raise EvolveAIProfileError(
+                f"{capability_id} maturity must remain {expected_maturity} at this profile revision"
+            )
+        if capability.scope_posture != "external_scope_bridge":
+            raise EvolveAIProfileError(f"{capability_id} must use external_scope_bridge")
+        if capability.state_posture == "canonical":
+            raise EvolveAIProfileError(f"{capability_id} cannot become canonical Agent Memory state")
+        if capability.behavior_contract is None:
+            raise EvolveAIProfileError(f"{capability_id} is missing v2 behavior metadata")
+        if not capability.evidence_refs:
+            raise EvolveAIProfileError(f"{capability_id} requires bounded evidence refs")
+        expected_authority = "proposal_only" if capability_id in PROPOSAL_ONLY else "none"
+        if capability.authority_effect != expected_authority:
+            raise EvolveAIProfileError(
+                f"{capability_id} authority_effect must remain {expected_authority}"
+            )
+        if capability_id in REQUIRED_DISABLED and capability.enabled:
+            raise EvolveAIProfileError(f"{capability_id} must remain disabled")
+        if capability_id not in REQUIRED_DISABLED and not capability.enabled:
+            raise EvolveAIProfileError(f"{capability_id} unexpectedly disabled")
+        if capability_id in QUALIFIED_CAPABILITIES:
+            evidence_ref = qualification_evidence_ref(capability_id)
+            if evidence_ref not in capability.evidence_refs:
+                raise EvolveAIProfileError(
+                    f"{capability_id} must bind exact qualification evidence {evidence_ref}"
+                )
+        if _rank(capability.maturity) >= _rank("runtime_wired") and capability_id not in QUALIFIED_CAPABILITIES:
+            raise EvolveAIProfileError(
+                f"{capability_id} cannot advance beyond source-level maturity without #298 evidence"
+            )
+
+    if {cid for cid, cap in capabilities.items() if cap.maturity == "reference_qualified"} != set(
+        REFERENCE_QUALIFIED
+    ):
+        raise EvolveAIProfileError("reference-qualified EvolveAI capability set changed without review")
+
+    graph_rag = capabilities["graph_augmented_context_assembly"]
+    if graph_rag.maturity != "declared" or graph_rag.enabled:
+        raise EvolveAIProfileError("GraphRAG must remain declared and disabled")
+
+    vector = capabilities["vector_candidate_retrieval"]
+    if not any("mock" in item.lower() for item in vector.limitations):
+        raise EvolveAIProfileError("vector qualification must disclose the mock-engine boundary")
+
+    shadow = capabilities["negative_failure_memory"]
+    if shadow.authority_effect != "proposal_only" or not any(
+        "authority" in item.lower() for item in shadow.limitations
+    ):
+        raise EvolveAIProfileError("Shadow Genome must remain proposal-only evidence")
+
+    deletion = capabilities["audited_deletion"]
+    if not any("transitive" in item.lower() for item in deletion.limitations):
+        raise EvolveAIProfileError("audited deletion must refuse transitive-forgetting overclaim")
+    if not any("EvolveAI#19" in item for item in deletion.evidence_refs):
+        raise EvolveAIProfileError("audited deletion must bind the repaired EvolveAI #19 evidence")
+
+    return component
+
+
+def build_scope_binding(*, agent_memory_scope: str, provider_scope: str, profile_sha256: str) -> dict:
+    if not agent_memory_scope or not provider_scope:
+        raise EvolveAIProfileError("both Agent Memory and provider scopes are required")
+    if not profile_sha256.startswith("sha256:"):
+        raise EvolveAIProfileError("profile digest must be sha256-bound")
+    return {
+        "agent_memory_scope": agent_memory_scope,
+        "provider_scope": provider_scope,
+        "component_version": EVOLVEAI_COMMIT,
+        "component_profile_digest": profile_sha256,
+        "authority_effect": "none",
+    }
+
+
+def assert_scope_binding(
+    binding: Mapping[str, object],
+    *,
+    requested_scope: str,
+    profile_sha256: str,
+    component_version: str = EVOLVEAI_COMMIT,
+) -> None:
+    if binding.get("agent_memory_scope") != requested_scope:
+        raise EvolveAIProfileError("EvolveAI scope binding does not match requested Agent Memory scope")
+    if binding.get("component_version") != component_version:
+        raise EvolveAIProfileError("EvolveAI scope binding is stale for this component version")
+    if binding.get("component_profile_digest") != profile_sha256:
+        raise EvolveAIProfileError("EvolveAI scope binding is stale for this profile digest")
+    if binding.get("authority_effect") != "none":
+        raise EvolveAIProfileError("scope binding cannot create authority")
+
+
+def build_profile_report(value: Mapping[str, object], *, agent_memory_commit: str) -> dict:
+    if len(agent_memory_commit) != 40 or any(ch not in "0123456789abcdef" for ch in agent_memory_commit):
+        raise EvolveAIProfileError("agent_memory_commit must be 40 lowercase hex characters")
+    component = validate_profile(value)
+    capabilities = _capability_map(component)
+    maturity_counts = {name: 0 for name in MATURITY_ORDER}
+    for capability in component.capabilities:
+        maturity_counts[capability.maturity] += 1
+
+    direct_authority = [
+        capability.capability_id
+        for capability in component.capabilities
+        if capability.authority_effect not in {"none", "proposal_only"}
+    ]
+    invariants = {
+        "exact_repaired_evolveai_pin": component.component_version == EVOLVEAI_COMMIT,
+        "profile_v2_behavior_complete": all(
+            capability.behavior_contract is not None for capability in component.capabilities
+        ),
+        "external_scope_bridge_explicit": all(
+            capability.scope_posture == "external_scope_bridge" for capability in component.capabilities
+        ),
+        "graphrag_not_overstated": not capabilities["graph_augmented_context_assembly"].enabled,
+        "mock_vector_boundary_explicit": any(
+            "mock" in item.lower() for item in capabilities["vector_candidate_retrieval"].limitations
+        ),
+        "shadow_has_no_agent_memory_authority": capabilities["negative_failure_memory"].authority_effect
+        == "proposal_only",
+        "audited_delete_not_transitive_forgetting": any(
+            "transitive" in item.lower() for item in capabilities["audited_deletion"].limitations
+        ),
+        "reference_qualified_set_bounded": {
+            cid for cid, cap in capabilities.items() if cap.maturity == "reference_qualified"
+        }
+        == set(REFERENCE_QUALIFIED),
+        "no_canonical_state_claims": all(
+            capability.state_posture != "canonical" for capability in component.capabilities
+        ),
+        "no_direct_authority": not direct_authority,
+    }
+    return {
+        "schema_version": "1.0.0",
+        "agent_memory_commit": agent_memory_commit,
+        "component": {
+            "component_id": component.component_id,
+            "component_version": component.component_version,
+            "runtime_ref": component.runtime_ref,
+            "profile_version": component.profile_version,
+            "profile_digest": profile_digest(value),
+        },
+        "source_rights": {
+            "license_id": "Apache-2.0",
+            "license_ref": f"MythologIQ-Labs-LLC/EvolveAI/LICENSE@{EVOLVEAI_COMMIT}",
+            "use_posture": "runtime_allowed",
+        },
+        "maturity_counts": maturity_counts,
+        "reference_qualified_capabilities": sorted(REFERENCE_QUALIFIED),
+        "proposal_only_surfaces": sorted(PROPOSAL_ONLY),
+        "capabilities": [capability.to_dict() for capability in component.capabilities],
+        "invariants": invariants,
+        "authority_effect": "none",
+    }

--- a/reference/fixtures/component-capabilities/evolveai.example.json
+++ b/reference/fixtures/component-capabilities/evolveai.example.json
@@ -1,59 +1,440 @@
 {
-  "component_id": "evolveai-example",
-  "component_version": "7cd42412",
-  "profile_version": "component-capability-v1",
+  "component_id": "evolveai",
+  "component_version": "21161ce7b88dbffeb7ed59757b4d02d24a9c2acd",
+  "profile_version": "component-capability-v2",
   "enabled": true,
-  "runtime_ref": "MythologIQ-Labs-LLC/EvolveAI@7cd42412ceed2ab638249a1517b2a6dac46f1312",
-  "failure_posture": "fail_closed",
-  "provenance_refs": ["docs/programs/memory-modules/first-party-capability-inventory.md"],
+  "runtime_ref": "MythologIQ-Labs-LLC/EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd",
+  "failure_posture": "explicit_unavailable",
+  "provenance_refs": [
+    "repo://MythologIQ-Labs-LLC/EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd",
+    "issue://MythologIQ-Labs-LLC/agent-memory/292",
+    "issue://MythologIQ-Labs-LLC/EvolveAI/19",
+    "pr://MythologIQ-Labs-LLC/EvolveAI/21",
+    "qualification-profile://evolveai-public-facade-behavior@1.0.0"
+  ],
   "capabilities": [
     {
-      "capability_id": "temporal_graph",
+      "capability_id": "transient_cache_storage",
       "capability_version": "1.0",
-      "maturity": "runtime_wired",
+      "maturity": "implemented",
       "state_posture": "derived",
-      "scope_posture": "inherits_agent_memory_scope",
+      "scope_posture": "external_scope_bridge",
       "failure_posture": "explicit_unavailable",
       "authority_effect": "none",
       "enabled": true,
-      "evidence_refs": ["inventory:evolveai:temporal-graph"],
-      "limitations": []
+      "evidence_refs": [
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/tiers/l1_cache.rs"
+      ],
+      "limitations": [
+        "ephemeral_l1_state_is_not_restart_persistent",
+        "not_independently_exercised_by_the_1_0_0_qualification_workload"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "vector_representation",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:vector_representation@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/representation/mock.rs",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/representation/ggcore.rs"
+      ],
+      "limitations": [
+        "qualification_exercises_MockEngine_only",
+        "GG_CORE_ONNX_engine_is_implemented_but_not_exercised_or_product_default_qualified"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "candidate_only",
+        "deletion_model": "candidate_drop",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
     },
     {
       "capability_id": "vector_candidate_retrieval",
       "capability_version": "1.0",
-      "maturity": "runtime_wired",
+      "maturity": "evidence_proven",
       "state_posture": "derived",
-      "scope_posture": "inherits_agent_memory_scope",
+      "scope_posture": "external_scope_bridge",
       "failure_posture": "explicit_unavailable",
       "authority_effect": "none",
       "enabled": true,
-      "evidence_refs": ["inventory:evolveai:vector-retrieval"],
-      "limitations": ["mock_default_representation"]
+      "evidence_refs": [
+        "qualification:evolveai:vector_candidate_retrieval@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/processor/query.rs"
+      ],
+      "limitations": [
+        "qualification_exercises_mock_derived_vectors_not_real_embedding_quality",
+        "candidate_ranking_does_not_create_recall_admission"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "candidate_only",
+        "deletion_model": "candidate_drop",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "temporal_graph",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:temporal_graph@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/tiers/l2_graph.rs"
+      ],
+      "limitations": [
+        "provider_graph_state_is_not_agent_memory_canonical_state"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "graph_traversal",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:graph_traversal@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/tiers/l2_graph.rs",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/processor/facade.rs"
+      ],
+      "limitations": [
+        "qualification_covers_direct_neighbor_association_only",
+        "graph_reachability_is_candidate_evidence_not_recall_permission"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "candidate_only",
+        "deletion_model": "candidate_drop",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
     },
     {
       "capability_id": "graph_augmented_context_assembly",
       "capability_version": "1.0",
       "maturity": "declared",
       "state_posture": "derived",
-      "scope_posture": "inherits_agent_memory_scope",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": false,
+      "evidence_refs": [
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:README.md"
+      ],
+      "limitations": [
+        "L2_graph_plus_vector_scan_is_not_end_to_end_GraphRAG_context_assembly",
+        "disabled_until_dedicated_context_assembly_qualification_exists"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "candidate_only",
+        "deletion_model": "candidate_drop",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "content_addressed_exact_retrieval",
+      "capability_version": "1.0",
+      "maturity": "reference_qualified",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
       "failure_posture": "explicit_unavailable",
       "authority_effect": "none",
       "enabled": true,
-      "evidence_refs": ["inventory:evolveai:graphrag-design"],
-      "limitations": ["end_to_end_runtime_path_not_qualified"]
+      "evidence_refs": [
+        "qualification:evolveai:content_addressed_exact_retrieval@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/processor/query.rs"
+      ],
+      "limitations": [
+        "EvolveAI_content_address_is_provider_identity_not_universal_agent_memory_identity",
+        "explicit_Agent_Memory_scope_binding_is_required"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": false, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "tier_routing",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "proposal_only",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:tier_routing@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/tiers/router.rs"
+      ],
+      "limitations": [
+        "MTS_placement_is_provider_local_and_does_not_create_truth_or_agent_memory_authority",
+        "sensitivity_privilege_accuracy_compute_factors_are_not_epistemic_certification"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": false, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "not_applicable",
+        "deletion_model": "not_applicable",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "proposal_only"
+      }
     },
     {
       "capability_id": "lifecycle_decay",
       "capability_version": "1.0",
       "maturity": "runtime_wired",
       "state_posture": "derived",
-      "scope_posture": "inherits_agent_memory_scope",
-      "failure_posture": "fail_closed",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
       "authority_effect": "proposal_only",
       "enabled": true,
-      "evidence_refs": ["inventory:evolveai:decay"],
-      "limitations": ["does_not_self_authorize_lifecycle_mutation"]
+      "evidence_refs": [
+        "qualification:evolveai:lifecycle_decay@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/processor/metabolism.rs"
+      ],
+      "limitations": [
+        "qualification_proves_supported_invocation_path_not_all_decay_threshold_semantics",
+        "repeated_access_or_decay_weight_does_not_count_as_independent_corroboration"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "explicit_signal",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "proposal_only"
+      }
+    },
+    {
+      "capability_id": "lifecycle_orchestration",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "proposal_only",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:lifecycle_orchestration@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/lifecycle/orchestrator.rs",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/processor/facade.rs"
+      ],
+      "limitations": [
+        "provider_lifecycle_state_machine_does_not_create_agent_memory_mutation_or_action_authority"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "explicit_signal",
+        "correction_model": "not_applicable",
+        "deletion_model": "not_applicable",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "proposal_only"
+      }
+    },
+    {
+      "capability_id": "rem_synthesis_consolidation",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "proposal_only",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:rem_synthesis_consolidation@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/processor/facade.rs"
+      ],
+      "limitations": [
+        "current_REM_synthesis_path_runs_decay_promotion_and_consumes_traces",
+        "does_not_claim_semantic_consolidation_beyond_observed_runtime_behavior"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "explicit_signal",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "proposal_only"
+      }
+    },
+    {
+      "capability_id": "negative_failure_memory",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "proposal_only",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:negative_failure_memory@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/shadow/genome.rs",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/shadow/interceptor.rs"
+      ],
+      "limitations": [
+        "native_Shadow_Block_is_normalized_as_risk_candidate_evidence_only",
+        "similarity_or_trigger_count_never_becomes_agent_memory_PASS_BLOCK_or_action_authority"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": true},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "explicit_signal",
+        "correction_model": "candidate_only",
+        "deletion_model": "candidate_drop",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "proposal_only"
+      }
+    },
+    {
+      "capability_id": "persistent_snapshot_restart",
+      "capability_version": "1.0",
+      "maturity": "reference_qualified",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:persistent_snapshot_restart@evolveai-public-facade-behavior/1.0.0",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/processor/persist.rs"
+      ],
+      "limitations": [
+        "L1_is_intentionally_ephemeral_and_excluded_from_snapshot",
+        "qualification_covers_explicit_save_load_not_crash_consistency_beyond_provider_contract"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "audited_deletion",
+      "capability_version": "1.0",
+      "maturity": "reference_qualified",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:audited_deletion@evolveai-public-facade-behavior/1.0.0",
+        "fix:EvolveAI#19@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/tiers/l3_vault.rs"
+      ],
+      "limitations": [
+        "qualified_claim_is_native_L3_live_removal_plus_reconstructable_delete_history",
+        "does_not_prove_transitive_forgetting_or_erasure_of_external_derived_representations",
+        "explicit_Agent_Memory_scope_and_mutation_governance_remain_required"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "explicit_signal",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
+    },
+    {
+      "capability_id": "l3_provenance_audit",
+      "capability_version": "1.0",
+      "maturity": "reference_qualified",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "qualification:evolveai:l3_provenance_audit@evolveai-public-facade-behavior/1.0.0",
+        "fix:EvolveAI#19@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd",
+        "source:EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd:crates/evolve-core/src/tiers/l3_vault.rs"
+      ],
+      "limitations": [
+        "qualification_is_specific_to_L3_hash_chain_mutation_history",
+        "audit_evidence_is_not_truth_certification_or_agent_memory_authority"
+      ],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": false},
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "explicit_signal",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "provider_managed",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      }
     }
   ]
 }

--- a/reference/fixtures/evolveai-qualification-driver/Cargo.toml
+++ b/reference/fixtures/evolveai-qualification-driver/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "agent-memory-evolveai-qualification-driver"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+evolve-core = { path = "../../../_evolveai/crates/evolve-core" }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/reference/fixtures/evolveai-qualification-driver/src/main.rs
+++ b/reference/fixtures/evolveai-qualification-driver/src/main.rs
@@ -1,0 +1,189 @@
+use evolve_core::memory::types::{
+    ContentType, InputMetadata, Query, QueryConstraints, RawInput, Sensitivity, Tier, TrustLevel,
+};
+use evolve_core::processor::facade::MemoryProcessor;
+use evolve_core::processor::types::ProcessorConfig;
+use evolve_core::representation::mock::MockEngine;
+use evolve_core::shadow::interceptor::Verdict;
+use evolve_core::shadow::types::{FailureCategory, FailureTrace};
+use serde_json::json;
+
+const DIMS: usize = 384;
+
+fn raw(content: &str, sensitive: bool) -> RawInput {
+    RawInput {
+        content: content.to_string(),
+        content_type: ContentType::Text,
+        metadata: InputMetadata {
+            tags: if sensitive {
+                vec!["sensitive".to_string()]
+            } else {
+                Vec::new()
+            },
+            sensitivity: if sensitive {
+                Sensitivity::Restricted
+            } else {
+                Sensitivity::Public
+            },
+            trust: TrustLevel::Verified,
+            ..InputMetadata::default()
+        },
+    }
+}
+
+fn query(content: &str, tier: Option<Tier>) -> Query {
+    Query {
+        content: content.to_string(),
+        constraints: QueryConstraints {
+            require_tier: tier,
+            top_k: Some(10),
+            ..QueryConstraints::default()
+        },
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = ProcessorConfig::default();
+    config.lifecycle.synthesis_threshold = 3;
+    let mut proc = MemoryProcessor::new(MockEngine::new(DIMS), config.clone());
+    proc.start_session(1_000)?;
+
+    let alpha = proc.encode(&raw("alpha memory", false), 1_100).await?;
+    let beta = proc.encode(&raw("beta memory", false), 1_200).await?;
+    let gamma = proc.encode(&raw("gamma memory", false), 1_300).await?;
+    let l2_routing = [alpha.decision.tier, beta.decision.tier, gamma.decision.tier]
+        .into_iter()
+        .all(|tier| tier == Tier::L2);
+    let temporal_graph_association = !proc.related(&alpha.unit.address).is_empty();
+
+    let vector_result = proc.query(&query("alpha memory", None), 1_350).await?;
+    let vector_scan_runtime = vector_result.recall.metrics.candidates_evaluated >= 3
+        && !vector_result.recall.memories.is_empty();
+
+    let detach = proc.detach(1_400)?;
+    let lifecycle_synthesis = detach.synthesized && detach.traces_processed >= 3;
+
+    proc.record_failure(
+        FailureTrace {
+            category: FailureCategory::Hallucination,
+            severity: FailureCategory::Hallucination.default_severity(),
+            intent: "danger-intent".to_string(),
+            message: "qualification failure pattern".to_string(),
+            timestamp: 1_450,
+        },
+        1_450,
+    )
+    .await?;
+    let shadow_before = proc.shadow_stats();
+    let shadow_verdict = proc.check_safety("danger-intent").await?;
+    let shadow_candidate_block = matches!(shadow_verdict, Verdict::Block { .. })
+        && shadow_before.total_entries == 1
+        && shadow_before.active_entries == 1;
+
+    let sensitive_content = "qualification sensitive durable memory";
+    let sensitive = proc.encode(&raw(sensitive_content, true), 1_500).await?;
+    let sensitive_address = sensitive.unit.address.clone();
+    let l3_routing = sensitive.decision.tier == Tier::L3;
+
+    let exact_before = proc
+        .query(&query(sensitive_content, Some(Tier::L3)), 1_550)
+        .await?;
+    let exact_retrieval = exact_before.recall.metrics.candidates_evaluated == 1
+        && exact_before.recall.memories.len() == 1
+        && exact_before.recall.memories[0].unit.address == sensitive_address;
+
+    let before_snapshot = proc.snapshot(1_600);
+    let before_health = proc.health_check();
+    let before_blocks = before_snapshot.l3_blocks.len();
+
+    let state_path = std::env::temp_dir().join(format!(
+        "agent-memory-evolveai-qualification-{}.json",
+        std::process::id()
+    ));
+    proc.save_to_file(&state_path, 1_650)?;
+
+    let mut restarted = MemoryProcessor::new(MockEngine::new(DIMS), config.clone());
+    restarted.load_from_file(&state_path)?;
+    let restart_snapshot = restarted.snapshot(1_700);
+    let restart_result = restarted
+        .query(&query(sensitive_content, Some(Tier::L3)), 1_750)
+        .await?;
+    let restart_preserved_current = restarted.health_check()
+        && restart_snapshot.l3_blocks.len() == before_blocks
+        && restart_result.recall.memories.len() == 1
+        && restart_result.recall.memories[0].unit.address == sensitive_address;
+
+    let deleted = restarted.forget(&sensitive_address);
+    let after_delete = restarted.snapshot(1_800);
+    let delete_payload = after_delete
+        .l3_blocks
+        .last()
+        .map(|block| block.data_hash.clone())
+        .unwrap_or_default();
+    let audited_delete = deleted
+        && restarted.health_check()
+        && after_delete.l3_entries.is_empty()
+        && delete_payload.starts_with(&format!("delete:{}:", sensitive_address));
+
+    let post_delete_result = restarted
+        .query(&query(sensitive_content, Some(Tier::L3)), 1_850)
+        .await?;
+    let deleted_not_current = post_delete_result.recall.memories.is_empty();
+
+    restarted.save_to_file(&state_path, 1_900)?;
+    let mut after_restart = MemoryProcessor::new(MockEngine::new(DIMS), config);
+    after_restart.load_from_file(&state_path)?;
+    let final_snapshot = after_restart.snapshot(1_950);
+    let final_result = after_restart
+        .query(&query(sensitive_content, Some(Tier::L3)), 2_000)
+        .await?;
+    let deletion_history_survives_restart = after_restart.health_check()
+        && final_result.recall.memories.is_empty()
+        && final_snapshot.l3_entries.is_empty()
+        && final_snapshot
+            .l3_blocks
+            .last()
+            .map(|block| block.data_hash.as_str())
+            == Some(delete_payload.as_str());
+
+    let _ = std::fs::remove_file(&state_path);
+
+    let output = json!({
+        "schema_version": "1.0.0",
+        "provider": "evolveai",
+        "provider_version": "21161ce7b88dbffeb7ed59757b4d02d24a9c2acd",
+        "runtime": {
+            "engine": "MockEngine",
+            "dimensions": DIMS,
+            "lifecycle_synthesis_threshold": 3,
+            "real_embedding_path_exercised": false
+        },
+        "observations": {
+            "l2_routing": l2_routing,
+            "temporal_graph_association": temporal_graph_association,
+            "vector_scan_runtime": vector_scan_runtime,
+            "lifecycle_synthesis": lifecycle_synthesis,
+            "shadow_candidate_block": shadow_candidate_block,
+            "l3_routing": l3_routing,
+            "exact_retrieval": exact_retrieval,
+            "pre_restart_health": before_health,
+            "restart_preserved_current": restart_preserved_current,
+            "audited_delete": audited_delete,
+            "deleted_not_current": deleted_not_current,
+            "deletion_history_survives_restart": deletion_history_survives_restart
+        },
+        "native_evidence": {
+            "sensitive_address": sensitive_address.as_str(),
+            "l3_blocks_before_delete": before_blocks,
+            "l3_blocks_after_delete": after_delete.l3_blocks.len(),
+            "delete_payload": delete_payload,
+            "shadow_total_entries": shadow_before.total_entries,
+            "shadow_active_entries": shadow_before.active_entries,
+            "detach_traces_processed": detach.traces_processed
+        }
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}

--- a/reference/fixtures/evolveai-qualification.json
+++ b/reference/fixtures/evolveai-qualification.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "1.0.0",
+  "fixture_id": "evolveai-public-facade-v1",
+  "provider": {
+    "component_id": "evolveai",
+    "component_version": "21161ce7b88dbffeb7ed59757b4d02d24a9c2acd",
+    "implementation_ref": "MythologIQ-Labs-LLC/EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd"
+  },
+  "adapter": {
+    "adapter_id": "evolveai-public-facade-adapter",
+    "adapter_version": "1.0.0",
+    "qualification_profile_id": "evolveai-public-facade-behavior",
+    "qualification_profile_version": "1.0.0"
+  },
+  "runtime": {
+    "engine": "MockEngine",
+    "dimensions": 384,
+    "lifecycle_synthesis_threshold": 3,
+    "real_embedding_path_exercised": false
+  },
+  "scope_binding": {
+    "agent_memory_scope": "qualification://tenant-a/project-evolveai",
+    "provider_scope": "evolveai://qualification-store",
+    "requires_exact_component_version": true,
+    "requires_exact_component_profile_digest": true
+  },
+  "workload": {
+    "l2_inputs": ["alpha memory", "beta memory", "gamma memory"],
+    "shadow_failure_intent": "danger-intent",
+    "l3_sensitive_content": "qualification sensitive durable memory"
+  },
+  "claim_boundaries": {
+    "native_shadow_block_is_agent_memory_authority": false,
+    "native_l3_delete_proves_transitive_forgetting": false,
+    "mock_vector_quality_represents_real_embedding_quality": false,
+    "graph_storage_and_traversal_prove_graphrag": false
+  }
+}

--- a/reference/run_evolveai_failure_probe.py
+++ b/reference/run_evolveai_failure_probe.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Emit real unavailable-adapter evidence for the EvolveAI qualification lane."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from agentmem_ref.component_failure_probe import probe_missing_executable
+from agentmem_ref.evolveai_profile import (
+    ADAPTER_ID,
+    ADAPTER_VERSION,
+    EVOLVEAI_COMMIT,
+    IMPLEMENTATION_REF,
+    QUALIFICATION_PROFILE_ID,
+    QUALIFICATION_PROFILE_VERSION,
+)
+from agentmem_ref.qualification import QualificationSubject
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--executable", type=Path, required=True)
+    parser.add_argument("--raw-output", type=Path, required=True)
+    parser.add_argument("--normalized-output", type=Path, required=True)
+    parser.add_argument("--trace-ref", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    subject = QualificationSubject(
+        component_id="evolveai",
+        component_version=EVOLVEAI_COMMIT,
+        implementation_ref=IMPLEMENTATION_REF,
+        capability_id="content_addressed_exact_retrieval",
+        capability_version="1.0",
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        qualification_profile_id=QUALIFICATION_PROFILE_ID,
+        qualification_profile_version=QUALIFICATION_PROFILE_VERSION,
+    )
+    probe_missing_executable(
+        subject=subject,
+        executable=args.executable,
+        args=("--version",),
+        raw_path=args.raw_output,
+        normalized_path=args.normalized_output,
+        trace_ref=args.trace_ref,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/run_evolveai_multicapability_qualification.py
+++ b/reference/run_evolveai_multicapability_qualification.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Normalize EvolveAI public-facade evidence into #298 qualification records."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+from agentmem_ref.evolveai_profile import (
+    ADAPTER_ID,
+    ADAPTER_VERSION,
+    EVOLVEAI_COMMIT,
+    EXPECTED_MATURITY,
+    IMPLEMENTATION_REF,
+    QUALIFICATION_PROFILE_ID,
+    QUALIFICATION_PROFILE_VERSION,
+    QUALIFIED_CAPABILITIES,
+    assert_scope_binding,
+    build_profile_report,
+    build_scope_binding,
+    load_profile,
+    profile_digest,
+)
+from agentmem_ref.qualification import (
+    AdapterResult,
+    QualificationRuntime,
+    QualificationSubject,
+    qualification_from_adapter_results,
+)
+
+
+MaturityBefore = dict[str, str]
+MATURITY_BEFORE: MaturityBefore = {
+    "vector_representation": "runtime_wired",
+    "vector_candidate_retrieval": "runtime_wired",
+    "temporal_graph": "runtime_wired",
+    "graph_traversal": "implemented",
+    "content_addressed_exact_retrieval": "runtime_wired",
+    "tier_routing": "runtime_wired",
+    "lifecycle_decay": "runtime_wired",
+    "lifecycle_orchestration": "implemented",
+    "rem_synthesis_consolidation": "implemented",
+    "negative_failure_memory": "implemented",
+    "persistent_snapshot_restart": "runtime_wired",
+    "audited_deletion": "runtime_wired",
+    "l3_provenance_audit": "implemented",
+}
+
+CAPABILITY_OBSERVATIONS: dict[str, tuple[str, ...]] = {
+    "vector_representation": ("vector_scan_runtime",),
+    "vector_candidate_retrieval": ("vector_scan_runtime",),
+    "temporal_graph": ("l2_routing", "temporal_graph_association"),
+    "graph_traversal": ("temporal_graph_association",),
+    "content_addressed_exact_retrieval": (
+        "exact_retrieval",
+        "restart_preserved_current",
+        "deleted_not_current",
+    ),
+    "tier_routing": ("l2_routing", "l3_routing"),
+    "lifecycle_decay": ("lifecycle_synthesis",),
+    "lifecycle_orchestration": ("lifecycle_synthesis",),
+    "rem_synthesis_consolidation": ("lifecycle_synthesis",),
+    "negative_failure_memory": ("shadow_candidate_block",),
+    "persistent_snapshot_restart": (
+        "pre_restart_health",
+        "restart_preserved_current",
+        "deletion_history_survives_restart",
+    ),
+    "audited_deletion": (
+        "audited_delete",
+        "deleted_not_current",
+        "deletion_history_survives_restart",
+    ),
+    "l3_provenance_audit": (
+        "pre_restart_health",
+        "audited_delete",
+        "deletion_history_survives_restart",
+    ),
+}
+
+OPERATIONS = {
+    "vector_representation": "represent",
+    "vector_candidate_retrieval": "recall_candidate",
+    "temporal_graph": "graph_store",
+    "graph_traversal": "traverse",
+    "content_addressed_exact_retrieval": "exact_retrieve",
+    "tier_routing": "route",
+    "lifecycle_decay": "maintenance",
+    "lifecycle_orchestration": "orchestrate",
+    "rem_synthesis_consolidation": "consolidate",
+    "negative_failure_memory": "risk_candidate",
+    "persistent_snapshot_restart": "save_load",
+    "audited_deletion": "delete",
+    "l3_provenance_audit": "verify_audit",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", type=Path, required=True)
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--raw", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--agent-memory-commit", required=True)
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def canonical_digest(value: object) -> str:
+    rendered = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(rendered).hexdigest()
+
+
+def subject(capability_id: str) -> QualificationSubject:
+    return QualificationSubject(
+        component_id="evolveai",
+        component_version=EVOLVEAI_COMMIT,
+        implementation_ref=IMPLEMENTATION_REF,
+        capability_id=capability_id,
+        capability_version="1.0",
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        qualification_profile_id=QUALIFICATION_PROFILE_ID,
+        qualification_profile_version=QUALIFICATION_PROFILE_VERSION,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    profile = load_profile(args.profile)
+    fixture = json.loads(args.fixture.read_text(encoding="utf-8"))
+    raw = json.loads(args.raw.read_text(encoding="utf-8"))
+
+    if raw.get("provider") != "evolveai" or raw.get("provider_version") != EVOLVEAI_COMMIT:
+        raise SystemExit("native EvolveAI evidence is not bound to the repaired exact commit")
+    expected_runtime = fixture["runtime"]
+    if raw.get("runtime") != expected_runtime:
+        raise SystemExit(
+            f"native EvolveAI runtime identity drifted: observed={raw.get('runtime')} expected={expected_runtime}"
+        )
+    observations = raw.get("observations")
+    if not isinstance(observations, dict):
+        raise SystemExit("native EvolveAI evidence is missing observations")
+
+    required_observations = sorted({item for items in CAPABILITY_OBSERVATIONS.values() for item in items})
+    missing = [name for name in required_observations if observations.get(name) is not True]
+    if missing:
+        raise SystemExit(f"EvolveAI workload did not prove required observations: {missing}")
+
+    fixture_provider = fixture["provider"]
+    if fixture_provider["component_version"] != EVOLVEAI_COMMIT:
+        raise SystemExit("fixture component pin drifted")
+    if fixture_provider["implementation_ref"] != IMPLEMENTATION_REF:
+        raise SystemExit("fixture implementation ref drifted")
+    fixture_adapter = fixture["adapter"]
+    expected_adapter = {
+        "adapter_id": ADAPTER_ID,
+        "adapter_version": ADAPTER_VERSION,
+        "qualification_profile_id": QUALIFICATION_PROFILE_ID,
+        "qualification_profile_version": QUALIFICATION_PROFILE_VERSION,
+    }
+    if fixture_adapter != expected_adapter:
+        raise SystemExit("fixture adapter/profile identity drifted")
+
+    profile_sha = profile_digest(profile)
+    scope_spec = fixture["scope_binding"]
+    binding = build_scope_binding(
+        agent_memory_scope=scope_spec["agent_memory_scope"],
+        provider_scope=scope_spec["provider_scope"],
+        profile_sha256=profile_sha,
+    )
+    assert_scope_binding(
+        binding,
+        requested_scope=scope_spec["agent_memory_scope"],
+        profile_sha256=profile_sha,
+    )
+
+    configuration = {
+        "runtime": expected_runtime,
+        "scope_binding": binding,
+        "claim_boundaries": fixture["claim_boundaries"],
+    }
+    runtime = QualificationRuntime(
+        configuration_digest=canonical_digest(configuration),
+        fixture_id=fixture["fixture_id"],
+        fixture_digest=sha256_file(args.fixture),
+        dependency_refs=(
+            f"MythologIQ-Labs-LLC/EvolveAI@{EVOLVEAI_COMMIT}",
+            "rust:stable",
+            "engine:EvolveAI::MockEngine@384",
+        ),
+        runtime_refs=(
+            f"driver:{ADAPTER_ID}@{ADAPTER_VERSION}",
+            f"qualification-profile:{QUALIFICATION_PROFILE_ID}@{QUALIFICATION_PROFILE_VERSION}",
+            f"component-profile:{profile_sha}",
+        ),
+    )
+
+    raw_digest = sha256_file(args.raw)
+    profile_file_digest = sha256_file(args.profile)
+    fixture_digest = sha256_file(args.fixture)
+    artifact_digests = (raw_digest, profile_file_digest, fixture_digest)
+
+    normalized = {
+        "schema_version": "1.0.0",
+        "provider": "evolveai",
+        "provider_version": EVOLVEAI_COMMIT,
+        "profile_digest": profile_sha,
+        "scope_binding": binding,
+        "vector": {
+            "provider_engine": "MockEngine",
+            "runtime_path_proven": True,
+            "real_embedding_quality_proven": False,
+            "agent_memory_recall_authority": False,
+        },
+        "graph": {
+            "temporal_association_proven": True,
+            "direct_neighbor_traversal_proven": True,
+            "graph_augmented_context_assembly_proven": False,
+        },
+        "lifecycle": {
+            "orchestration_proven": True,
+            "rem_synthesis_path_proven": True,
+            "all_decay_threshold_semantics_proven": False,
+            "repetition_is_independent_corroboration": False,
+        },
+        "shadow": {
+            "provider_native_block_observed": True,
+            "agent_memory_interpretation": "risk_candidate_only",
+            "agent_memory_pass_block_authority": False,
+        },
+        "persistence": {
+            "current_state_survives_explicit_save_load": True,
+            "delete_history_survives_explicit_save_load": True,
+            "l1_restart_persistence_proven": False,
+        },
+        "deletion": {
+            "native_l3_live_removal_proven": True,
+            "native_delete_ledger_event_proven": True,
+            "deleted_value_not_current_after_delete": True,
+            "delete_history_survives_restart": True,
+            "transitive_forgetting_proven": False,
+            "external_derived_residue_absence_proven": False,
+        },
+        "correction": {
+            "agent_memory_supersession_semantics_proven": False,
+            "provider_revalidation_required": True,
+        },
+        "authority_effect": "none",
+    }
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    normalized_path = args.output_dir / "evolveai-normalized-evidence.json"
+    normalized_path.write_text(json.dumps(normalized, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    normalized_ref = "artifact://evolveai-normalized-evidence.json"
+    raw_ref = "artifact://evolveai-native-observation.json"
+
+    records = []
+    for capability_id in sorted(QUALIFIED_CAPABILITIES):
+        expected_maturity = EXPECTED_MATURITY[capability_id]
+        cap_subject = subject(capability_id)
+        observation_names = CAPABILITY_OBSERVATIONS[capability_id]
+        checks = [
+            (f"native.{name}", observations[name] is True, raw_ref)
+            for name in observation_names
+        ]
+        checks.extend(
+            [
+                ("exact_component_pin", raw["provider_version"] == EVOLVEAI_COMMIT, raw_ref),
+                ("external_scope_bridge_bound", binding["agent_memory_scope"] == scope_spec["agent_memory_scope"], normalized_ref),
+                ("profile_digest_bound", binding["component_profile_digest"] == profile_sha, normalized_ref),
+                ("no_agent_memory_authority", normalized["authority_effect"] == "none", normalized_ref),
+            ]
+        )
+        if capability_id in {"vector_representation", "vector_candidate_retrieval"}:
+            checks.extend(
+                [
+                    ("mock_engine_explicit", raw["runtime"]["engine"] == "MockEngine", raw_ref),
+                    ("real_embedding_quality_not_overclaimed", not normalized["vector"]["real_embedding_quality_proven"], normalized_ref),
+                ]
+            )
+        if capability_id == "negative_failure_memory":
+            checks.append(
+                ("native_block_not_policy_authority", not normalized["shadow"]["agent_memory_pass_block_authority"], normalized_ref)
+            )
+        if capability_id in {"audited_deletion", "l3_provenance_audit"}:
+            checks.extend(
+                [
+                    ("transitive_forgetting_not_overclaimed", not normalized["deletion"]["transitive_forgetting_proven"], normalized_ref),
+                    ("external_residue_not_overclaimed", not normalized["deletion"]["external_derived_residue_absence_proven"], normalized_ref),
+                ]
+            )
+        if capability_id == "content_addressed_exact_retrieval":
+            checks.append(
+                ("post_delete_currentness_absent", normalized["deletion"]["deleted_value_not_current_after_delete"], normalized_ref)
+            )
+
+        result = AdapterResult(
+            subject=cap_subject,
+            operation=OPERATIONS[capability_id],
+            runtime_identity=f"EvolveAI@{EVOLVEAI_COMMIT};MockEngine:{expected_runtime['dimensions']}",
+            input_refs=(f"fixture://{fixture['fixture_id']}",),
+            raw_provider_refs=(raw_ref,),
+            normalized_refs=(f"{normalized_ref}#{capability_id}",),
+            currentness="current",
+            failure_result="none",
+            trace_ref=f"trace://evolveai/{capability_id}/1.0.0",
+        )
+        record = qualification_from_adapter_results(
+            subject=cap_subject,
+            runtime=runtime,
+            license_id="Apache-2.0",
+            license_ref=f"MythologIQ-Labs-LLC/EvolveAI/LICENSE@{EVOLVEAI_COMMIT}",
+            use_posture="runtime_allowed",
+            results=(result,),
+            checks=checks,
+            artifact_digests=artifact_digests,
+            maturity_before=MATURITY_BEFORE[capability_id],
+            profile_maturity_ceiling=expected_maturity,
+            earned_maturity=expected_maturity,
+            limitations=tuple(
+                next(
+                    capability["limitations"]
+                    for capability in profile["capabilities"]
+                    if capability["capability_id"] == capability_id
+                )
+            ),
+        )
+        record_path = args.output_dir / f"qualification-{capability_id}.json"
+        record_path.write_text(json.dumps(record.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        records.append(
+            {
+                "capability_id": capability_id,
+                "earned_maturity": expected_maturity,
+                "applicability_digest": record.applicability_digest,
+                "record": record_path.name,
+            }
+        )
+
+    profile_report = build_profile_report(profile, agent_memory_commit=args.agent_memory_commit)
+    profile_report_path = args.output_dir / "evolveai-profile-report.json"
+    profile_report_path.write_text(
+        json.dumps(profile_report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    invariants = {
+        "all_native_observations_true": all(observations[name] is True for name in required_observations),
+        "exact_repaired_pin": raw["provider_version"] == EVOLVEAI_COMMIT,
+        "scope_binding_exact": binding["agent_memory_scope"] == scope_spec["agent_memory_scope"],
+        "scope_binding_version_bound": binding["component_version"] == EVOLVEAI_COMMIT,
+        "scope_binding_profile_bound": binding["component_profile_digest"] == profile_sha,
+        "mock_vector_boundary_explicit": raw["runtime"]["engine"] == "MockEngine" and not normalized["vector"]["real_embedding_quality_proven"],
+        "graphrag_not_inferred": not normalized["graph"]["graph_augmented_context_assembly_proven"],
+        "shadow_block_not_authority": not normalized["shadow"]["agent_memory_pass_block_authority"],
+        "deletion_currentness_proven": normalized["deletion"]["deleted_value_not_current_after_delete"],
+        "delete_history_restart_proven": normalized["deletion"]["delete_history_survives_restart"],
+        "transitive_forgetting_not_claimed": not normalized["deletion"]["transitive_forgetting_proven"],
+        "external_residue_not_claimed_absent": not normalized["deletion"]["external_derived_residue_absence_proven"],
+        "qualification_records_independent": len(records) == len(QUALIFIED_CAPABILITIES) and len({item["applicability_digest"] for item in records}) == len(records),
+        "authority_effect_none": normalized["authority_effect"] == "none" and profile_report["authority_effect"] == "none",
+    }
+    if not all(invariants.values()):
+        raise SystemExit(f"EvolveAI qualification invariants failed: {invariants}")
+
+    summary = {
+        "schema_version": "1.0.0",
+        "agent_memory_commit": args.agent_memory_commit,
+        "provider_commit": EVOLVEAI_COMMIT,
+        "profile_digest": profile_sha,
+        "raw_provider_digest": raw_digest,
+        "fixture_digest": fixture_digest,
+        "normalized_digest": sha256_file(normalized_path),
+        "records": records,
+        "invariants": invariants,
+        "authority_effect": "none",
+    }
+    (args.output_dir / "evolveai-qualification-summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/tests/test_evolveai_profile.py
+++ b/reference/tests/test_evolveai_profile.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from agentmem_ref.evolveai_profile import (
+    EVOLVEAI_COMMIT,
+    EvolveAIProfileError,
+    assert_scope_binding,
+    build_profile_report,
+    build_scope_binding,
+    profile_digest,
+    validate_profile,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE_PATH = ROOT / "reference/fixtures/component-capabilities/evolveai.example.json"
+
+
+def profile() -> dict:
+    return json.loads(PROFILE_PATH.read_text(encoding="utf-8"))
+
+
+def capability(value: dict, capability_id: str) -> dict:
+    return next(item for item in value["capabilities"] if item["capability_id"] == capability_id)
+
+
+def test_current_profile_is_valid_and_bounded() -> None:
+    value = profile()
+    component = validate_profile(value)
+    assert component.component_version == EVOLVEAI_COMMIT
+    report = build_profile_report(value, agent_memory_commit="a" * 40)
+    assert all(report["invariants"].values())
+    assert report["maturity_counts"]["reference_qualified"] == 4
+    assert report["maturity_counts"]["declared"] == 1
+    assert report["maturity_counts"]["implemented"] == 1
+
+
+def test_old_pre_delete_fix_pin_is_rejected() -> None:
+    value = profile()
+    value["component_version"] = "7cd42412ceed2ab638249a1517b2a6dac46f1312"
+    with pytest.raises(EvolveAIProfileError, match="repaired commit"):
+        validate_profile(value)
+
+
+def test_graphrag_cannot_hitchhike_on_graph_and_vector_evidence() -> None:
+    value = profile()
+    graph_rag = capability(value, "graph_augmented_context_assembly")
+    graph_rag["maturity"] = "evidence_proven"
+    graph_rag["enabled"] = True
+    with pytest.raises(EvolveAIProfileError):
+        validate_profile(value)
+
+
+def test_mock_vector_boundary_cannot_be_removed() -> None:
+    value = profile()
+    vector = capability(value, "vector_candidate_retrieval")
+    vector["limitations"] = ["candidate_ranking_does_not_create_recall_admission"]
+    with pytest.raises(EvolveAIProfileError, match="mock-engine"):
+        validate_profile(value)
+
+
+def test_shadow_native_block_cannot_gain_agent_memory_authority() -> None:
+    value = profile()
+    shadow = capability(value, "negative_failure_memory")
+    shadow["authority_effect"] = "none"
+    with pytest.raises(EvolveAIProfileError, match="proposal_only"):
+        validate_profile(value)
+
+
+def test_native_delete_cannot_be_reframed_as_transitive_forgetting() -> None:
+    value = profile()
+    deletion = capability(value, "audited_deletion")
+    deletion["limitations"] = [
+        "qualified_claim_is_native_L3_live_removal_plus_reconstructable_delete_history"
+    ]
+    with pytest.raises(EvolveAIProfileError, match="transitive"):
+        validate_profile(value)
+
+
+def test_scope_binding_rejects_foreign_scope() -> None:
+    digest = profile_digest(profile())
+    binding = build_scope_binding(
+        agent_memory_scope="qualification://tenant-a/project-evolveai",
+        provider_scope="evolveai://qualification-store",
+        profile_sha256=digest,
+    )
+    with pytest.raises(EvolveAIProfileError, match="requested Agent Memory scope"):
+        assert_scope_binding(
+            binding,
+            requested_scope="qualification://tenant-b/project-evolveai",
+            profile_sha256=digest,
+        )
+
+
+def test_scope_binding_rejects_stale_component_version() -> None:
+    digest = profile_digest(profile())
+    binding = build_scope_binding(
+        agent_memory_scope="qualification://tenant-a/project-evolveai",
+        provider_scope="evolveai://qualification-store",
+        profile_sha256=digest,
+    )
+    with pytest.raises(EvolveAIProfileError, match="stale for this component version"):
+        assert_scope_binding(
+            binding,
+            requested_scope=binding["agent_memory_scope"],
+            profile_sha256=digest,
+            component_version="0" * 40,
+        )
+
+
+def test_scope_binding_rejects_stale_profile_digest() -> None:
+    digest = profile_digest(profile())
+    binding = build_scope_binding(
+        agent_memory_scope="qualification://tenant-a/project-evolveai",
+        provider_scope="evolveai://qualification-store",
+        profile_sha256=digest,
+    )
+    with pytest.raises(EvolveAIProfileError, match="stale for this profile digest"):
+        assert_scope_binding(
+            binding,
+            requested_scope=binding["agent_memory_scope"],
+            profile_sha256="sha256:" + "0" * 64,
+        )
+
+
+def test_profile_edit_changes_digest_and_invalidates_old_binding() -> None:
+    original = profile()
+    old_digest = profile_digest(original)
+    binding = build_scope_binding(
+        agent_memory_scope="qualification://tenant-a/project-evolveai",
+        provider_scope="evolveai://qualification-store",
+        profile_sha256=old_digest,
+    )
+    edited = copy.deepcopy(original)
+    capability(edited, "temporal_graph")["limitations"].append("material_profile_change")
+    new_digest = profile_digest(edited)
+    assert new_digest != old_digest
+    with pytest.raises(EvolveAIProfileError, match="stale for this profile digest"):
+        assert_scope_binding(
+            binding,
+            requested_scope=binding["agent_memory_scope"],
+            profile_sha256=new_digest,
+        )

--- a/reference/tests/test_evolveai_profile.py
+++ b/reference/tests/test_evolveai_profile.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import copy
 import json
 from pathlib import Path
-
-import pytest
+import unittest
 
 from agentmem_ref.evolveai_profile import (
     EVOLVEAI_COMMIT,
@@ -28,120 +27,116 @@ def capability(value: dict, capability_id: str) -> dict:
     return next(item for item in value["capabilities"] if item["capability_id"] == capability_id)
 
 
-def test_current_profile_is_valid_and_bounded() -> None:
-    value = profile()
-    component = validate_profile(value)
-    assert component.component_version == EVOLVEAI_COMMIT
-    report = build_profile_report(value, agent_memory_commit="a" * 40)
-    assert all(report["invariants"].values())
-    assert report["maturity_counts"]["reference_qualified"] == 4
-    assert report["maturity_counts"]["declared"] == 1
-    assert report["maturity_counts"]["implemented"] == 1
+class EvolveAIProfileTests(unittest.TestCase):
+    def test_current_profile_is_valid_and_bounded(self) -> None:
+        value = profile()
+        component = validate_profile(value)
+        self.assertEqual(component.component_version, EVOLVEAI_COMMIT)
+        report = build_profile_report(value, agent_memory_commit="a" * 40)
+        self.assertTrue(all(report["invariants"].values()))
+        self.assertEqual(report["maturity_counts"]["reference_qualified"], 4)
+        self.assertEqual(report["maturity_counts"]["declared"], 1)
+        self.assertEqual(report["maturity_counts"]["implemented"], 1)
 
+    def test_old_pre_delete_fix_pin_is_rejected(self) -> None:
+        value = profile()
+        value["component_version"] = "7cd42412ceed2ab638249a1517b2a6dac46f1312"
+        with self.assertRaisesRegex(EvolveAIProfileError, "repaired commit"):
+            validate_profile(value)
 
-def test_old_pre_delete_fix_pin_is_rejected() -> None:
-    value = profile()
-    value["component_version"] = "7cd42412ceed2ab638249a1517b2a6dac46f1312"
-    with pytest.raises(EvolveAIProfileError, match="repaired commit"):
-        validate_profile(value)
+    def test_graphrag_cannot_hitchhike_on_graph_and_vector_evidence(self) -> None:
+        value = profile()
+        graph_rag = capability(value, "graph_augmented_context_assembly")
+        graph_rag["maturity"] = "evidence_proven"
+        graph_rag["enabled"] = True
+        with self.assertRaises(EvolveAIProfileError):
+            validate_profile(value)
 
+    def test_mock_vector_boundary_cannot_be_removed(self) -> None:
+        value = profile()
+        vector = capability(value, "vector_candidate_retrieval")
+        vector["limitations"] = ["candidate_ranking_does_not_create_recall_admission"]
+        with self.assertRaisesRegex(EvolveAIProfileError, "mock-engine"):
+            validate_profile(value)
 
-def test_graphrag_cannot_hitchhike_on_graph_and_vector_evidence() -> None:
-    value = profile()
-    graph_rag = capability(value, "graph_augmented_context_assembly")
-    graph_rag["maturity"] = "evidence_proven"
-    graph_rag["enabled"] = True
-    with pytest.raises(EvolveAIProfileError):
-        validate_profile(value)
+    def test_shadow_native_block_cannot_gain_agent_memory_authority(self) -> None:
+        value = profile()
+        shadow = capability(value, "negative_failure_memory")
+        shadow["authority_effect"] = "none"
+        with self.assertRaisesRegex(EvolveAIProfileError, "proposal_only"):
+            validate_profile(value)
 
+    def test_native_delete_cannot_be_reframed_as_transitive_forgetting(self) -> None:
+        value = profile()
+        deletion = capability(value, "audited_deletion")
+        deletion["limitations"] = [
+            "qualified_claim_is_native_L3_live_removal_plus_reconstructable_delete_history"
+        ]
+        with self.assertRaisesRegex(EvolveAIProfileError, "transitive"):
+            validate_profile(value)
 
-def test_mock_vector_boundary_cannot_be_removed() -> None:
-    value = profile()
-    vector = capability(value, "vector_candidate_retrieval")
-    vector["limitations"] = ["candidate_ranking_does_not_create_recall_admission"]
-    with pytest.raises(EvolveAIProfileError, match="mock-engine"):
-        validate_profile(value)
-
-
-def test_shadow_native_block_cannot_gain_agent_memory_authority() -> None:
-    value = profile()
-    shadow = capability(value, "negative_failure_memory")
-    shadow["authority_effect"] = "none"
-    with pytest.raises(EvolveAIProfileError, match="proposal_only"):
-        validate_profile(value)
-
-
-def test_native_delete_cannot_be_reframed_as_transitive_forgetting() -> None:
-    value = profile()
-    deletion = capability(value, "audited_deletion")
-    deletion["limitations"] = [
-        "qualified_claim_is_native_L3_live_removal_plus_reconstructable_delete_history"
-    ]
-    with pytest.raises(EvolveAIProfileError, match="transitive"):
-        validate_profile(value)
-
-
-def test_scope_binding_rejects_foreign_scope() -> None:
-    digest = profile_digest(profile())
-    binding = build_scope_binding(
-        agent_memory_scope="qualification://tenant-a/project-evolveai",
-        provider_scope="evolveai://qualification-store",
-        profile_sha256=digest,
-    )
-    with pytest.raises(EvolveAIProfileError, match="requested Agent Memory scope"):
-        assert_scope_binding(
-            binding,
-            requested_scope="qualification://tenant-b/project-evolveai",
+    def test_scope_binding_rejects_foreign_scope(self) -> None:
+        digest = profile_digest(profile())
+        binding = build_scope_binding(
+            agent_memory_scope="qualification://tenant-a/project-evolveai",
+            provider_scope="evolveai://qualification-store",
             profile_sha256=digest,
         )
+        with self.assertRaisesRegex(EvolveAIProfileError, "requested Agent Memory scope"):
+            assert_scope_binding(
+                binding,
+                requested_scope="qualification://tenant-b/project-evolveai",
+                profile_sha256=digest,
+            )
 
-
-def test_scope_binding_rejects_stale_component_version() -> None:
-    digest = profile_digest(profile())
-    binding = build_scope_binding(
-        agent_memory_scope="qualification://tenant-a/project-evolveai",
-        provider_scope="evolveai://qualification-store",
-        profile_sha256=digest,
-    )
-    with pytest.raises(EvolveAIProfileError, match="stale for this component version"):
-        assert_scope_binding(
-            binding,
-            requested_scope=binding["agent_memory_scope"],
+    def test_scope_binding_rejects_stale_component_version(self) -> None:
+        digest = profile_digest(profile())
+        binding = build_scope_binding(
+            agent_memory_scope="qualification://tenant-a/project-evolveai",
+            provider_scope="evolveai://qualification-store",
             profile_sha256=digest,
-            component_version="0" * 40,
         )
+        with self.assertRaisesRegex(EvolveAIProfileError, "stale for this component version"):
+            assert_scope_binding(
+                binding,
+                requested_scope=binding["agent_memory_scope"],
+                profile_sha256=digest,
+                component_version="0" * 40,
+            )
 
-
-def test_scope_binding_rejects_stale_profile_digest() -> None:
-    digest = profile_digest(profile())
-    binding = build_scope_binding(
-        agent_memory_scope="qualification://tenant-a/project-evolveai",
-        provider_scope="evolveai://qualification-store",
-        profile_sha256=digest,
-    )
-    with pytest.raises(EvolveAIProfileError, match="stale for this profile digest"):
-        assert_scope_binding(
-            binding,
-            requested_scope=binding["agent_memory_scope"],
-            profile_sha256="sha256:" + "0" * 64,
+    def test_scope_binding_rejects_stale_profile_digest(self) -> None:
+        digest = profile_digest(profile())
+        binding = build_scope_binding(
+            agent_memory_scope="qualification://tenant-a/project-evolveai",
+            provider_scope="evolveai://qualification-store",
+            profile_sha256=digest,
         )
+        with self.assertRaisesRegex(EvolveAIProfileError, "stale for this profile digest"):
+            assert_scope_binding(
+                binding,
+                requested_scope=binding["agent_memory_scope"],
+                profile_sha256="sha256:" + "0" * 64,
+            )
 
-
-def test_profile_edit_changes_digest_and_invalidates_old_binding() -> None:
-    original = profile()
-    old_digest = profile_digest(original)
-    binding = build_scope_binding(
-        agent_memory_scope="qualification://tenant-a/project-evolveai",
-        provider_scope="evolveai://qualification-store",
-        profile_sha256=old_digest,
-    )
-    edited = copy.deepcopy(original)
-    capability(edited, "temporal_graph")["limitations"].append("material_profile_change")
-    new_digest = profile_digest(edited)
-    assert new_digest != old_digest
-    with pytest.raises(EvolveAIProfileError, match="stale for this profile digest"):
-        assert_scope_binding(
-            binding,
-            requested_scope=binding["agent_memory_scope"],
-            profile_sha256=new_digest,
+    def test_profile_edit_changes_digest_and_invalidates_old_binding(self) -> None:
+        original = profile()
+        old_digest = profile_digest(original)
+        binding = build_scope_binding(
+            agent_memory_scope="qualification://tenant-a/project-evolveai",
+            provider_scope="evolveai://qualification-store",
+            profile_sha256=old_digest,
         )
+        edited = copy.deepcopy(original)
+        capability(edited, "temporal_graph")["limitations"].append("material_profile_change")
+        new_digest = profile_digest(edited)
+        self.assertNotEqual(new_digest, old_digest)
+        with self.assertRaisesRegex(EvolveAIProfileError, "stale for this profile digest"):
+            assert_scope_binding(
+                binding,
+                requested_scope=binding["agent_memory_scope"],
+                profile_sha256=new_digest,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #292 against the repaired first-party provider pin:

`MythologIQ-Labs-LLC/EvolveAI@21161ce7b88dbffeb7ed59757b4d02d24a9c2acd`

That exact revision includes EvolveAI PR #21 / issue #19's audited-L3-delete repair.

### Multi-capability v2 profile

Replaces the stale four-row `component-capability-v1` example with a 15-capability `component-capability-v2` declaration. Every capability has independent maturity, behavior metadata, evidence refs, limitations, external scope bridging, failure posture, and authority posture.

The profile deliberately keeps:

- GraphRAG/context assembly declared and disabled;
- transient cache at source-level maturity in this workload;
- lifecycle decay at `runtime_wired` rather than overstating all decay semantics;
- mock-backed vector behavior distinct from unqualified GG-CORE real embedding quality;
- Shadow Genome `Block` evidence proposal-only;
- native audited deletion distinct from transitive forgetting completeness.

### Common #298 qualification contract

Adds an Agent Memory-owned Rust qualification driver compiled against the exact EvolveAI crate. It exercises public `MemoryProcessor` behavior for:

- L2 routing and temporal associations;
- mock-vector candidate retrieval;
- lifecycle trace/detach synthesis;
- Shadow failure memory/native Block;
- L3 sensitive routing and exact retrieval;
- explicit persistence/restart;
- repaired audited delete;
- post-delete non-currentness;
- delete-history persistence across restart.

The Python normalizer emits 13 independent schema-1.1.0 #298 qualification records with separate subjects/applicability digests. Four bounded capabilities target `reference_qualified`: exact retrieval, snapshot/restart, audited deletion, and L3 provenance/audit.

### Adversarial and failure evidence

Fail-closed tests cover old pre-fix provider pin, GraphRAG inflation, mock-vector laundering, Shadow authority escalation, transitive-forgetting overclaim, foreign scope, stale provider version, stale profile digest, and material profile edits.

Focused CI also removes the built qualification adapter from its configured path and uses the common real provider-unavailable probe, preserving raw FileNotFoundError evidence and normalized `provider_unavailable` without authority.

### Claim boundary

No EvolveAI heuristic, tier decision, lifecycle signal, Shadow verdict, provider delete, or qualification result gains Agent Memory mutation, structural, recall-admission, PASS/BLOCK, or action authority.

Closes #292 only after focused and repository-wide exact-head evidence are green and independently inspected.