### PR TITLE
Prove bounded Cognitive Mesh runtime path

### DIFF
--- a/.github/workflows/cognitive-mesh-evidence.yml
+++ b/.github/workflows/cognitive-mesh-evidence.yml
@@ -1,0 +1,49 @@
+name: Cognitive Mesh Evidence
+
+on:
+  pull_request:
+    paths:
+      - "reference/agentmem_ref/cognitive_mesh.py"
+      - "reference/tests/test_cognitive_mesh.py"
+      - "reference/run_cognitive_mesh.py"
+      - "reference/agentmem_ref/adapter.py"
+      - "reference/agentmem_ref/policy.py"
+      - "reference/agentmem_ref/contextual_recall.py"
+      - "reference/agentmem_ref/substrate.py"
+      - "docs/adr/ADR-035-agent-memory-is-a-governed-cognitive-framework.md"
+      - "docs/programs/runtime-evidence/cognitive-mesh.md"
+      - ".github/workflows/cognitive-mesh-evidence.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cognitive-mesh-evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install reference dependencies
+        run: python -m pip install -r reference/requirements.txt
+
+      - name: Validate schemas
+        run: python scripts/validate_schemas.py
+
+      - name: Test Cognitive Mesh reference path
+        run: python -m unittest discover -s reference/tests -p 'test_cognitive_mesh.py' -t reference
+
+      - name: Emit Cognitive Mesh evidence
+        run: python reference/run_cognitive_mesh.py --output artifacts/cognitive-mesh-evidence.json
+
+      - name: Upload Cognitive Mesh evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: cognitive-mesh-evidence
+          path: artifacts/cognitive-mesh-evidence.json

--- a/docs/programs/runtime-evidence/cognitive-mesh.md
+++ b/docs/programs/runtime-evidence/cognitive-mesh.md
@@ -1,0 +1,190 @@
+# ADR-035 Cognitive Mesh Reference Evidence
+
+Status: **reference slice implemented; ADR-035 remains Proposed**
+
+This evidence slice proves a bounded composition path for the Cognitive Mesh proposed by ADR-035. It does not claim a complete cognitive substrate, production cognition, or universal ontology.
+
+## Evidence boundary
+
+The executable path is:
+
+```text
+experience / observation
+  -> stable logical cognitive identity + evidence
+  -> typed Cognitive Metabolism / Reality Graph / predictive signal
+  -> Agent Memory proposal
+  -> deterministic PAMA authority envelope
+  -> governed durable commit or refusal
+  -> substrate candidate retrieval
+  -> governed recall admission
+  -> active cognition
+```
+
+The reference implementation is:
+
+- `reference/agentmem_ref/cognitive_mesh.py`
+- `reference/tests/test_cognitive_mesh.py`
+- `reference/run_cognitive_mesh.py`
+- `.github/workflows/cognitive-mesh-evidence.yml`
+
+It composes existing Agent Memory primitives rather than creating a parallel memory runtime:
+
+- `reference/agentmem_ref/adapter.py`
+- `reference/agentmem_ref/policy.py`
+- `reference/agentmem_ref/contextual_recall.py`
+- `reference/agentmem_ref/substrate.py`
+
+## Minimal Cognitive Mesh contract
+
+The slice introduces three bounded reference types:
+
+```text
+CognitiveExperience
+  source observation retained as evidence
+
+MeshObject
+  stable representation-neutral logical cognitive identity
+
+CognitiveSignal
+  typed non-authoritative provider output
+```
+
+`MeshObject.object_type` and `CognitiveSignal.module_role` are deliberately open strings. This slice does not establish a closed universal cognitive ontology.
+
+Logical Agent Memory identity remains distinct from provider storage identity:
+
+```text
+MeshObject.object_ref
+  !=
+TemporalGraph Fact.uuid
+```
+
+Provider replacement therefore need not rewrite the logical object identity.
+
+## Provider signals are proposals, not authority
+
+A `CognitiveSignal` may preserve:
+
+```text
+module role
+source component
+signal type
+estimator identity/version
+confidence
+evidence references
+provider-native verdict
+```
+
+Those fields are evidence and proposal context only.
+
+The signal does not choose the PAMA outcome and has no direct commit path.
+
+The focused adversarial cases prove:
+
+```text
+reinforcement confidence 1.0
+  != crystallization authority
+
+graph confidence 1.0
+  != durable-memory authority
+
+prediction confidence 1.0 + provider PASS
+  != external-action authority
+```
+
+For otherwise identical low-risk crystallization proposals, confidence `0.01` and `1.0` both resolve to `require_review` and neither commits.
+
+## Happy path
+
+The positive fixture uses an EvolveAI-labelled Cognitive Metabolism signal to propose low-risk promotion of a semantic candidate.
+
+The expected sequence is:
+
+```text
+experience retained
+  -> proposal carries evidence + estimator metadata
+  -> PAMA returns allow_with_ledger
+  -> governed adapter writes provider fact + receipt
+  -> matching isolation-domain recall retrieves candidate
+  -> current contextual policy admits candidate
+  -> logical object enters active cognition
+```
+
+The EvolveAI label identifies the source component in the fixture. It does not assert additional EvolveAI capability qualification.
+
+## CodeGenome boundary
+
+The CodeGenome-labelled fixture contributes a `reality_graph` signal with graph confidence `1.0`.
+
+The graph signal remains typed estimator evidence. A crystallization request still reaches PAMA and remains uncommitted when review is required.
+
+This demonstrates the ADR-035 boundary:
+
+```text
+Reality Graph evidence
+  -> may influence a candidate cognitive transition
+  -> may not authorize the transition
+```
+
+It does not upgrade CodeGenome's existing capability maturity profile.
+
+## Recall admission remains separate
+
+One fixture first earns a durable low-risk promotion, then applies a contextual recall rule that blocks the same logical memory from entering active cognition.
+
+Therefore:
+
+```text
+durable memory
+  != currently admissible memory
+
+substrate candidate
+  != active cognition
+```
+
+The contextual decision reports `authority_effect = current_recall_only` and does not mutate the durable memory.
+
+## Explicit module absence and replacement
+
+The reference runtime requires the named source component to be configured before a signal may enter the proposal path.
+
+If it is absent:
+
+```text
+CognitiveModuleUnavailable
+  -> no episode write
+  -> no proposal commit
+  -> no implicit fallback
+```
+
+A replacement component may then be registered explicitly. The subsequent transition keeps the same `MeshObject.object_ref` while receiving a new provider fact UUID.
+
+This is narrow evidence for ADR-035's module-replacement requirement. It does not yet prove restart persistence of the replacement registry or provider-state migration.
+
+## What this slice proves
+
+At the reference boundary, this slice establishes:
+
+1. one logical cognitive object can flow through evidence, provider signal, PAMA, durable commit, governed recall, and active cognition;
+2. Cognitive Metabolism, Reality Graph, and predictive signals remain non-authoritative;
+3. confidence magnitude does not grant consequence authority;
+4. a provider-native `PASS` verdict does not grant consequence authority;
+5. durable commit and active recall are separate governed stages;
+6. absent modules fail explicitly rather than silently degrading;
+7. replacing a provider does not require changing canonical logical cognitive identity.
+
+## What this slice does not prove
+
+This evidence does not establish:
+
+- a complete Cognitive Mesh ontology;
+- cross-process persistence of mesh/provider mappings;
+- production EvolveAI integration;
+- production CodeGenome integration;
+- cognitive quality or learning effectiveness;
+- consolidation quality;
+- prediction calibration;
+- transitive deletion completeness across every future cognitive derivative;
+- that ADR-035 has satisfied all doctrine acceptance gates.
+
+ADR-035 remains **Proposed** until its full acceptance boundary is reviewed against repository-wide doctrine and evidence.

--- a/reference/agentmem_ref/cognitive_mesh.py
+++ b/reference/agentmem_ref/cognitive_mesh.py
@@ -1,0 +1,247 @@
+"""Bounded ADR-035 Cognitive Mesh reference path.
+
+This module does not attempt to implement cognition. It composes existing Agent
+Memory primitives to prove the architectural seam introduced by ADR-035:
+
+experience / observation
+  -> stable logical cognitive identity + evidence
+  -> typed provider signal
+  -> PAMA-governed candidate transition
+  -> durable commit or refusal
+  -> governed recall
+  -> active cognition
+
+The provider signal is deliberately non-authoritative. Reinforcement, graph
+confidence, prediction confidence, and provider-native verdicts remain typed
+inputs/evidence. They never select a PAMA outcome or bypass recall admission.
+
+The Cognitive Mesh contract here is intentionally small. Object types and
+module roles are open strings rather than a universal ontology. The reference
+proves shared identity and handoff semantics, not a final cognitive taxonomy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from . import policy
+from .adapter import CommitResult, GovernedMemoryAdapter, RecallContext
+from .contextual_recall import ADMITTING_OUTCOMES, DeterministicContextualRecallPolicy
+from .substrate import Episode
+
+
+class CognitiveModuleUnavailable(RuntimeError):
+    """Raised when a requested provider is not present in the configured mesh."""
+
+
+@dataclass(frozen=True)
+class CognitiveExperience:
+    """Source experience/observation retained as evidence before promotion."""
+
+    experience_ref: str
+    content: str
+    source_description: str
+    observed_at: str
+
+    def __post_init__(self) -> None:
+        if not self.experience_ref or not self.content or not self.observed_at:
+            raise ValueError("experience_ref, content, and observed_at are required")
+
+
+@dataclass(frozen=True)
+class MeshObject:
+    """Representation-neutral logical cognitive identity.
+
+    `object_type` is intentionally not an enum. ADR-035 must not accidentally
+    turn this bounded reference slice into a universal ontology.
+    """
+
+    object_ref: str
+    object_type: str
+    scope: str
+    evidence_refs: tuple[str, ...] = ()
+    isolation_domain_refs: tuple[str, ...] = ()
+    required_isolation_domain_refs: tuple[str, ...] = ()
+    project_ref: str = ""
+    task_ref: str = ""
+    purpose: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.object_ref or not self.object_type or not self.scope:
+            raise ValueError("object_ref, object_type, and scope are required")
+
+
+@dataclass(frozen=True)
+class CognitiveSignal:
+    """Typed, non-authoritative output from a cognitive/reality provider."""
+
+    module_role: str
+    source_component: str
+    signal_type: str
+    evidence_refs: tuple[str, ...] = ()
+    estimator_ref: str = ""
+    estimator_version: str = ""
+    confidence: float | None = None
+    provider_verdict: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.module_role or not self.source_component or not self.signal_type:
+            raise ValueError("module_role, source_component, and signal_type are required")
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class CognitiveTransition:
+    """One cognitive proposal plus the governed consequence it actually earned."""
+
+    object_ref: str
+    object_type: str
+    experience_ref: str
+    signal: CognitiveSignal
+    proposal: policy.Proposal
+    commit: CommitResult
+
+
+@dataclass
+class ActiveCognition:
+    """Governed recall result after substrate and contextual admission."""
+
+    candidate_fact_uuids: list[str] = field(default_factory=list)
+    admitted_fact_uuids: list[str] = field(default_factory=list)
+    active_object_refs: list[str] = field(default_factory=list)
+    refusals: dict[str, str] = field(default_factory=dict)
+    contextual_decisions: dict[str, dict] = field(default_factory=dict)
+
+
+class CognitiveMeshRuntime:
+    """Minimal composition layer over existing Agent Memory runtime primitives."""
+
+    def __init__(
+        self,
+        *,
+        adapter: GovernedMemoryAdapter,
+        available_components: tuple[str, ...],
+        recall_policy: DeterministicContextualRecallPolicy | None = None,
+    ) -> None:
+        self._adapter = adapter
+        self._available_components = set(available_components)
+        self._recall_policy = recall_policy or DeterministicContextualRecallPolicy(
+            policy_ref="policy:cognitive-mesh-recall",
+            policy_version="1.0.0",
+        )
+        self._object_by_fact: dict[str, str] = {}
+
+    def apply_signal(
+        self,
+        *,
+        experience: CognitiveExperience,
+        cognitive_object: MeshObject,
+        signal: CognitiveSignal,
+        actor_id: str,
+        requested_operation: str,
+        target_class: str,
+        downstream_authority: str,
+        risk_class: str,
+        reversibility: str = "reversible",
+        current_strength: str = "observed",
+        proposed_strength: str = "promoted",
+        charter_version: str = "cognitive-mesh-ref-v1",
+        proposal_id: str | None = None,
+        review_satisfied: bool = False,
+        approval_refs: tuple[str, ...] = (),
+    ) -> CognitiveTransition:
+        """Turn a provider signal into a proposal, never directly into authority."""
+        self._require_component(signal.source_component)
+        evidence_refs = tuple(
+            dict.fromkeys(
+                (experience.experience_ref,)
+                + cognitive_object.evidence_refs
+                + signal.evidence_refs
+            )
+        )
+        estimator_refs = (signal.estimator_ref,) if signal.estimator_ref else ()
+        estimator_versions = (signal.estimator_version,) if signal.estimator_version else ()
+        proposal = policy.Proposal(
+            proposal_id=proposal_id or f"proposal:{cognitive_object.object_ref}:{signal.signal_type}",
+            actor_id=actor_id,
+            charter_version=charter_version,
+            target_reference=cognitive_object.object_ref,
+            target_class=target_class,
+            scope=cognitive_object.scope,
+            operation=requested_operation,
+            current_strength=current_strength,
+            proposed_strength=proposed_strength,
+            downstream_authority=downstream_authority,
+            reversibility=reversibility,
+            risk_class=risk_class,
+            evidence_refs=evidence_refs,
+            estimator_refs=estimator_refs,
+            estimator_versions=estimator_versions,
+            confidence=signal.confidence,
+            review_satisfied=review_satisfied,
+            approval_refs=approval_refs,
+            purpose=cognitive_object.purpose,
+            isolation_domain_refs=cognitive_object.isolation_domain_refs,
+            required_isolation_domain_refs=cognitive_object.required_isolation_domain_refs,
+            project_ref=cognitive_object.project_ref,
+            task_ref=cognitive_object.task_ref,
+        )
+        episode = Episode(
+            uuid=experience.experience_ref,
+            content=experience.content,
+            source_description=experience.source_description,
+            valid_at=experience.observed_at,
+            group_id=cognitive_object.scope,
+        )
+        commit = self._adapter.commit_proposal(proposal, experience.content, episode=episode)
+        if commit.committed and commit.fact_uuid:
+            self._object_by_fact[commit.fact_uuid] = cognitive_object.object_ref
+        return CognitiveTransition(
+            object_ref=cognitive_object.object_ref,
+            object_type=cognitive_object.object_type,
+            experience_ref=experience.experience_ref,
+            signal=signal,
+            proposal=proposal,
+            commit=commit,
+        )
+
+    def recall_active(
+        self,
+        query: str,
+        *,
+        context: RecallContext,
+    ) -> ActiveCognition:
+        """Retrieve through the adapter, then apply current contextual admission."""
+        substrate_admission = self._adapter.governed_recall(query, context=context)
+        result = ActiveCognition(
+            candidate_fact_uuids=list(substrate_admission.candidates),
+            admitted_fact_uuids=list(substrate_admission.admitted),
+            refusals=dict(substrate_admission.refusals),
+        )
+        for fact_uuid in substrate_admission.admitted:
+            object_ref = self._object_by_fact.get(fact_uuid, fact_uuid)
+            decision = self._recall_policy.evaluate(
+                object_ref,
+                context,
+                evaluated_at="2026-01-01T00:10:00Z",
+            )
+            result.contextual_decisions[object_ref] = decision
+            if decision["outcome"] in ADMITTING_OUTCOMES:
+                result.active_object_refs.append(object_ref)
+            else:
+                result.refusals[fact_uuid] = f"contextual_{decision['outcome']}"
+        return result
+
+    def replace_component(self, *, old_component: str, new_component: str) -> None:
+        """Replace an implementation registration without rewriting mesh identity."""
+        if not new_component:
+            raise ValueError("new_component is required")
+        self._available_components.discard(old_component)
+        self._available_components.add(new_component)
+
+    def _require_component(self, source_component: str) -> None:
+        if source_component not in self._available_components:
+            raise CognitiveModuleUnavailable(
+                f"cognitive component unavailable: {source_component}"
+            )

--- a/reference/run_cognitive_mesh.py
+++ b/reference/run_cognitive_mesh.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Emit deterministic ADR-035 Cognitive Mesh reference evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext
+from agentmem_ref.cognitive_mesh import (
+    CognitiveExperience,
+    CognitiveMeshRuntime,
+    CognitiveModuleUnavailable,
+    CognitiveSignal,
+    MeshObject,
+)
+from agentmem_ref.contextual_recall import ContextualRule, DeterministicContextualRecallPolicy
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+TENANT = "tenant:cognitive-mesh-evidence"
+PROJECT = "project:cognitive-mesh-evidence"
+
+
+def _runtime(*components: str, recall_policy=None):
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    mesh = CognitiveMeshRuntime(
+        adapter=adapter,
+        available_components=tuple(components),
+        recall_policy=recall_policy,
+    )
+    return mesh, substrate
+
+
+def _object(ref: str) -> MeshObject:
+    return MeshObject(
+        object_ref=ref,
+        object_type="semantic_candidate",
+        scope=TENANT,
+        isolation_domain_refs=(TENANT, PROJECT),
+        required_isolation_domain_refs=(TENANT, PROJECT),
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def _experience(ref: str, content: str) -> CognitiveExperience:
+    return CognitiveExperience(
+        experience_ref=ref,
+        content=content,
+        source_description="ADR-035 deterministic evidence fixture",
+        observed_at="2026-01-01T00:00:00Z",
+    )
+
+
+def _context() -> RecallContext:
+    return RecallContext(
+        target_domain_refs=(TENANT, PROJECT),
+        principal_ref="agent:cognitive-mesh-evidence",
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def run() -> dict:
+    mesh, substrate = _runtime("EvolveAI", "CodeGenome", "PredictiveReference")
+    happy = mesh.apply_signal(
+        experience=_experience("episode:happy", "Prefer explicit evidence before durable promotion"),
+        cognitive_object=_object("memory:happy"),
+        signal=CognitiveSignal(
+            module_role="cognitive_metabolism",
+            source_component="EvolveAI",
+            signal_type="reinforcement",
+            estimator_ref="evolveai:metabolism",
+            estimator_version="fixture-v1",
+            confidence=0.93,
+            evidence_refs=("trace:successful-recall",),
+        ),
+        actor_id="agent:cognitive-mesh-evidence",
+        requested_operation="promotion",
+        target_class=policy.M2,
+        downstream_authority=policy.A1,
+        risk_class="low",
+    )
+    happy_recall = mesh.recall_active("explicit evidence durable promotion", context=_context())
+
+    confidence_outcomes = []
+    for confidence in (0.01, 1.0):
+        candidate, _ = _runtime("EvolveAI")
+        transition = candidate.apply_signal(
+            experience=_experience(f"episode:confidence:{confidence}", "Candidate for crystallization"),
+            cognitive_object=_object(f"memory:confidence:{confidence}"),
+            signal=CognitiveSignal(
+                module_role="cognitive_metabolism",
+                source_component="EvolveAI",
+                signal_type="crystallization_candidate",
+                estimator_ref="evolveai:crystallizer",
+                estimator_version="fixture-v1",
+                confidence=confidence,
+            ),
+            actor_id="agent:optimizer",
+            requested_operation="crystallization",
+            target_class=policy.M2,
+            downstream_authority=policy.A1,
+            risk_class="low",
+        )
+        confidence_outcomes.append(
+            {
+                "confidence": confidence,
+                "pama_outcome": transition.commit.decision.outcome,
+                "committed": transition.commit.committed,
+            }
+        )
+
+    code_mesh, _ = _runtime("CodeGenome")
+    code_graph = code_mesh.apply_signal(
+        experience=_experience("episode:code", "Function A calls privileged function B"),
+        cognitive_object=_object("memory:code"),
+        signal=CognitiveSignal(
+            module_role="reality_graph",
+            source_component="CodeGenome",
+            signal_type="graph_relation_confidence",
+            estimator_ref="codegenome:fused-edge",
+            estimator_version="fixture-v1",
+            confidence=1.0,
+        ),
+        actor_id="agent:code",
+        requested_operation="crystallization",
+        target_class=policy.M2,
+        downstream_authority=policy.A1,
+        risk_class="low",
+    )
+
+    predictive_mesh, _ = _runtime("PredictiveReference")
+    prediction = predictive_mesh.apply_signal(
+        experience=_experience("episode:prediction", "Predicted deployment is safe"),
+        cognitive_object=_object("memory:prediction"),
+        signal=CognitiveSignal(
+            module_role="predictive_world_model",
+            source_component="PredictiveReference",
+            signal_type="prediction_confidence",
+            estimator_ref="predictor:deployment",
+            estimator_version="fixture-v1",
+            confidence=1.0,
+            provider_verdict="PASS",
+        ),
+        actor_id="agent:predictor",
+        requested_operation="promotion",
+        target_class=policy.M2,
+        downstream_authority=policy.A4,
+        risk_class="low",
+    )
+
+    contextual_policy = DeterministicContextualRecallPolicy(
+        policy_ref="policy:cognitive-mesh-context",
+        policy_version="1.0.0",
+        rules=(
+            ContextualRule(
+                rule_id="fixture-block",
+                candidate_ref="memory:context-block",
+                outcome="block",
+                reason_code="fixture_context_block",
+            ),
+        ),
+    )
+    context_mesh, _ = _runtime("EvolveAI", recall_policy=contextual_policy)
+    context_transition = context_mesh.apply_signal(
+        experience=_experience("episode:context", "Context-sensitive durable memory"),
+        cognitive_object=_object("memory:context-block"),
+        signal=CognitiveSignal(
+            module_role="cognitive_metabolism",
+            source_component="EvolveAI",
+            signal_type="retention_candidate",
+            confidence=0.8,
+        ),
+        actor_id="agent:cognitive-mesh-evidence",
+        requested_operation="promotion",
+        target_class=policy.M2,
+        downstream_authority=policy.A1,
+        risk_class="low",
+    )
+    context_recall = context_mesh.recall_active("context sensitive durable memory", context=_context())
+
+    replacement_mesh, replacement_substrate = _runtime("EvolveAI")
+    replacement_signal = CognitiveSignal(
+        module_role="cognitive_metabolism",
+        source_component="MetabolismV2",
+        signal_type="retention_candidate",
+        confidence=0.7,
+    )
+    missing_component = "not_attempted"
+    try:
+        replacement_mesh.apply_signal(
+            experience=_experience("episode:missing", "Replacement provider memory"),
+            cognitive_object=_object("memory:replaceable"),
+            signal=replacement_signal,
+            actor_id="agent:cognitive-mesh-evidence",
+            requested_operation="promotion",
+            target_class=policy.M2,
+            downstream_authority=policy.A1,
+            risk_class="low",
+        )
+    except CognitiveModuleUnavailable as exc:
+        missing_component = str(exc)
+    writes_before_replacement = len(replacement_substrate.write_log)
+    replacement_mesh.replace_component(old_component="EvolveAI", new_component="MetabolismV2")
+    replacement = replacement_mesh.apply_signal(
+        experience=_experience("episode:replacement", "Replacement provider memory"),
+        cognitive_object=_object("memory:replaceable"),
+        signal=replacement_signal,
+        actor_id="agent:cognitive-mesh-evidence",
+        requested_operation="promotion",
+        target_class=policy.M2,
+        downstream_authority=policy.A1,
+        risk_class="low",
+    )
+
+    return {
+        "profile": "adr-035-cognitive-mesh-reference-v1",
+        "happy_path": {
+            "logical_object_ref": happy.object_ref,
+            "physical_fact_uuid": happy.commit.fact_uuid,
+            "pama_outcome": happy.commit.decision.outcome,
+            "committed": happy.commit.committed,
+            "experience_retained": ("add_episode", "episode:happy") in substrate.write_log,
+            "admitted_fact_uuids": happy_recall.admitted_fact_uuids,
+            "active_object_refs": happy_recall.active_object_refs,
+            "receipt_id": happy.commit.receipt["receipt_id"],
+        },
+        "confidence_is_not_authority": confidence_outcomes,
+        "reality_graph_is_not_authority": {
+            "confidence": code_graph.signal.confidence,
+            "pama_outcome": code_graph.commit.decision.outcome,
+            "committed": code_graph.commit.committed,
+        },
+        "provider_verdict_is_not_authority": {
+            "provider_verdict": prediction.signal.provider_verdict,
+            "confidence": prediction.signal.confidence,
+            "requested_downstream_authority": prediction.proposal.downstream_authority,
+            "pama_outcome": prediction.commit.decision.outcome,
+            "committed": prediction.commit.committed,
+        },
+        "recall_admission_is_separate": {
+            "durable_commit": context_transition.commit.committed,
+            "substrate_admitted_fact_uuids": context_recall.admitted_fact_uuids,
+            "active_object_refs": context_recall.active_object_refs,
+            "refusals": context_recall.refusals,
+            "contextual_decision": context_recall.contextual_decisions.get("memory:context-block"),
+        },
+        "module_replacement": {
+            "missing_component_refusal": missing_component,
+            "writes_before_replacement": writes_before_replacement,
+            "replacement_committed": replacement.commit.committed,
+            "logical_object_ref": replacement.object_ref,
+            "proposal_target_ref": replacement.proposal.target_reference,
+            "physical_fact_uuid": replacement.commit.fact_uuid,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    report = run()
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_cognitive_mesh.py
+++ b/reference/tests/test_cognitive_mesh.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext
+from agentmem_ref.cognitive_mesh import (
+    CognitiveExperience,
+    CognitiveMeshRuntime,
+    CognitiveModuleUnavailable,
+    CognitiveSignal,
+    MeshObject,
+)
+from agentmem_ref.contextual_recall import ContextualRule, DeterministicContextualRecallPolicy
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+TENANT = "tenant:mesh-fixture"
+PROJECT = "project:mesh-fixture"
+
+
+def experience(ref: str = "episode:mesh-1", content: str = "Prefer explicit evidence before durable promotion") -> CognitiveExperience:
+    return CognitiveExperience(
+        experience_ref=ref,
+        content=content,
+        source_description="ADR-035 cognitive mesh fixture",
+        observed_at="2026-01-01T00:00:00Z",
+    )
+
+
+def mesh_object(ref: str = "memory:mesh-1") -> MeshObject:
+    return MeshObject(
+        object_ref=ref,
+        object_type="semantic_candidate",
+        scope=TENANT,
+        isolation_domain_refs=(TENANT, PROJECT),
+        required_isolation_domain_refs=(TENANT, PROJECT),
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def context() -> RecallContext:
+    return RecallContext(
+        target_domain_refs=(TENANT, PROJECT),
+        principal_ref="agent:mesh-test",
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def runtime(*components: str, recall_policy=None) -> tuple[CognitiveMeshRuntime, InMemoryTemporalGraph]:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    return (
+        CognitiveMeshRuntime(
+            adapter=adapter,
+            available_components=tuple(components),
+            recall_policy=recall_policy,
+        ),
+        substrate,
+    )
+
+
+class CognitiveMeshTests(unittest.TestCase):
+    def test_evolveai_metabolic_signal_commits_only_through_pama_then_recall(self) -> None:
+        mesh, substrate = runtime("EvolveAI")
+        signal = CognitiveSignal(
+            module_role="cognitive_metabolism",
+            source_component="EvolveAI",
+            signal_type="reinforcement",
+            estimator_ref="evolveai:metabolism",
+            estimator_version="fixture-v1",
+            confidence=0.93,
+            evidence_refs=("trace:successful-recall",),
+        )
+
+        transition = mesh.apply_signal(
+            experience=experience(),
+            cognitive_object=mesh_object(),
+            signal=signal,
+            actor_id="agent:mesh-test",
+            requested_operation="promotion",
+            target_class=policy.M2,
+            downstream_authority=policy.A1,
+            risk_class="low",
+        )
+
+        self.assertEqual(policy.ALLOW_WITH_LEDGER, transition.commit.decision.outcome)
+        self.assertTrue(transition.commit.committed)
+        self.assertIsNotNone(transition.commit.fact_uuid)
+        self.assertEqual(transition.object_ref, transition.proposal.target_reference)
+        self.assertEqual(0.93, transition.proposal.confidence)
+        self.assertIn(("add_episode", "episode:mesh-1"), substrate.write_log)
+
+        active = mesh.recall_active("explicit evidence durable promotion", context=context())
+        self.assertIn(transition.commit.fact_uuid, active.candidate_fact_uuids)
+        self.assertIn(transition.commit.fact_uuid, active.admitted_fact_uuids)
+        self.assertEqual(["memory:mesh-1"], active.active_object_refs)
+
+    def test_reinforcement_confidence_cannot_self_authorize_crystallization(self) -> None:
+        outcomes = []
+        for confidence in (0.01, 1.0):
+            mesh, _ = runtime("EvolveAI")
+            transition = mesh.apply_signal(
+                experience=experience(ref=f"episode:confidence:{confidence}"),
+                cognitive_object=mesh_object(ref=f"memory:confidence:{confidence}"),
+                signal=CognitiveSignal(
+                    module_role="cognitive_metabolism",
+                    source_component="EvolveAI",
+                    signal_type="crystallization_candidate",
+                    estimator_ref="evolveai:crystallizer",
+                    estimator_version="fixture-v1",
+                    confidence=confidence,
+                ),
+                actor_id="agent:optimizer",
+                requested_operation="crystallization",
+                target_class=policy.M2,
+                downstream_authority=policy.A1,
+                risk_class="low",
+            )
+            outcomes.append(transition.commit.decision.outcome)
+            self.assertFalse(transition.commit.committed)
+            self.assertIn("crystallization", transition.commit.decision.prohibited_actions)
+
+        self.assertEqual([policy.REQUIRE_REVIEW, policy.REQUIRE_REVIEW], outcomes)
+
+    def test_codegenome_graph_confidence_cannot_grant_durable_authority(self) -> None:
+        mesh, _ = runtime("CodeGenome")
+        transition = mesh.apply_signal(
+            experience=experience(ref="episode:codegraph", content="Function A calls privileged function B"),
+            cognitive_object=mesh_object(ref="memory:codegraph"),
+            signal=CognitiveSignal(
+                module_role="reality_graph",
+                source_component="CodeGenome",
+                signal_type="graph_relation_confidence",
+                estimator_ref="codegenome:fused-edge",
+                estimator_version="fixture-v1",
+                confidence=1.0,
+            ),
+            actor_id="agent:code",
+            requested_operation="crystallization",
+            target_class=policy.M2,
+            downstream_authority=policy.A1,
+            risk_class="low",
+        )
+
+        self.assertEqual(policy.REQUIRE_REVIEW, transition.commit.decision.outcome)
+        self.assertFalse(transition.commit.committed)
+        self.assertEqual(("codegenome:fused-edge",), transition.proposal.estimator_refs)
+
+    def test_provider_pass_verdict_cannot_grant_external_action_authority(self) -> None:
+        mesh, _ = runtime("PredictiveReference")
+        transition = mesh.apply_signal(
+            experience=experience(ref="episode:prediction", content="Predicted deployment is safe"),
+            cognitive_object=mesh_object(ref="memory:prediction"),
+            signal=CognitiveSignal(
+                module_role="predictive_world_model",
+                source_component="PredictiveReference",
+                signal_type="prediction_confidence",
+                estimator_ref="predictor:deployment",
+                estimator_version="fixture-v1",
+                confidence=1.0,
+                provider_verdict="PASS",
+            ),
+            actor_id="agent:predictor",
+            requested_operation="promotion",
+            target_class=policy.M2,
+            downstream_authority=policy.A4,
+            risk_class="low",
+        )
+
+        self.assertEqual("PASS", transition.signal.provider_verdict)
+        self.assertEqual(policy.REQUIRE_REVIEW, transition.commit.decision.outcome)
+        self.assertFalse(transition.commit.committed)
+        self.assertIn("promotion", transition.commit.decision.prohibited_actions)
+
+    def test_contextual_recall_can_block_already_durable_memory(self) -> None:
+        recall_policy = DeterministicContextualRecallPolicy(
+            policy_ref="policy:mesh-context",
+            policy_version="1.0.0",
+            rules=(
+                ContextualRule(
+                    rule_id="block-sensitive-context",
+                    candidate_ref="memory:context-block",
+                    outcome="block",
+                    reason_code="fixture_context_block",
+                ),
+            ),
+        )
+        mesh, _ = runtime("EvolveAI", recall_policy=recall_policy)
+        transition = mesh.apply_signal(
+            experience=experience(ref="episode:context-block", content="Context-sensitive durable memory"),
+            cognitive_object=mesh_object(ref="memory:context-block"),
+            signal=CognitiveSignal(
+                module_role="cognitive_metabolism",
+                source_component="EvolveAI",
+                signal_type="retention_candidate",
+                confidence=0.8,
+            ),
+            actor_id="agent:mesh-test",
+            requested_operation="promotion",
+            target_class=policy.M2,
+            downstream_authority=policy.A1,
+            risk_class="low",
+        )
+        self.assertTrue(transition.commit.committed)
+
+        active = mesh.recall_active("context sensitive durable memory", context=context())
+        self.assertIn(transition.commit.fact_uuid, active.admitted_fact_uuids)
+        self.assertEqual([], active.active_object_refs)
+        self.assertEqual(
+            "contextual_block",
+            active.refusals[transition.commit.fact_uuid],
+        )
+        self.assertEqual(
+            "current_recall_only",
+            active.contextual_decisions["memory:context-block"]["interpretation"]["authority_effect"],
+        )
+
+    def test_missing_component_fails_explicitly_and_replacement_preserves_logical_identity(self) -> None:
+        mesh, substrate = runtime("EvolveAI")
+        replacement_signal = CognitiveSignal(
+            module_role="cognitive_metabolism",
+            source_component="MetabolismV2",
+            signal_type="retention_candidate",
+            confidence=0.7,
+        )
+        obj = mesh_object(ref="memory:replaceable")
+
+        with self.assertRaises(CognitiveModuleUnavailable):
+            mesh.apply_signal(
+                experience=experience(ref="episode:unavailable"),
+                cognitive_object=obj,
+                signal=replacement_signal,
+                actor_id="agent:mesh-test",
+                requested_operation="promotion",
+                target_class=policy.M2,
+                downstream_authority=policy.A1,
+                risk_class="low",
+            )
+        self.assertEqual([], substrate.write_log)
+
+        mesh.replace_component(old_component="EvolveAI", new_component="MetabolismV2")
+        transition = mesh.apply_signal(
+            experience=experience(ref="episode:replacement"),
+            cognitive_object=obj,
+            signal=replacement_signal,
+            actor_id="agent:mesh-test",
+            requested_operation="promotion",
+            target_class=policy.M2,
+            downstream_authority=policy.A1,
+            risk_class="low",
+        )
+
+        self.assertTrue(transition.commit.committed)
+        self.assertEqual("memory:replaceable", transition.object_ref)
+        self.assertEqual("memory:replaceable", transition.proposal.target_reference)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the first executable ADR-035 evidence slice on top of the now-merged #337 architecture proposal.

This PR adds a deliberately bounded Cognitive Mesh reference path that composes existing Agent Memory primitives rather than creating a parallel memory engine.

### Proven path

```text
experience / observation
  -> stable logical cognitive identity + evidence
  -> typed provider signal
  -> PAMA authority evaluation
  -> governed durable commit or refusal
  -> governed recall
  -> active cognition
```

### Added

- `reference/agentmem_ref/cognitive_mesh.py`
- `reference/tests/test_cognitive_mesh.py` with six focused cases
- deterministic evidence runner
- focused path-scoped GitHub workflow
- bounded runtime-evidence documentation

## Authority boundary

The provider signal may carry estimator identity/version, confidence, evidence refs, and a provider-native verdict. None of those fields selects the PAMA outcome or creates a direct commit path.

The adversarial fixtures require:

```text
reinforcement confidence 1.0 != crystallization authority
graph confidence 1.0 != durable-memory authority
prediction confidence 1.0 + provider PASS != external-action authority
```

## Scope discipline

This PR does **not**:

- accept ADR-035;
- claim a complete cognitive substrate;
- create a closed universal Cognitive Mesh ontology;
- promote EvolveAI or CodeGenome capability maturity;
- change provider packaging or repository boundaries;
- claim production integration with either provider;
- prove restart persistence, learning quality, prediction calibration, or full transitive deletion.

ADR-035 remains Proposed until its full acceptance boundary is independently satisfied.

## History note

#337 was squash-merged to `main`. This evidence branch was then cleanly reset onto that merge and rebuilt with only the five evidence files so the PR no longer carries duplicate stacked history.