### PR TITLE
Add host-neutral governed memory runtime adapter

### DIFF
--- a/.github/workflows/agent-memory-runtime-adapter.yml
+++ b/.github/workflows/agent-memory-runtime-adapter.yml
@@ -1,0 +1,35 @@
+name: Agent Memory Runtime Adapter
+
+on:
+  pull_request:
+    paths:
+      - 'integrations/agent-memory-runtime/**'
+      - '.github/workflows/agent-memory-runtime-adapter.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/agent-memory-runtime/**'
+      - '.github/workflows/agent-memory-runtime-adapter.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-adapter:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: integrations/agent-memory-runtime
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Syntax check
+        run: npm run check
+
+      - name: Runtime adapter tests
+        run: npm test

--- a/integrations/agent-memory-runtime/README.md
+++ b/integrations/agent-memory-runtime/README.md
@@ -1,0 +1,85 @@
+# Agent Memory Runtime Adapter
+
+A bounded, host-neutral ESM adapter for governed runtime recall and correction/supersession.
+
+It exists to let a runtime host consume Agent Memory doctrine without copying memory semantics into the host. It is intentionally not a complete Agent Memory implementation.
+
+## What this adapter owns
+
+- exact actor/project/task scope validation;
+- recall admission after candidate loading;
+- rejection of unknown-scope, foreign-scope, disputed, and superseded memory;
+- explicit `authority_effect: "none"` on recall;
+- correction as an append-only replacement plus supersession linkage;
+- evidence and authority requirements for committed correction;
+- idempotent correction handoff;
+- stale-state refusal.
+
+## What the storage port owns
+
+The host supplies three persistence methods:
+
+```text
+load(scope)
+lookupIdempotency(scope, idempotencyKey)
+commitCorrection(scope, transaction)
+```
+
+`commitCorrection` must atomically enforce `expected_revision`, persist the replacement memory and correction event, retain prior history, and bind the idempotency key to the resulting receipt.
+
+A storage implementation that sees an old `expected_revision` must fail with:
+
+```js
+{ code: 'STALE_REVISION' }
+```
+
+The adapter converts that to the semantic `stale_state` refusal.
+
+For the QOR Agent Cloudflare proving ground, the storage port will be implemented by a scoped SQLite Durable Object. That Cloudflare implementation belongs to QOR Agent, not this repository.
+
+## Recall
+
+```js
+const result = await memory.recall({
+  scope: {
+    actor_id: 'actor:one',
+    project_id: 'project:alpha',
+    task_id: 'task:release-marker',
+  },
+  policy_version: 'policy-v1',
+  purpose: 'release_target_recall',
+});
+```
+
+The result separates `admitted` and `rejected` candidates and reports the storage `revision` and `checkpoint`. Candidate relevance does not grant execution authority, standing permission, or a consumer policy verdict.
+
+## Correction
+
+```js
+const receipt = await memory.correct({
+  scope,
+  memory_id: 'memory-original',
+  idempotency_key: 'correction:123',
+  policy_version: 'policy-v1',
+  evidence_refs: ['evidence:user-correction'],
+  authority_refs: ['authority:human-confirmed'],
+  replacement: {
+    kind: 'correction',
+    value_ref: 'value:main',
+  },
+});
+```
+
+The prior memory remains historical. The replacement carries `supersedes: [prior_memory_id]`, and active recall rejects the superseded record.
+
+## Doctrine boundary
+
+This package implements the bounded seam described by:
+
+- `docs/34-adapter-contracts.md` runtime memory adapter;
+- `docs/34-adapter-contracts.md` correction and dispute adapter;
+- the repository's scope, tenancy, authority, and historical-truth distinctions.
+
+It does not implement PAMA, standing authorization, a general retrieval engine, ranking, embeddings, a production approval system, or a universal durable store.
+
+Tracks `MythologIQ-Labs-LLC/agent-memory#333` and the pre-cloud route in `MythologIQ-Labs-LLC/Myth-Tech-Forge#262`.

--- a/integrations/agent-memory-runtime/package.json
+++ b/integrations/agent-memory-runtime/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@mythologiq/agent-memory-runtime",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "exports": {
+    ".": "./src/index.mjs"
+  },
+  "scripts": {
+    "check": "node --check src/index.mjs && node --check test/runtime-adapter.test.mjs",
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/integrations/agent-memory-runtime/src/index.mjs
+++ b/integrations/agent-memory-runtime/src/index.mjs
@@ -1,0 +1,312 @@
+export const CONTRACT_VERSION = '0.1';
+export const ADAPTER_NAME = 'agent-memory-runtime';
+export const ADAPTER_VERSION = '0.1.0';
+
+export class MemoryAdapterError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = 'MemoryAdapterError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function requireObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new MemoryAdapterError('invalid_handoff', `${name} must be an object`);
+  }
+  return value;
+}
+
+function requireString(value, name) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new MemoryAdapterError('invalid_handoff', `${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireStringArray(value, name, { minItems = 0 } = {}) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new MemoryAdapterError('invalid_handoff', `${name} must be an array of non-empty strings`);
+  }
+  if (value.length < minItems) {
+    throw new MemoryAdapterError('invalid_handoff', `${name} must contain at least ${minItems} item(s)`);
+  }
+  return [...new Set(value)];
+}
+
+function normalizeScope(scope) {
+  const input = requireObject(scope, 'scope');
+  return Object.freeze({
+    actor_id: requireString(input.actor_id, 'scope.actor_id'),
+    project_id: requireString(input.project_id, 'scope.project_id'),
+    task_id: requireString(input.task_id, 'scope.task_id'),
+  });
+}
+
+function sameScope(left, right) {
+  return Boolean(
+    left && right
+    && left.actor_id === right.actor_id
+    && left.project_id === right.project_id
+    && left.task_id === right.task_id,
+  );
+}
+
+function normalizeSnapshot(snapshot) {
+  const input = requireObject(snapshot, 'storage snapshot');
+  return {
+    revision: requireString(input.revision, 'storage snapshot.revision'),
+    checkpoint: input.checkpoint == null ? null : requireString(input.checkpoint, 'storage snapshot.checkpoint'),
+    records: Array.isArray(input.records) ? input.records : [],
+  };
+}
+
+function assertStorage(storage) {
+  const value = requireObject(storage, 'storage');
+  for (const method of ['load', 'lookupIdempotency', 'commitCorrection']) {
+    if (typeof value[method] !== 'function') {
+      throw new MemoryAdapterError('invalid_storage_port', `storage.${method} must be a function`);
+    }
+  }
+  return value;
+}
+
+function nowIso(clock) {
+  const value = clock();
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new MemoryAdapterError('invalid_clock', 'clock must return a valid Date-compatible value');
+  }
+  return date.toISOString();
+}
+
+function defaultIdFactory(prefix) {
+  if (globalThis.crypto?.randomUUID) return `${prefix}_${globalThis.crypto.randomUUID()}`;
+  return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
+function recordScope(record) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) return null;
+  const scope = record.scope;
+  if (!scope || typeof scope !== 'object' || Array.isArray(scope)) return null;
+  if (![scope.actor_id, scope.project_id, scope.task_id].every((value) => typeof value === 'string' && value.length > 0)) {
+    return null;
+  }
+  return scope;
+}
+
+function rejection(memoryId, reason) {
+  return Object.freeze({ memory_id: memoryId ?? null, reason });
+}
+
+function admissionForRecord(record, scope, supersededIds) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    return { admitted: false, rejection: rejection(null, 'invalid_record') };
+  }
+
+  const memoryId = typeof record.memory_id === 'string' && record.memory_id.length > 0
+    ? record.memory_id
+    : null;
+  if (!memoryId) return { admitted: false, rejection: rejection(null, 'missing_identity') };
+
+  const scopeValue = recordScope(record);
+  if (!scopeValue) return { admitted: false, rejection: rejection(memoryId, 'unknown_scope') };
+  if (!sameScope(scopeValue, scope)) return { admitted: false, rejection: rejection(memoryId, 'out_of_scope') };
+  if (record.state === 'disputed') return { admitted: false, rejection: rejection(memoryId, 'disputed') };
+  if (record.state === 'superseded' || supersededIds.has(memoryId)) {
+    return { admitted: false, rejection: rejection(memoryId, 'superseded') };
+  }
+  if (record.state && record.state !== 'active') {
+    return { admitted: false, rejection: rejection(memoryId, `state_${record.state}`) };
+  }
+
+  return {
+    admitted: true,
+    value: Object.freeze({
+      memory_id: memoryId,
+      kind: requireString(record.kind ?? 'memory', `record ${memoryId}.kind`),
+      value_ref: requireString(record.value_ref, `record ${memoryId}.value_ref`),
+      scope: Object.freeze({ ...scopeValue }),
+      state: 'active',
+      evidence_refs: Array.isArray(record.evidence_refs) ? [...record.evidence_refs] : [],
+      authority_refs: Array.isArray(record.authority_refs) ? [...record.authority_refs] : [],
+      supersedes: Array.isArray(record.supersedes) ? [...record.supersedes] : [],
+      created_at: record.created_at ?? null,
+    }),
+  };
+}
+
+function supersededSet(records) {
+  const result = new Set();
+  for (const record of records) {
+    if (!record || typeof record !== 'object' || Array.isArray(record)) continue;
+    if (!Array.isArray(record.supersedes)) continue;
+    for (const id of record.supersedes) {
+      if (typeof id === 'string' && id.length > 0) result.add(id);
+    }
+  }
+  return result;
+}
+
+function normalizeRecallRequest(request) {
+  const input = requireObject(request, 'recall request');
+  return {
+    scope: normalizeScope(input.scope),
+    policy_version: requireString(input.policy_version, 'recall request.policy_version'),
+    purpose: requireString(input.purpose, 'recall request.purpose'),
+  };
+}
+
+function normalizeCorrectionRequest(request) {
+  const input = requireObject(request, 'correction request');
+  const replacement = requireObject(input.replacement, 'correction request.replacement');
+  return {
+    scope: normalizeScope(input.scope),
+    memory_id: requireString(input.memory_id, 'correction request.memory_id'),
+    idempotency_key: requireString(input.idempotency_key, 'correction request.idempotency_key'),
+    policy_version: requireString(input.policy_version, 'correction request.policy_version'),
+    evidence_refs: requireStringArray(input.evidence_refs, 'correction request.evidence_refs', { minItems: 1 }),
+    authority_refs: requireStringArray(input.authority_refs, 'correction request.authority_refs', { minItems: 1 }),
+    replacement: {
+      kind: requireString(replacement.kind ?? 'correction', 'correction request.replacement.kind'),
+      value_ref: requireString(replacement.value_ref, 'correction request.replacement.value_ref'),
+    },
+  };
+}
+
+export function createGovernedMemoryAdapter({
+  storage,
+  clock = () => new Date(),
+  memoryIdFactory = () => defaultIdFactory('memory'),
+  eventIdFactory = () => defaultIdFactory('memory_event'),
+} = {}) {
+  const persistence = assertStorage(storage);
+
+  return Object.freeze({
+    async recall(rawRequest) {
+      const request = normalizeRecallRequest(rawRequest);
+      const snapshot = normalizeSnapshot(await persistence.load(request.scope));
+      const supersededIds = supersededSet(snapshot.records);
+      const admitted = [];
+      const rejected = [];
+
+      for (const record of snapshot.records) {
+        const admission = admissionForRecord(record, request.scope, supersededIds);
+        if (admission.admitted) admitted.push(admission.value);
+        else rejected.push(admission.rejection);
+      }
+
+      return Object.freeze({
+        contract_version: CONTRACT_VERSION,
+        adapter: ADAPTER_NAME,
+        adapter_version: ADAPTER_VERSION,
+        scope: request.scope,
+        purpose: request.purpose,
+        policy_version: request.policy_version,
+        revision: snapshot.revision,
+        checkpoint: snapshot.checkpoint,
+        admitted: Object.freeze(admitted),
+        rejected: Object.freeze(rejected),
+        source_memory_refs: Object.freeze(admitted.map((record) => record.memory_id)),
+        authority_effect: 'none',
+        generated_at: nowIso(clock),
+      });
+    },
+
+    async correct(rawRequest) {
+      const request = normalizeCorrectionRequest(rawRequest);
+      const replay = await persistence.lookupIdempotency(request.scope, request.idempotency_key);
+      if (replay) return Object.freeze({ ...replay, replayed: true });
+
+      const snapshot = normalizeSnapshot(await persistence.load(request.scope));
+      const supersededIds = supersededSet(snapshot.records);
+      const current = snapshot.records.find((record) => record?.memory_id === request.memory_id);
+
+      if (!current) {
+        throw new MemoryAdapterError('memory_not_found', 'The memory selected for correction does not exist', {
+          memory_id: request.memory_id,
+        });
+      }
+      const admission = admissionForRecord(current, request.scope, supersededIds);
+      if (!admission.admitted) {
+        throw new MemoryAdapterError('memory_not_current', 'Only a current in-scope memory can be corrected', {
+          memory_id: request.memory_id,
+          reason: admission.rejection.reason,
+        });
+      }
+
+      const committedAt = nowIso(clock);
+      const replacementMemoryId = requireString(memoryIdFactory(), 'memoryIdFactory result');
+      const eventId = requireString(eventIdFactory(), 'eventIdFactory result');
+      const replacement = Object.freeze({
+        memory_id: replacementMemoryId,
+        kind: request.replacement.kind,
+        value_ref: request.replacement.value_ref,
+        scope: request.scope,
+        state: 'active',
+        evidence_refs: request.evidence_refs,
+        authority_refs: request.authority_refs,
+        supersedes: [request.memory_id],
+        created_at: committedAt,
+      });
+      const event = Object.freeze({
+        event_id: eventId,
+        event_type: 'correction_committed',
+        prior_memory_id: request.memory_id,
+        replacement_memory_id: replacementMemoryId,
+        state_snapshot: snapshot.revision,
+        policy_version: request.policy_version,
+        evidence_refs: request.evidence_refs,
+        authority_refs: request.authority_refs,
+        committed_at: committedAt,
+      });
+
+      let committed;
+      try {
+        committed = await persistence.commitCorrection(request.scope, {
+          idempotency_key: request.idempotency_key,
+          expected_revision: snapshot.revision,
+          replacement,
+          event,
+        });
+      } catch (error) {
+        if (error?.code === 'STALE_REVISION') {
+          throw new MemoryAdapterError('stale_state', 'Memory state changed before the correction could commit', {
+            expected_revision: snapshot.revision,
+          });
+        }
+        throw error;
+      }
+
+      const result = requireObject(committed, 'correction commit result');
+      const revision = requireString(result.revision, 'correction commit result.revision');
+      const ledgerRef = requireString(result.ledger_ref, 'correction commit result.ledger_ref');
+      const checkpoint = result.checkpoint == null
+        ? null
+        : requireString(result.checkpoint, 'correction commit result.checkpoint');
+
+      return Object.freeze({
+        contract_version: CONTRACT_VERSION,
+        adapter: ADAPTER_NAME,
+        adapter_version: ADAPTER_VERSION,
+        scope: request.scope,
+        prior_memory_id: request.memory_id,
+        replacement_memory_id: replacementMemoryId,
+        supersession: Object.freeze({
+          prior_memory_id: request.memory_id,
+          replacement_memory_id: replacementMemoryId,
+        }),
+        event_id: eventId,
+        revision,
+        checkpoint,
+        ledger_ref: ledgerRef,
+        policy_version: request.policy_version,
+        authority_refs: Object.freeze(request.authority_refs),
+        evidence_refs: Object.freeze(request.evidence_refs),
+        replayed: Boolean(result.replayed),
+        committed_at: committedAt,
+      });
+    },
+  });
+}

--- a/integrations/agent-memory-runtime/test/runtime-adapter.test.mjs
+++ b/integrations/agent-memory-runtime/test/runtime-adapter.test.mjs
@@ -1,0 +1,271 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  MemoryAdapterError,
+  createGovernedMemoryAdapter,
+} from '../src/index.mjs';
+
+const scope = Object.freeze({
+  actor_id: 'actor:one',
+  project_id: 'project:alpha',
+  task_id: 'task:release-marker',
+});
+
+class InMemoryStorage {
+  constructor(records = []) {
+    this.records = structuredClone(records);
+    this.revision = 'rev-1';
+    this.checkpoint = 'checkpoint-1';
+    this.idempotency = new Map();
+    this.events = [];
+    this.failStale = false;
+  }
+
+  async load() {
+    return {
+      revision: this.revision,
+      checkpoint: this.checkpoint,
+      records: structuredClone(this.records),
+    };
+  }
+
+  async lookupIdempotency(_scope, key) {
+    return this.idempotency.get(key) ?? null;
+  }
+
+  async commitCorrection(_scope, transaction) {
+    if (this.failStale || transaction.expected_revision !== this.revision) {
+      throw Object.assign(new Error('stale'), { code: 'STALE_REVISION' });
+    }
+
+    this.records.push(structuredClone(transaction.replacement));
+    this.events.push(structuredClone(transaction.event));
+    this.revision = `rev-${Number(this.revision.split('-')[1]) + 1}`;
+    this.checkpoint = `checkpoint-${this.events.length + 1}`;
+
+    const receipt = {
+      contract_version: '0.1',
+      adapter: 'agent-memory-runtime',
+      adapter_version: '0.1.0',
+      scope: structuredClone(scope),
+      prior_memory_id: transaction.event.prior_memory_id,
+      replacement_memory_id: transaction.event.replacement_memory_id,
+      supersession: {
+        prior_memory_id: transaction.event.prior_memory_id,
+        replacement_memory_id: transaction.event.replacement_memory_id,
+      },
+      event_id: transaction.event.event_id,
+      revision: this.revision,
+      checkpoint: this.checkpoint,
+      ledger_ref: `ledger:${transaction.event.event_id}`,
+      policy_version: transaction.event.policy_version,
+      authority_refs: [...transaction.event.authority_refs],
+      evidence_refs: [...transaction.event.evidence_refs],
+      replayed: false,
+      committed_at: transaction.event.committed_at,
+    };
+    this.idempotency.set(transaction.idempotency_key, receipt);
+    return {
+      revision: this.revision,
+      checkpoint: this.checkpoint,
+      ledger_ref: receipt.ledger_ref,
+      replayed: false,
+    };
+  }
+}
+
+function baseRecord(overrides = {}) {
+  return {
+    memory_id: 'memory-original',
+    kind: 'fact',
+    value_ref: 'value:staging',
+    scope: structuredClone(scope),
+    state: 'active',
+    evidence_refs: ['evidence:seed'],
+    authority_refs: [],
+    supersedes: [],
+    created_at: '2026-08-22T20:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function adapter(storage) {
+  let memoryCounter = 0;
+  let eventCounter = 0;
+  return createGovernedMemoryAdapter({
+    storage,
+    clock: () => new Date('2026-08-22T21:00:00.000Z'),
+    memoryIdFactory: () => `memory-correction-${++memoryCounter}`,
+    eventIdFactory: () => `event-correction-${++eventCounter}`,
+  });
+}
+
+const recallRequest = {
+  scope,
+  policy_version: 'policy-v1',
+  purpose: 'release_target_recall',
+};
+
+test('recall admits only exact-scope current memory and never grants authority', async () => {
+  const storage = new InMemoryStorage([
+    baseRecord(),
+    baseRecord({
+      memory_id: 'memory-foreign',
+      scope: { ...scope, task_id: 'task:other' },
+      value_ref: 'value:foreign',
+    }),
+    baseRecord({
+      memory_id: 'memory-unknown-scope',
+      scope: undefined,
+      value_ref: 'value:unknown',
+    }),
+  ]);
+
+  const result = await adapter(storage).recall(recallRequest);
+
+  assert.deepEqual(result.source_memory_refs, ['memory-original']);
+  assert.equal(result.admitted.length, 1);
+  assert.equal(result.admitted[0].value_ref, 'value:staging');
+  assert.equal(result.authority_effect, 'none');
+  assert.equal('permitted_action_set' in result, false);
+  assert.deepEqual(
+    result.rejected.map((item) => item.reason).sort(),
+    ['out_of_scope', 'unknown_scope'],
+  );
+});
+
+test('superseded and disputed memory are rejected from active recall', async () => {
+  const storage = new InMemoryStorage([
+    baseRecord(),
+    baseRecord({
+      memory_id: 'memory-new',
+      value_ref: 'value:main',
+      supersedes: ['memory-original'],
+    }),
+    baseRecord({
+      memory_id: 'memory-disputed',
+      value_ref: 'value:disputed',
+      state: 'disputed',
+    }),
+  ]);
+
+  const result = await adapter(storage).recall(recallRequest);
+
+  assert.deepEqual(result.source_memory_refs, ['memory-new']);
+  assert.deepEqual(
+    result.rejected.map((item) => [item.memory_id, item.reason]).sort(),
+    [
+      ['memory-disputed', 'disputed'],
+      ['memory-original', 'superseded'],
+    ],
+  );
+});
+
+test('correction appends replacement and explicit supersession without erasing prior history', async () => {
+  const storage = new InMemoryStorage([baseRecord()]);
+  const governed = adapter(storage);
+
+  const receipt = await governed.correct({
+    scope,
+    memory_id: 'memory-original',
+    idempotency_key: 'correction:one',
+    policy_version: 'policy-v1',
+    evidence_refs: ['evidence:user-correction'],
+    authority_refs: ['authority:human-confirmed'],
+    replacement: {
+      kind: 'correction',
+      value_ref: 'value:main',
+    },
+  });
+
+  assert.equal(receipt.prior_memory_id, 'memory-original');
+  assert.equal(receipt.replacement_memory_id, 'memory-correction-1');
+  assert.equal(storage.records.length, 2);
+  assert.equal(storage.records[0].memory_id, 'memory-original');
+  assert.deepEqual(storage.records[1].supersedes, ['memory-original']);
+  assert.equal(storage.events.length, 1);
+  assert.equal(storage.events[0].event_type, 'correction_committed');
+
+  const recalled = await governed.recall(recallRequest);
+  assert.deepEqual(recalled.source_memory_refs, ['memory-correction-1']);
+});
+
+test('idempotent correction replay returns the original receipt and does not append twice', async () => {
+  const storage = new InMemoryStorage([baseRecord()]);
+  const governed = adapter(storage);
+  const request = {
+    scope,
+    memory_id: 'memory-original',
+    idempotency_key: 'correction:one',
+    policy_version: 'policy-v1',
+    evidence_refs: ['evidence:user-correction'],
+    authority_refs: ['authority:human-confirmed'],
+    replacement: { value_ref: 'value:main' },
+  };
+
+  const first = await governed.correct(request);
+  const second = await governed.correct(request);
+
+  assert.equal(first.replacement_memory_id, second.replacement_memory_id);
+  assert.equal(second.replayed, true);
+  assert.equal(storage.records.length, 2);
+  assert.equal(storage.events.length, 1);
+});
+
+test('correction requires explicit authority and evidence', async () => {
+  const storage = new InMemoryStorage([baseRecord()]);
+  const governed = adapter(storage);
+
+  await assert.rejects(
+    governed.correct({
+      scope,
+      memory_id: 'memory-original',
+      idempotency_key: 'correction:no-authority',
+      policy_version: 'policy-v1',
+      evidence_refs: ['evidence:user-correction'],
+      authority_refs: [],
+      replacement: { value_ref: 'value:main' },
+    }),
+    (error) => error instanceof MemoryAdapterError && error.code === 'invalid_handoff',
+  );
+  assert.equal(storage.records.length, 1);
+});
+
+test('stale state fails closed instead of committing against an old snapshot', async () => {
+  const storage = new InMemoryStorage([baseRecord()]);
+  storage.failStale = true;
+
+  await assert.rejects(
+    adapter(storage).correct({
+      scope,
+      memory_id: 'memory-original',
+      idempotency_key: 'correction:stale',
+      policy_version: 'policy-v1',
+      evidence_refs: ['evidence:user-correction'],
+      authority_refs: ['authority:human-confirmed'],
+      replacement: { value_ref: 'value:main' },
+    }),
+    (error) => error instanceof MemoryAdapterError && error.code === 'stale_state',
+  );
+  assert.equal(storage.records.length, 1);
+});
+
+test('invalid scope is rejected before storage can launder it into local context', async () => {
+  let loaded = false;
+  const storage = new InMemoryStorage([baseRecord()]);
+  storage.load = async () => {
+    loaded = true;
+    return { revision: 'rev-1', checkpoint: null, records: [] };
+  };
+
+  await assert.rejects(
+    adapter(storage).recall({
+      scope: { actor_id: 'actor:one', project_id: 'project:alpha', task_id: '' },
+      policy_version: 'policy-v1',
+      purpose: 'test',
+    }),
+    (error) => error instanceof MemoryAdapterError && error.code === 'invalid_handoff',
+  );
+  assert.equal(loaded, false);
+});


### PR DESCRIPTION
## Summary

Implements #333 with a bounded host-neutral ESM adapter for governed recall and correction/supersession.

The adapter preserves Agent Memory semantic ownership while allowing QOR Agent to provide only the Cloudflare persistence port.

## Implemented boundaries

- exact actor/project/task scope validation;
- governed recall after candidate loading;
- rejection of unknown-scope, foreign-scope, disputed, and superseded memory;
- explicit `authority_effect: none` with no permission-bearing recall field;
- append-only correction with explicit supersession linkage;
- required evidence and authority references for correction commits;
- idempotent correction replay;
- expected-revision stale-state refusal;
- storage port limited to `load`, `lookupIdempotency`, and `commitCorrection`.

## Cloudflare boundary

This repository does **not** implement Durable Objects. QOR Agent will provide a scoped SQLite Durable Object that satisfies the storage port. The Durable Object owns persistence mechanics only; scope/admission/correction semantics remain here.

## Validation

An independent Node 22 workflow exercises:

- exact-scope admission;
- foreign/unknown-scope refusal;
- disputed/superseded refusal;
- append-only correction history;
- correction idempotency;
- explicit authority/evidence requirements;
- stale-state fail-closed behavior;
- pre-storage invalid-scope rejection.

## Non-goals

- full Agent Memory implementation;
- PAMA implementation;
- universal retrieval/ranking;
- Cloudflare-specific storage;
- standing permission or consumer policy verdicts.

Parent project: `MythologIQ-Labs-LLC/Myth-Tech-Forge#247`
Pre-cloud route: `MythologIQ-Labs-LLC/Myth-Tech-Forge#262`