### PR TITLE
Fix runtime adapter idempotency ownership boundary

### DIFF
--- a/integrations/agent-memory-runtime/README.md
+++ b/integrations/agent-memory-runtime/README.md
@@ -12,7 +12,7 @@ It exists to let a runtime host consume Agent Memory doctrine without copying me
 - explicit `authority_effect: "none"` on recall;
 - correction as an append-only replacement plus supersession linkage;
 - evidence and authority requirements for committed correction;
-- idempotent correction handoff;
+- semantic correction receipts on first commit and idempotent replay;
 - stale-state refusal.
 
 ## What the storage port owns
@@ -21,13 +21,39 @@ The host supplies three persistence methods:
 
 ```text
 load(scope)
-lookupIdempotency(scope, idempotencyKey)
+getCorrection(scope, idempotencyKey)
 commitCorrection(scope, transaction)
 ```
 
-`commitCorrection` must atomically enforce `expected_revision`, persist the replacement memory and correction event, retain prior history, and bind the idempotency key to the resulting receipt.
+The storage port persists mechanics, not Agent Memory's public receipt semantics.
 
-A storage implementation that sees an old `expected_revision` must fail with:
+`getCorrection` returns either `null` or the low-level persisted commit record originally produced by `commitCorrection`:
+
+```text
+revision
+checkpoint
+ledger_ref
+replacement
+  # the exact replacement memory record supplied by Agent Memory
+event
+  # the exact correction event supplied by Agent Memory
+replayed
+```
+
+The host must not manufacture `contract_version`, adapter identity, supersession receipts, authority/evidence projection, or other Agent Memory public fields. The Agent Memory adapter reconstructs those semantic fields from the persisted replacement/event record on both first commit and replay.
+
+`commitCorrection` must atomically:
+
+1. return the original persisted commit record with `replayed: true` if the idempotency key already exists;
+2. otherwise enforce `expected_revision`;
+3. persist the replacement memory and correction event without erasing prior history;
+4. advance revision/checkpoint state;
+5. bind the idempotency key to the resulting low-level commit record; and
+6. return that record.
+
+The idempotency check must also occur inside the atomic commit boundary. A retry racing after the caller's initial `getCorrection` lookup must return the already-committed replacement/event identities rather than apply a second candidate mutation.
+
+A genuinely new correction that sees an old `expected_revision` must fail with:
 
 ```js
 { code: 'STALE_REVISION' }
@@ -35,7 +61,7 @@ A storage implementation that sees an old `expected_revision` must fail with:
 
 The adapter converts that to the semantic `stale_state` refusal.
 
-For the QOR Agent Cloudflare proving ground, the storage port will be implemented by a scoped SQLite Durable Object. That Cloudflare implementation belongs to QOR Agent, not this repository.
+For the QOR Agent Cloudflare proving ground, this storage port is implemented by a scoped SQLite Durable Object. That Cloudflare implementation belongs to QOR Agent, not this repository.
 
 ## Recall
 
@@ -72,6 +98,8 @@ const receipt = await memory.correct({
 
 The prior memory remains historical. The replacement carries `supersedes: [prior_memory_id]`, and active recall rejects the superseded record.
 
+An idempotent retry returns the same semantic correction identity and commit time, with `replayed: true`; persistence does not recreate that public receipt.
+
 ## Doctrine boundary
 
 This package implements the bounded seam described by:
@@ -82,4 +110,4 @@ This package implements the bounded seam described by:
 
 It does not implement PAMA, standing authorization, a general retrieval engine, ranking, embeddings, a production approval system, or a universal durable store.
 
-Tracks `MythologIQ-Labs-LLC/agent-memory#333` and the pre-cloud route in `MythologIQ-Labs-LLC/Myth-Tech-Forge#262`.
+Tracks `MythologIQ-Labs-LLC/agent-memory#333` and defect correction `MythologIQ-Labs-LLC/agent-memory#335`, under the pre-cloud route in `MythologIQ-Labs-LLC/Myth-Tech-Forge#262`.

--- a/integrations/agent-memory-runtime/package.json
+++ b/integrations/agent-memory-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mythologiq/agent-memory-runtime",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/integrations/agent-memory-runtime/src/index.mjs
+++ b/integrations/agent-memory-runtime/src/index.mjs
@@ -1,6 +1,6 @@
 export const CONTRACT_VERSION = '0.1';
 export const ADAPTER_NAME = 'agent-memory-runtime';
-export const ADAPTER_VERSION = '0.1.0';
+export const ADAPTER_VERSION = '0.1.1';
 
 export class MemoryAdapterError extends Error {
   constructor(code, message, details = {}) {
@@ -64,7 +64,7 @@ function normalizeSnapshot(snapshot) {
 
 function assertStorage(storage) {
   const value = requireObject(storage, 'storage');
-  for (const method of ['load', 'lookupIdempotency', 'commitCorrection']) {
+  for (const method of ['load', 'getCorrection', 'commitCorrection']) {
     if (typeof value[method] !== 'function') {
       throw new MemoryAdapterError('invalid_storage_port', `storage.${method} must be a function`);
     }
@@ -175,6 +175,75 @@ function normalizeCorrectionRequest(request) {
   };
 }
 
+function normalizeCommitRecord(raw) {
+  const record = requireObject(raw, 'correction commit record');
+  const replacement = requireObject(record.replacement, 'correction commit record.replacement');
+  const event = requireObject(record.event, 'correction commit record.event');
+  return Object.freeze({
+    revision: requireString(record.revision, 'correction commit record.revision'),
+    checkpoint: record.checkpoint == null
+      ? null
+      : requireString(record.checkpoint, 'correction commit record.checkpoint'),
+    ledger_ref: requireString(record.ledger_ref, 'correction commit record.ledger_ref'),
+    replacement: Object.freeze({ ...replacement }),
+    event: Object.freeze({ ...event }),
+    replayed: Boolean(record.replayed),
+  });
+}
+
+function correctionReceipt(scope, rawCommit, replayedOverride) {
+  const commit = normalizeCommitRecord(rawCommit);
+  const replacementMemoryId = requireString(
+    commit.replacement.memory_id,
+    'correction commit record.replacement.memory_id',
+  );
+  const priorMemoryId = requireString(
+    commit.event.prior_memory_id,
+    'correction commit record.event.prior_memory_id',
+  );
+  const eventId = requireString(commit.event.event_id, 'correction commit record.event.event_id');
+  const policyVersion = requireString(
+    commit.event.policy_version,
+    'correction commit record.event.policy_version',
+  );
+  const committedAt = requireString(
+    commit.event.committed_at,
+    'correction commit record.event.committed_at',
+  );
+  const authorityRefs = requireStringArray(
+    commit.event.authority_refs,
+    'correction commit record.event.authority_refs',
+    { minItems: 1 },
+  );
+  const evidenceRefs = requireStringArray(
+    commit.event.evidence_refs,
+    'correction commit record.event.evidence_refs',
+    { minItems: 1 },
+  );
+
+  return Object.freeze({
+    contract_version: CONTRACT_VERSION,
+    adapter: ADAPTER_NAME,
+    adapter_version: ADAPTER_VERSION,
+    scope,
+    prior_memory_id: priorMemoryId,
+    replacement_memory_id: replacementMemoryId,
+    supersession: Object.freeze({
+      prior_memory_id: priorMemoryId,
+      replacement_memory_id: replacementMemoryId,
+    }),
+    event_id: eventId,
+    revision: commit.revision,
+    checkpoint: commit.checkpoint,
+    ledger_ref: commit.ledger_ref,
+    policy_version: policyVersion,
+    authority_refs: Object.freeze(authorityRefs),
+    evidence_refs: Object.freeze(evidenceRefs),
+    replayed: replayedOverride ?? commit.replayed,
+    committed_at: committedAt,
+  });
+}
+
 export function createGovernedMemoryAdapter({
   storage,
   clock = () => new Date(),
@@ -216,8 +285,8 @@ export function createGovernedMemoryAdapter({
 
     async correct(rawRequest) {
       const request = normalizeCorrectionRequest(rawRequest);
-      const replay = await persistence.lookupIdempotency(request.scope, request.idempotency_key);
-      if (replay) return Object.freeze({ ...replay, replayed: true });
+      const replay = await persistence.getCorrection(request.scope, request.idempotency_key);
+      if (replay) return correctionReceipt(request.scope, replay, true);
 
       const snapshot = normalizeSnapshot(await persistence.load(request.scope));
       const supersededIds = supersededSet(snapshot.records);
@@ -279,34 +348,7 @@ export function createGovernedMemoryAdapter({
         throw error;
       }
 
-      const result = requireObject(committed, 'correction commit result');
-      const revision = requireString(result.revision, 'correction commit result.revision');
-      const ledgerRef = requireString(result.ledger_ref, 'correction commit result.ledger_ref');
-      const checkpoint = result.checkpoint == null
-        ? null
-        : requireString(result.checkpoint, 'correction commit result.checkpoint');
-
-      return Object.freeze({
-        contract_version: CONTRACT_VERSION,
-        adapter: ADAPTER_NAME,
-        adapter_version: ADAPTER_VERSION,
-        scope: request.scope,
-        prior_memory_id: request.memory_id,
-        replacement_memory_id: replacementMemoryId,
-        supersession: Object.freeze({
-          prior_memory_id: request.memory_id,
-          replacement_memory_id: replacementMemoryId,
-        }),
-        event_id: eventId,
-        revision,
-        checkpoint,
-        ledger_ref: ledgerRef,
-        policy_version: request.policy_version,
-        authority_refs: Object.freeze(request.authority_refs),
-        evidence_refs: Object.freeze(request.evidence_refs),
-        replayed: Boolean(result.replayed),
-        committed_at: committedAt,
-      });
+      return correctionReceipt(request.scope, committed);
     },
   });
 }

--- a/integrations/agent-memory-runtime/test/runtime-adapter.test.mjs
+++ b/integrations/agent-memory-runtime/test/runtime-adapter.test.mjs
@@ -17,9 +17,10 @@ class InMemoryStorage {
     this.records = structuredClone(records);
     this.revision = 'rev-1';
     this.checkpoint = 'checkpoint-1';
-    this.idempotency = new Map();
+    this.corrections = new Map();
     this.events = [];
     this.failStale = false;
+    this.raceCommit = null;
   }
 
   async load() {
@@ -30,11 +31,16 @@ class InMemoryStorage {
     };
   }
 
-  async lookupIdempotency(_scope, key) {
-    return this.idempotency.get(key) ?? null;
+  async getCorrection(_scope, key) {
+    const record = this.corrections.get(key);
+    return record ? structuredClone(record) : null;
   }
 
   async commitCorrection(_scope, transaction) {
+    const existing = this.corrections.get(transaction.idempotency_key);
+    if (existing) return { ...structuredClone(existing), replayed: true };
+    if (this.raceCommit) return { ...structuredClone(this.raceCommit), replayed: true };
+
     if (this.failStale || transaction.expected_revision !== this.revision) {
       throw Object.assign(new Error('stale'), { code: 'STALE_REVISION' });
     }
@@ -44,34 +50,16 @@ class InMemoryStorage {
     this.revision = `rev-${Number(this.revision.split('-')[1]) + 1}`;
     this.checkpoint = `checkpoint-${this.events.length + 1}`;
 
-    const receipt = {
-      contract_version: '0.1',
-      adapter: 'agent-memory-runtime',
-      adapter_version: '0.1.0',
-      scope: structuredClone(scope),
-      prior_memory_id: transaction.event.prior_memory_id,
-      replacement_memory_id: transaction.event.replacement_memory_id,
-      supersession: {
-        prior_memory_id: transaction.event.prior_memory_id,
-        replacement_memory_id: transaction.event.replacement_memory_id,
-      },
-      event_id: transaction.event.event_id,
+    const commitRecord = {
       revision: this.revision,
       checkpoint: this.checkpoint,
       ledger_ref: `ledger:${transaction.event.event_id}`,
-      policy_version: transaction.event.policy_version,
-      authority_refs: [...transaction.event.authority_refs],
-      evidence_refs: [...transaction.event.evidence_refs],
-      replayed: false,
-      committed_at: transaction.event.committed_at,
-    };
-    this.idempotency.set(transaction.idempotency_key, receipt);
-    return {
-      revision: this.revision,
-      checkpoint: this.checkpoint,
-      ledger_ref: receipt.ledger_ref,
+      replacement: structuredClone(transaction.replacement),
+      event: structuredClone(transaction.event),
       replayed: false,
     };
+    this.corrections.set(transaction.idempotency_key, commitRecord);
+    return structuredClone(commitRecord);
   }
 }
 
@@ -179,6 +167,7 @@ test('correction appends replacement and explicit supersession without erasing p
     },
   });
 
+  assert.equal(receipt.adapter_version, '0.1.1');
   assert.equal(receipt.prior_memory_id, 'memory-original');
   assert.equal(receipt.replacement_memory_id, 'memory-correction-1');
   assert.equal(storage.records.length, 2);
@@ -187,11 +176,19 @@ test('correction appends replacement and explicit supersession without erasing p
   assert.equal(storage.events.length, 1);
   assert.equal(storage.events[0].event_type, 'correction_committed');
 
+  const persisted = storage.corrections.get('correction:one');
+  assert.deepEqual(
+    Object.keys(persisted).sort(),
+    ['checkpoint', 'event', 'ledger_ref', 'replacement', 'replayed', 'revision'],
+  );
+  assert.equal('contract_version' in persisted, false);
+  assert.equal('supersession' in persisted, false);
+
   const recalled = await governed.recall(recallRequest);
   assert.deepEqual(recalled.source_memory_refs, ['memory-correction-1']);
 });
 
-test('idempotent correction replay returns the original receipt and does not append twice', async () => {
+test('idempotent correction replay reconstructs the original semantic receipt in Agent Memory', async () => {
   const storage = new InMemoryStorage([baseRecord()]);
   const governed = adapter(storage);
   const request = {
@@ -208,9 +205,62 @@ test('idempotent correction replay returns the original receipt and does not app
   const second = await governed.correct(request);
 
   assert.equal(first.replacement_memory_id, second.replacement_memory_id);
+  assert.equal(first.event_id, second.event_id);
+  assert.equal(first.committed_at, second.committed_at);
+  assert.equal(first.ledger_ref, second.ledger_ref);
+  assert.equal(first.replayed, false);
   assert.equal(second.replayed, true);
   assert.equal(storage.records.length, 2);
   assert.equal(storage.events.length, 1);
+});
+
+test('commit-time idempotency race returns the original persisted transaction instead of candidate identities', async () => {
+  const storage = new InMemoryStorage([baseRecord()]);
+  storage.raceCommit = {
+    revision: 'rev-2',
+    checkpoint: 'checkpoint-2',
+    ledger_ref: 'ledger:event-existing',
+    replacement: {
+      memory_id: 'memory-existing',
+      kind: 'correction',
+      value_ref: 'value:main',
+      scope,
+      state: 'active',
+      evidence_refs: ['evidence:user-correction'],
+      authority_refs: ['authority:human-confirmed'],
+      supersedes: ['memory-original'],
+      created_at: '2026-08-22T20:59:59.000Z',
+    },
+    event: {
+      event_id: 'event-existing',
+      event_type: 'correction_committed',
+      prior_memory_id: 'memory-original',
+      replacement_memory_id: 'memory-existing',
+      state_snapshot: 'rev-1',
+      policy_version: 'policy-v1',
+      evidence_refs: ['evidence:user-correction'],
+      authority_refs: ['authority:human-confirmed'],
+      committed_at: '2026-08-22T20:59:59.000Z',
+    },
+    replayed: false,
+  };
+
+  const receipt = await adapter(storage).correct({
+    scope,
+    memory_id: 'memory-original',
+    idempotency_key: 'correction:race',
+    policy_version: 'policy-v1',
+    evidence_refs: ['evidence:user-correction'],
+    authority_refs: ['authority:human-confirmed'],
+    replacement: { value_ref: 'value:main' },
+  });
+
+  assert.equal(receipt.replacement_memory_id, 'memory-existing');
+  assert.equal(receipt.event_id, 'event-existing');
+  assert.equal(receipt.committed_at, '2026-08-22T20:59:59.000Z');
+  assert.equal(receipt.replayed, true);
+  assert.equal(storage.records.length, 1);
+  assert.equal(storage.events.length, 0);
 });
 
 test('correction requires explicit authority and evidence', async () => {


### PR DESCRIPTION
## Summary

Fixes #335, discovered while implementing the real QOR Agent SQLite Durable Object consumer of the runtime adapter merged in #334.

The original storage port required `lookupIdempotency()` to return an Agent Memory semantic correction receipt even though `commitCorrection()` never supplied that receipt to persistence. A real host would therefore have been forced to reconstruct Agent Memory public semantics inside its storage adapter.

This patch keeps that semantic ownership in Agent Memory.

## Contract correction

Storage now exposes:

```text
load(scope)
getCorrection(scope, idempotencyKey)
commitCorrection(scope, transaction)
```

Persistence stores and returns only a low-level commit record:

```text
revision
checkpoint
ledger_ref
replacement
original correction event
replayed
```

The Agent Memory adapter reconstructs the public correction receipt from that record on both first commit and replay.

## Race semantics

`commitCorrection()` is required to check idempotency atomically inside the commit boundary. If another attempt committed after the caller's initial lookup, persistence returns the original stored replacement/event record rather than applying the new candidate.

A genuinely new stale expected revision still fails closed with `STALE_REVISION` -> semantic `stale_state`.

## Evidence

Tests now prove:

- persisted state contains no Agent Memory public receipt fields;
- first commit and replay preserve replacement/event identity and commit time;
- only `replayed` changes on replay;
- commit-time idempotency races return the already-persisted identities;
- no duplicate record/event is appended;
- all prior scope, correction, authority, supersession, and stale-state invariants remain covered.

Adapter/package version advances from 0.1.0 to 0.1.1. The proving contract version remains 0.1 because the host storage-port correction removes an ownership defect without changing the public correction/recall envelope.

Parent integration: `MythologIQ-Labs-LLC/Qor-Agent#17`
Pre-cloud route: `MythologIQ-Labs-LLC/Myth-Tech-Forge#262`