### PR TITLE
Map Hermes recursive-learning mutation boundaries

### DIFF
--- a/.github/workflows/hermes-recursive-learning-research.yml
+++ b/.github/workflows/hermes-recursive-learning-research.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Verify recursive background review path
         run: |
           grep -q 'skip_memory=True' _hermes/agent/background_review.py
-          grep -q 'review_agent.memory = parent_agent.memory' _hermes/agent/background_review.py
+          grep -q 'review_agent._memory_store = agent._memory_store' _hermes/agent/background_review.py
           grep -q '"memory", "skill_manage"' _hermes/agent/background_review.py
-          grep -q '_background_skill_write_origin' _hermes/agent/background_review.py
+          grep -q '_memory_write_origin = "background_review"' _hermes/agent/background_review.py
 
       - name: Verify approval replay bypass paths
         run: |

--- a/.github/workflows/hermes-recursive-learning-research.yml
+++ b/.github/workflows/hermes-recursive-learning-research.yml
@@ -1,0 +1,130 @@
+name: Hermes Recursive Learning Research
+
+on:
+  pull_request:
+    paths:
+      - 'docs/programs/hermes-research/**'
+      - 'scripts/validate_hermes_recursive_learning_research.py'
+      - '.github/workflows/hermes-recursive-learning-research.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/programs/hermes-research/**'
+      - 'scripts/validate_hermes_recursive_learning_research.py'
+      - '.github/workflows/hermes-recursive-learning-research.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-hermes-research:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Agent Memory
+        uses: actions/checkout@v4
+
+      - name: Checkout exact Hermes source
+        uses: actions/checkout@v4
+        with:
+          repository: NousResearch/hermes-agent
+          ref: 165c889e5b4277b56dadd42949a4112c1e6175a6
+          path: _hermes
+          persist-credentials: false
+
+      - name: Verify exact Hermes source identity and license
+        run: |
+          test "$(git -C _hermes rev-parse HEAD)" = "165c889e5b4277b56dadd42949a4112c1e6175a6"
+          head -n 1 _hermes/LICENSE | grep -q 'MIT License'
+
+      - name: Validate Agent Memory research record
+        run: python scripts/validate_hermes_recursive_learning_research.py
+
+      - name: Verify normal tool mutation interception seam
+        run: |
+          grep -q 'resolve_pre_tool_block' _hermes/agent/tool_executor.py
+          grep -q 'pre_tool_block_checked=True' _hermes/agent/tool_executor.py
+          grep -q '_AGENT_LOOP_TOOLS' _hermes/model_tools.py
+          grep -q '"memory"' _hermes/model_tools.py
+
+      - name: Verify recursive background review path
+        run: |
+          grep -q 'skip_memory=True' _hermes/agent/background_review.py
+          grep -q 'review_agent.memory = parent_agent.memory' _hermes/agent/background_review.py
+          grep -q '"memory", "skill_manage"' _hermes/agent/background_review.py
+          grep -q '_background_skill_write_origin' _hermes/agent/background_review.py
+
+      - name: Verify approval replay bypass paths
+        run: |
+          grep -q 'apply_memory_pending' _hermes/hermes_cli/write_approval_commands.py
+          grep -q 'apply_skill_pending' _hermes/hermes_cli/write_approval_commands.py
+          grep -q 'bypassing the write gate' _hermes/tools/memory_tool.py
+          grep -q '_skill_gate_bypass.set(True)' _hermes/tools/skill_manager_tool.py
+
+      - name: Verify curator direct durable mutation path
+        run: |
+          grep -q 'def apply_automatic_transitions' _hermes/agent/curator.py
+          grep -q 'archive_skill(name)' _hermes/agent/curator.py
+          grep -q 'def archive_skill' _hermes/tools/skill_usage.py
+
+      - name: Verify Journey direct mutation paths
+        run: |
+          grep -q 'def delete_node' _hermes/agent/learning_mutations.py
+          grep -q 'def edit_node' _hermes/agent/learning_mutations.py
+          grep -q 'MemoryStore._write_file' _hermes/agent/learning_mutations.py
+          grep -q 'skill_usage.archive_skill' _hermes/agent/learning_mutations.py
+
+      - name: Verify external provider is a post-commit mirror
+        run: |
+          grep -q 'def notify_memory_tool_write' _hermes/agent/memory_manager.py
+          grep -q 'provider.on_memory_write' _hermes/agent/memory_manager.py
+          grep -q 'on_memory_write failed' _hermes/agent/memory_manager.py
+          grep -q 'Only ONE external plugin provider is allowed' _hermes/agent/memory_manager.py
+
+      - name: Record exact-head research evidence
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          mkdir -p /tmp/hermes-research
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          files = [
+              Path('docs/programs/hermes-research/hermes-mutation-surface.json'),
+              Path('docs/programs/hermes-research/README.md'),
+          ]
+          digests = {
+              str(path): 'sha256:' + hashlib.sha256(path.read_bytes()).hexdigest()
+              for path in files
+          }
+          record = json.loads(files[0].read_text())
+          evidence = {
+              'schema_version': '1.0.0',
+              'agent_memory_commit': os.environ['HEAD_SHA'],
+              'hermes_commit': '165c889e5b4277b56dadd42949a4112c1e6175a6',
+              'surface_count': len(record['surfaces']),
+              'strict_gap_count': len(record['integration_postures']['strict']['blocking_gaps']),
+              'research_conclusion': record['research_conclusion'],
+              'doctrine_disposition': record['doctrine_disposition'],
+              'authority_effect': record['authority_effect'],
+              'digests': digests,
+          }
+          assert evidence['surface_count'] == 12
+          assert evidence['strict_gap_count'] == 6
+          assert evidence['authority_effect'] == 'none'
+          Path('/tmp/hermes-research/hermes-research-evidence.json').write_text(
+              json.dumps(evidence, indent=2, sort_keys=True) + '\n', encoding='utf-8'
+          )
+          PY
+          cat /tmp/hermes-research/hermes-research-evidence.json
+
+      - name: Upload exact-head Hermes research evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-recursive-learning-${{ github.event.pull_request.head.sha || github.sha }}
+          path: /tmp/hermes-research/hermes-research-evidence.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/hermes-recursive-learning-research.yml
+++ b/.github/workflows/hermes-recursive-learning-research.yml
@@ -56,10 +56,14 @@ jobs:
 
       - name: Verify approval replay bypass paths
         run: |
-          grep -q 'apply_memory_pending' _hermes/hermes_cli/write_approval_commands.py
-          grep -q 'apply_skill_pending' _hermes/hermes_cli/write_approval_commands.py
-          grep -q 'bypassing the write gate' _hermes/tools/memory_tool.py
+          grep -q 'from tools.memory_tool import apply_memory_pending' _hermes/hermes_cli/write_approval_commands.py
+          grep -q 'result = apply_memory_pending(payload, memory_store)' _hermes/hermes_cli/write_approval_commands.py
+          grep -q 'def apply_memory_pending' _hermes/tools/memory_tool.py
+          grep -q 'return store.apply_batch' _hermes/tools/memory_tool.py
+          grep -q 'from tools.skill_manager_tool import apply_skill_pending' _hermes/hermes_cli/write_approval_commands.py
+          grep -q 'def apply_skill_pending' _hermes/tools/skill_manager_tool.py
           grep -q '_skill_gate_bypass.set(True)' _hermes/tools/skill_manager_tool.py
+          grep -q 'return skill_manage(' _hermes/tools/skill_manager_tool.py
 
       - name: Verify curator direct durable mutation path
         run: |

--- a/docs/programs/hermes-research/README.md
+++ b/docs/programs/hermes-research/README.md
@@ -1,0 +1,318 @@
+# Hermes recursive-learning governance research
+
+Issue: #317
+
+Status: **source-bound architecture conclusion; no Hermes adapter implementation in this research slice**
+
+Hermes evidence boundary:
+
+```text
+NousResearch/hermes-agent@165c889e5b4277b56dadd42949a4112c1e6175a6
+license: MIT
+```
+
+Agent Memory starting boundary:
+
+```text
+0df4cf3337b3752105e1b5a110f38eee31f46fef
+```
+
+The machine-readable research record is [`hermes-mutation-surface.json`](hermes-mutation-surface.json).
+
+## Conclusion
+
+The original architecture hypothesis survives, with one important qualification:
+
+> **Hermes should decide what it learned. Agent Memory should decide what that learning is allowed to become as governed durable state.**
+
+Current Hermes already exposes enough generic machinery to support useful **observe** and **govern** integrations without replacing its recursive loop. However, a `pre_tool_call` plugin alone cannot honestly provide **strict** durable-state governance at the pinned revision.
+
+The reason is not that Hermes' main learning loop is opaque. In fact, the current live tool executor is better than its older documentation suggests: normal foreground and background-review `memory` and `skill_manage` calls run through `resolve_pre_tool_block()` before execution.
+
+The strict-mode gap exists because several legitimate durable mutations do not traverse the tool executor at all.
+
+## What is interceptable today
+
+### Foreground model-driven memory and skill writes
+
+The live executor applies the generic pre-tool block before invoking the agent tool. This covers normal model-driven:
+
+- built-in `memory` writes;
+- `skill_manage` creation/edit/patch/delete/supporting-file writes;
+- external provider tools that traverse normal tool execution.
+
+This is enough for an Agent Memory governance plugin to evaluate the ordinary proposal before the underlying tool mutates durable state.
+
+### Background recursive review
+
+Hermes background review creates a forked `AIAgent`, shares the parent built-in `MemoryStore`, restricts mutation tools to `memory` and `skill_manage`, and runs through the normal conversation/tool executor.
+
+Therefore the same generic pre-tool governor can intercept ordinary background-review memory and skill proposals.
+
+This is an important positive result: governing recursive learning does **not** require replacing the background learning loop.
+
+## What bypasses the tool-level governor
+
+### Approved pending memory replay
+
+Hermes write approval can stage a memory mutation. Later `/memory approve` or its gateway equivalent calls `apply_memory_pending()` directly against `MemoryStore`.
+
+That replay:
+
+- does not re-enter the normal tool executor;
+- deliberately bypasses the write-approval gate;
+- does not traverse `pre_tool_call`;
+- does not traverse the normal agent-loop `notify_memory_tool_write()` bridge used to mirror successful built-in writes to external providers.
+
+A human approval is evidence of authorization, but it is not proof that the candidate is still current or that execution used the state the human reviewed.
+
+### Approved pending skill replay
+
+`/skills approve` calls `apply_skill_pending()`, which directly invokes `skill_manage()` while a ContextVar explicitly bypasses the skill write-approval gate.
+
+It likewise does not re-enter the outer model tool middleware.
+
+### Deterministic curator archival
+
+Hermes' curator has two materially different paths:
+
+1. optional LLM consolidation through normal agent/tool execution, which is interceptable;
+2. deterministic inactivity transitions, which can call `skill_usage.archive_skill()` directly.
+
+The second path is a real procedural-memory lifecycle mutation outside the tool executor. Disabling the curator merely to claim strict governance would make Hermes less capable instead of making its existing capabilities governable.
+
+### Journey edit/delete
+
+Hermes' Journey UI/CLI mutation layer directly edits learned state:
+
+- memory edits/deletes rewrite the memory file through `MemoryStore._write_file()`;
+- skill edits call lower-level skill edit logic directly;
+- skill deletes/archive call `skill_usage.archive_skill()`.
+
+These operations are explicitly user-initiated, which is useful authority evidence, but they still need an execution/admission boundary if Agent Memory is to claim complete durable-state governance.
+
+### Direct filesystem paths
+
+Hermes' memory and skill implementations explicitly defend against external/drifted files, and the skill implementation notes that equivalent code paths can be reached outside `skill_manage` (for example through terminal/file operations).
+
+A plugin can inspect a `terminal` tool call, but shell-command parsing is not a trustworthy semantic durable-state boundary. The persistence primitive, not the command string, is the right place to make a strict claim.
+
+## Why the external MemoryProvider is additive, not authoritative
+
+Hermes allows one external memory provider in addition to built-in memory.
+
+The provider lifecycle is useful for an Agent Memory integration:
+
+- initialization and scoped provider state;
+- system-prompt context;
+- prefetch/recall;
+- turn synchronization;
+- session-end extraction;
+- provider tools;
+- built-in-memory write mirroring;
+- backup paths and session lifecycle hooks.
+
+But the built-in write bridge is post-commit. `MemoryManager.notify_memory_tool_write()` only notifies providers after a successful, non-staged built-in memory write. Provider exceptions are logged rather than rolling back the built-in commit.
+
+The provider therefore cannot be the admission authority for built-in memory.
+
+It is also not a complete observer of recursive learning:
+
+- background review is created with `skip_memory=True` for external-provider setup even though it shares the parent's built-in memory store;
+- approved pending replay bypasses the normal memory-write bridge;
+- curator/Journey/direct filesystem mutations are outside the provider bridge.
+
+So a provider-only integration is useful but incomplete by construction.
+
+## Integration postures
+
+### Observe
+
+Useful today, but explicitly partial unless supplemented by broader durable-state observation.
+
+Recommended shape:
+
+```text
+Hermes built-in memory / skills / learning loop
+        |
+        +--> Agent Memory external MemoryProvider
+        |      recall / prefetch / sync / provider tools
+        |
+        +--> Agent Memory general plugin
+               provenance / tool proposal observations
+```
+
+This is appropriate for research, provenance collection, and comparative runtime evidence. It must not claim every durable mutation was observed.
+
+### Govern
+
+Useful today for normal model-driven recursive learning.
+
+```text
+Hermes foreground/background model proposal
+        |
+        v
+pre_tool_call
+        |
+        v
+Agent Memory admission
+   allow | block
+        |
+        v
+Hermes memory / skill tool
+```
+
+The deployment must disclose that pending replay, deterministic curator lifecycle, Journey mutations, and direct durable file writes are outside this gate unless separately wrapped or disabled.
+
+Agent Memory governor failure cannot be implemented by throwing an exception and hoping Hermes stops. A required-governor deployment must turn unavailable/invalid admission into an explicit block decision.
+
+### Strict
+
+**Not honestly available at the pinned Hermes revision using plugins/providers alone while preserving all existing durable mutation surfaces.**
+
+Strict mode becomes defensible when every consequential durable mutation routes through one common persistence-adjacent admission boundary.
+
+## Recommended Hermes interoperability primitive
+
+The smallest clean upstream change is not an Agent Memory-specific integration. It is a generic **durable-state mutation middleware** shared by every canonical memory/skill mutation path.
+
+Conceptually:
+
+```text
+candidate durable mutation
+        |
+        v
+before_durable_state_mutation(event)
+        |
+        +--> allow
+        +--> stage
+        +--> reject
+        |
+        v
+canonical persistence operation
+        |
+        v
+after_durable_state_mutation(receipt)
+```
+
+The before event should bind at least:
+
+- stable mutation id;
+- subsystem (`memory`, `user_profile`, `skill`, `skill_lifecycle`);
+- operation;
+- origin (`foreground_model`, `background_review`, `curator`, `human_approval_replay`, `journey`, etc.);
+- execution context;
+- target identity;
+- before-state digest or explicit absence;
+- candidate-state digest or explicit absence;
+- scope;
+- provenance/evidence references;
+- human/external approval references where present.
+
+A required governor must be able to fail closed when unavailable or when it does not return a valid decision.
+
+The after receipt should distinguish **admission/approval** from **actual execution** and bind:
+
+- mutation id;
+- committed/failed outcome;
+- committed digest or absence;
+- execution error if any;
+- durable receipt/evidence references.
+
+The middleware should cover, at minimum:
+
+- normal built-in memory writes;
+- normal `skill_manage` writes;
+- approved pending memory replay;
+- approved pending skill replay;
+- deterministic curator archive/restore transitions;
+- Journey memory/skill edits and deletes;
+- equivalent agent-originated canonical durable writes.
+
+This is a Hermes interoperability primitive, not Agent Memory ontology. Agent Memory would simply be one consumer.
+
+## Human approval composition
+
+Hermes' existing write-approval UX should remain useful.
+
+Agent Memory does not need to replace `/memory pending`, `/skills pending`, approve/reject UX, or the user's authority to approve a candidate. The required distinction is:
+
+```text
+human approved candidate M
+!= M is still current
+!= M was executed against the reviewed before-state
+!= M completed successfully
+```
+
+A durable mutation middleware lets approval remain a human authority reference while Agent Memory revalidates currentness/scope/candidate identity immediately before persistence and records the execution receipt afterward.
+
+## Recursive evidence pressure
+
+Hermes is especially valuable as an adversarial runtime because its own learned outputs can feed future learning.
+
+Agent Memory must preserve derivation lineage across sequences such as:
+
+```text
+experience A
+-> skill B
+-> B produces observation C
+-> C contributes to generalized skill D
+```
+
+B, C, and D are causally related. They cannot be counted as three independent corroborating sources merely because Hermes created three durable artifacts.
+
+Likewise, a corrected value must not silently regain current status because background review encounters the old value again, and an old staged mutation must not remain executable after its before-state changes.
+
+The machine-readable record includes five bounded adversarial scenarios covering self-reinforcement, correction readmission, stale approval replay, curator retirement, and provider-mirror lag.
+
+## Source-neutral capability mapping
+
+Hermes exercises several existing Agent Memory capabilities without requiring new doctrine:
+
+- semantic durable memory;
+- user/profile memory;
+- procedural memory;
+- recursive/background learning origin;
+- lifecycle/archive maintenance;
+- external memory-provider integration;
+- async currentness and quiescence;
+- human/external authority composition.
+
+The existing Agent Memory rules remain sufficient:
+
+- origin is provenance, not evidentiary privilege;
+- repetition is not corroboration;
+- procedural memory is not execution authority;
+- correction/supersession and rejected-value protections remain controlling;
+- provider/learned outputs do not launder authority;
+- approval and execution evidence are distinct;
+- committed, current, settled, and quiescent are distinct lifecycle states.
+
+For that reason this research creates **no new ADR**.
+
+## Recommendation
+
+The implementation sequence should be one bounded follow-on, not a fleet of Hermes-specific tickets:
+
+1. build a standalone Agent Memory Hermes integration package using the supported external-provider and plugin surfaces;
+2. support `observe` and explicitly bounded `govern` modes first;
+3. include exact Hermes version/profile applicability and a `doctor` check that reports uncovered mutation paths rather than advertising false strictness;
+4. upstream or collaborate on a generic durable-state mutation middleware in Hermes;
+5. expose `strict` only when runtime evidence proves every declared consequential mutation path crosses that boundary;
+6. use Hermes as a reference adversarial runtime for recursive-learning lineage, stale approval, background mutation, and currentness/quiescence tests.
+
+No Hermes-specific ontology belongs in Agent Memory core.
+
+## Stopping rule
+
+The source audit stops here because every consequential mutation family identified by #317 now has an explicit classification, and additional examples would reproduce an already-owned obligation rather than reveal a new failure class.
+
+The research result is therefore:
+
+```text
+provider only                 -> insufficient
+provider + pre-tool plugin    -> useful observe/govern, not strict
+strict without disabling UX   -> needs generic durable-state mutation middleware
+new Agent Memory doctrine     -> not needed
+Hermes recursive loop replace -> not needed
+```

--- a/docs/programs/hermes-research/hermes-mutation-surface.json
+++ b/docs/programs/hermes-research/hermes-mutation-surface.json
@@ -1,0 +1,266 @@
+{
+  "schema_version": "1.0.0",
+  "research_issue": "#317",
+  "hermes": {
+    "repository": "NousResearch/hermes-agent",
+    "commit": "165c889e5b4277b56dadd42949a4112c1e6175a6",
+    "license": "MIT",
+    "source_rights_posture": "reference_and_runtime_integration_allowed_subject_to_license"
+  },
+  "agent_memory_evidence_boundary": "0df4cf3337b3752105e1b5a110f38eee31f46fef",
+  "research_conclusion": "generic_durable_state_mutation_middleware_needed_for_strict_mode",
+  "doctrine_disposition": "no_new_adr",
+  "authority_effect": "none",
+  "surfaces": [
+    {
+      "id": "foreground_builtin_memory_tool",
+      "state_kind": "semantic_memory",
+      "origin": "foreground_model",
+      "mutation_path": "tool_executor -> pre_tool_call -> AIAgent._invoke_tool -> memory_tool -> MemoryStore",
+      "pre_tool_interceptable": true,
+      "external_memory_provider_complete_observer": true,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": true,
+      "source_refs": ["agent/tool_executor.py", "tools/memory_tool.py", "agent/memory_manager.py"],
+      "notes": "Normal model-driven built-in memory writes pass through resolve_pre_tool_block before persistence. Successful non-staged writes may then be mirrored post-commit to an external provider."
+    },
+    {
+      "id": "foreground_skill_manage",
+      "state_kind": "procedural_memory",
+      "origin": "foreground_model",
+      "mutation_path": "tool_executor -> pre_tool_call -> AIAgent._invoke_tool -> skill_manage",
+      "pre_tool_interceptable": true,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": true,
+      "source_refs": ["agent/tool_executor.py", "tools/skill_manager_tool.py"],
+      "notes": "Normal skill creation/edit/patch/delete/supporting-file writes are interceptable before skill_manage executes."
+    },
+    {
+      "id": "background_review_memory",
+      "state_kind": "semantic_memory",
+      "origin": "background_review",
+      "mutation_path": "forked AIAgent.run_conversation -> tool_executor -> pre_tool_call -> shared parent MemoryStore",
+      "pre_tool_interceptable": true,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": true,
+      "source_refs": ["agent/background_review.py", "agent/tool_executor.py"],
+      "notes": "The review fork uses the normal tool executor and shares the parent MemoryStore, but is created with skip_memory=True for external provider setup. Provider-only observation is therefore not a complete recursive-learning record."
+    },
+    {
+      "id": "background_review_skill_manage",
+      "state_kind": "procedural_memory",
+      "origin": "background_review",
+      "mutation_path": "forked AIAgent.run_conversation -> tool_executor -> pre_tool_call -> skill_manage",
+      "pre_tool_interceptable": true,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": true,
+      "source_refs": ["agent/background_review.py", "agent/tool_executor.py", "tools/skill_manager_tool.py"],
+      "notes": "Background review restricts its mutation tools and carries provenance/read-before-write guards; the normal tool-level governor can intercept the model proposal."
+    },
+    {
+      "id": "approved_pending_memory_replay",
+      "state_kind": "semantic_memory",
+      "origin": "human_approval_replay",
+      "mutation_path": "slash/gateway approval -> write_approval_commands._apply_one -> apply_memory_pending -> MemoryStore",
+      "pre_tool_interceptable": false,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": false,
+      "source_refs": ["hermes_cli/write_approval_commands.py", "tools/memory_tool.py"],
+      "notes": "Replay deliberately bypasses the Hermes write gate and does not traverse the normal tool executor. It also bypasses the agent-loop memory-write bridge used to mirror committed writes to external providers."
+    },
+    {
+      "id": "approved_pending_skill_replay",
+      "state_kind": "procedural_memory",
+      "origin": "human_approval_replay",
+      "mutation_path": "slash/gateway approval -> write_approval_commands._apply_one -> apply_skill_pending -> skill_manage with gate-bypass ContextVar",
+      "pre_tool_interceptable": false,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": false,
+      "source_refs": ["hermes_cli/write_approval_commands.py", "tools/skill_manager_tool.py"],
+      "notes": "Approved skill replay directly calls skill_manage and explicitly bypasses its write-approval gate; it does not re-enter the outer tool middleware."
+    },
+    {
+      "id": "deterministic_curator_archive",
+      "state_kind": "procedural_memory_lifecycle",
+      "origin": "curator_automatic_transition",
+      "mutation_path": "agent.curator.apply_automatic_transitions -> skill_usage.archive_skill",
+      "pre_tool_interceptable": false,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": false,
+      "source_refs": ["agent/curator.py", "tools/skill_usage.py"],
+      "notes": "The non-LLM curator path can durably archive skills without skill_manage. Disabling this path to claim strictness would make lifecycle behavior less capable rather than govern it."
+    },
+    {
+      "id": "curator_llm_consolidation",
+      "state_kind": "procedural_memory_lifecycle",
+      "origin": "curator_background_model",
+      "mutation_path": "curator fork -> normal AIAgent tool execution -> pre_tool_call -> skill_manage",
+      "pre_tool_interceptable": true,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": true,
+      "source_refs": ["agent/curator.py", "agent/tool_executor.py", "tools/skill_manager_tool.py"],
+      "notes": "The optional LLM consolidation pass uses normal tool execution; this differs from deterministic automatic archival."
+    },
+    {
+      "id": "journey_memory_edit_delete",
+      "state_kind": "semantic_memory",
+      "origin": "user_initiated_journey_edit",
+      "mutation_path": "agent.learning_mutations -> direct MemoryStore._write_file",
+      "pre_tool_interceptable": false,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": false,
+      "source_refs": ["agent/learning_mutations.py", "tools/memory_tool.py"],
+      "notes": "CLI/TUI/Desktop Journey mutations are explicitly user initiated but still bypass tool middleware and normal provider mirroring. Human approval is authority evidence, not execution evidence by itself."
+    },
+    {
+      "id": "journey_skill_edit_delete",
+      "state_kind": "procedural_memory",
+      "origin": "user_initiated_journey_edit",
+      "mutation_path": "agent.learning_mutations -> _edit_skill or skill_usage.archive_skill",
+      "pre_tool_interceptable": false,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": false,
+      "source_refs": ["agent/learning_mutations.py", "tools/skill_manager_tool.py", "tools/skill_usage.py"],
+      "notes": "User-facing Journey edits and recoverable archives are real durable procedural-state mutations outside the model tool executor."
+    },
+    {
+      "id": "external_memory_provider_mirror",
+      "state_kind": "external_derived_or_parallel_memory",
+      "origin": "post_commit_bridge",
+      "mutation_path": "committed built-in memory tool result -> MemoryManager.notify_memory_tool_write -> provider.on_memory_write",
+      "pre_tool_interceptable": false,
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": "provider_dependent",
+      "strict_plugin_only_covered": false,
+      "source_refs": ["agent/memory_manager.py", "agent/memory_provider.py"],
+      "notes": "The provider callback occurs after built-in commit and provider exceptions are logged. It cannot be the built-in-state admission gate and does not cover every non-tool mutation path."
+    },
+    {
+      "id": "out_of_band_memory_skill_filesystem_write",
+      "state_kind": "semantic_or_procedural_memory",
+      "origin": "agent_terminal_or_external_writer",
+      "mutation_path": "terminal/script/manual/direct filesystem -> MEMORY.md/USER.md/SKILL.md",
+      "pre_tool_interceptable": "tool_call_only_not_semantic_write",
+      "external_memory_provider_complete_observer": false,
+      "durable_mutation": true,
+      "strict_plugin_only_covered": false,
+      "source_refs": ["tools/memory_tool.py", "tools/skill_manager_tool.py"],
+      "notes": "Hermes explicitly defends against external/drifted memory files and acknowledges that agent code can reach equivalent filesystem paths. Command-level interception is not a reliable semantic durable-state boundary."
+    }
+  ],
+  "integration_postures": {
+    "observe": {
+      "supported_today": true,
+      "recommended_components": ["external_memory_provider", "general_plugin", "durable_file_or_event_observation_where_needed"],
+      "coverage": "partial_without_additional_observation",
+      "limitations": [
+        "MemoryProvider is additive and post-commit for built-in memory mirroring.",
+        "Background review is instantiated without the external provider.",
+        "Approved replay, deterministic curator mutations, Journey mutations, and direct filesystem mutations can bypass provider mirroring."
+      ]
+    },
+    "govern": {
+      "supported_today": true,
+      "recommended_components": ["general_plugin_pre_tool_call", "external_memory_provider"],
+      "coverage": "model_driven_mutations_only_unless_bypass_surfaces_are_disabled_or_separately_wrapped",
+      "limitations": [
+        "Normal foreground/background memory and skill_manage proposals can be admitted or blocked before tool execution.",
+        "Human-approved replay, deterministic curator archival, Journey mutations, and equivalent direct durable writes require separate handling.",
+        "Provider/plugin failure must be translated into an explicit policy decision; exception behavior cannot be treated as fail-closed governance."
+      ]
+    },
+    "strict": {
+      "supported_today": false,
+      "coverage": "not_honestly_claimable_without_disabling_legitimate_mutation_surfaces_or_modifying_Hermes",
+      "blocking_gaps": [
+        "approved_pending_memory_replay",
+        "approved_pending_skill_replay",
+        "deterministic_curator_archive",
+        "journey_memory_edit_delete",
+        "journey_skill_edit_delete",
+        "out_of_band_memory_skill_filesystem_write"
+      ]
+    }
+  },
+  "recommended_interoperability_primitive": {
+    "name": "generic_durable_state_mutation_middleware",
+    "placement": "immediately_before_and_after_canonical_durable_state_mutation",
+    "scope": ["built_in_memory", "user_profile", "skills_and_supporting_files", "skill_lifecycle_archive_restore"],
+    "before_phase": {
+      "decision": ["allow", "stage", "reject"],
+      "required_fields": [
+        "mutation_id",
+        "subsystem",
+        "operation",
+        "origin",
+        "execution_context",
+        "target_identity",
+        "before_digest_or_absence",
+        "candidate_digest_or_absence",
+        "scope",
+        "provenance_refs",
+        "approval_refs"
+      ],
+      "strict_failure_posture": "reject_when_required_governor_is_unavailable_or_returns_no_valid_decision"
+    },
+    "after_phase": {
+      "purpose": "separate admission_or_approval_from_actual_execution",
+      "required_fields": ["mutation_id", "outcome", "committed_digest_or_absence", "error_or_none", "receipt_refs"]
+    },
+    "requirements": [
+      "Normal model-driven memory/skill mutations must route through it.",
+      "Pending approval replay must route through it before applying staged payloads.",
+      "Deterministic curator lifecycle mutations must route through it.",
+      "Journey edit/delete mutations must route through it.",
+      "It must be generic and vendor-neutral rather than Agent Memory-specific.",
+      "Existing Hermes human approval may remain the presentation/authority UX; approval does not bypass admission/currentness checks.",
+      "The hook must not grant truth, recall, mutation, or execution authority by source identity."
+    ]
+  },
+  "recursive_evidence_scenarios": [
+    {
+      "id": "self_reinforcing_skill_lineage",
+      "sequence": ["experience_A", "skill_B_created", "B_produces_C", "C_supports_skill_D"],
+      "required_agent_memory_rule": "B_C_D_share_derivation_lineage_and_do_not_count_as_independent_corroboration"
+    },
+    {
+      "id": "correction_relearned_by_background_review",
+      "sequence": ["value_X_recorded", "X_corrected_to_Y", "later_transcript_contains_X", "background_review_proposes_X_again"],
+      "required_agent_memory_rule": "rejected_or_superseded_X_remains_non_current_and_requires_new_independent_evidence_for_readmission"
+    },
+    {
+      "id": "stale_human_approval_replay",
+      "sequence": ["mutation_M_staged", "underlying_skill_or_memory_changes", "old_M_approved"],
+      "required_agent_memory_rule": "approval_replay_must_revalidate_before_digest_scope_and_candidate_identity_before_commit"
+    },
+    {
+      "id": "curator_archive_during_pending_dependency",
+      "sequence": ["skill_S_referenced_by_durable_state", "curator_marks_S_archive_candidate", "archive_runs"],
+      "required_agent_memory_rule": "retirement_requires_dependency_and_residue_checks_and_execution_receipt"
+    },
+    {
+      "id": "provider_mirror_failure_after_builtin_commit",
+      "sequence": ["builtin_memory_commit", "external_provider_mirror_throws", "next_turn_recall_uses_divergent_stores"],
+      "required_agent_memory_rule": "canonical_currentness_and_projection_obligations_must_distinguish_committed_from_settled_and_quiescent"
+    }
+  ],
+  "capability_mapping": [
+    {"capability": "semantic_memory", "hermes_surface": "MEMORY.md", "agent_memory_role": "governed_durable_state", "authority_effect": "none"},
+    {"capability": "user_profile_memory", "hermes_surface": "USER.md", "agent_memory_role": "governed_scoped_durable_state", "authority_effect": "none"},
+    {"capability": "procedural_memory", "hermes_surface": "skills", "agent_memory_role": "retain_lineage_and_admission_evidence_not_execution_authority", "authority_effect": "none"},
+    {"capability": "background_recursive_learning", "hermes_surface": "background_review", "agent_memory_role": "candidate_mutation_origin_and_derivation_evidence", "authority_effect": "none"},
+    {"capability": "skill_lifecycle_maintenance", "hermes_surface": "curator", "agent_memory_role": "govern_retirement_archive_and_dependency_obligations", "authority_effect": "none"},
+    {"capability": "external_memory_provider", "hermes_surface": "MemoryProvider", "agent_memory_role": "recall_sync_and_observation_surface_not_builtin_admission_authority", "authority_effect": "none"}
+  ],
+  "stopping_rule_result": "stop_source_audit_after_all_consequential_mutation_families_are_classified_and_the_strict_mode_gap_is_reproducible_from_exact_source",
+  "follow_on_recommendation": "one_bounded_Hermes_integration_issue_after_this_research_merges; implementation_should_target_observe_and_govern_today_and_prepare_for_strict_only_after_generic_Hermes_durable_state_middleware_exists_or_is_upstreamed"
+}

--- a/scripts/validate_hermes_recursive_learning_research.py
+++ b/scripts/validate_hermes_recursive_learning_research.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validate #317 Hermes recursive-learning research records."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+PROGRAM = ROOT / "docs/programs/hermes-research"
+RECORD = PROGRAM / "hermes-mutation-surface.json"
+README = PROGRAM / "README.md"
+
+HERMES_COMMIT = "165c889e5b4277b56dadd42949a4112c1e6175a6"
+EXPECTED_SURFACE_IDS = {
+    "foreground_builtin_memory_tool",
+    "foreground_skill_manage",
+    "background_review_memory",
+    "background_review_skill_manage",
+    "approved_pending_memory_replay",
+    "approved_pending_skill_replay",
+    "deterministic_curator_archive",
+    "curator_llm_consolidation",
+    "journey_memory_edit_delete",
+    "journey_skill_edit_delete",
+    "external_memory_provider_mirror",
+    "out_of_band_memory_skill_filesystem_write",
+}
+EXPECTED_STRICT_GAPS = {
+    "approved_pending_memory_replay",
+    "approved_pending_skill_replay",
+    "deterministic_curator_archive",
+    "journey_memory_edit_delete",
+    "journey_skill_edit_delete",
+    "out_of_band_memory_skill_filesystem_write",
+}
+EXPECTED_RECURSIVE_SCENARIOS = {
+    "self_reinforcing_skill_lineage",
+    "correction_relearned_by_background_review",
+    "stale_human_approval_replay",
+    "curator_archive_during_pending_dependency",
+    "provider_mirror_failure_after_builtin_commit",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def main() -> int:
+    value = json.loads(RECORD.read_text(encoding="utf-8"))
+    readme = README.read_text(encoding="utf-8")
+
+    if value.get("schema_version") != "1.0.0":
+        fail("Hermes research record must use schema_version 1.0.0")
+    if value.get("research_issue") != "#317":
+        fail("Hermes research record must bind #317")
+    hermes = value.get("hermes", {})
+    if hermes.get("repository") != "NousResearch/hermes-agent":
+        fail("Hermes repository identity drifted")
+    if hermes.get("commit") != HERMES_COMMIT:
+        fail("Hermes research must remain bound to the exact reviewed commit")
+    if hermes.get("license") != "MIT":
+        fail("Hermes source-rights record must preserve MIT")
+    if value.get("research_conclusion") != "generic_durable_state_mutation_middleware_needed_for_strict_mode":
+        fail("Hermes research conclusion drifted")
+    if value.get("doctrine_disposition") != "no_new_adr":
+        fail("#317 must not invent doctrine without a representation-neutral gap")
+    if value.get("authority_effect") != "none":
+        fail("Hermes research evidence cannot create authority")
+
+    surfaces = value.get("surfaces")
+    if not isinstance(surfaces, list):
+        fail("Hermes surfaces must be a list")
+    surface_ids = [item.get("id") for item in surfaces]
+    if len(surface_ids) != len(set(surface_ids)):
+        fail("Hermes mutation surfaces contain duplicate ids")
+    if set(surface_ids) != EXPECTED_SURFACE_IDS:
+        fail(
+            "Hermes mutation surface set drifted: "
+            f"missing={sorted(EXPECTED_SURFACE_IDS.difference(surface_ids))} "
+            f"extra={sorted(set(surface_ids).difference(EXPECTED_SURFACE_IDS))}"
+        )
+    for item in surfaces:
+        if item.get("durable_mutation") not in {True, "provider_dependent"}:
+            fail(f"surface lacks durable-mutation classification: {item.get('id')}")
+        refs = item.get("source_refs")
+        if not isinstance(refs, list) or not refs:
+            fail(f"surface lacks source refs: {item.get('id')}")
+        if not isinstance(item.get("notes"), str) or not item["notes"].strip():
+            fail(f"surface lacks bounded notes: {item.get('id')}")
+
+    postures = value.get("integration_postures", {})
+    if set(postures) != {"observe", "govern", "strict"}:
+        fail("integration posture set must be observe/govern/strict")
+    if postures["observe"].get("supported_today") is not True:
+        fail("observe posture should remain available today")
+    if postures["govern"].get("supported_today") is not True:
+        fail("bounded govern posture should remain available today")
+    if postures["strict"].get("supported_today") is not False:
+        fail("strict must remain unsupported at the pinned revision")
+    strict_gaps = set(postures["strict"].get("blocking_gaps", []))
+    if strict_gaps != EXPECTED_STRICT_GAPS:
+        fail(f"strict-mode gap set drifted: {sorted(strict_gaps)}")
+    for gap in strict_gaps:
+        surface = next(item for item in surfaces if item["id"] == gap)
+        if surface.get("strict_plugin_only_covered") is not False:
+            fail(f"strict blocker unexpectedly claims plugin-only coverage: {gap}")
+
+    primitive = value.get("recommended_interoperability_primitive", {})
+    if primitive.get("name") != "generic_durable_state_mutation_middleware":
+        fail("recommended Hermes primitive must remain generic durable-state mutation middleware")
+    if primitive.get("placement") != "immediately_before_and_after_canonical_durable_state_mutation":
+        fail("durable-state middleware must remain persistence-adjacent")
+    if set(primitive.get("before_phase", {}).get("decision", [])) != {"allow", "stage", "reject"}:
+        fail("before phase must preserve allow/stage/reject decisions")
+    if primitive.get("before_phase", {}).get("strict_failure_posture") != "reject_when_required_governor_is_unavailable_or_returns_no_valid_decision":
+        fail("strict governor failure posture must remain fail-closed")
+    if not primitive.get("after_phase", {}).get("required_fields"):
+        fail("after phase must preserve execution receipt fields")
+
+    scenarios = value.get("recursive_evidence_scenarios")
+    if not isinstance(scenarios, list):
+        fail("recursive evidence scenarios must be a list")
+    scenario_ids = {item.get("id") for item in scenarios}
+    if scenario_ids != EXPECTED_RECURSIVE_SCENARIOS:
+        fail(f"recursive evidence scenario set drifted: {sorted(scenario_ids)}")
+
+    mappings = value.get("capability_mapping")
+    if not isinstance(mappings, list) or len(mappings) < 6:
+        fail("Hermes capability mapping is incomplete")
+    if any(item.get("authority_effect") != "none" for item in mappings):
+        fail("Hermes capability mapping cannot create authority")
+
+    if not str(value.get("follow_on_recommendation", "")).startswith("one_bounded_Hermes_integration_issue"):
+        fail("#317 follow-on must remain one bounded integration issue")
+
+    required_readme_markers = (
+        HERMES_COMMIT,
+        "Approved pending memory replay",
+        "Deterministic curator archival",
+        "Journey edit/delete",
+        "generic **durable-state mutation middleware**",
+        "provider + pre-tool plugin    -> useful observe/govern, not strict",
+        "new Agent Memory doctrine     -> not needed",
+    )
+    for marker in required_readme_markers:
+        if marker not in readme:
+            fail(f"Hermes research README missing required conclusion marker: {marker!r}")
+
+    print(
+        "hermes-recursive-learning-research: valid "
+        f"surfaces={len(surfaces)} strict_gaps={len(strict_gaps)} "
+        f"recursive_scenarios={len(scenarios)} doctrine=no_new_adr authority_effect=none"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Completes the source-bound research required by #317 against:

`NousResearch/hermes-agent@165c889e5b4277b56dadd42949a4112c1e6175a6`

This PR does **not** implement a Hermes adapter or modify Agent Memory doctrine.

### Main finding

Current Hermes' live tool executor applies the generic `pre_tool_call` block before normal foreground and background-review `memory` / `skill_manage` execution. That is sufficient for useful model-driven `govern` integration without replacing Hermes' recursive learning loop.

However, plugin-only `strict` mode is not honestly complete because several legitimate durable mutation paths bypass the outer tool executor:

- approved pending memory replay;
- approved pending skill replay;
- deterministic curator archival;
- Journey memory edit/delete;
- Journey skill edit/delete;
- equivalent direct memory/skill filesystem mutation paths.

The external `MemoryProvider` is also additive/post-commit rather than a built-in-state admission gate, and is not a complete observer of all recursive/background mutations.

### Research outputs

Adds a machine-readable 12-surface mutation map with:

- exact Hermes revision/license;
- origin and mutation path;
- pre-tool interceptability;
- external-provider observation coverage;
- strict-plugin-only coverage;
- exact source refs;
- observe/govern/strict coverage matrix;
- five recursive-evidence adversarial scenarios;
- source-neutral capability mapping;
- explicit `authority_effect = none`.

### Recommended interoperability primitive

For strict mode without disabling legitimate Hermes features, recommend one generic persistence-adjacent durable-state mutation middleware, not an Agent Memory-specific core dependency:

`before_durable_state_mutation(event) -> allow | stage | reject`

followed by an execution receipt such as:

`after_durable_state_mutation(receipt)`

The same middleware must cover model tools, approval replay, curator lifecycle mutations, Journey edits/deletes, and equivalent canonical durable writes. Human approval remains useful authority evidence but does not bypass currentness/candidate revalidation or execution receipts.

### Doctrine result

`no_new_adr`

Existing Agent Memory doctrine already expresses the transferable obligations: provenance != evidence != authority, repetition is not corroboration, procedural memory != execution authority, stale approval requires revalidation, and committed/current/settled/quiescent remain distinct.

### Exact-head verification

Adds a focused workflow that checks out the exact Hermes revision and verifies the load-bearing source seams for:

- outer pre-tool interception;
- background-review shared memory + tool restrictions;
- approval replay bypass;
- curator direct archival;
- Journey direct mutation;
- post-commit MemoryProvider bridge;
- MIT license.

The workflow also validates the exact 12-surface / 6-strict-gap research record and emits exact-head evidence.

After this research merges, create at most one bounded implementation follow-on for a standalone Hermes integration package. Implement observe + bounded govern first; expose strict only after the generic durable-state mutation boundary is available and executable evidence proves coverage.