### PR TITLE
Define Agent Memory as a governed cognitive framework

### DIFF
--- a/docs/11-component-architecture.md
+++ b/docs/11-component-architecture.md
@@ -16,7 +16,147 @@ It is not one monolithic product, library, database, score, graph, vault, protoc
 
 PAMA is a native governance component of this architecture, not an external product dependency.
 
-## System shape
+## Proposed cognitive-framework extension
+
+> **Status:** Proposed by [ADR-035](adr/ADR-035-agent-memory-is-a-governed-cognitive-framework.md). This section describes the candidate system topology. Existing Accepted ADR boundaries remain controlling until ADR-035 satisfies its acceptance requirements.
+
+ADR-035 proposes making explicit what the existing component architecture only implies: the bounded components participate in one persistent cognitive system rather than merely surrounding a collection of memory providers.
+
+The proposed top-level architecture is:
+
+```text
+Agent Memory
+|
++-- Cognitive Plane
+|   +-- Cognitive Mesh
+|   +-- Working Memory & Attention
+|   +-- Cognitive Metabolism
+|   +-- Consolidation & Abstraction
+|   +-- Procedural Memory & Skills
+|   +-- Predictive / World Modeling
+|   +-- Metacognitive Signals
+|
++-- Reality Plane
+|   +-- Reality Graphs
+|       +-- Code Reality Graph
+|       +-- Environment Reality Graph
+|       +-- Task Reality Graph
+|       +-- Social Reality Graph
+|       +-- Organizational Reality Graph
+|
++-- Authority Plane
+    +-- PAMA
+    +-- Governed Recall Admission
+    +-- Certification & Durable Commit
+    +-- Scope / Privacy / Isolation
+    +-- Correction / Supersession
+    +-- Deletion / Forgetting Authority
+    +-- Inheritance / Multi-Agent Crossing
+
+Cross-cutting:
+  Identity & Continuity
+  Evidence & Provenance
+  Conformance / Calibration / Evaluation
+```
+
+The planes are logical responsibility groupings, not exclusive component categories or deployment boundaries.
+
+ADR-033 remains controlling for composition:
+
+```text
+module identity != component identity
+component identity != capability identity
+
+one component -> many capabilities
+one capability -> many candidate implementations
+```
+
+Under the proposed mapping:
+
+- **EvolveAI** is the initial first-party reference/research implementation for **Cognitive Metabolism**, while its retrieval, graph, persistence, provenance, and other capabilities continue to mature independently;
+- **CodeGenome** is the initial first-party implementation of the **Code Reality Graph**, while its graph, retrieval, structural-reasoning, provenance, freshness, and evaluation capabilities continue to mature independently;
+- **Agent Memory core** owns the Cognitive Mesh contract, cross-module semantics, governance boundaries, and conformance requirements rather than adopting either implementation's internal ontology as canonical doctrine.
+
+This mapping is architectural responsibility, not capability promotion. First-party ownership does not confer `reference_qualified` maturity.
+
+### Proposed Cognitive Mesh
+
+The Cognitive Mesh is the candidate shared substrate through which persistent cognitive objects and typed relationships can participate in multiple bounded modules without losing their semantic type, provenance, uncertainty, scope, lifecycle, or authority posture.
+
+Candidate object classes include:
+
+```text
+Experience
+Observation
+Episode
+Concept
+Fact
+Preference
+Relationship
+Procedure
+Skill
+Goal
+Task
+Prediction
+Failure
+Decision
+Policy
+Person
+CodeArtifact
+EnvironmentState
+Correction
+Evidence
+DerivedState
+```
+
+Candidate typed relationships include:
+
+```text
+supports
+contradicts
+derived_from
+supersedes
+associated_with
+caused_by
+part_of
+depends_on
+predicts
+performed_by
+applies_to
+learned_from
+similar_to
+evidenced_by
+invalidates
+```
+
+The mesh must not collapse unlike semantics:
+
+```text
+common mesh != common behavior
+relationship != truth
+activation != authority
+confidence != permission
+persistence != correctness
+```
+
+### Proposed module responsibilities
+
+| Module | Candidate responsibility | Initial implementation / source | Must not silently own |
+|---|---|---|---|
+| Cognitive Mesh | Shared cognitive identity and typed relation substrate | Agent Memory core contract/reference substrate | universal truth, mutation authority |
+| Cognitive Metabolism | salience, decay, reinforcement, persistence pressure, consolidation candidacy, adaptive restructuring proposals | EvolveAI | truth, deletion authority, crystallization authority |
+| Working Memory & Attention | active admitted cognitive state | Agent Memory reference implementation | bypass of recall admission |
+| Consolidation & Abstraction | candidate semantic/procedural/generalized structures | Agent Memory contract + qualified provider mechanisms | canonicality from repetition alone |
+| Predictive / World Modeling | expectations about future or latent state | pluggable; no canonical implementation yet | factual truth or action authority |
+| Procedural Memory & Skills | retained reusable procedures | Agent Memory procedural-memory profile | execution permission |
+| Reality Graphs | domain-specific external/operational reality | pluggable domain implementations | memory permanence or downstream authority |
+| Code Reality Graph | code-domain identity, structure, evidence, freshness, impact | CodeGenome | universal Cognitive Mesh ontology |
+| PAMA | mutation/consequence authority | Agent Memory native doctrine | factual truth |
+| Conformance / Evaluation | module and composition evidence | Agent Memory | product claims without evidence |
+
+## Current accepted system shape
+
+Until ADR-035 is accepted, the current canonical component decomposition remains:
 
 ```text
 Agent Memory System
@@ -35,6 +175,8 @@ Agent Memory System
 ├── Conformance and Calibration Harness
 └── Product and Agent Integrations
 ```
+
+ADR-035 proposes a system-level composition of these responsibilities. It does not erase their distinct failure modes.
 
 ## Component map
 
@@ -77,6 +219,23 @@ Corrections and disputes can re-enter the pipeline at Evidence, Lifecycle, Gover
 
 The pipeline describes responsibility and authority flow, not necessarily one synchronous execution order.
 
+The ADR-035 candidate architecture generalizes the same boundary into a cognitive loop:
+
+```text
+experience / observation
+  -> stable cognitive identity + evidence
+  -> Cognitive Mesh
+  -> Cognitive Metabolism and/or Reality Graph processing
+  -> candidate cognitive change
+  -> PAMA authority evaluation
+  -> governed durable commit or refusal
+  -> governed recall
+  -> Working Memory & Attention
+  -> active cognition
+```
+
+A learned signal, graph score, prediction, or provider-native verdict remains a proposal unless existing authority doctrine says otherwise.
+
 Governance Context Projection is an optional derived branch from canonical memory and governed recall, not a replacement stage in the canonical write/read path:
 
 ```text
@@ -108,6 +267,8 @@ For example, a CodeGenome relation with confidence `0.82` must not arrive at PAM
 
 Likewise, a sensitivity classifier that reports uncertainty must not be converted into `non_sensitive=true` merely because an API wanted a boolean.
 
+A Cognitive Metabolism signal such as high reinforcement, low predicted utility, or crystallization candidacy must remain typed as a metabolic/lifecycle proposal. It must not arrive downstream disguised as truth, deletion authority, or permission to become canonical.
+
 A Governance Context Projection selected through semantic similarity must likewise preserve the estimator and uncertainty that selected the precedent. The consumer may receive candidate relevance; it must not receive probabilistic similarity disguised as permission.
 
 ## Proposal, authority, selection, commit
@@ -138,9 +299,12 @@ A concept belongs in a separate component when it has a distinct failure mode.
 
 Examples:
 
+- cognitive-mesh failure means identity, type, or relationship semantics are corrupted across modules
 - identity failure means the wrong object is addressed
 - evidence failure means the object lacks support
-- estimator failure means a confidence, relevance, sensitivity, or persistence estimate is miscalibrated or out of scope
+- estimator failure means a confidence, relevance, sensitivity, persistence, or prediction estimate is miscalibrated or out of scope
+- metabolic failure means the system reinforces, consolidates, retains, or forgets poorly
+- reality-graph failure means domain state or relationships are wrong, stale, or insufficiently evidenced
 - saturation failure means the system remembers or forgets poorly
 - governance failure means the system changes memory or authority without permission
 - certification failure means an unverified memory becomes durable
@@ -162,6 +326,9 @@ Examples:
 safe retriever + missing tenant filter -> cross-tenant leakage
 accurate sensitivity classifier + stale policy -> unsafe sharing
 calibrated utility estimator + overbroad deletion authority -> irreversible loss
+high reinforcement + bad evidence -> durable false belief candidate
+accurate reality graph + stale currentness -> incorrect active cognition
+useful prediction + authority collapse -> unauthorized action
 valid individual memories + unsafe composition -> poisoned context
 valid PAMA outcome + stale state snapshot -> incorrect commit
 valid precedent + consumer-specific overgeneralization -> approval laundering
@@ -171,13 +338,13 @@ Therefore conformance must test handoffs and composition, not only isolated comp
 
 ## Unification principle
 
-A concept belongs under the same overall architecture when it participates in governed memory state transition or in a governed projection of remembered state whose semantics must remain reconstructable.
+A concept belongs under the same overall architecture when it participates in governed memory state transition, persistent cognition, or a governed projection of remembered state whose semantics must remain reconstructable.
 
 Examples:
 
 - UOR participates by providing stable identity
-- CodeGenome participates by providing domain evidence and graph relations
-- EvolveAI participates by modeling lifecycle and decay
+- CodeGenome participates as the initial Code Reality Graph implementation and provider of domain evidence and graph relations
+- EvolveAI participates as the initial Cognitive Metabolism implementation and provider of lifecycle/decay/consolidation mechanisms
 - PAMA participates as native doctrine controlling mutation and downstream authority
 - COREFORGE Vault and Neurospace may participate by operationalizing memory
 - FailSafe and Arbiter may participate as enforcement implementations
@@ -189,22 +356,25 @@ An adjacent product name is not itself an architectural role. Implementations sh
 ## Boundary rules
 
 1. Shared doctrine, segmented implementation.
-2. Components may depend on each other, but must not redefine each other.
-3. Every durable memory transition must cross identity, evidence, authority, and certification boundaries; scoring may propose but not authorize.
-4. Runtime memory may use uncertified memory only with scope and warning semantics.
-5. Domain reality graphs may provide evidence, but do not own permanence.
-6. PAMA may authorize mutation, but does not determine factual truth.
-7. Certification may confirm durability, but does not block later correction.
-8. Probabilistic outputs must preserve semantic type, provenance, and uncertainty across handoffs.
-9. A blocked action must remain blocked even when another component assigns it high confidence or utility.
-10. Stochastic selection may occur only inside a policy-permitted action set.
-11. Commit boundaries must bind to the state and policy snapshot under which authority was granted.
-12. Composition-specific failure modes require composition-specific tests.
-13. PAMA target class, lifecycle strength, requested operation, and downstream authority remain separate dimensions.
-14. External implementation names require an evidence-backed mapping role, not mere conceptual proximity.
-15. Derived Governance Context Projection is reconstructable context, never an alternate canonical memory store or final policy authority.
-16. Consumer-specific fields belong in consumer adapters unless they expose a genuinely general missing Agent Memory primitive.
-17. Returned external approval or execution evidence re-enters Agent Memory through normal evidence/governance boundaries; an integration callback is not a privileged write path.
+2. A shared Cognitive Mesh, if ADR-035 is accepted, does not erase component or capability boundaries.
+3. Components may depend on each other, but must not redefine each other.
+4. Every durable memory transition must cross identity, evidence, authority, and certification boundaries; scoring may propose but not authorize.
+5. Runtime memory may use uncertified memory only with scope and warning semantics.
+6. Domain reality graphs may provide evidence, but do not own permanence.
+7. Cognitive Metabolism may propose reinforcement, decay, consolidation, or restructuring, but does not own truth or consequence authority.
+8. PAMA may authorize mutation, but does not determine factual truth.
+9. Certification may confirm durability, but does not block later correction.
+10. Probabilistic outputs must preserve semantic type, provenance, and uncertainty across handoffs.
+11. A blocked action must remain blocked even when another component assigns it high confidence, utility, reinforcement, or predicted value.
+12. Stochastic selection may occur only inside a policy-permitted action set.
+13. Commit boundaries must bind to the state and policy snapshot under which authority was granted.
+14. Composition-specific failure modes require composition-specific tests.
+15. PAMA target class, lifecycle strength, requested operation, and downstream authority remain separate dimensions.
+16. Module identity, component identity, and capability identity remain distinct.
+17. External implementation names require an evidence-backed mapping role, not mere conceptual proximity.
+18. Derived Governance Context Projection is reconstructable context, never an alternate canonical memory store or final policy authority.
+19. Consumer-specific fields belong in consumer adapters unless they expose a genuinely general missing Agent Memory primitive.
+20. Returned external approval or execution evidence re-enters Agent Memory through normal evidence/governance boundaries; an integration callback is not a privileged write path.
 
 ## Cross-component handoff contract
 
@@ -236,6 +406,8 @@ ledger_ref
 timestamp
 ```
 
+For Cognitive Mesh participation, additional typed metadata may be required to preserve object class, relationship semantics, activation posture, canonical/derived posture, and currentness. ADR-035 acceptance requires that this be defined without forcing one implementation-specific universal ontology.
+
 Not all fields apply to every handoff. Omitted authority-critical fields must not be guessed downstream.
 
 Governance Context Projection has a separate minimized schema because it is a consumer-facing derived view rather than a canonical component mutation handoff. It must still preserve source-memory references, scope, derivation, validity, and uncertainty sufficient for reconstruction.
@@ -253,10 +425,14 @@ Governance Context Projection has a separate minimized schema because it is a co
 | Enforced | The component blocks unsafe behavior at runtime |
 | Cross-repo adopted | Multiple repos conform to the same boundary |
 
+These architectural maturity descriptions do not replace ADR-033 capability maturity (`declared`, `implemented`, `runtime_wired`, `evidence_proven`, `reference_qualified`). Capability qualification remains independently version- and evidence-scoped.
+
 ## Architecture decision
 
 This repo owns the overall architecture and native doctrine, including PAMA and the vendor-neutral Governance Context Projection profile.
 
+If ADR-035 is accepted, Agent Memory will additionally own the canonical Cognitive Mesh contract and the module-level topology of the governed cognitive framework. That ownership will define interfaces and boundaries, not grant Agent Memory core a monopoly on implementation mechanisms.
+
 Individual repos may own implementation slices after they demonstrate a meaningful mapping. Consumer-specific governance adapters should normally be owned with the consumer integration, not by changing Agent Memory core to mirror the consumer's policy model.
 
-The shared architecture should stabilize concepts, boundaries, handoff semantics, and conformance expectations. It should not force every implementation into one repository or one runtime, and it should not grant doctrine ownership to whichever product happens to implement a feature first.
+The shared architecture should stabilize concepts, boundaries, handoff semantics, and conformance expectations. It should not force every implementation into one repository or one runtime, and it should not grant doctrine ownership or capability maturity to whichever product happens to implement a feature first.

--- a/docs/adr/ADR-035-agent-memory-is-a-governed-cognitive-framework.md
+++ b/docs/adr/ADR-035-agent-memory-is-a-governed-cognitive-framework.md
@@ -1,0 +1,709 @@
+# ADR-035: Agent Memory Is a Governed Cognitive Framework Built on a Shared Cognitive Mesh
+
+## Status
+
+Proposed
+
+## Context
+
+Agent Memory already defines bounded responsibilities for identity, evidence, lifecycle, decay, reality graphs, recall, correction, mutation authority, certification, scope, procedural memory, and conformance.
+
+ADR-033 further establishes that component identity and capability identity are orthogonal:
+
+```text
+one component -> many capabilities
+one capability -> many candidate implementations
+```
+
+That decision remains valid.
+
+The missing architectural decision is the composition of those responsibilities into persistent cognition.
+
+An agent's durable memory should participate in one cohesive cognitive substrate rather than exist as a collection of adjacent storage, retrieval, lifecycle, graph, and governance services. The current decomposition correctly identifies distinct failure modes, but it can make Agent Memory appear to be governance infrastructure around memory implementations rather than the persistent cognition layer itself.
+
+First-party systems expose this gap clearly.
+
+EvolveAI implements and experiments with adaptive memory metabolism, including lifecycle progression, salience, reinforcement, decay, temporal graph memory, consolidation, REM-style synthesis, crystallization proposals, negative/failure memory, and persistent continuity.
+
+CodeGenome implements and experiments with structured reality representation, including content-addressed identity, graph-based code reality, structural and semantic relationships, provenance, independent observers, confidence fusion, freshness, and propagation/impact reasoning.
+
+Agent Memory supplies the doctrine required to govern those mechanisms: identity and continuity, evidence and provenance, lifecycle, recall admission, correction and supersession, scope and isolation, procedural memory, PAMA mutation authority, certification, deletion, inheritance, conformance, and audit.
+
+Treating these systems only as neighboring providers understates their architectural relationship. They are bounded subsystems participating in a common cognitive architecture.
+
+The architecture therefore needs a shared **Cognitive Mesh** through which memory, learned structure, external reality, evidence, activation, uncertainty, lifecycle, scope, and authority can interoperate without collapsing their semantics.
+
+## Decision
+
+Agent Memory adopts the following architectural identity:
+
+> **Agent Memory is a governed cognitive framework for persistent agents, built on a shared Cognitive Mesh and composed from bounded cognitive, reality, and authority modules.**
+
+Agent Memory owns:
+
+```text
+canonical cognitive contracts
+shared object and relationship semantics
+cross-module boundaries
+governance doctrine
+authority constraints
+conformance requirements
+composition rules
+```
+
+Individual modules own mechanisms.
+
+```text
+Agent Memory defines the contract.
+Modules implement the mechanism.
+PAMA governs consequential change.
+Conformance establishes what has actually been proven.
+```
+
+Agent Memory is therefore not merely:
+
+```text
+storage
++ retrieval
++ governance
+```
+
+It is:
+
+```text
+persistent cognitive state
++ adaptive cognitive structure
++ models of reality
++ memory metabolism
++ governed recall
++ bounded adaptation
++ consequence authority
++ durable continuity
+```
+
+## Three-plane architecture
+
+The framework is organized into three primary logical planes.
+
+```text
+Agent Memory
+|
++-- Cognitive Plane
+|   +-- Cognitive Mesh
+|   +-- Working Memory & Attention
+|   +-- Cognitive Metabolism
+|   +-- Consolidation & Abstraction
+|   +-- Procedural Memory & Skills
+|   +-- Predictive / World Modeling
+|   +-- Metacognitive Signals
+|
++-- Reality Plane
+|   +-- Reality Graphs
+|       +-- Code Reality Graph
+|       +-- Environment Reality Graph
+|       +-- Task Reality Graph
+|       +-- Social Reality Graph
+|       +-- Organizational Reality Graph
+|       +-- other domain graphs
+|
++-- Authority Plane
+    +-- PAMA
+    +-- Governed Recall Admission
+    +-- Certification & Durable Commit
+    +-- Scope / Privacy / Isolation
+    +-- Correction / Supersession
+    +-- Deletion / Forgetting Authority
+    +-- Inheritance / Multi-Agent Crossing
+
+Cross-cutting substrates:
+  Identity & Continuity
+  Evidence & Provenance
+  Conformance / Calibration / Evaluation
+```
+
+The planes describe responsibility, not physical deployment. A component may participate in more than one plane and expose multiple independently qualified capabilities under ADR-033.
+
+## Cognitive Mesh
+
+The Cognitive Mesh is the common representational substrate of Agent Memory.
+
+It supports durable and transient cognitive objects with stable identity and typed relationships. Candidate object classes include:
+
+```text
+Experience
+Observation
+Episode
+Concept
+Fact
+Preference
+Relationship
+Procedure
+Skill
+Goal
+Task
+Prediction
+Failure
+Decision
+Policy
+Person
+CodeArtifact
+EnvironmentState
+Correction
+Evidence
+DerivedState
+```
+
+The canonical vocabulary may evolve through normal schema and structural-governance processes.
+
+A cognitive object should preserve, where applicable:
+
+```text
+identity
+object type
+temporal state
+scope / isolation domain
+provenance
+evidence references
+confidence / uncertainty
+activation
+lifecycle state
+canonical / derived posture
+currentness
+authority ceiling
+relationships
+```
+
+A shared mesh does not imply identical behavior or authority:
+
+```text
+common mesh != common behavior
+relationship != truth
+activation != authority
+confidence != permission
+persistence != correctness
+```
+
+Typed relationships may include:
+
+```text
+supports
+contradicts
+derived_from
+supersedes
+associated_with
+caused_by
+part_of
+depends_on
+predicts
+performed_by
+applies_to
+learned_from
+similar_to
+evidenced_by
+invalidates
+```
+
+Observed, inferred, learned, and synthesized relationships must preserve their epistemic character. An inferred relation does not become an observed fact merely because both occupy the same mesh.
+
+## Cognitive Metabolism
+
+Agent Memory defines **Cognitive Metabolism** as the module responsible for changes in persistence pressure, activation pressure, reinforcement, decay, interference, consolidation candidacy, and adaptive restructuring over time.
+
+EvolveAI is the initial first-party reference and research implementation for this responsibility. This mapping does not promote all EvolveAI capabilities or make its internal ontology canonical.
+
+Cognitive Metabolism may include:
+
+```text
+salience
+reinforcement
+decay
+interference
+persistence pressure
+lifecycle proposals
+memory tiering
+consolidation candidacy
+synthesis
+crystallization candidacy
+forgetting pressure
+adaptive structural proposals
+failure-pattern learning
+```
+
+The module may use deterministic, probabilistic, heuristic, learned, or hybrid mechanisms.
+
+Its consequential outputs remain proposals or estimates until authorized:
+
+```text
+high reinforcement != truth
+high salience != permanence
+decay pressure != deletion authority
+consolidation candidate != canonical memory
+crystallization proposal != permission to crystallize
+```
+
+Cognitive Metabolism must not grant itself authority to perform irreversible, canonical, cross-scope, action-enabling, or governance-bearing mutations.
+
+## Reality Graphs
+
+Agent Memory defines **Reality Graphs** as domain-specific structured models of external or operational reality.
+
+A Reality Graph answers:
+
+> What entities and relationships does current evidence support within this domain?
+
+Reality Graphs preserve, where applicable:
+
+```text
+stable identity
+domain semantics
+provenance
+observer/source identity
+observed vs inferred distinction
+confidence / uncertainty
+temporal validity
+currentness / freshness
+evidence relationships
+```
+
+Reality Graphs do not own memory permanence or downstream authority.
+
+### Code Reality Graph
+
+CodeGenome is the initial first-party implementation of the **Code Reality Graph**.
+
+Its role includes representations such as:
+
+```text
+code artifacts
+syntax
+symbols
+references
+dependencies
+control flow
+data flow
+runtime relationships
+process relationships
+change impact
+structural provenance
+freshness
+```
+
+CodeGenome's code-specific ontology does not become the universal ontology of the Cognitive Mesh. It implements the Reality Graph contract for the code domain.
+
+### Additional Reality Graphs
+
+The architecture permits additional domain graphs such as Environment, Task, Social, Organizational, System, or Product Reality Graphs where domain-specific identity, evidence, temporal, or relationship semantics justify specialization.
+
+These are architectural roles, not required repositories.
+
+## Working Memory and Attention
+
+Working Memory and Attention owns active cognition: the portion of admissible cognitive state currently activated for reasoning, planning, perception, or action selection.
+
+```text
+persistent memory != active cognition
+```
+
+Activation may use relevance, goals, novelty, recency, association, learned salience, prediction error, or other signals. Activation never bypasses governed recall admission.
+
+## Consolidation and Abstraction
+
+Consolidation and Abstraction transforms lower-level experiences into candidate higher-level cognitive structures.
+
+Examples include:
+
+```text
+episodes -> concepts
+repeated observations -> semantic candidates
+successful traces -> procedural candidates
+multiple records -> summaries
+recurring relations -> generalized structures
+experiences -> learned associations
+```
+
+Consolidation remains distinct from persistence pressure and authority:
+
+```text
+frequent != true
+similar != equivalent
+repeated != canonical
+generalized != authorized
+```
+
+Consequential consolidation crosses normal Agent Memory evidence, lifecycle, structural-mutation, and authority boundaries.
+
+## Predictive and World Modeling
+
+Predictive modeling is a first-class cognitive responsibility distinct from Reality Graphs.
+
+Reality Graphs represent what current evidence supports. Predictive models represent what the system expects next given current state.
+
+This boundary permits future implementations such as temporal prediction, causal models, latent world models, JEPA-like representations, probabilistic forecasts, and learned environment dynamics.
+
+Prediction remains epistemic output. Prediction confidence does not create mutation or action authority.
+
+## Procedural Memory and Skills
+
+Procedural Memory owns retained knowledge of how to perform tasks. It may learn reusable sequences from successful behavior, demonstrations, validated workflows, or other evidence.
+
+```text
+experience
+  -> repeated / successful structure
+  -> procedure candidate
+  -> validation
+  -> governed retention
+  -> recall
+  -> planning influence
+```
+
+ADR-034 remains controlling:
+
+```text
+procedure != permission
+skill retention != execution authority
+```
+
+## Identity, Evidence, and Continuity
+
+Identity and Continuity provides stable addressing across sessions, process restarts, representation changes, derived structures, module boundaries, agent versions, migrations, and successor agents.
+
+Changing storage provider, graph representation, embedding model, or module implementation must not silently create a new logical identity for existing canonical memory.
+
+Evidence and Provenance preserves the reconstructable basis for cognitive state and distinguishes observation, assertion, inference, synthesis, inheritance, external evidence, execution evidence, correction, and derived evidence.
+
+No module may treat its own output as authoritative evidence merely because it generated that output.
+
+## Governed Recall and Active Cognition
+
+Governed Recall remains responsible for deciding which portions of the Cognitive Mesh may influence active cognition.
+
+Candidate generation may use exact lookup, graph traversal, semantic retrieval, temporal retrieval, associative activation, procedural retrieval, prediction, reality-graph query, or learned routing.
+
+Candidate discovery remains separate from admission:
+
+```text
+retrievable != admissible
+relevant != permitted
+```
+
+Context Assembly operates only over admitted state and preserves material uncertainty, provenance, correction, scope, currentness, and policy information.
+
+## Conflict, Correction, and Supersession
+
+Agent Memory preserves disagreement and correction as explicit cognitive state. Conflicting memories or graph relations must not be silently merged merely because they share the same mesh.
+
+The system must be able to distinguish:
+
+```text
+currently believed
+historically believed
+disputed
+superseded
+incorrect and corrected
+unknown
+```
+
+Existing correction, dispute, and supersession doctrine remains controlling.
+
+## PAMA Authority
+
+PAMA remains the canonical Adaptive Mutation and Consequence Authority layer.
+
+Every module may propose. No module may convert its own confidence, reinforcement, graph position, prediction, retrieval score, learned pattern, or native verdict into permission.
+
+```text
+Cognitive Metabolism
+  -> may propose persistence or restructuring
+
+Reality Graph
+  -> may propose belief or relation updates
+
+Consolidation
+  -> may propose abstraction
+
+Predictive Modeling
+  -> may propose expected state
+
+Procedural Memory
+  -> may propose reusable behavior
+
+PAMA
+  -> determines permitted consequence
+```
+
+PAMA evaluates consequences according to applicable target class, lifecycle strength, requested operation, downstream authority, scope, reversibility, evidence, risk, and policy.
+
+## Certification and Durable Commit
+
+Certification owns required verification before high-consequence state becomes canonical or equivalently durable.
+
+Durable commit binds consequential changes to the evidence, authority, state, policy, and implementation context under which the change was permitted.
+
+Successful provider execution is not sufficient evidence of justified durable mutation.
+
+## Scope, Privacy, Isolation, and Inheritance
+
+The Cognitive Mesh may be physically shared while remaining logically partitioned.
+
+```text
+same mesh != same authorized domain
+```
+
+Project, user, task, tenant, purpose, agent, and shared-memory boundaries remain governed isolation domains. Relationships and derived state must not silently widen scope.
+
+Inheritance is a first-class cognitive operation, including crossings such as:
+
+```text
+agent -> successor agent
+agent -> agent
+agent -> team
+agent -> organization
+generation N -> generation N+1
+```
+
+Inherited state preserves provenance, scope, authority limitations, uncertainty, lifecycle status, and applicable policy. Receiving inherited memory does not imply accepting it as current canonical belief.
+
+## Conformance, Calibration, and Evaluation
+
+The framework evaluates module behavior and composed cognition separately.
+
+```text
+module conformance
++
+cross-module composition conformance
+```
+
+Evaluation should cover, where applicable:
+
+```text
+identity continuity
+retrieval quality
+recall admission
+memory interference
+consolidation quality
+decay behavior
+correction propagation
+prediction calibration
+scope isolation
+authority containment
+deletion completeness
+restart continuity
+module replacement
+cross-module provenance
+unsafe cognitive composition
+```
+
+Claims such as improved learning, lower drift, better recall, useful consolidation, or successful prediction require empirical evidence rather than architectural assertion.
+
+## Component identity, module identity, and capability identity
+
+This ADR does not supersede ADR-033.
+
+A module describes an architectural responsibility. A component is an implementation that may expose capabilities relevant to one or more modules.
+
+```text
+module identity != component identity
+component identity != capability identity
+```
+
+EvolveAI may primarily implement Cognitive Metabolism while also exposing retrieval, graph, persistence, provenance, or other capabilities.
+
+CodeGenome may primarily implement a Code Reality Graph while also exposing retrieval, structural reasoning, provenance, freshness, evaluation, or other capabilities.
+
+Those capabilities continue to mature and qualify independently.
+
+This ADR adds coherent system topology. It does not restore exclusive product categories.
+
+## Initial first-party mapping
+
+| Architectural responsibility | Initial implementation / source |
+|---|---|
+| Cognitive Mesh | Agent Memory core contract and reference substrate |
+| Cognitive Metabolism | EvolveAI |
+| Code Reality Graph | CodeGenome |
+| Identity & Continuity | Agent Memory core plus qualified providers |
+| Evidence & Provenance | Agent Memory core contract |
+| Working Memory & Attention | Agent Memory reference implementation |
+| Consolidation & Abstraction | Agent Memory contract with qualified provider mechanisms |
+| Recall & Context Assembly | Agent Memory governed recall |
+| Conflict / Correction / Supersession | Agent Memory |
+| Predictive / World Modeling | Pluggable; no canonical implementation yet |
+| Procedural Memory & Skills | Agent Memory procedural-memory profile |
+| PAMA Authority | Agent Memory native doctrine |
+| Certification & Durable Commit | Agent Memory |
+| Scope / Privacy / Isolation | Agent Memory |
+| Inheritance / Multi-Agent Memory | Agent Memory |
+| Conformance / Calibration / Evaluation | Agent Memory |
+
+This table identifies primary architectural responsibility only. It is not a claim of implementation completeness or capability qualification.
+
+## Repository and packaging implications
+
+This ADR defines architectural modules, not Git repository mechanics.
+
+It does not require EvolveAI or CodeGenome to immediately become Git submodules, directories, packages, or vendored source inside the Agent Memory repository.
+
+Physical composition may use workspace packages, versioned dependencies, Git submodules, service boundaries, adapters, embedded libraries, or other reproducible packaging.
+
+Whatever packaging is selected must preserve:
+
+```text
+version identity
+capability qualification
+dependency boundaries
+reproducibility
+replaceability
+licensing
+failure isolation
+authority boundaries
+```
+
+The long-term product surface should present these capabilities as one Agent Memory framework rather than requiring users to understand an accidental collection of research repositories.
+
+## Framework ownership rule
+
+Agent Memory owns interfaces and doctrine. Submodules own mechanisms.
+
+```text
+Agent Memory:
+  defines Cognitive Metabolism requirements
+
+EvolveAI:
+  implements one Cognitive Metabolism strategy
+
+Agent Memory:
+  defines Reality Graph requirements
+
+CodeGenome:
+  implements the Code Reality Graph
+
+Agent Memory:
+  defines cognitive-object, evidence, lifecycle,
+  recall, authority, and conformance semantics
+
+implementations:
+  satisfy those contracts at independently proven maturity
+```
+
+First-party ownership does not confer conformance. A first-party module may be experimental, incomplete, replaceable, or rejected without changing the canonical Agent Memory contract.
+
+## Consequences
+
+### Positive
+
+- gives Agent Memory an explicit cognitive substrate rather than implying one through scattered components;
+- makes EvolveAI and CodeGenome coherent parts of one architecture;
+- preserves modularity without presenting the system as disconnected projects;
+- creates a shared substrate for episodic, semantic, procedural, predictive, and reality-linked cognition;
+- creates explicit homes for attention, consolidation, prediction, and metacognitive signals;
+- preserves PAMA as the consequence boundary across the cognitive system;
+- keeps external cognitive technologies replaceable implementations rather than architectural definitions;
+- allows future reality domains beyond code;
+- gives Agent Memory a clearer identity as persistent governed cognition rather than advanced RAG infrastructure.
+
+### Negative
+
+- expands Agent Memory's declared scope from governed memory architecture toward governed cognition;
+- requires careful vocabulary work to keep the Cognitive Mesh from becoming an unbounded universal ontology;
+- increases cross-module conformance requirements;
+- creates implementation pressure for currently conceptual responsibilities such as predictive modeling;
+- requires documentation and diagram updates across the repository;
+- may eventually require repository/package restructuring after architectural boundaries stabilize.
+
+These costs are preferable to leaving the already-existing cognitive composition implicit.
+
+## Alternatives considered
+
+### Continue treating EvolveAI and CodeGenome only as adjacent providers
+
+Rejected. This preserves implementation flexibility but fails to express that memory metabolism, structured reality, recall, continuity, and governance participate in one cognitive system.
+
+### Adopt EvolveAI as the complete cognitive substrate
+
+Rejected. EvolveAI provides useful first-party mechanisms but remains replaceable and independently qualified. Implementation identity must not become canonical architecture.
+
+### Adopt CodeGenome's graph as the universal Cognitive Mesh
+
+Rejected. CodeGenome models code reality. Its ontology and evidence structure are useful, but a code-domain reality graph is not a universal cognitive ontology.
+
+### Adopt an external cognitive substrate wholesale
+
+Rejected as the architectural default. External research implementations may provide useful mechanisms and evidence, but Agent Memory's foundational cognitive contract must not inherit unproven topology, learning, authority, or representation assumptions from one implementation.
+
+### Build one monolithic cognitive engine
+
+Rejected. A cohesive cognitive framework does not require a monolithic implementation. Identity, evidence, metabolism, reality representation, prediction, recall, authority, and certification have distinct failure modes and must retain explicit boundaries.
+
+### Remain representation-neutral and avoid a shared mesh
+
+Rejected. Representation neutrality should prevent provider/storage lock-in, not prevent Agent Memory from defining the common semantic contracts required for persistent cognition.
+
+## Relationship to existing doctrine
+
+This ADR extends rather than supersedes:
+
+- ADR-020, probabilistic discovery and governed consequence;
+- ADR-022, memory isolation domains;
+- ADR-028, language-neutral core and implementation profiles;
+- ADR-032, governed mutable memory structure;
+- ADR-033, capability-oriented composition;
+- ADR-034, procedural memory is not execution authority.
+
+The shared Cognitive Mesh does not weaken any authority, isolation, deletion, correction, currentness, or capability-maturity boundary established by those decisions.
+
+## Acceptance requirements
+
+ADR-035 may move from Proposed to Accepted when:
+
+1. the Cognitive Mesh boundary is documented without creating a universal implementation-specific ontology;
+2. the three-plane architecture is integrated consistently into canonical documentation;
+3. EvolveAI is mapped to Cognitive Metabolism without falsely promoting unqualified capabilities;
+4. CodeGenome is mapped to Code Reality Graph without promoting its domain ontology to universal memory semantics;
+5. module identity, component identity, and capability identity remain distinct and consistent with ADR-033;
+6. at least one end-to-end reference path demonstrates:
+
+```text
+experience / observation
+  -> Cognitive Mesh identity
+  -> Evidence / Provenance
+  -> Cognitive Metabolism or Reality Graph processing
+  -> candidate cognitive change
+  -> PAMA authority evaluation
+  -> governed durable commit or refusal
+  -> governed recall
+  -> active cognition
+```
+
+7. an adversarial path proves that learned reinforcement, graph confidence, prediction confidence, or a provider-native verdict cannot independently grant durable or action authority;
+8. module replacement or absence fails explicitly without corrupting canonical cognitive identity;
+9. conformance documentation distinguishes architectural acceptance from implementation maturity.
+
+## Decision summary
+
+Agent Memory is the canonical framework for persistent governed agent cognition.
+
+Its shared substrate is the Cognitive Mesh.
+
+EvolveAI becomes the initial first-party Cognitive Metabolism implementation.
+
+CodeGenome becomes the initial first-party Code Reality Graph implementation.
+
+Additional bounded modules provide working cognition, consolidation, prediction, procedural memory, evidence, correction, scope, inheritance, recall, certification, and conformance.
+
+All modules may adapt, infer, retrieve, associate, predict, or propose according to their contracts.
+
+None may convert those signals into consequential authority on its own.
+
+```text
+shared cognition
+      +
+bounded modules
+      +
+explicit evidence
+      +
+governed adaptation
+      +
+PAMA authority
+      =
+Agent Memory
+```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ ADR-031: Accepted
 ADR-032: Accepted
 ADR-033: Accepted
 ADR-034: Accepted
+ADR-035: Proposed
 ```
 
 ADRs 001-020, ADR-022, ADR-024, ADR-028, ADR-030, ADR-031, ADR-032, ADR-033, and ADR-034 have satisfied their doctrine-maturity gates.
@@ -280,6 +281,26 @@ Acceptance is backed by the #295 reference vertical slice and the focused exact-
 
 The adversarial path explicitly proves that approval for one procedure payload cannot commit a substituted payload. Acceptance remains bounded to the reference evidence and does not claim process-restart durability or universal production conformance.
 
+### Governed cognitive framework
+
+[`ADR-035`](ADR-035-agent-memory-is-a-governed-cognitive-framework.md) is **Proposed**.
+
+Its candidate system identity is:
+
+```text
+Agent Memory
+  -> shared Cognitive Mesh
+  -> bounded Cognitive, Reality, and Authority planes
+  -> independently composed/qualified implementations
+  -> PAMA-governed consequence
+```
+
+ADR-035 makes the cognitive substrate explicit without reversing ADR-033. Module identity, component identity, and capability identity remain distinct.
+
+The proposed first-party responsibility mapping treats EvolveAI as the initial Cognitive Metabolism implementation and CodeGenome as the initial Code Reality Graph implementation. Those mappings do not promote capability maturity, make either provider's internal ontology canonical, or require immediate repository/submodule consolidation.
+
+Acceptance requires a bounded Cognitive Mesh contract, canonical documentation integration, an end-to-end cognitive path through evidence and PAMA, an adversarial authority-containment path, and explicit module-replacement behavior.
+
 ## Remaining Proposed ADRs
 
 The remaining Proposed decisions intentionally stay separate:
@@ -289,7 +310,8 @@ The remaining Proposed decisions intentionally stay separate:
 - [`ADR-025`](ADR-025-durable-decision-overwrites-require-explicit-authority.md): explicit authority for durable decision overwrite;
 - [`ADR-026`](ADR-026-origin-is-provenance-not-evidentiary-authority.md): source-neutral evidence authority;
 - [`ADR-027`](ADR-027-rejected-values-require-governed-readmission.md): governed re-admission of rejected values;
-- [`ADR-029`](ADR-029-governance-projection-is-derived-context-not-authority.md): vendor-neutral governance context projection.
+- [`ADR-029`](ADR-029-governance-projection-is-derived-context-not-authority.md): vendor-neutral governance context projection;
+- [`ADR-035`](ADR-035-agent-memory-is-a-governed-cognitive-framework.md): shared Cognitive Mesh and governed cognitive-framework topology.
 
 These must not be collapsed into a generic "memory safety" claim. Each has its own evidence and acceptance boundary.
 


### PR DESCRIPTION
## Summary

Introduces ADR-035 as a **Proposed** architecture decision making Agent Memory's cognitive substrate explicit.

This slice:

- defines Agent Memory as a governed cognitive framework built on a shared Cognitive Mesh;
- defines Cognitive, Reality, and Authority planes as logical responsibility groupings;
- maps EvolveAI to the initial **Cognitive Metabolism** implementation role;
- maps CodeGenome to the initial **Code Reality Graph** implementation role;
- preserves ADR-033's separation of module, component, and capability identity;
- preserves PAMA as the consequence-authority boundary;
- explicitly avoids promoting first-party capability maturity or adopting provider-specific ontologies as canonical;
- registers ADR-035 in the ADR index;
- updates the component architecture with the proposed topology while keeping current Accepted doctrine controlling until ADR-035 earns acceptance.

## Intentionally out of scope

- moving EvolveAI or CodeGenome into this repository;
- choosing Git submodules/workspaces/package mechanics;
- changing provider qualification or maturity;
- implementing the Cognitive Mesh schema/runtime;
- implementing predictive/world-model components;
- accepting ADR-035 before its stated evidence gates are met.

## Next evidence slice

ADR-035 requires a bounded reference path:

```text
experience / observation
  -> Cognitive Mesh identity
  -> Evidence / Provenance
  -> Cognitive Metabolism or Reality Graph processing
  -> candidate cognitive change
  -> PAMA authority evaluation
  -> governed durable commit or refusal
  -> governed recall
  -> active cognition
```

The paired adversarial path must prove that reinforcement, graph confidence, prediction confidence, or a provider-native verdict cannot independently grant durable or action authority.