### PR TITLE
Integrate Hermes observe and govern modes without false strictness

### DIFF
--- a/.github/workflows/hermes-observe-govern-integration.yml
+++ b/.github/workflows/hermes-observe-govern-integration.yml
@@ -1,0 +1,240 @@
+name: Hermes Observe Govern Integration
+
+on:
+  pull_request:
+    paths:
+      - 'integrations/hermes-agent-memory/**'
+      - 'docs/programs/hermes-integration/**'
+      - '.github/workflows/hermes-observe-govern-integration.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/hermes-agent-memory/**'
+      - 'docs/programs/hermes-integration/**'
+      - '.github/workflows/hermes-observe-govern-integration.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hermes-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Agent Memory
+        uses: actions/checkout@v4
+
+      - name: Checkout exact Hermes source
+        uses: actions/checkout@v4
+        with:
+          repository: NousResearch/hermes-agent
+          ref: 165c889e5b4277b56dadd42949a4112c1e6175a6
+          path: _hermes
+          persist-credentials: false
+
+      - name: Verify exact Hermes source and extension seams
+        run: |
+          test "$(git -C _hermes rev-parse HEAD)" = "165c889e5b4277b56dadd42949a4112c1e6175a6"
+          head -n 1 _hermes/LICENSE | grep -q 'MIT License'
+          grep -q 'resolve_pre_tool_block' _hermes/agent/tool_executor.py
+          grep -q '_AGENT_LOOP_TOOLS' _hermes/model_tools.py
+          grep -q 'apply_memory_pending' _hermes/hermes_cli/write_approval_commands.py
+          grep -q '_skill_gate_bypass.set(True)' _hermes/tools/skill_manager_tool.py
+          grep -q 'archive_skill(name)' _hermes/agent/curator.py
+          grep -q 'MemoryStore._write_file' _hermes/agent/learning_mutations.py
+          grep -q 'provider.on_memory_write' _hermes/agent/memory_manager.py
+          grep -q 'hermes_agent.plugins' _hermes/website/docs/developer-guide/plugins/index.md
+          grep -q 'hermes_agent.memory_providers' _hermes/website/docs/developer-guide/memory-provider-plugin.md
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Agent Memory reference and Hermes integration dependencies
+        run: |
+          python -m pip install --disable-pip-version-check -r reference/requirements.txt
+          python -m pip install --disable-pip-version-check ./integrations/hermes-agent-memory
+
+      - name: Compile standalone integration package
+        run: python -m compileall -q integrations/hermes-agent-memory/src
+
+      - name: Exercise package against exact Hermes MemoryProvider contract
+        env:
+          PYTHONPATH: ${{ github.workspace }}/_hermes
+        run: python -m unittest integrations/hermes-agent-memory/tests/test_exact_hermes_contract.py
+
+      - name: Execute observe govern failure and recursive scenario tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/_hermes
+        run: >-
+          python -m unittest discover
+          -s integrations/hermes-agent-memory/tests
+          -p 'test_*.py'
+
+      - name: Exercise installed doctor in observe govern and strict modes
+        env:
+          AGENT_MEMORY_HERMES_REVISION: 165c889e5b4277b56dadd42949a4112c1e6175a6
+          PYTHONPATH: ${{ github.workspace }}/_hermes
+        run: |
+          set -euo pipefail
+          export HERMES_HOME="$(mktemp -d)"
+          mkdir -p /tmp/hermes-integration
+
+          agent-memory-hermes doctor \
+            --hermes-home "$HERMES_HOME" \
+            --hermes-revision "$AGENT_MEMORY_HERMES_REVISION" \
+            --mode observe --json \
+            > /tmp/hermes-integration/observe-doctor.json
+
+          python - <<'PY'
+          import sys
+          from agent_memory_hermes.config import IntegrationConfig, save_config
+          import os
+          save_config(
+              os.environ['HERMES_HOME'],
+              IntegrationConfig(
+                  mode='govern',
+                  governor_command=(
+                      sys.executable,
+                      'integrations/hermes-agent-memory/tests/fake_governor.py',
+                      'allow',
+                  ),
+                  governor_required=True,
+              ),
+          )
+          PY
+
+          agent-memory-hermes doctor \
+            --hermes-home "$HERMES_HOME" \
+            --hermes-revision "$AGENT_MEMORY_HERMES_REVISION" \
+            --mode govern --json \
+            > /tmp/hermes-integration/govern-doctor.json
+
+          set +e
+          agent-memory-hermes doctor \
+            --hermes-home "$HERMES_HOME" \
+            --hermes-revision "$AGENT_MEMORY_HERMES_REVISION" \
+            --mode strict --json \
+            > /tmp/hermes-integration/strict-doctor.json
+          strict_rc=$?
+          set -e
+          test "$strict_rc" -eq 2
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          observe = json.loads(Path('/tmp/hermes-integration/observe-doctor.json').read_text())
+          govern = json.loads(Path('/tmp/hermes-integration/govern-doctor.json').read_text())
+          strict = json.loads(Path('/tmp/hermes-integration/strict-doctor.json').read_text())
+          assert observe['integration']['ready'] is True
+          assert govern['integration']['ready'] is True
+          assert strict['integration']['ready'] is False
+          assert observe['hermes']['profile_current'] is True
+          assert len(observe['surfaces']) == 12
+          assert len(observe['recursive_evidence_scenarios']) == 5
+          assert strict['strict']['supported'] is False
+          assert len(strict['strict']['blocking_surfaces']) == 6
+          assert strict['authority_effect'] == 'none'
+          PY
+
+      - name: Prove exact profile drift invalidates doctor applicability
+        env:
+          PYTHONPATH: ${{ github.workspace }}/_hermes
+        run: |
+          set +e
+          agent-memory-hermes doctor \
+            --hermes-home "$(mktemp -d)" \
+            --hermes-revision 0000000000000000000000000000000000000000 \
+            --mode observe --json \
+            > /tmp/hermes-integration/drift-doctor.json
+          drift_rc=$?
+          set -e
+          test "$drift_rc" -eq 2
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          value = json.loads(Path('/tmp/hermes-integration/drift-doctor.json').read_text())
+          assert value['hermes']['profile_current'] is False
+          assert value['integration']['ready'] is False
+          assert value['authority_effect'] == 'none'
+          PY
+
+      - name: Run full Agent Memory reference regression
+        env:
+          PYTHONPATH: reference
+        run: python -m unittest discover -s reference/tests -p 'test_*.py'
+
+      - name: Record exact-head integration evidence
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import importlib.metadata
+          import json
+          import os
+          from pathlib import Path
+
+          observe = json.loads(Path('/tmp/hermes-integration/observe-doctor.json').read_text())
+          govern = json.loads(Path('/tmp/hermes-integration/govern-doctor.json').read_text())
+          strict = json.loads(Path('/tmp/hermes-integration/strict-doctor.json').read_text())
+          drift = json.loads(Path('/tmp/hermes-integration/drift-doctor.json').read_text())
+          plugin_eps = {
+              ep.name: ep.value
+              for ep in importlib.metadata.entry_points(group='hermes_agent.plugins')
+          }
+          provider_eps = {
+              ep.name: ep.value
+              for ep in importlib.metadata.entry_points(group='hermes_agent.memory_providers')
+          }
+          invariants = {
+              'exact_hermes_pin': observe['hermes']['observed_revision'] == '165c889e5b4277b56dadd42949a4112c1e6175a6',
+              'observe_ready': observe['integration']['ready'] is True,
+              'govern_ready_with_governor': govern['integration']['ready'] is True,
+              'strict_refused': strict['integration']['ready'] is False and strict['strict']['supported'] is False,
+              'strict_six_blockers': len(strict['strict']['blocking_surfaces']) == 6,
+              'all_twelve_surfaces_reported': len(observe['surfaces']) == 12,
+              'five_recursive_scenarios_reported': len(observe['recursive_evidence_scenarios']) == 5,
+              'profile_drift_invalidates': drift['integration']['ready'] is False and drift['hermes']['profile_current'] is False,
+              'plugin_entrypoint_exact': plugin_eps.get('agent-memory') == 'agent_memory_hermes.safe_plugin:register',
+              'provider_entrypoint_exact': provider_eps.get('agent-memory') == 'agent_memory_hermes.provider:register_memory',
+              'authority_effect_none': all(item['authority_effect'] == 'none' for item in (observe, govern, strict, drift)),
+          }
+          assert all(type(value) is bool and value for value in invariants.values()), invariants
+          files = [
+              Path('integrations/hermes-agent-memory/pyproject.toml'),
+              Path('integrations/hermes-agent-memory/src/agent_memory_hermes/plugin.py'),
+              Path('integrations/hermes-agent-memory/src/agent_memory_hermes/provider.py'),
+              Path('docs/programs/hermes-integration/README.md'),
+          ]
+          report = {
+              'schema_version': '1.0.0',
+              'agent_memory_commit': os.environ['HEAD_SHA'],
+              'hermes_commit': '165c889e5b4277b56dadd42949a4112c1e6175a6',
+              'integration_version': importlib.metadata.version('agent-memory-hermes'),
+              'invariants': invariants,
+              'digests': {
+                  str(path): 'sha256:' + hashlib.sha256(path.read_bytes()).hexdigest()
+                  for path in files
+              },
+              'authority_effect': 'none',
+          }
+          out = Path('/tmp/hermes-integration/integration-evidence.json')
+          out.write_text(json.dumps(report, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          print(out.read_text())
+          PY
+
+      - name: Upload exact-head Hermes integration evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-observe-govern-${{ github.event.pull_request.head.sha || github.sha }}
+          path: |
+            /tmp/hermes-integration/observe-doctor.json
+            /tmp/hermes-integration/govern-doctor.json
+            /tmp/hermes-integration/strict-doctor.json
+            /tmp/hermes-integration/drift-doctor.json
+            /tmp/hermes-integration/integration-evidence.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/programs/hermes-integration/README.md
+++ b/docs/programs/hermes-integration/README.md
@@ -1,0 +1,329 @@
+# Hermes observe/govern integration
+
+Issue: #330
+
+Status: **standalone integration implementation for the exact #317 Hermes profile**
+
+Hermes applicability pin:
+
+```text
+NousResearch/hermes-agent@165c889e5b4277b56dadd42949a4112c1e6175a6
+license: MIT
+```
+
+Package:
+
+```text
+integrations/hermes-agent-memory/
+package: agent-memory-hermes
+integration profile: agent-memory-hermes/1.0.0
+```
+
+The package publishes both supported Hermes extension points:
+
+```toml
+[project.entry-points."hermes_agent.plugins"]
+agent-memory = "agent_memory_hermes.safe_plugin:register"
+
+[project.entry-points."hermes_agent.memory_providers"]
+agent-memory = "agent_memory_hermes.provider:register_memory"
+```
+
+It does not replace Hermes' built-in memory, skill executor, recursive background review, curator, or human approval UX.
+
+## Installation and shared configuration
+
+Install the package into the same Python environment used by Hermes:
+
+```text
+pip install ./integrations/hermes-agent-memory
+```
+
+The general plugin and external MemoryProvider share profile-scoped configuration at:
+
+```text
+$HERMES_HOME/agent-memory/config.json
+```
+
+Default configuration is equivalent to:
+
+```json
+{
+  "mode": "observe",
+  "governor_command": [],
+  "governor_required": true,
+  "governor_timeout_seconds": 10.0,
+  "record_payloads": false,
+  "require_exact_profile": true,
+  "expected_hermes_revision": "165c889e5b4277b56dadd42949a4112c1e6175a6"
+}
+```
+
+Hermes' memory-provider setup can persist the provider-visible subset through `AgentMemoryProvider.save_config()`.
+
+Raw memory/skill payloads are **not** persisted by default. Local evidence stores payload digests and operational metadata unless `record_payloads=true` is explicitly selected.
+
+## Exact profile detection
+
+Qualification applicability is commit-bound.
+
+The integration detects the observed Hermes source revision from:
+
+1. `AGENT_MEMORY_HERMES_REVISION`, when explicitly supplied by a packaged/deployment environment; or
+2. the imported Hermes `agent` package's containing Git checkout.
+
+If neither yields an exact 40-character revision, the observed revision is `unknown`.
+
+Unknown or changed revision does not inherit #317 coverage by resemblance. With the default `require_exact_profile=true`, doctor reports not ready and govern mode blocks interceptable durable tool mutations until the profile is revalidated.
+
+## Observe mode
+
+Observe mode registers `pre_tool_call` and `post_tool_call` hooks for the two normal model-driven durable-state surfaces available at the pinned Hermes profile:
+
+```text
+memory
+skill_manage
+```
+
+It records:
+
+- proposal operation and target;
+- exact Hermes/integration profile identity;
+- session/task/turn/tool-call scope supplied by Hermes;
+- candidate digest;
+- optional provenance/lineage refs when actually available;
+- execution receipt/result digest separately from admission/proposal evidence.
+
+The pinned Hermes hook does **not** expose `_memory_write_origin`. Therefore foreground versus `background_review` origin is not invented. The coverage report marks those background surfaces as mechanically observed/intercepted with limited origin precision.
+
+The external `MemoryProvider` additionally observes:
+
+- initialization/session identity;
+- prefetch lifecycle calls;
+- turn synchronization;
+- built-in-memory post-commit mirror callbacks;
+- session switch/end;
+- shutdown/backup path state.
+
+Version 0.1.0 intentionally does not invent an Agent Memory recall backend. `prefetch()` records the recall lifecycle request and returns no injected context. A future backend transport may add recall without changing the provider's admission authority, which remains none.
+
+## Govern mode
+
+Govern mode sends the full interceptable candidate privately to an external JSON admission command configured by `governor_command`.
+
+Input shape includes:
+
+```text
+kind = hermes_durable_state_candidate
+Hermes revision/profile
+integration profile
+memory | skill_manage
+operation
+target
+session/task/turn/tool-call scope
+origin hint + origin precision
+lineage refs when available
+provenance refs when available
+full tool args for the private governor process
+args digest
+authority_effect = none
+```
+
+The command reads one JSON object on stdin and returns one JSON object on stdout:
+
+```json
+{
+  "decision": "allow | reject | stage",
+  "reason": "bounded human-readable reason",
+  "evidence_refs": ["optional://reference"]
+}
+```
+
+Current Hermes mapping is truthful:
+
+```text
+allow  -> allow tool execution
+reject -> return Hermes native {action:block, message:...}
+stage  -> block with explicit stage-unsupported explanation
+```
+
+`stage` is **not** silently treated as either allow or native Hermes write approval. The generic `pre_tool_call` hook cannot create a native staged durable mutation.
+
+When `governor_required=true`, the following all produce an explicit native block:
+
+- command missing;
+- command cannot execute;
+- timeout/nonzero exit;
+- invalid JSON;
+- invalid decision schema;
+- exact Hermes profile drift.
+
+This matters because Hermes intentionally isolates plugin callback exceptions. The published plugin entry point is therefore a fail-closed wrapper: integration/configuration failure while handling `memory` or `skill_manage` becomes an explicit block rather than an exception that Hermes could log and continue past.
+
+## External MemoryProvider is not admission authority
+
+Hermes calls `on_memory_write()` after a built-in memory mutation commits.
+
+The Agent Memory provider records that lifecycle honestly:
+
+```text
+canonical_builtin_state = committed
+external_projection = observed | failed
+settled = true | false
+quiescent = true | false
+rollback_claimed = false
+```
+
+A provider callback failure does not retroactively claim the built-in write rolled back.
+
+The provider is therefore useful for observation/synchronization but structurally remains outside built-in admission authority.
+
+## Strict mode is refused
+
+At the pinned Hermes profile:
+
+```text
+strict.supported = false
+```
+
+The exact six blockers from #317 remain:
+
+1. `approved_pending_memory_replay`
+2. `approved_pending_skill_replay`
+3. `deterministic_curator_archive`
+4. `journey_memory_edit_delete`
+5. `journey_skill_edit_delete`
+6. `out_of_band_memory_skill_filesystem_write`
+
+If configuration requests `strict`, doctor returns nonzero and lists those blockers. The plugin also blocks the normal interceptable `memory` / `skill_manage` mutations rather than pretending those blocks somehow cover the six bypass paths.
+
+This is intentionally inconvenient. A false strict badge would be easier to ship and much less useful.
+
+## Doctor / coverage
+
+Installed command:
+
+```text
+agent-memory-hermes doctor --json
+```
+
+The report contains exactly the 12 #317 mutation families and classifies each as:
+
+```text
+observed
+intercepted
+uncovered
+not applicable
+```
+
+It also records:
+
+- exact expected/observed Hermes revision;
+- integration profile/version;
+- mode;
+- governor configured/required state;
+- strict support and blockers;
+- origin-precision limitations;
+- five recursive-learning adversarial scenario dispositions;
+- `authority_effect = none`.
+
+The coverage file is written to:
+
+```text
+$HERMES_HOME/agent-memory/coverage.json
+```
+
+## Recursive-learning adversarial scenarios
+
+The package carries executable evidence for all five #317 cases.
+
+### Self-reinforcing skill lineage
+
+When lineage/provenance refs are available, the integration preserves them to the external governor rather than collapsing each recursive artifact into a fresh independent source. The governor can reject a skill/memory proposal whose apparent corroboration is causally descended from the same lineage.
+
+The pinned Hermes hook does not expose complete causal lineage automatically, so the integration records that limitation rather than fabricating independence.
+
+### Corrected value proposed again by background learning
+
+Supersession/rejection evidence supplied to the candidate is preserved to the external governor. A rejected governor decision becomes a native Hermes block.
+
+The integration does not promote an old value merely because background learning encountered it again.
+
+### Stale human approval replay
+
+Still uncovered at the pinned profile. Future strict support must revalidate at least:
+
+```text
+reviewed before-state digest
+current before-state digest
+reviewed candidate digest
+current candidate digest
+scope
+```
+
+immediately before the approved pending payload commits.
+
+### Curator retirement
+
+Deterministic curator archival remains uncovered. Future strict support requires the persistence-adjacent middleware identified by #317 so dependency and residue obligations can be checked before retirement.
+
+### Provider mirror failure after built-in commit
+
+Executable provider tests prove the required lifecycle distinction:
+
+```text
+built-in state committed
+external projection failed
+settled = false
+quiescent = false
+rollback_claimed = false
+```
+
+## Evidence and privacy
+
+Local event evidence is JSONL under:
+
+```text
+$HERMES_HOME/agent-memory/events.jsonl
+```
+
+Default persisted records use hashes rather than raw memory/skill content. The full candidate is sent to the configured external governor process because admission may require semantic inspection, but local payload persistence remains opt-in.
+
+Evidence identity is not authority. Event records always carry:
+
+```text
+authority_effect = none
+```
+
+## Upstream strict-mode prerequisite
+
+#317 identified the smallest clean Hermes interoperability primitive as a generic persistence-adjacent durable-state mutation middleware:
+
+```text
+before_durable_state_mutation(event)
+  -> allow | stage | reject
+
+canonical persistence
+
+after_durable_state_mutation(receipt)
+```
+
+That middleware must cover normal model tools, approved pending replay, deterministic curator lifecycle, Journey edits/deletes, and equivalent canonical durable writes.
+
+It should be vendor-neutral. Agent Memory would be one consumer, not a Hermes core dependency.
+
+## Claim boundary
+
+This integration proves useful observe/govern behavior at one exact Hermes source profile. It does not claim:
+
+```text
+plugin/provider coverage == strict coverage
+MemoryProvider mirror == built-in admission authority
+Hermes native Block == Agent Memory policy authority
+repetition == independent corroboration
+human approval == current execution validity
+provider failure == built-in rollback
+old Hermes qualification == future Hermes qualification
+```
+
+Hermes keeps its recursive loop. Agent Memory governs only the durable consequences it can actually reach, and reports the rest rather than hiding them.

--- a/integrations/hermes-agent-memory/pyproject.toml
+++ b/integrations/hermes-agent-memory/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = []
 agent-memory-hermes = "agent_memory_hermes.cli:main"
 
 [project.entry-points."hermes_agent.plugins"]
-agent-memory = "agent_memory_hermes.plugin:register"
+agent-memory = "agent_memory_hermes.safe_plugin:register"
 
 [project.entry-points."hermes_agent.memory_providers"]
 agent-memory = "agent_memory_hermes.provider:register_memory"

--- a/integrations/hermes-agent-memory/pyproject.toml
+++ b/integrations/hermes-agent-memory/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agent-memory-hermes"
+version = "0.1.0"
+description = "Agent Memory observe/govern integration for Hermes Agent"
+requires-python = ">=3.11"
+license = {text = "Apache-2.0"}
+authors = [{name = "MythologIQ Labs LLC"}]
+dependencies = []
+
+[project.scripts]
+agent-memory-hermes = "agent_memory_hermes.cli:main"
+
+[project.entry-points."hermes_agent.plugins"]
+agent-memory = "agent_memory_hermes.plugin:register"
+
+[project.entry-points."hermes_agent.memory_providers"]
+agent-memory = "agent_memory_hermes.provider:register_memory"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/__init__.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/__init__.py
@@ -1,0 +1,44 @@
+"""Agent Memory integration for Hermes Agent."""
+
+from __future__ import annotations
+
+INTEGRATION_VERSION = "0.1.0"
+INTEGRATION_PROFILE = "agent-memory-hermes/1.0.0"
+HERMES_REPOSITORY = "NousResearch/hermes-agent"
+HERMES_COMMIT = "165c889e5b4277b56dadd42949a4112c1e6175a6"
+
+INTERCEPTABLE_TOOLS = frozenset({"memory", "skill_manage"})
+
+STRICT_BLOCKERS = (
+    "approved_pending_memory_replay",
+    "approved_pending_skill_replay",
+    "deterministic_curator_archive",
+    "journey_memory_edit_delete",
+    "journey_skill_edit_delete",
+    "out_of_band_memory_skill_filesystem_write",
+)
+
+MUTATION_SURFACES = (
+    "foreground_builtin_memory_tool",
+    "foreground_skill_manage",
+    "background_review_memory",
+    "background_review_skill_manage",
+    "approved_pending_memory_replay",
+    "approved_pending_skill_replay",
+    "deterministic_curator_archive",
+    "curator_llm_consolidation",
+    "journey_memory_edit_delete",
+    "journey_skill_edit_delete",
+    "external_memory_provider_mirror",
+    "out_of_band_memory_skill_filesystem_write",
+)
+
+__all__ = [
+    "HERMES_COMMIT",
+    "HERMES_REPOSITORY",
+    "INTEGRATION_PROFILE",
+    "INTEGRATION_VERSION",
+    "INTERCEPTABLE_TOOLS",
+    "MUTATION_SURFACES",
+    "STRICT_BLOCKERS",
+]

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/cli.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/cli.py
@@ -1,0 +1,78 @@
+"""Installed doctor surface for the Agent Memory Hermes integration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from .config import IntegrationConfigError, detect_hermes_revision, integration_dir, load_config
+from .coverage import build_coverage_report
+
+
+def _default_home() -> Path:
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore
+
+        return Path(get_hermes_home()).expanduser().resolve()
+    except Exception:
+        import os
+
+        return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="agent-memory-hermes")
+    sub = parser.add_subparsers(dest="command", required=True)
+    doctor = sub.add_parser("doctor", help="report exact Hermes integration coverage/readiness")
+    doctor.add_argument("--hermes-home", type=Path, default=None)
+    doctor.add_argument("--hermes-revision", default=None)
+    doctor.add_argument("--mode", choices=["observe", "govern", "strict"], default=None)
+    doctor.add_argument("--json", action="store_true", dest="as_json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command != "doctor":
+        return 2
+
+    home = (args.hermes_home or _default_home()).expanduser().resolve()
+    try:
+        config = load_config(home).with_mode(args.mode)
+    except (IntegrationConfigError, json.JSONDecodeError, OSError) as exc:
+        report = {
+            "schema_version": "1.0.0",
+            "integration": {"ready": False, "mode": args.mode or "unknown"},
+            "reasons_not_ready": [f"configuration_error: {exc}"],
+            "authority_effect": "none",
+        }
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 2
+
+    observed = (args.hermes_revision or detect_hermes_revision()).strip().lower()
+    report = build_coverage_report(config, observed_hermes_revision=observed)
+    target = integration_dir(home) / "coverage.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.as_json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Agent Memory Hermes: mode={config.mode} ready={str(report['integration']['ready']).lower()} "
+            f"profile_current={str(report['hermes']['profile_current']).lower()}"
+        )
+        if report["reasons_not_ready"]:
+            for reason in report["reasons_not_ready"]:
+                print(f"- {reason}")
+        if config.mode == "strict":
+            print("- strict blockers: " + ", ".join(report["strict"]["blocking_surfaces"]))
+        print(f"coverage: {target}")
+
+    return 0 if report["integration"]["ready"] else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/config.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/config.py
@@ -1,0 +1,153 @@
+"""Configuration and exact Hermes profile detection."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+import shlex
+import subprocess
+from typing import Any, Mapping, Sequence
+
+from . import HERMES_COMMIT
+
+
+class IntegrationConfigError(ValueError):
+    """Invalid Agent Memory Hermes integration configuration."""
+
+
+@dataclass(frozen=True)
+class IntegrationConfig:
+    mode: str = "observe"
+    governor_command: tuple[str, ...] = ()
+    governor_required: bool = True
+    governor_timeout_seconds: float = 10.0
+    record_payloads: bool = False
+    require_exact_profile: bool = True
+    expected_hermes_revision: str = HERMES_COMMIT
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any] | None) -> "IntegrationConfig":
+        raw = dict(value or {})
+        command = raw.get("governor_command", ())
+        if isinstance(command, str):
+            command = tuple(shlex.split(command))
+        elif isinstance(command, Sequence):
+            command = tuple(str(item) for item in command)
+        else:
+            raise IntegrationConfigError("governor_command must be a string or sequence")
+        config = cls(
+            mode=str(raw.get("mode", "observe")).strip().lower(),
+            governor_command=command,
+            governor_required=bool(raw.get("governor_required", True)),
+            governor_timeout_seconds=float(raw.get("governor_timeout_seconds", 10.0)),
+            record_payloads=bool(raw.get("record_payloads", False)),
+            require_exact_profile=bool(raw.get("require_exact_profile", True)),
+            expected_hermes_revision=str(raw.get("expected_hermes_revision", HERMES_COMMIT)).strip(),
+        )
+        config.validate()
+        return config
+
+    def validate(self) -> None:
+        if self.mode not in {"observe", "govern", "strict"}:
+            raise IntegrationConfigError("mode must be observe, govern, or strict")
+        if self.governor_timeout_seconds <= 0 or self.governor_timeout_seconds > 120:
+            raise IntegrationConfigError("governor_timeout_seconds must be >0 and <=120")
+        if len(self.expected_hermes_revision) != 40 or any(
+            ch not in "0123456789abcdef" for ch in self.expected_hermes_revision
+        ):
+            raise IntegrationConfigError("expected_hermes_revision must be a 40-character lowercase git SHA")
+
+    def with_mode(self, mode: str | None) -> "IntegrationConfig":
+        if mode is None:
+            return self
+        updated = replace(self, mode=mode.strip().lower())
+        updated.validate()
+        return updated
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["governor_command"] = list(self.governor_command)
+        return value
+
+
+def integration_dir(hermes_home: str | Path) -> Path:
+    return Path(hermes_home).expanduser().resolve() / "agent-memory"
+
+
+def config_path(hermes_home: str | Path) -> Path:
+    return integration_dir(hermes_home) / "config.json"
+
+
+def load_config(hermes_home: str | Path) -> IntegrationConfig:
+    path = config_path(hermes_home)
+    value: dict[str, Any] = {}
+    if path.exists():
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(parsed, dict):
+            raise IntegrationConfigError(f"{path} must contain a JSON object")
+        value.update(parsed)
+
+    env_mode = os.environ.get("AGENT_MEMORY_HERMES_MODE")
+    env_command = os.environ.get("AGENT_MEMORY_HERMES_GOVERNOR_COMMAND")
+    env_required = os.environ.get("AGENT_MEMORY_HERMES_GOVERNOR_REQUIRED")
+    env_revision = os.environ.get("AGENT_MEMORY_HERMES_EXPECTED_REVISION")
+    if env_mode:
+        value["mode"] = env_mode
+    if env_command:
+        value["governor_command"] = env_command
+    if env_required is not None:
+        value["governor_required"] = env_required.strip().lower() in {"1", "true", "yes", "on"}
+    if env_revision:
+        value["expected_hermes_revision"] = env_revision
+    return IntegrationConfig.from_mapping(value)
+
+
+def save_config(hermes_home: str | Path, config: IntegrationConfig) -> Path:
+    config.validate()
+    path = config_path(hermes_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(config.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+    return path
+
+
+def detect_hermes_revision() -> str:
+    """Return the exact Hermes git revision when deterministically discoverable.
+
+    The environment override exists for packaged/test deployments where Hermes
+    source is mounted separately. Without exact evidence, return ``unknown``.
+    """
+    override = os.environ.get("AGENT_MEMORY_HERMES_REVISION", "").strip().lower()
+    if override:
+        if len(override) == 40 and all(ch in "0123456789abcdef" for ch in override):
+            return override
+        return "unknown"
+
+    try:
+        import agent  # type: ignore
+    except Exception:
+        return "unknown"
+
+    package_path = Path(getattr(agent, "__file__", "")).resolve()
+    for parent in (package_path.parent, *package_path.parents):
+        if not (parent / ".git").exists():
+            continue
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(parent), "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return "unknown"
+        revision = result.stdout.strip().lower()
+        if len(revision) == 40 and all(ch in "0123456789abcdef" for ch in revision):
+            return revision
+        return "unknown"
+    return "unknown"

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/coverage.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/coverage.py
@@ -1,0 +1,109 @@
+"""Coverage and doctor semantics for the pinned Hermes integration profile."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import (
+    HERMES_COMMIT,
+    HERMES_REPOSITORY,
+    INTEGRATION_PROFILE,
+    INTEGRATION_VERSION,
+    MUTATION_SURFACES,
+    STRICT_BLOCKERS,
+)
+from .config import IntegrationConfig
+
+
+_INTERCEPTABLE = {
+    "foreground_builtin_memory_tool",
+    "foreground_skill_manage",
+    "background_review_memory",
+    "background_review_skill_manage",
+    "curator_llm_consolidation",
+}
+_OBSERVED_PROVIDER = {"external_memory_provider_mirror"}
+
+
+def _surface_status(surface: str, mode: str) -> str:
+    if surface in _INTERCEPTABLE:
+        return "intercepted" if mode in {"govern", "strict"} else "observed"
+    if surface in _OBSERVED_PROVIDER:
+        return "observed"
+    return "uncovered"
+
+
+def build_coverage_report(
+    config: IntegrationConfig,
+    *,
+    observed_hermes_revision: str,
+) -> dict[str, Any]:
+    current = observed_hermes_revision == config.expected_hermes_revision == HERMES_COMMIT
+    surfaces = []
+    for surface in MUTATION_SURFACES:
+        notes: list[str] = []
+        if surface in {"background_review_memory", "background_review_skill_manage"}:
+            notes.append(
+                "mechanically routed through the same model tool hook, but the pinned pre_tool_call metadata does not expose Hermes _memory_write_origin"
+            )
+        if surface == "external_memory_provider_mirror":
+            notes.append("post-commit observation only; provider callback is not built-in admission authority")
+        if surface in STRICT_BLOCKERS:
+            notes.append("does not traverse the normal tool executor at the pinned Hermes profile")
+        surfaces.append(
+            {
+                "surface_id": surface,
+                "status": _surface_status(surface, config.mode),
+                "origin_precision": (
+                    "mechanical_path_only"
+                    if surface in {"background_review_memory", "background_review_skill_manage"}
+                    else "surface_specific"
+                ),
+                "notes": notes,
+            }
+        )
+
+    reasons: list[str] = []
+    if config.mode == "strict":
+        reasons.append("strict mode is unsupported at the pinned Hermes profile")
+    if config.require_exact_profile and not current:
+        reasons.append(
+            "exact Hermes profile is not current: "
+            f"observed={observed_hermes_revision} expected={config.expected_hermes_revision}"
+        )
+    if config.mode == "govern" and config.governor_required and not config.governor_command:
+        reasons.append("govern mode requires a configured governor_command")
+
+    ready = not reasons
+    return {
+        "schema_version": "1.0.0",
+        "hermes": {
+            "repository": HERMES_REPOSITORY,
+            "observed_revision": observed_hermes_revision,
+            "expected_revision": config.expected_hermes_revision,
+            "research_pin": HERMES_COMMIT,
+            "profile_current": current,
+        },
+        "integration": {
+            "profile": INTEGRATION_PROFILE,
+            "version": INTEGRATION_VERSION,
+            "mode": config.mode,
+            "ready": ready,
+            "governor_required": config.governor_required,
+            "governor_configured": bool(config.governor_command),
+            "record_payloads": config.record_payloads,
+        },
+        "surfaces": surfaces,
+        "strict": {
+            "supported": False,
+            "blocking_surfaces": list(STRICT_BLOCKERS),
+            "reason": "six consequential durable mutation families remain outside plugin/provider interception",
+        },
+        "limitations": [
+            "external MemoryProvider observation is post-commit and incomplete for background/approval/curator/Journey/direct-file mutation paths",
+            "pre_tool_call cannot distinguish foreground from background_review origin at the pinned profile without additional Hermes metadata",
+            "Agent Memory stage cannot be represented as a native staged durable mutation through the generic pre_tool_call hook",
+        ],
+        "reasons_not_ready": reasons,
+        "authority_effect": "none",
+    }

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/coverage.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/coverage.py
@@ -33,6 +33,41 @@ def _surface_status(surface: str, mode: str) -> str:
     return "uncovered"
 
 
+def _recursive_scenarios() -> list[dict[str, Any]]:
+    return [
+        {
+            "scenario_id": "self_reinforcing_skill_lineage",
+            "status": "governor_evaluable_when_lineage_available",
+            "requirement": "causally related experience/skill/output lineage must not be counted as independent corroboration",
+            "integration_support": "candidate schema preserves lineage_refs when upstream/caller provides them and always preserves Hermes tool/session scope",
+        },
+        {
+            "scenario_id": "correction_relearned_by_background_review",
+            "status": "governor_evaluable_when_supersession_evidence_available",
+            "requirement": "a corrected/rejected value remains non-current unless new independent evidence satisfies readmission policy",
+            "integration_support": "candidate schema preserves provenance_refs and blocks when the external governor rejects the reproposal",
+        },
+        {
+            "scenario_id": "stale_human_approval_replay",
+            "status": "uncovered_requires_future_durable_state_hook",
+            "requirement": "approval replay must revalidate reviewed before-state digest, candidate digest, and scope immediately before commit",
+            "blocking_surface": "approved_pending_memory_replay",
+        },
+        {
+            "scenario_id": "curator_archive_during_pending_dependency",
+            "status": "uncovered_requires_future_durable_state_hook",
+            "requirement": "skill retirement/archive must check live dependencies and residue obligations before durable transition",
+            "blocking_surface": "deterministic_curator_archive",
+        },
+        {
+            "scenario_id": "provider_mirror_failure_after_builtin_commit",
+            "status": "modeled",
+            "requirement": "built-in commit remains committed while failed external projection is unsettled/non-quiescent; no rollback may be claimed",
+            "integration_support": "MemoryProvider records canonical_builtin_state=committed, external_projection=failed, settled=false, quiescent=false",
+        },
+    ]
+
+
 def build_coverage_report(
     config: IntegrationConfig,
     *,
@@ -99,10 +134,12 @@ def build_coverage_report(
             "blocking_surfaces": list(STRICT_BLOCKERS),
             "reason": "six consequential durable mutation families remain outside plugin/provider interception",
         },
+        "recursive_evidence_scenarios": _recursive_scenarios(),
         "limitations": [
             "external MemoryProvider observation is post-commit and incomplete for background/approval/curator/Journey/direct-file mutation paths",
             "pre_tool_call cannot distinguish foreground from background_review origin at the pinned profile without additional Hermes metadata",
             "Agent Memory stage cannot be represented as a native staged durable mutation through the generic pre_tool_call hook",
+            "full causal lineage and supersession state are not exposed by Hermes pre_tool_call metadata; govern mode preserves such refs when supplied and must not invent them",
         ],
         "reasons_not_ready": reasons,
         "authority_effect": "none",

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/evidence.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/evidence.py
@@ -1,0 +1,72 @@
+"""Append-only local evidence for Hermes integration events."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import threading
+import time
+from typing import Any, Mapping
+import uuid
+
+from . import HERMES_COMMIT, INTEGRATION_PROFILE, INTEGRATION_VERSION
+from .config import integration_dir
+
+
+class EvidenceStore:
+    """Profile-scoped JSONL evidence store.
+
+    Payloads are hashed by default. ``record_payloads`` must be explicitly
+    enabled to persist raw candidate/tool content.
+    """
+
+    def __init__(self, hermes_home: str | Path, *, record_payloads: bool = False):
+        self.root = integration_dir(hermes_home)
+        self.path = self.root / "events.jsonl"
+        self.record_payloads = record_payloads
+        self._lock = threading.Lock()
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def digest(value: Any) -> str:
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+        return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+    def append(
+        self,
+        event_type: str,
+        *,
+        mode: str,
+        hermes_revision: str,
+        metadata: Mapping[str, Any] | None = None,
+        payload: Any = None,
+    ) -> dict[str, Any]:
+        record: dict[str, Any] = {
+            "schema_version": "1.0.0",
+            "event_id": str(uuid.uuid4()),
+            "observed_at_unix_ms": int(time.time() * 1000),
+            "event_type": event_type,
+            "mode": mode,
+            "integration_profile": INTEGRATION_PROFILE,
+            "integration_version": INTEGRATION_VERSION,
+            "hermes_revision": hermes_revision,
+            "expected_hermes_revision": HERMES_COMMIT,
+            "metadata": dict(metadata or {}),
+            "payload_digest": self.digest(payload) if payload is not None else None,
+            "payload_recorded": bool(payload is not None and self.record_payloads),
+            "authority_effect": "none",
+        }
+        if payload is not None and self.record_payloads:
+            record["payload"] = payload
+        rendered = json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n"
+        with self._lock:
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(rendered)
+                handle.flush()
+                os.fsync(handle.fileno())
+        return record
+
+    def backup_paths(self) -> list[str]:
+        return [str(self.root)]

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/governor.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/governor.py
@@ -1,0 +1,64 @@
+"""External admission command transport for Hermes govern mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import subprocess
+from typing import Any, Mapping, Sequence
+
+
+class GovernorError(RuntimeError):
+    """The configured governor could not return a valid decision."""
+
+
+@dataclass(frozen=True)
+class GovernorDecision:
+    decision: str
+    reason: str
+    evidence_refs: tuple[str, ...] = ()
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "GovernorDecision":
+        decision = str(value.get("decision", "")).strip().lower()
+        if decision not in {"allow", "reject", "stage"}:
+            raise GovernorError("governor decision must be allow, reject, or stage")
+        reason = str(value.get("reason", "")).strip()
+        if not reason:
+            raise GovernorError("governor decision requires a non-empty reason")
+        raw_refs = value.get("evidence_refs", [])
+        if not isinstance(raw_refs, list) or any(not isinstance(item, str) or not item for item in raw_refs):
+            raise GovernorError("governor evidence_refs must be a list of non-empty strings")
+        return cls(decision=decision, reason=reason, evidence_refs=tuple(raw_refs))
+
+
+class SubprocessGovernor:
+    def __init__(self, command: Sequence[str], *, timeout_seconds: float = 10.0):
+        self.command = tuple(command)
+        self.timeout_seconds = timeout_seconds
+
+    def evaluate(self, candidate: Mapping[str, Any]) -> GovernorDecision:
+        if not self.command:
+            raise GovernorError("governor command is not configured")
+        try:
+            completed = subprocess.run(
+                list(self.command),
+                input=json.dumps(candidate, sort_keys=True),
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise GovernorError(f"governor unavailable: {exc}") from exc
+        if completed.returncode != 0:
+            stderr = completed.stderr.strip()
+            suffix = f": {stderr}" if stderr else ""
+            raise GovernorError(f"governor exited with status {completed.returncode}{suffix}")
+        try:
+            value = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise GovernorError("governor did not return valid JSON") from exc
+        if not isinstance(value, dict):
+            raise GovernorError("governor response must be a JSON object")
+        return GovernorDecision.from_mapping(value)

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/mutation.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/mutation.py
@@ -1,0 +1,41 @@
+"""Conservative mutation classification for pinned Hermes memory/skill tools."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from . import INTERCEPTABLE_TOOLS
+
+_READ_ONLY_ACTIONS = frozenset(
+    {
+        "show",
+        "read",
+        "list",
+        "get",
+        "status",
+        "inspect",
+        "pending",
+    }
+)
+
+
+def operation_name(tool_name: str, args: Optional[Mapping[str, Any]]) -> str:
+    safe = args if isinstance(args, Mapping) else {}
+    if tool_name == "memory":
+        return str(safe.get("action") or "unknown").strip().lower()
+    if tool_name == "skill_manage":
+        return str(safe.get("action") or safe.get("mode") or "unknown").strip().lower()
+    return "not_applicable"
+
+
+def is_potential_durable_mutation(
+    tool_name: str,
+    args: Optional[Mapping[str, Any]],
+) -> bool:
+    if tool_name not in INTERCEPTABLE_TOOLS:
+        return False
+    operation = operation_name(tool_name, args)
+    # At the exact researched profile, known read-only operations are allowed
+    # through untouched. Unknown/new actions are treated conservatively as
+    # potential mutations until a new Hermes profile is qualified.
+    return operation not in _READ_ONLY_ACTIONS

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/plugin.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/plugin.py
@@ -1,0 +1,352 @@
+"""Hermes general plugin for observe/govern interception."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import threading
+from typing import Any, Mapping, Optional
+
+from . import HERMES_COMMIT, INTEGRATION_PROFILE, INTERCEPTABLE_TOOLS, STRICT_BLOCKERS
+from .config import IntegrationConfig, detect_hermes_revision, load_config
+from .evidence import EvidenceStore
+from .governor import GovernorDecision, GovernorError, SubprocessGovernor
+
+
+@dataclass(frozen=True)
+class PendingDecision:
+    proposal_event_id: str
+    decision: str
+    reason: str
+    tool_name: str
+    args_digest: str
+
+
+class HermesPluginRuntime:
+    def __init__(
+        self,
+        hermes_home: str | Path,
+        *,
+        config: IntegrationConfig | None = None,
+        observed_hermes_revision: str | None = None,
+    ):
+        self.hermes_home = Path(hermes_home).expanduser().resolve()
+        self.config = config or load_config(self.hermes_home)
+        self.observed_hermes_revision = observed_hermes_revision or detect_hermes_revision()
+        self.store = EvidenceStore(self.hermes_home, record_payloads=self.config.record_payloads)
+        self._pending: dict[str, PendingDecision] = {}
+        self._lock = threading.Lock()
+
+    def _profile_current(self) -> bool:
+        return (
+            self.observed_hermes_revision
+            == self.config.expected_hermes_revision
+            == HERMES_COMMIT
+        )
+
+    @staticmethod
+    def _operation(tool_name: str, args: Mapping[str, Any]) -> str:
+        if tool_name == "memory":
+            return str(args.get("action") or "unknown")
+        if tool_name == "skill_manage":
+            return str(args.get("action") or args.get("mode") or "unknown")
+        return "not_applicable"
+
+    @staticmethod
+    def _target(tool_name: str, args: Mapping[str, Any]) -> str:
+        if tool_name == "memory":
+            return str(args.get("target") or "memory")
+        if tool_name == "skill_manage":
+            return str(args.get("name") or args.get("skill_name") or args.get("file_path") or "skill")
+        return "unknown"
+
+    def _candidate(self, tool_name: str, args: Mapping[str, Any], metadata: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "schema_version": "1.0.0",
+            "kind": "hermes_durable_state_candidate",
+            "integration_profile": INTEGRATION_PROFILE,
+            "hermes_revision": self.observed_hermes_revision,
+            "expected_hermes_revision": self.config.expected_hermes_revision,
+            "tool_name": tool_name,
+            "operation": self._operation(tool_name, args),
+            "target": self._target(tool_name, args),
+            "origin_hint": str(metadata.get("origin_hint") or "unknown_model_tool"),
+            "origin_precision": "hook_does_not_expose_background_review_origin",
+            "scope": {
+                key: str(metadata.get(key) or "")
+                for key in (
+                    "task_id",
+                    "session_id",
+                    "tool_call_id",
+                    "turn_id",
+                    "api_request_id",
+                )
+            },
+            "lineage_refs": list(args.get("lineage_refs", []))
+            if isinstance(args.get("lineage_refs"), list)
+            else [],
+            "provenance_refs": list(args.get("provenance_refs", []))
+            if isinstance(args.get("provenance_refs"), list)
+            else [],
+            "args": dict(args),
+            "args_digest": EvidenceStore.digest(args),
+            "authority_effect": "none",
+        }
+
+    def _remember(self, tool_call_id: str, pending: PendingDecision) -> None:
+        if not tool_call_id:
+            return
+        with self._lock:
+            self._pending[tool_call_id] = pending
+
+    def _pop(self, tool_call_id: str) -> PendingDecision | None:
+        if not tool_call_id:
+            return None
+        with self._lock:
+            return self._pending.pop(tool_call_id, None)
+
+    @staticmethod
+    def _block(message: str) -> dict[str, str]:
+        return {"action": "block", "message": message}
+
+    def _record_proposal(
+        self,
+        candidate: Mapping[str, Any],
+        *,
+        decision: str,
+        reason: str,
+        evidence_refs: tuple[str, ...] = (),
+    ) -> dict[str, Any]:
+        scope = candidate["scope"]
+        metadata = {
+            "tool_name": candidate["tool_name"],
+            "operation": candidate["operation"],
+            "target": candidate["target"],
+            "origin_hint": candidate["origin_hint"],
+            "origin_precision": candidate["origin_precision"],
+            "args_digest": candidate["args_digest"],
+            "task_id": scope["task_id"],
+            "session_id": scope["session_id"],
+            "tool_call_id": scope["tool_call_id"],
+            "turn_id": scope["turn_id"],
+            "api_request_id": scope["api_request_id"],
+            "decision": decision,
+            "reason": reason,
+            "evidence_refs": list(evidence_refs),
+            "profile_current": self._profile_current(),
+        }
+        return self.store.append(
+            "durable_tool_proposal",
+            mode=self.config.mode,
+            hermes_revision=self.observed_hermes_revision,
+            metadata=metadata,
+            payload=candidate if self.config.record_payloads else None,
+        )
+
+    def on_pre_tool_call(
+        self,
+        tool_name: str = "",
+        args: Optional[Mapping[str, Any]] = None,
+        **metadata: Any,
+    ) -> Optional[dict[str, str]]:
+        if tool_name not in INTERCEPTABLE_TOOLS:
+            return None
+        safe_args: Mapping[str, Any] = args if isinstance(args, Mapping) else {}
+        candidate = self._candidate(tool_name, safe_args, metadata)
+        tool_call_id = candidate["scope"]["tool_call_id"]
+
+        if self.config.mode == "observe":
+            record = self._record_proposal(
+                candidate,
+                decision="observe_allow",
+                reason="observe mode records the proposal without changing Hermes execution",
+            )
+            self._remember(
+                tool_call_id,
+                PendingDecision(
+                    proposal_event_id=record["event_id"],
+                    decision="observe_allow",
+                    reason="observe mode",
+                    tool_name=tool_name,
+                    args_digest=candidate["args_digest"],
+                ),
+            )
+            return None
+
+        if self.config.mode == "strict":
+            reason = (
+                "Agent Memory strict mode is unsupported for this Hermes profile; "
+                "known uncovered durable mutation surfaces: " + ", ".join(STRICT_BLOCKERS)
+            )
+            record = self._record_proposal(candidate, decision="reject", reason=reason)
+            self._remember(
+                tool_call_id,
+                PendingDecision(record["event_id"], "reject", reason, tool_name, candidate["args_digest"]),
+            )
+            return self._block(reason)
+
+        if self.config.require_exact_profile and not self._profile_current():
+            reason = (
+                "Agent Memory Hermes govern profile is not current; "
+                f"observed={self.observed_hermes_revision} expected={self.config.expected_hermes_revision}"
+            )
+            record = self._record_proposal(candidate, decision="reject", reason=reason)
+            self._remember(
+                tool_call_id,
+                PendingDecision(record["event_id"], "reject", reason, tool_name, candidate["args_digest"]),
+            )
+            return self._block(reason)
+
+        governor: SubprocessGovernor | None = None
+        if self.config.governor_command:
+            governor = SubprocessGovernor(
+                self.config.governor_command,
+                timeout_seconds=self.config.governor_timeout_seconds,
+            )
+
+        if governor is None:
+            reason = "Agent Memory governor command is not configured"
+            decision_name = "reject" if self.config.governor_required else "allow_unqualified"
+            record = self._record_proposal(candidate, decision=decision_name, reason=reason)
+            self._remember(
+                tool_call_id,
+                PendingDecision(record["event_id"], decision_name, reason, tool_name, candidate["args_digest"]),
+            )
+            return self._block(reason) if self.config.governor_required else None
+
+        try:
+            decision: GovernorDecision = governor.evaluate(candidate)
+        except GovernorError as exc:
+            reason = str(exc)
+            decision_name = "reject" if self.config.governor_required else "allow_governor_unavailable"
+            record = self._record_proposal(candidate, decision=decision_name, reason=reason)
+            self._remember(
+                tool_call_id,
+                PendingDecision(record["event_id"], decision_name, reason, tool_name, candidate["args_digest"]),
+            )
+            return self._block(reason) if self.config.governor_required else None
+
+        if decision.decision == "allow":
+            record = self._record_proposal(
+                candidate,
+                decision="allow",
+                reason=decision.reason,
+                evidence_refs=decision.evidence_refs,
+            )
+            self._remember(
+                tool_call_id,
+                PendingDecision(record["event_id"], "allow", decision.reason, tool_name, candidate["args_digest"]),
+            )
+            return None
+
+        if decision.decision == "stage":
+            reason = (
+                "Agent Memory governor requested stage, but the pinned Hermes pre_tool_call hook "
+                "cannot create a native staged durable mutation; blocking instead. "
+                f"Governor reason: {decision.reason}"
+            )
+            record = self._record_proposal(
+                candidate,
+                decision="stage_unsupported_block",
+                reason=reason,
+                evidence_refs=decision.evidence_refs,
+            )
+            self._remember(
+                tool_call_id,
+                PendingDecision(record["event_id"], "stage_unsupported_block", reason, tool_name, candidate["args_digest"]),
+            )
+            return self._block(reason)
+
+        record = self._record_proposal(
+            candidate,
+            decision="reject",
+            reason=decision.reason,
+            evidence_refs=decision.evidence_refs,
+        )
+        self._remember(
+            tool_call_id,
+            PendingDecision(record["event_id"], "reject", decision.reason, tool_name, candidate["args_digest"]),
+        )
+        return self._block(decision.reason)
+
+    def on_post_tool_call(
+        self,
+        tool_name: str = "",
+        args: Optional[Mapping[str, Any]] = None,
+        result: Any = None,
+        tool_call_id: str = "",
+        status: str = "",
+        error_type: str = "",
+        error_message: str = "",
+        **metadata: Any,
+    ) -> None:
+        if tool_name not in INTERCEPTABLE_TOOLS:
+            return
+        pending = self._pop(tool_call_id)
+        safe_args: Mapping[str, Any] = args if isinstance(args, Mapping) else {}
+        self.store.append(
+            "durable_tool_execution_receipt",
+            mode=self.config.mode,
+            hermes_revision=self.observed_hermes_revision,
+            metadata={
+                "proposal_event_id": pending.proposal_event_id if pending else None,
+                "proposal_decision": pending.decision if pending else "unmatched",
+                "tool_name": tool_name,
+                "operation": self._operation(tool_name, safe_args),
+                "target": self._target(tool_name, safe_args),
+                "args_digest": EvidenceStore.digest(safe_args),
+                "result_digest": EvidenceStore.digest(result),
+                "tool_call_id": tool_call_id,
+                "task_id": str(metadata.get("task_id") or ""),
+                "session_id": str(metadata.get("session_id") or ""),
+                "status": status or ("failed" if error_type or error_message else "completed"),
+                "error_type": error_type or None,
+                "error_message_digest": EvidenceStore.digest(error_message) if error_message else None,
+                "admission_is_not_execution": True,
+            },
+            payload={"args": dict(safe_args), "result": result} if self.config.record_payloads else None,
+        )
+
+
+_RUNTIME_CACHE: dict[str, HermesPluginRuntime] = {}
+_RUNTIME_LOCK = threading.Lock()
+
+
+def _current_home() -> Path:
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore
+
+        return Path(get_hermes_home()).expanduser().resolve()
+    except Exception:
+        import os
+
+        return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve()
+
+
+def runtime_for_current_home() -> HermesPluginRuntime:
+    home = _current_home()
+    key = str(home)
+    with _RUNTIME_LOCK:
+        runtime = _RUNTIME_CACHE.get(key)
+        if runtime is None:
+            runtime = HermesPluginRuntime(home)
+            _RUNTIME_CACHE[key] = runtime
+        return runtime
+
+
+def _pre_tool_hook(tool_name: str = "", args: Optional[Mapping[str, Any]] = None, **kwargs: Any):
+    return runtime_for_current_home().on_pre_tool_call(tool_name=tool_name, args=args, **kwargs)
+
+
+def _post_tool_hook(tool_name: str = "", args: Optional[Mapping[str, Any]] = None, **kwargs: Any):
+    return runtime_for_current_home().on_post_tool_call(tool_name=tool_name, args=args, **kwargs)
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_tool_call", _pre_tool_hook)
+    ctx.register_hook("post_tool_call", _post_tool_hook)
+
+
+def _clear_runtime_cache_for_tests() -> None:
+    with _RUNTIME_LOCK:
+        _RUNTIME_CACHE.clear()

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/provider.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/provider.py
@@ -1,0 +1,269 @@
+"""Hermes MemoryProvider implementation for Agent Memory observation/sync."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from . import INTEGRATION_PROFILE
+from .config import IntegrationConfig, detect_hermes_revision, load_config, save_config
+from .coverage import build_coverage_report
+from .evidence import EvidenceStore
+
+try:
+    from agent.memory_provider import MemoryProvider  # type: ignore
+except Exception:  # pragma: no cover - only imported by Hermes/provider tests
+    class MemoryProvider:  # type: ignore[no-redef]
+        pass
+
+
+class AgentMemoryProvider(MemoryProvider):
+    def __init__(self) -> None:
+        self._session_id = ""
+        self._hermes_home: Path | None = None
+        self._config: IntegrationConfig | None = None
+        self._store: EvidenceStore | None = None
+        self._observed_revision = "unknown"
+        self._last_projection_state: dict[str, Any] | None = None
+
+    @property
+    def name(self) -> str:
+        return "agent-memory"
+
+    def is_available(self) -> bool:
+        # Local provider has no network/runtime dependency of its own. Exact
+        # profile readiness is reported by doctor and does not get conflated
+        # with Hermes' provider discovery availability.
+        return True
+
+    def unavailable_reason(self) -> str:
+        return ""
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        hermes_home = kwargs.get("hermes_home") or os.environ.get("HERMES_HOME") or "~/.hermes"
+        self._hermes_home = Path(str(hermes_home)).expanduser().resolve()
+        self._config = load_config(self._hermes_home)
+        self._observed_revision = detect_hermes_revision()
+        self._store = EvidenceStore(self._hermes_home, record_payloads=self._config.record_payloads)
+        self._session_id = session_id
+        report = build_coverage_report(
+            self._config,
+            observed_hermes_revision=self._observed_revision,
+        )
+        self._store.append(
+            "provider_initialize",
+            mode=self._config.mode,
+            hermes_revision=self._observed_revision,
+            metadata={
+                "session_id": session_id,
+                "platform": str(kwargs.get("platform") or ""),
+                "agent_context": str(kwargs.get("agent_context") or ""),
+                "agent_identity": str(kwargs.get("agent_identity") or ""),
+                "agent_workspace": str(kwargs.get("agent_workspace") or ""),
+                "profile_current": report["hermes"]["profile_current"],
+                "ready": report["integration"]["ready"],
+                "provider_is_admission_authority": False,
+            },
+        )
+
+    def _require_store(self) -> tuple[IntegrationConfig, EvidenceStore]:
+        if self._config is None or self._store is None:
+            raise RuntimeError("Agent Memory Hermes provider has not been initialized")
+        return self._config, self._store
+
+    def system_prompt_block(self) -> str:
+        return (
+            "Agent Memory external memory integration is active as an advisory/observation surface. "
+            "Provider context and learned signals do not grant tool, mutation, recall-admission, or action authority."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        config, store = self._require_store()
+        store.append(
+            "provider_prefetch",
+            mode=config.mode,
+            hermes_revision=self._observed_revision,
+            metadata={
+                "session_id": session_id or self._session_id,
+                "query_digest": EvidenceStore.digest(query),
+                "context_injected": False,
+                "reason": "0.1.0 provider is observation/sync only; recall backend is not configured by this package",
+            },
+            payload=query if config.record_payloads else None,
+        )
+        return ""
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        config, store = self._require_store()
+        payload = {
+            "user_content": user_content,
+            "assistant_content": assistant_content,
+            "messages": messages,
+        }
+        store.append(
+            "provider_sync_turn",
+            mode=config.mode,
+            hermes_revision=self._observed_revision,
+            metadata={
+                "session_id": session_id or self._session_id,
+                "user_digest": EvidenceStore.digest(user_content),
+                "assistant_digest": EvidenceStore.digest(assistant_content),
+                "message_count": len(messages) if isinstance(messages, list) else None,
+                "authority_effect": "none",
+            },
+            payload=payload if config.record_payloads else None,
+        )
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        config, store = self._require_store()
+        common = {
+            "action": action,
+            "target": target,
+            "content_digest": EvidenceStore.digest(content),
+            "provider_callback_is_post_commit": True,
+            "canonical_builtin_state": "committed",
+            "provider_is_admission_authority": False,
+        }
+        if os.environ.get("AGENT_MEMORY_HERMES_TEST_MIRROR_FAILURE") == "1":
+            self._last_projection_state = {
+                "canonical_builtin_state": "committed",
+                "external_projection": "failed",
+                "settled": False,
+                "quiescent": False,
+                "rollback_claimed": False,
+            }
+            store.append(
+                "provider_memory_mirror_failed",
+                mode=config.mode,
+                hermes_revision=self._observed_revision,
+                metadata={**common, **self._last_projection_state},
+                payload={"content": content, "metadata": metadata} if config.record_payloads else None,
+            )
+            raise RuntimeError("injected Agent Memory provider mirror failure")
+
+        self._last_projection_state = {
+            "canonical_builtin_state": "committed",
+            "external_projection": "observed",
+            "settled": True,
+            "quiescent": True,
+            "rollback_claimed": False,
+        }
+        store.append(
+            "provider_memory_mirror_observed",
+            mode=config.mode,
+            hermes_revision=self._observed_revision,
+            metadata={**common, **self._last_projection_state},
+            payload={"content": content, "metadata": metadata} if config.record_payloads else None,
+        )
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        config, store = self._require_store()
+        store.append(
+            "provider_session_end",
+            mode=config.mode,
+            hermes_revision=self._observed_revision,
+            metadata={"session_id": self._session_id, "message_count": len(messages)},
+        )
+
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        rewound: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        config, store = self._require_store()
+        store.append(
+            "provider_session_switch",
+            mode=config.mode,
+            hermes_revision=self._observed_revision,
+            metadata={
+                "old_session_id": self._session_id,
+                "new_session_id": new_session_id,
+                "parent_session_id": parent_session_id,
+                "reset": reset,
+                "rewound": rewound,
+            },
+        )
+        self._session_id = new_session_id
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return []
+
+    def backup_paths(self) -> List[str]:
+        if self._store is not None:
+            return self._store.backup_paths()
+        if self._hermes_home is not None:
+            return [str(self._hermes_home / "agent-memory")]
+        return []
+
+    def shutdown(self) -> None:
+        if self._config is None or self._store is None:
+            return
+        self._store.append(
+            "provider_shutdown",
+            mode=self._config.mode,
+            hermes_revision=self._observed_revision,
+            metadata={"session_id": self._session_id},
+        )
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "mode",
+                "description": "Agent Memory integration mode. Strict is reported unsupported at this Hermes profile.",
+                "required": True,
+                "default": "observe",
+                "choices": ["observe", "govern", "strict"],
+                "type": "text",
+            },
+            {
+                "key": "governor_command",
+                "description": "External JSON admission command used by govern mode.",
+                "required": False,
+                "default": "",
+                "type": "text",
+            },
+            {
+                "key": "governor_required",
+                "description": "Fail closed when the governor is absent, unavailable, or invalid.",
+                "required": True,
+                "default": True,
+                "type": "boolean",
+            },
+            {
+                "key": "record_payloads",
+                "description": "Persist raw memory/skill payloads in local evidence instead of hashes only.",
+                "required": True,
+                "default": False,
+                "type": "boolean",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        config = IntegrationConfig.from_mapping(values)
+        save_config(hermes_home, config)
+
+    @property
+    def last_projection_state(self) -> dict[str, Any] | None:
+        return dict(self._last_projection_state) if self._last_projection_state else None
+
+
+def register_memory(ctx) -> None:
+    ctx.register_memory_provider(lambda: AgentMemoryProvider())

--- a/integrations/hermes-agent-memory/src/agent_memory_hermes/safe_plugin.py
+++ b/integrations/hermes-agent-memory/src/agent_memory_hermes/safe_plugin.py
@@ -1,0 +1,55 @@
+"""Fail-closed Hermes hook wrapper.
+
+Hermes deliberately isolates plugin callback exceptions. A required governance
+integration therefore cannot rely on an exception to stop a durable tool call.
+This wrapper converts integration/configuration failure into an explicit native
+Hermes block for the two durable model-tool surfaces this profile governs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from . import INTERCEPTABLE_TOOLS
+from .plugin import runtime_for_current_home
+
+
+def _pre_tool_hook(
+    tool_name: str = "",
+    args: Optional[Mapping[str, Any]] = None,
+    **kwargs: Any,
+):
+    if tool_name not in INTERCEPTABLE_TOOLS:
+        return None
+    try:
+        return runtime_for_current_home().on_pre_tool_call(tool_name=tool_name, args=args, **kwargs)
+    except Exception as exc:
+        return {
+            "action": "block",
+            "message": (
+                "Agent Memory Hermes integration failed before durable-state admission; "
+                f"refusing {tool_name} mutation rather than allowing through plugin failure. "
+                f"error={type(exc).__name__}"
+            ),
+        }
+
+
+def _post_tool_hook(
+    tool_name: str = "",
+    args: Optional[Mapping[str, Any]] = None,
+    **kwargs: Any,
+) -> None:
+    if tool_name not in INTERCEPTABLE_TOOLS:
+        return
+    try:
+        runtime_for_current_home().on_post_tool_call(tool_name=tool_name, args=args, **kwargs)
+    except Exception:
+        # Post-execution evidence failure cannot retroactively change the
+        # execution result. Hermes' own hook isolation will also log plugin
+        # errors; the next doctor/coverage run reports integration readiness.
+        return
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_tool_call", _pre_tool_hook)
+    ctx.register_hook("post_tool_call", _post_tool_hook)

--- a/integrations/hermes-agent-memory/tests/fake_governor.py
+++ b/integrations/hermes-agent-memory/tests/fake_governor.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Deterministic fake external governor for Hermes integration tests."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    decision = sys.argv[1] if len(sys.argv) > 1 else "allow"
+    capture = Path(sys.argv[2]) if len(sys.argv) > 2 and sys.argv[2] else None
+    candidate = json.load(sys.stdin)
+    if capture is not None:
+        capture.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if decision == "exit-failure":
+        print("governor unavailable", file=sys.stderr)
+        return 17
+    if decision == "invalid-json":
+        print("not-json")
+        return 0
+    if decision == "invalid-decision":
+        print(json.dumps({"decision": "maybe", "reason": "invalid fixture"}))
+        return 0
+
+    reason = os.environ.get("FAKE_GOVERNOR_REASON", f"fake governor {decision}")
+    print(
+        json.dumps(
+            {
+                "decision": decision,
+                "reason": reason,
+                "evidence_refs": [f"fixture://fake-governor/{decision}"],
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/hermes-agent-memory/tests/test_exact_hermes_contract.py
+++ b/integrations/hermes-agent-memory/tests/test_exact_hermes_contract.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import importlib.metadata
+import unittest
+
+from agent.memory_provider import MemoryProvider
+from agent_memory_hermes.provider import AgentMemoryProvider
+
+
+class ExactHermesContractTests(unittest.TestCase):
+    def test_provider_subclasses_exact_hermes_memory_provider(self) -> None:
+        self.assertTrue(issubclass(AgentMemoryProvider, MemoryProvider))
+        provider = AgentMemoryProvider()
+        self.assertEqual(provider.name, "agent-memory")
+        self.assertEqual(provider.get_tool_schemas(), [])
+
+    def test_installed_entry_points_use_supported_hermes_groups(self) -> None:
+        plugin = {
+            ep.name: ep.value
+            for ep in importlib.metadata.entry_points(group="hermes_agent.plugins")
+        }
+        provider = {
+            ep.name: ep.value
+            for ep in importlib.metadata.entry_points(group="hermes_agent.memory_providers")
+        }
+        self.assertEqual(plugin["agent-memory"], "agent_memory_hermes.safe_plugin:register")
+        self.assertEqual(provider["agent-memory"], "agent_memory_hermes.provider:register_memory")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/hermes-agent-memory/tests/test_integration.py
+++ b/integrations/hermes-agent-memory/tests/test_integration.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+import importlib.metadata
+import io
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+from agent_memory_hermes import HERMES_COMMIT, MUTATION_SURFACES, STRICT_BLOCKERS
+from agent_memory_hermes.cli import main as cli_main
+from agent_memory_hermes.config import IntegrationConfig, save_config
+from agent_memory_hermes.coverage import build_coverage_report
+from agent_memory_hermes.plugin import HermesPluginRuntime, _clear_runtime_cache_for_tests
+from agent_memory_hermes.provider import AgentMemoryProvider, register_memory
+from agent_memory_hermes.safe_plugin import register as register_plugin
+from agent_memory_hermes import safe_plugin
+
+HERE = Path(__file__).resolve().parent
+FAKE_GOVERNOR = HERE / "fake_governor.py"
+
+
+class FakePluginContext:
+    def __init__(self) -> None:
+        self.hooks: dict[str, object] = {}
+        self.provider_factory = None
+
+    def register_hook(self, event: str, callback) -> None:
+        self.hooks[event] = callback
+
+    def register_memory_provider(self, factory) -> None:
+        self.provider_factory = factory
+
+
+class HermesIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._old_env = dict(os.environ)
+        _clear_runtime_cache_for_tests()
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_env)
+        _clear_runtime_cache_for_tests()
+
+    def governor_command(self, decision: str, capture: Path | None = None) -> tuple[str, ...]:
+        return (
+            sys.executable,
+            str(FAKE_GOVERNOR),
+            decision,
+            str(capture) if capture is not None else "",
+        )
+
+    def test_package_publishes_both_supported_hermes_entry_points(self) -> None:
+        plugin_eps = {
+            ep.name: ep.value for ep in importlib.metadata.entry_points(group="hermes_agent.plugins")
+        }
+        provider_eps = {
+            ep.name: ep.value
+            for ep in importlib.metadata.entry_points(group="hermes_agent.memory_providers")
+        }
+        self.assertEqual(plugin_eps.get("agent-memory"), "agent_memory_hermes.safe_plugin:register")
+        self.assertEqual(provider_eps.get("agent-memory"), "agent_memory_hermes.provider:register_memory")
+
+    def test_registers_pre_post_hooks_and_memory_provider(self) -> None:
+        ctx = FakePluginContext()
+        register_plugin(ctx)
+        register_memory(ctx)
+        self.assertIn("pre_tool_call", ctx.hooks)
+        self.assertIn("post_tool_call", ctx.hooks)
+        self.assertIsNotNone(ctx.provider_factory)
+        provider = ctx.provider_factory()
+        self.assertIsInstance(provider, AgentMemoryProvider)
+        self.assertEqual(provider.name, "agent-memory")
+
+    def test_observe_records_memory_and_skill_proposals_without_raw_payloads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = IntegrationConfig(mode="observe")
+            runtime = HermesPluginRuntime(tmp, config=config, observed_hermes_revision=HERMES_COMMIT)
+            self.assertIsNone(
+                runtime.on_pre_tool_call(
+                    tool_name="memory",
+                    args={"action": "add", "target": "memory", "content": "secret-value"},
+                    session_id="s1",
+                    tool_call_id="m1",
+                )
+            )
+            self.assertIsNone(
+                runtime.on_pre_tool_call(
+                    tool_name="skill_manage",
+                    args={"action": "create", "name": "learned-skill", "content": "procedure"},
+                    session_id="s1",
+                    tool_call_id="k1",
+                )
+            )
+            runtime.on_post_tool_call(
+                tool_name="memory",
+                args={"action": "add", "target": "memory", "content": "secret-value"},
+                result="Memory added successfully",
+                session_id="s1",
+                tool_call_id="m1",
+                status="completed",
+            )
+            events = [json.loads(line) for line in runtime.store.path.read_text().splitlines()]
+            proposals = [item for item in events if item["event_type"] == "durable_tool_proposal"]
+            receipts = [item for item in events if item["event_type"] == "durable_tool_execution_receipt"]
+            self.assertEqual(len(proposals), 2)
+            self.assertEqual(len(receipts), 1)
+            self.assertTrue(all(item["metadata"]["origin_hint"] == "unknown_model_tool" for item in proposals))
+            self.assertTrue(all(item["payload_recorded"] is False for item in events))
+            self.assertNotIn("secret-value", runtime.store.path.read_text())
+            self.assertTrue(receipts[0]["metadata"]["admission_is_not_execution"])
+
+    def test_govern_allow_preserves_lineage_for_external_governor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            capture = Path(tmp) / "candidate.json"
+            config = IntegrationConfig(
+                mode="govern",
+                governor_command=self.governor_command("allow", capture),
+                governor_required=True,
+            )
+            runtime = HermesPluginRuntime(tmp, config=config, observed_hermes_revision=HERMES_COMMIT)
+            result = runtime.on_pre_tool_call(
+                tool_name="skill_manage",
+                args={
+                    "action": "patch",
+                    "name": "skill-d",
+                    "lineage_refs": ["experience:A", "skill:B", "observation:C"],
+                    "provenance_refs": ["session://recursive-learning/1"],
+                },
+                session_id="recursive-session",
+                tool_call_id="recursive-call",
+            )
+            self.assertIsNone(result)
+            candidate = json.loads(capture.read_text())
+            self.assertEqual(candidate["lineage_refs"], ["experience:A", "skill:B", "observation:C"])
+            self.assertEqual(candidate["provenance_refs"], ["session://recursive-learning/1"])
+            self.assertEqual(candidate["authority_effect"], "none")
+
+    def test_external_governor_can_reject_self_reinforcing_or_corrected_reproposal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            capture = Path(tmp) / "candidate.json"
+            config = IntegrationConfig(
+                mode="govern",
+                governor_command=self.governor_command("reject", capture),
+                governor_required=True,
+            )
+            runtime = HermesPluginRuntime(tmp, config=config, observed_hermes_revision=HERMES_COMMIT)
+            blocked = runtime.on_pre_tool_call(
+                tool_name="memory",
+                args={
+                    "action": "add",
+                    "target": "memory",
+                    "content": "old corrected value X",
+                    "lineage_refs": ["experience:A", "skill:B", "skill:B-output:C"],
+                    "provenance_refs": ["superseded://value-X", "current://value-Y"],
+                },
+                session_id="background-like-session",
+                tool_call_id="reproposal",
+            )
+            self.assertEqual(blocked["action"], "block")
+            candidate = json.loads(capture.read_text())
+            self.assertIn("superseded://value-X", candidate["provenance_refs"])
+            self.assertIn("skill:B-output:C", candidate["lineage_refs"])
+
+    def test_required_governor_unavailable_or_invalid_fails_closed(self) -> None:
+        for decision in ("exit-failure", "invalid-json", "invalid-decision"):
+            with self.subTest(decision=decision), tempfile.TemporaryDirectory() as tmp:
+                config = IntegrationConfig(
+                    mode="govern",
+                    governor_command=self.governor_command(decision),
+                    governor_required=True,
+                )
+                runtime = HermesPluginRuntime(tmp, config=config, observed_hermes_revision=HERMES_COMMIT)
+                blocked = runtime.on_pre_tool_call(
+                    tool_name="memory",
+                    args={"action": "add", "target": "memory", "content": "candidate"},
+                    tool_call_id=decision,
+                )
+                self.assertEqual(blocked["action"], "block")
+
+    def test_stage_is_blocked_instead_of_faking_native_hermes_staging(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = IntegrationConfig(
+                mode="govern",
+                governor_command=self.governor_command("stage"),
+                governor_required=True,
+            )
+            runtime = HermesPluginRuntime(tmp, config=config, observed_hermes_revision=HERMES_COMMIT)
+            blocked = runtime.on_pre_tool_call(
+                tool_name="skill_manage",
+                args={"action": "edit", "name": "skill-x"},
+                tool_call_id="stage-call",
+            )
+            self.assertEqual(blocked["action"], "block")
+            self.assertIn("cannot create a native staged durable mutation", blocked["message"])
+
+    def test_profile_drift_invalidates_govern_applicability(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = IntegrationConfig(
+                mode="govern",
+                governor_command=self.governor_command("allow"),
+                governor_required=True,
+                require_exact_profile=True,
+            )
+            runtime = HermesPluginRuntime(tmp, config=config, observed_hermes_revision="0" * 40)
+            blocked = runtime.on_pre_tool_call(
+                tool_name="memory",
+                args={"action": "add", "target": "memory", "content": "candidate"},
+                tool_call_id="drift",
+            )
+            self.assertEqual(blocked["action"], "block")
+            self.assertIn("profile is not current", blocked["message"])
+
+    def test_fail_closed_wrapper_blocks_malformed_config_instead_of_throwing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / "agent-memory").mkdir()
+            (home / "agent-memory" / "config.json").write_text("{bad-json", encoding="utf-8")
+            os.environ["HERMES_HOME"] = str(home)
+            _clear_runtime_cache_for_tests()
+            blocked = safe_plugin._pre_tool_hook(
+                tool_name="memory",
+                args={"action": "add", "content": "candidate"},
+                tool_call_id="bad-config",
+            )
+            self.assertEqual(blocked["action"], "block")
+            self.assertIn("failed before durable-state admission", blocked["message"])
+
+    def test_strict_coverage_and_doctor_refuse_with_exact_six_blockers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            save_config(home, IntegrationConfig(mode="observe"))
+            report = build_coverage_report(
+                IntegrationConfig(mode="strict"),
+                observed_hermes_revision=HERMES_COMMIT,
+            )
+            self.assertEqual(len(report["surfaces"]), len(MUTATION_SURFACES))
+            self.assertEqual(tuple(report["strict"]["blocking_surfaces"]), STRICT_BLOCKERS)
+            self.assertFalse(report["strict"]["supported"])
+            self.assertFalse(report["integration"]["ready"])
+            statuses = {item["surface_id"]: item["status"] for item in report["surfaces"]}
+            for blocker in STRICT_BLOCKERS:
+                self.assertEqual(statuses[blocker], "uncovered")
+
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = cli_main(
+                    [
+                        "doctor",
+                        "--hermes-home",
+                        str(home),
+                        "--hermes-revision",
+                        HERMES_COMMIT,
+                        "--mode",
+                        "strict",
+                        "--json",
+                    ]
+                )
+            self.assertEqual(rc, 2)
+            parsed = json.loads(out.getvalue())
+            self.assertEqual(parsed["strict"]["blocking_surfaces"], list(STRICT_BLOCKERS))
+
+    def test_coverage_keeps_approval_replay_and_curator_uncovered(self) -> None:
+        report = build_coverage_report(
+            IntegrationConfig(mode="govern", governor_command=("/bin/true",)),
+            observed_hermes_revision=HERMES_COMMIT,
+        )
+        statuses = {item["surface_id"]: item["status"] for item in report["surfaces"]}
+        self.assertEqual(statuses["approved_pending_memory_replay"], "uncovered")
+        self.assertEqual(statuses["approved_pending_skill_replay"], "uncovered")
+        self.assertEqual(statuses["deterministic_curator_archive"], "uncovered")
+        self.assertEqual(statuses["foreground_builtin_memory_tool"], "intercepted")
+        self.assertEqual(statuses["background_review_memory"], "intercepted")
+
+    def test_provider_records_post_commit_mirror_and_failure_without_rollback_fiction(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            os.environ["HERMES_HOME"] = str(home)
+            os.environ["AGENT_MEMORY_HERMES_REVISION"] = HERMES_COMMIT
+            save_config(home, IntegrationConfig(mode="observe"))
+            provider = AgentMemoryProvider()
+            provider.initialize("session-1", hermes_home=str(home), platform="cli")
+            self.assertEqual(provider.prefetch("what changed?", session_id="session-1"), "")
+            provider.sync_turn("user secret", "assistant response", session_id="session-1")
+            provider.on_memory_write("add", "memory", "durable value", {"origin": "foreground"})
+            self.assertEqual(provider.last_projection_state["canonical_builtin_state"], "committed")
+            self.assertEqual(provider.last_projection_state["external_projection"], "observed")
+            self.assertFalse(provider.last_projection_state["rollback_claimed"])
+
+            os.environ["AGENT_MEMORY_HERMES_TEST_MIRROR_FAILURE"] = "1"
+            with self.assertRaisesRegex(RuntimeError, "injected"):
+                provider.on_memory_write("replace", "memory", "new durable value", None)
+            failed = provider.last_projection_state
+            self.assertEqual(failed["canonical_builtin_state"], "committed")
+            self.assertEqual(failed["external_projection"], "failed")
+            self.assertFalse(failed["settled"])
+            self.assertFalse(failed["quiescent"])
+            self.assertFalse(failed["rollback_claimed"])
+
+            events_text = (home / "agent-memory" / "events.jsonl").read_text()
+            self.assertNotIn("user secret", events_text)
+            self.assertNotIn("durable value", events_text)
+            self.assertIn("provider_memory_mirror_failed", events_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/hermes-agent-memory/tests/test_mutation_classification.py
+++ b/integrations/hermes-agent-memory/tests/test_mutation_classification.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import unittest
+
+from agent_memory_hermes.mutation import is_potential_durable_mutation, operation_name
+
+
+class MutationClassificationTests(unittest.TestCase):
+    def test_known_read_only_memory_and_skill_calls_are_not_governed(self) -> None:
+        for tool, args in (
+            ("memory", {"action": "show"}),
+            ("memory", {"action": "read"}),
+            ("skill_manage", {"action": "list"}),
+            ("skill_manage", {"action": "read", "name": "skill-x"}),
+        ):
+            with self.subTest(tool=tool, args=args):
+                self.assertFalse(is_potential_durable_mutation(tool, args))
+
+    def test_known_mutations_and_unknown_future_actions_are_conservative(self) -> None:
+        for tool, args in (
+            ("memory", {"action": "add"}),
+            ("memory", {"action": "replace"}),
+            ("memory", {"action": "remove"}),
+            ("skill_manage", {"action": "create"}),
+            ("skill_manage", {"action": "patch"}),
+            ("skill_manage", {"action": "edit"}),
+            ("skill_manage", {"action": "delete"}),
+            ("skill_manage", {"action": "future_mutation"}),
+        ):
+            with self.subTest(tool=tool, args=args):
+                self.assertTrue(is_potential_durable_mutation(tool, args))
+
+    def test_operation_name_is_stable(self) -> None:
+        self.assertEqual(operation_name("memory", {"action": "ADD"}), "add")
+        self.assertEqual(operation_name("skill_manage", {"mode": "PATCH"}), "patch")
+        self.assertEqual(operation_name("terminal", {"action": "write"}), "not_applicable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/hermes-agent-memory/tests/test_recursive_scenarios.py
+++ b/integrations/hermes-agent-memory/tests/test_recursive_scenarios.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import unittest
+
+from agent_memory_hermes import HERMES_COMMIT
+from agent_memory_hermes.config import IntegrationConfig
+from agent_memory_hermes.coverage import build_coverage_report
+
+
+class RecursiveScenarioCoverageTests(unittest.TestCase):
+    def test_all_research_scenarios_have_executable_coverage_disposition(self) -> None:
+        report = build_coverage_report(
+            IntegrationConfig(mode="govern", governor_command=("/bin/true",)),
+            observed_hermes_revision=HERMES_COMMIT,
+        )
+        scenarios = {
+            item["scenario_id"]: item for item in report["recursive_evidence_scenarios"]
+        }
+        self.assertEqual(
+            set(scenarios),
+            {
+                "self_reinforcing_skill_lineage",
+                "correction_relearned_by_background_review",
+                "stale_human_approval_replay",
+                "curator_archive_during_pending_dependency",
+                "provider_mirror_failure_after_builtin_commit",
+            },
+        )
+        self.assertIn("independent corroboration", scenarios["self_reinforcing_skill_lineage"]["requirement"])
+        self.assertIn("non-current", scenarios["correction_relearned_by_background_review"]["requirement"])
+        self.assertEqual(
+            scenarios["stale_human_approval_replay"]["status"],
+            "uncovered_requires_future_durable_state_hook",
+        )
+        self.assertIn("before-state digest", scenarios["stale_human_approval_replay"]["requirement"])
+        self.assertEqual(
+            scenarios["curator_archive_during_pending_dependency"]["blocking_surface"],
+            "deterministic_curator_archive",
+        )
+        mirror = scenarios["provider_mirror_failure_after_builtin_commit"]
+        self.assertEqual(mirror["status"], "modeled")
+        self.assertIn("unsettled/non-quiescent", mirror["requirement"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/hermes-agent-memory/tests/test_research_alignment.py
+++ b/integrations/hermes-agent-memory/tests/test_research_alignment.py
@@ -6,7 +6,7 @@ import unittest
 
 from agent_memory_hermes import HERMES_COMMIT, MUTATION_SURFACES, STRICT_BLOCKERS
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[3]
 RESEARCH = ROOT / "docs/programs/hermes-research/hermes-mutation-surface.json"
 
 

--- a/integrations/hermes-agent-memory/tests/test_research_alignment.py
+++ b/integrations/hermes-agent-memory/tests/test_research_alignment.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+from agent_memory_hermes import HERMES_COMMIT, MUTATION_SURFACES, STRICT_BLOCKERS
+
+ROOT = Path(__file__).resolve().parents[2]
+RESEARCH = ROOT / "docs/programs/hermes-research/hermes-mutation-surface.json"
+
+
+class ResearchAlignmentTests(unittest.TestCase):
+    def test_integration_profile_matches_completed_317_research_boundary(self) -> None:
+        value = json.loads(RESEARCH.read_text(encoding="utf-8"))
+        self.assertEqual(value["hermes"]["commit"], HERMES_COMMIT)
+        self.assertEqual(
+            {item["id"] for item in value["surfaces"]},
+            set(MUTATION_SURFACES),
+        )
+        self.assertEqual(
+            set(value["integration_postures"]["strict"]["blocking_gaps"]),
+            set(STRICT_BLOCKERS),
+        )
+        self.assertFalse(value["integration_postures"]["strict"]["supported_today"])
+        self.assertEqual(value["authority_effect"], "none")
+        self.assertEqual(value["doctrine_disposition"], "no_new_adr")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #330 against the exact researched Hermes profile:

`NousResearch/hermes-agent@165c889e5b4277b56dadd42949a4112c1e6175a6`

This adds a standalone `agent-memory-hermes` package using Hermes' supported third-party extension points. It does not modify Hermes or import Hermes-specific ontology into Agent Memory core.

### Supported extension points

The package publishes:

- `hermes_agent.plugins` -> fail-closed `pre_tool_call` + `post_tool_call` integration;
- `hermes_agent.memory_providers` -> Agent Memory observation/sync MemoryProvider;
- installed `agent-memory-hermes doctor` coverage/readiness command.

### Observe mode

Records normal model-driven `memory` and `skill_manage` proposals and execution receipts without changing Hermes behavior. Persisted local evidence is hash/redaction-first by default; raw memory/skill payloads are opt-in.

The external MemoryProvider observes provider lifecycle, prefetch, turn sync, post-commit built-in memory mirroring, session changes/end, and backup state. Version 0.1.0 intentionally does not invent a recall backend; prefetch records the lifecycle request and injects no fabricated context.

### Govern mode

For interceptable `memory` / `skill_manage` calls, the package sends a full private candidate to a configured external JSON admission command.

Current Hermes mapping:

- `allow` -> tool proceeds;
- `reject` -> Hermes native block directive;
- `stage` -> explicit block because the pinned generic hook cannot create a native staged durable mutation;
- required governor missing/unavailable/invalid -> explicit block;
- exact Hermes profile drift with `require_exact_profile=true` -> explicit block.

The published plugin entry point is a fail-closed wrapper because Hermes intentionally isolates plugin callback exceptions. Integration/configuration failure therefore cannot silently become permission for the governed durable tool surfaces.

### No false strictness

`strict` is always unsupported at the pinned profile and `doctor` returns nonzero with the exact six #317 blockers:

- approved pending memory replay;
- approved pending skill replay;
- deterministic curator archival;
- Journey memory edit/delete;
- Journey skill edit/delete;
- out-of-band memory/skill filesystem mutation.

The coverage report contains all 12 #317 mutation families and five recursive-learning adversarial scenario dispositions.

### Recursive-learning evidence

Executable tests pressure:

- lineage/provenance preservation to an external governor for self-reinforcing learning;
- corrected/superseded value reproposal rejected by the governor;
- stale approval replay explicitly left uncovered pending before-state/candidate/scope revalidation at a future durable-state hook;
- deterministic curator retirement explicitly left uncovered;
- provider mirror failure represented as built-in state committed, external projection failed, unsettled/non-quiescent, no rollback fiction.

The pinned Hermes hook does not expose `_memory_write_origin` or complete causal lineage, so the integration records limited origin/lineage precision rather than inventing it.

### Exact-head evidence

Focused CI:

- checks out exact Hermes source and MIT license;
- re-verifies normal pre-tool seam plus the six researched bypass families;
- installs the standalone package;
- verifies the package subclasses Hermes' real `MemoryProvider`;
- verifies both pip entry-point groups;
- executes observe/govern/failure/recursive tests;
- exercises installed doctor for observe, govern, strict, and profile drift;
- runs the full Agent Memory reference suite;
- emits exact-head evidence with literal Boolean invariants and SHA-256 bindings.

Closes #330 only after the focused workflow and complete repository-wide exact-head matrix are green and the artifact is independently inspected.