### PR TITLE
Wire native CodeGenome Reality Graph into Cognitive Mesh

### DIFF
--- a/.github/workflows/codegenome-reality-mesh-evidence.yml
+++ b/.github/workflows/codegenome-reality-mesh-evidence.yml
@@ -1,0 +1,168 @@
+name: CodeGenome Reality Graph Evidence
+
+on:
+  pull_request:
+    paths:
+      - "reference/agentmem_ref/codegenome_cognitive_mesh.py"
+      - "reference/native/codegenome_reality_driver.rs"
+      - "reference/run_codegenome_cognitive_mesh.py"
+      - "reference/tests/test_codegenome_cognitive_mesh.py"
+      - "reference/agentmem_ref/cognitive_mesh.py"
+      - "reference/agentmem_ref/codegenome_profile.py"
+      - "reference/agentmem_ref/code_graph_qualification.py"
+      - "reference/fixtures/component-qualification/**"
+      - "docs/programs/runtime-evidence/codegenome-reality-mesh.md"
+      - ".github/workflows/codegenome-reality-mesh-evidence.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CODEGENOME_COMMIT: 43a6b7147ec78ec5c616723fa1dd30f342174860
+  EVIDENCE_ROOT: /tmp/codegenome-reality-mesh
+  STORE_DIR: /tmp/codegenome-reality-store
+
+jobs:
+  codegenome-reality-mesh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Agent Memory
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Agent Memory reference dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Run Reality Graph adapter and maturity-boundary tests
+        env:
+          PYTHONPATH: reference
+        run: |
+          python -m unittest \
+            reference/tests/test_codegenome_cognitive_mesh.py \
+            reference/tests/test_cognitive_mesh.py \
+            reference/tests/test_codegenome_multicapability_profile.py \
+            reference/tests/test_code_graph_qualification.py
+
+      - name: Fetch exact CodeGenome provider
+        run: |
+          git clone --filter=blob:none --no-checkout https://github.com/MythologIQ-Labs-LLC/CodeGenome.git /tmp/codegenome
+          git -C /tmp/codegenome fetch --depth=1 origin "$CODEGENOME_COMMIT"
+          git -C /tmp/codegenome checkout --detach "$CODEGENOME_COMMIT"
+          test "$(git -C /tmp/codegenome rev-parse HEAD)" = "$CODEGENOME_COMMIT"
+
+      - name: Verify provider source and rights boundary
+        working-directory: /tmp/codegenome
+        run: |
+          grep -qi "MIT License" LICENSE
+          test -f codegenome-identity/src/graph/edge.rs
+          test -f codegenome-identity/src/graph/node.rs
+          test -f codegenome-identity/src/graph/query.rs
+          test -f codegenome-identity/src/graph/query_context.rs
+          test -f codegenome-identity/src/graph/traversal.rs
+          test -f codegenome-identity/src/store/ondisk.rs
+          mkdir -p "$EVIDENCE_ROOT/source-rights"
+          cp LICENSE "$EVIDENCE_ROOT/source-rights/CodeGenome-LICENSE"
+
+      - name: Build native CodeGenome CLI and index evidence fixture
+        run: |
+          cargo build --manifest-path /tmp/codegenome/Cargo.toml -p codegenome-cli
+          /tmp/codegenome/target/debug/codegenome index \
+            --source-dir "${{ github.workspace }}/reference/fixtures/component-qualification/v2" \
+            --store-dir "$STORE_DIR" \
+            > "$EVIDENCE_ROOT/index.txt"
+
+      - name: Build provider-native Reality Graph driver
+        run: |
+          mkdir -p /tmp/codegenome-reality-driver/src
+          cp reference/native/codegenome_reality_driver.rs /tmp/codegenome-reality-driver/src/main.rs
+          cat > /tmp/codegenome-reality-driver/Cargo.toml <<'EOF'
+          [package]
+          name = "codegenome-reality-driver"
+          version = "0.1.0"
+          edition = "2021"
+
+          [dependencies]
+          codegenome-identity = { path = "/tmp/codegenome/codegenome-identity" }
+          serde_json = "1"
+          EOF
+          cargo build --manifest-path /tmp/codegenome-reality-driver/Cargo.toml
+
+      - name: Execute native CodeGenome traversal and retain raw relation evidence
+        run: |
+          mkdir -p "$EVIDENCE_ROOT"
+          /tmp/codegenome-reality-driver/target/debug/codegenome-reality-driver \
+            "$STORE_DIR" main.rs 6 \
+            > "$EVIDENCE_ROOT/native-relation.json"
+          cat "$EVIDENCE_ROOT/native-relation.json"
+
+      - name: Carry native Reality Graph output through Cognitive Mesh
+        env:
+          PYTHONPATH: reference
+        run: |
+          python reference/run_codegenome_cognitive_mesh.py \
+            --raw "$EVIDENCE_ROOT/native-relation.json" \
+            --output "$EVIDENCE_ROOT/codegenome-reality-mesh.json"
+
+      - name: Validate exact evidence and authority boundary
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["EVIDENCE_ROOT"])
+          raw = json.loads((root / "native-relation.json").read_text())
+          report = json.loads((root / "codegenome-reality-mesh.json").read_text())
+          expected = os.environ["CODEGENOME_COMMIT"]
+
+          assert raw["provider"] == "codegenome"
+          assert raw["provider_version"] == expected
+          assert raw["operation"] == "code_graph_traversal"
+          assert raw["relation"]["kind"] == "Calls"
+          assert len(raw["relation"]["source_uor"]) == 64
+          assert len(raw["relation"]["target_uor"]) == 64
+          assert 0.0 <= raw["relation"]["confidence"] <= 1.0
+          assert raw["relation"]["provenance"]["source"]
+          assert raw["relation"]["provenance"]["actor"]
+
+          assert report["provider"]["component_id"] == "codegenome"
+          assert report["provider"]["component_version"] == expected
+          assert report["normalized_signal"]["module_role"] == "reality_graph"
+          assert report["normalized_signal"]["source_component"] == "codegenome"
+          assert report["normalized_signal"]["signal_type"] == "code_relation_observation"
+          assert report["normalized_signal"]["confidence"] == raw["relation"]["confidence"]
+          assert report["normalized_signal"]["provider_verdict"] == ""
+          assert report["adapter"]["capability_id"] == "code_graph_traversal"
+          assert report["adapter"]["authority_effect"] == "none"
+          assert report["adapter"]["maturity_change"] == "none"
+          assert report["governed_positive_path"]["committed"] is True
+          assert report["governed_positive_path"]["identity_independent"] is True
+          assert report["governed_positive_path"]["active_object_refs"] == ["reality:code:native-call-relation"]
+          assert report["authority_containment"]["pama_outcome"] == "require_review"
+          assert report["authority_containment"]["committed"] is False
+          PY
+
+      - name: Record evidence digests
+        run: |
+          sha256sum \
+            "$EVIDENCE_ROOT/native-relation.json" \
+            "$EVIDENCE_ROOT/codegenome-reality-mesh.json" \
+            "$EVIDENCE_ROOT/index.txt" \
+            > "$EVIDENCE_ROOT/SHA256SUMS"
+          cat "$EVIDENCE_ROOT/SHA256SUMS"
+
+      - name: Upload CodeGenome Reality Graph evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codegenome-reality-mesh-${{ github.event.pull_request.head.sha || github.sha }}
+          path: /tmp/codegenome-reality-mesh
+          if-no-files-found: error

--- a/docs/programs/runtime-evidence/codegenome-reality-mesh.md
+++ b/docs/programs/runtime-evidence/codegenome-reality-mesh.md
@@ -1,0 +1,162 @@
+# CodeGenome Reality Graph -> Cognitive Mesh Evidence
+
+Status: implementation evidence slice; no capability maturity promotion.
+
+This slice implements the first native Code Reality Graph seam under Accepted ADR-035.
+
+## Provider boundary
+
+The provider remains pinned to:
+
+```text
+MythologIQ-Labs-LLC/CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860
+```
+
+That is the same revision already qualified by the `code-graph-traversal-currentness@1.1.0` profile. At this boundary `code_graph_traversal` remains `evidence_proven`; CodeGenome has no `reference_qualified` capability.
+
+This integration does not change those maturity claims.
+
+## Why relation/traversal is the first Reality Graph seam
+
+CodeGenome exposes richer native graph values than its convenience MCP surfaces:
+
+```text
+Node
+  UOR identity
+  kind
+  confidence
+  provenance
+  content hash
+  source span
+
+Edge
+  source UOR
+  target UOR
+  typed relation
+  confidence
+  provenance
+  evidence UORs
+```
+
+The first Agent Memory seam therefore consumes a provider-native relation produced from CodeGenome's fused graph and native traversal APIs.
+
+It deliberately does not use:
+
+- MCP `context` as the canonical seam because that surface reduces graph relations to a count;
+- impact propagation as the first seam because propagated impact is a derived scoring/inference surface rather than a basic Reality Graph observation;
+- CodeGenome governance/experiment verdicts as Agent Memory authority.
+
+## Native evidence path
+
+```text
+pinned CodeGenome source
+  -> native codegenome index of the existing v2 qualification fixture
+  -> fused on-disk overlay
+  -> native symbol resolution
+  -> LocalQueryContext
+  -> graph::traversal::execute
+  -> direct provider-native Calls edge
+       source UOR
+       target UOR
+       relation
+       confidence
+       provenance
+       evidence refs
+  -> raw JSON evidence artifact
+  -> codegenome-code-reality-mesh-adapter@1.0.0
+  -> CognitiveSignal(module_role=reality_graph)
+  -> CognitiveMeshRuntime
+  -> PAMA
+  -> governed durable commit or refusal
+  -> governed recall
+  -> active cognition
+```
+
+The checked-in Rust driver is not a replacement graph engine. It loads CodeGenome's own fused store and executes CodeGenome's own graph types, `LocalQueryContext`, and traversal function at the exact provider pin.
+
+## Identity boundary
+
+CodeGenome UOR identity is provider/domain identity evidence.
+
+It does not silently become Agent Memory's logical Cognitive Mesh identity.
+
+```text
+CodeGenome source UOR
+CodeGenome target UOR
+        !=
+Agent Memory MeshObject.object_ref
+```
+
+The provider UORs are retained as evidence references while Agent Memory owns the logical object reference used for governed durable state and recall.
+
+## Confidence and authority
+
+Native edge confidence is preserved exactly as a provider confidence signal.
+
+```text
+provider confidence
+  -> Proposal.confidence evidence
+  != PAMA outcome
+```
+
+The focused adversarial path sends the same native Reality Graph signal through a crystallization request. Even if CodeGenome reports confidence `1.0`, the provider cannot self-authorize the consequence. PAMA remains controlling and the mutation is refused/review-gated according to Agent Memory policy.
+
+## Provenance and evidence
+
+The adapter preserves:
+
+- exact CodeGenome commit;
+- raw provider artifact digest/reference;
+- source and target UORs;
+- relation kind;
+- native relation confidence;
+- provider provenance source;
+- provider provenance actor;
+- provider provenance timestamp;
+- provider evidence UORs;
+- existing Agent Memory qualification evidence reference.
+
+Normalization does not convert provider provenance into independent corroboration or authority.
+
+## Maturity boundary
+
+This slice proves interoperability of an already-evidenced capability. It does not change CodeGenome's capability profile.
+
+Expected posture remains:
+
+```text
+code_graph_traversal: evidence_proven
+reference_qualified CodeGenome capabilities: 0
+authority effect from this integration: none
+```
+
+Separate evidence would be required to promote any capability maturity.
+
+## Non-claims
+
+This slice does not claim:
+
+- CodeGenome is the universal Cognitive Mesh ontology;
+- all CodeGenome graph overlays are qualified;
+- impact propagation is qualified as predictive cognition;
+- provider confidence is truth or permission;
+- provider UOR is Agent Memory canonical identity;
+- CodeGenome deletion/rebuild residue is fully qualified;
+- MCP GraphRAG/context assembly is qualified;
+- physical repository/package consolidation has been decided;
+- universal production conformance.
+
+## Focused evidence
+
+`.github/workflows/codegenome-reality-mesh-evidence.yml` must prove at the exact PR head:
+
+1. exact provider checkout and MIT source boundary;
+2. existing adapter/profile/qualification regression tests remain green;
+3. native CodeGenome CLI indexes the existing evidence fixture;
+4. the native driver loads the fused overlay and emits a real `Calls` relation;
+5. the raw relation preserves UOR, confidence, provenance, and evidence fields;
+6. the versioned adapter normalizes it into a Reality Plane `CognitiveSignal`;
+7. the signal traverses Cognitive Mesh, PAMA, commit/refusal, recall, and active cognition;
+8. logical mesh identity remains independent of CodeGenome UOR identity;
+9. provider confidence cannot self-authorize crystallization;
+10. CodeGenome capability maturity remains unchanged.

--- a/reference/agentmem_ref/codegenome_cognitive_mesh.py
+++ b/reference/agentmem_ref/codegenome_cognitive_mesh.py
@@ -1,0 +1,166 @@
+"""Normalize pinned native CodeGenome graph observations into Cognitive Mesh signals.
+
+This adapter consumes one provider-native, evidence-bearing relation discovered by
+the already-qualified code_graph_traversal surface and translates it into a
+non-authoritative Reality Plane signal.
+
+Provider UOR identity, confidence, provenance, and evidence remain provider
+claims/evidence. They do not become Agent Memory logical identity or authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from .cognitive_mesh import CognitiveExperience, CognitiveSignal
+from .codegenome_profile import COMPONENT_ID, QUALIFICATION_EVIDENCE_REF, SOURCE_REF
+from .code_graph_qualification import CODEGENOME_COMMIT
+
+ADAPTER_ID = "codegenome-code-reality-mesh-adapter"
+ADAPTER_VERSION = "1.0.0"
+CAPABILITY_ID = "code_graph_traversal"
+SIGNAL_TYPE = "code_relation_observation"
+
+
+class CodeGenomeCognitiveMeshError(ValueError):
+    """Native CodeGenome evidence is absent, stale, or outside this adapter contract."""
+
+
+@dataclass(frozen=True)
+class CodeGenomeNativeRelationObservation:
+    provider_version: str
+    source_uor: str
+    target_uor: str
+    relation: str
+    confidence: float
+    provenance_source: str
+    provenance_actor: str
+    provenance_timestamp_ms: int
+    evidence_uors: tuple[str, ...]
+    raw_evidence_ref: str
+
+
+def _nonempty_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise CodeGenomeCognitiveMeshError(f"{field} must be a non-empty string")
+    return value
+
+
+def _uor(value: object, field: str) -> str:
+    text = _nonempty_string(value, field)
+    if len(text) != 64 or any(ch not in "0123456789abcdef" for ch in text):
+        raise CodeGenomeCognitiveMeshError(
+            f"{field} must be a 64-character lowercase UOR hex value"
+        )
+    return text
+
+
+def _evidence_uors(value: object) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise CodeGenomeCognitiveMeshError("relation.evidence must be a sequence")
+    return tuple(_uor(item, "relation.evidence[]") for item in value)
+
+
+def parse_native_relation_observation(
+    value: Mapping[str, object],
+    *,
+    raw_evidence_ref: str,
+) -> CodeGenomeNativeRelationObservation:
+    """Validate one relation emitted by the pinned provider-native traversal driver."""
+    if value.get("provider") != COMPONENT_ID:
+        raise CodeGenomeCognitiveMeshError("native observation provider must be codegenome")
+    if value.get("provider_version") != CODEGENOME_COMMIT:
+        raise CodeGenomeCognitiveMeshError(
+            f"native observation must bind CodeGenome commit {CODEGENOME_COMMIT}"
+        )
+    if value.get("operation") != "code_graph_traversal":
+        raise CodeGenomeCognitiveMeshError(
+            "native observation must come from code_graph_traversal"
+        )
+    if not raw_evidence_ref:
+        raise CodeGenomeCognitiveMeshError("raw_evidence_ref is required")
+
+    relation = value.get("relation")
+    if not isinstance(relation, Mapping):
+        raise CodeGenomeCognitiveMeshError("native observation is missing relation")
+    confidence = relation.get("confidence")
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+        raise CodeGenomeCognitiveMeshError("relation.confidence must be numeric")
+    confidence = float(confidence)
+    if not 0.0 <= confidence <= 1.0:
+        raise CodeGenomeCognitiveMeshError("relation.confidence must be between 0 and 1")
+
+    provenance = relation.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise CodeGenomeCognitiveMeshError("native relation is missing provenance")
+    timestamp = provenance.get("timestamp_ms")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, int) or timestamp < 0:
+        raise CodeGenomeCognitiveMeshError(
+            "relation provenance timestamp_ms must be a non-negative integer"
+        )
+
+    return CodeGenomeNativeRelationObservation(
+        provider_version=CODEGENOME_COMMIT,
+        source_uor=_uor(relation.get("source_uor"), "relation.source_uor"),
+        target_uor=_uor(relation.get("target_uor"), "relation.target_uor"),
+        relation=_nonempty_string(relation.get("kind"), "relation.kind"),
+        confidence=confidence,
+        provenance_source=_nonempty_string(
+            provenance.get("source"), "relation.provenance.source"
+        ),
+        provenance_actor=_nonempty_string(
+            provenance.get("actor"), "relation.provenance.actor"
+        ),
+        provenance_timestamp_ms=timestamp,
+        evidence_uors=_evidence_uors(relation.get("evidence", [])),
+        raw_evidence_ref=raw_evidence_ref,
+    )
+
+
+def cognitive_signal_from_native_relation(
+    observation: CodeGenomeNativeRelationObservation,
+) -> CognitiveSignal:
+    """Translate provider-native graph evidence into a non-authoritative Reality signal."""
+    provider_evidence = tuple(f"uor:{value}" for value in observation.evidence_uors)
+    return CognitiveSignal(
+        module_role="reality_graph",
+        source_component=COMPONENT_ID,
+        signal_type=SIGNAL_TYPE,
+        evidence_refs=(
+            observation.raw_evidence_ref,
+            SOURCE_REF,
+            QUALIFICATION_EVIDENCE_REF,
+            f"uor:{observation.source_uor}",
+            f"uor:{observation.target_uor}",
+            *provider_evidence,
+        ),
+        estimator_ref=f"{SOURCE_REF}#graph::traversal::execute",
+        estimator_version=observation.provider_version,
+        confidence=observation.confidence,
+        provider_verdict="",
+    )
+
+
+def experience_from_native_relation(
+    observation: CodeGenomeNativeRelationObservation,
+    *,
+    experience_ref: str,
+    observed_at: str,
+) -> CognitiveExperience:
+    """Create the Agent Memory evidence object describing the native relation observation."""
+    return CognitiveExperience(
+        experience_ref=experience_ref,
+        content=(
+            "CodeGenome observed code relation "
+            f"{observation.source_uor} {observation.relation} {observation.target_uor} "
+            f"with provider confidence {observation.confidence:.6f}"
+        ),
+        source_description=(
+            f"{ADAPTER_ID}@{ADAPTER_VERSION}; "
+            f"provider={COMPONENT_ID}@{observation.provider_version}; "
+            f"provenance={observation.provenance_source}:{observation.provenance_actor}; "
+            f"raw={observation.raw_evidence_ref}"
+        ),
+        observed_at=observed_at,
+    )

--- a/reference/native/codegenome_reality_driver.rs
+++ b/reference/native/codegenome_reality_driver.rs
@@ -1,0 +1,165 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use codegenome_identity::graph::edge::{Edge, Relation};
+use codegenome_identity::graph::node::Node;
+use codegenome_identity::graph::overlay::OverlayKind;
+use codegenome_identity::graph::query::Query;
+use codegenome_identity::graph::query_context::LocalQueryContext;
+use codegenome_identity::graph::traversal;
+use codegenome_identity::identity::{address_of, UorAddress};
+use codegenome_identity::store::backend::StoreBackend;
+use codegenome_identity::store::meta;
+use codegenome_identity::store::ondisk::OnDiskStore;
+use serde_json::json;
+
+const PROVIDER_VERSION: &str = "43a6b7147ec78ec5c616723fa1dd30f342174860";
+
+fn normalize_path(value: &str) -> String {
+    let normalized = value.replace('\\', "/");
+    normalized
+        .strip_prefix("./")
+        .unwrap_or(&normalized)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn resolve_indexed_file(store_dir: &Path, requested_file: &str) -> Result<String, String> {
+    let index = meta::load(store_dir)?
+        .ok_or_else(|| format!("no index metadata found at {}", store_dir.display()))?;
+    let requested = normalize_path(requested_file);
+    let mut exact = Vec::new();
+    let mut suffix = Vec::new();
+    for indexed in index.source_hashes.keys() {
+        let normalized = normalize_path(indexed);
+        if normalized == requested {
+            exact.push(indexed.clone());
+        } else if normalized.ends_with(&format!("/{requested}")) {
+            suffix.push(indexed.clone());
+        }
+    }
+    let matches = if exact.is_empty() { suffix } else { exact };
+    match matches.as_slice() {
+        [only] => Ok(only.clone()),
+        [] => Err(format!("file is not present in the index: {requested_file}")),
+        many => Err(format!("file path is ambiguous across {} indexed sources", many.len())),
+    }
+}
+
+fn find_node_at(nodes: &[Node], edges: &[Edge], indexed_file: &str, line: u32) -> Result<UorAddress, String> {
+    let file_addr = address_of(format!("file:{indexed_file}").as_bytes());
+    let contained: HashSet<UorAddress> = edges
+        .iter()
+        .filter(|edge| edge.source == file_addr && edge.relation == Relation::Contains)
+        .map(|edge| edge.target)
+        .collect();
+    let mut candidates: Vec<&Node> = nodes
+        .iter()
+        .filter(|node| contained.contains(&node.address))
+        .filter(|node| {
+            node.span
+                .as_ref()
+                .is_some_and(|span| span.start_line <= line && span.end_line >= line)
+        })
+        .collect();
+    if candidates.is_empty() {
+        return Err(format!("no symbol found at {indexed_file}:{line}"));
+    }
+    candidates.sort_by_key(|node| {
+        node.span
+            .as_ref()
+            .map(|span| span.end_line.saturating_sub(span.start_line))
+            .unwrap_or(u32::MAX)
+    });
+    let best_width = candidates[0]
+        .span
+        .as_ref()
+        .map(|span| span.end_line.saturating_sub(span.start_line))
+        .unwrap_or(u32::MAX);
+    let best: Vec<&Node> = candidates
+        .into_iter()
+        .take_while(|node| {
+            node.span
+                .as_ref()
+                .map(|span| span.end_line.saturating_sub(span.start_line))
+                .unwrap_or(u32::MAX)
+                == best_width
+        })
+        .collect();
+    match best.as_slice() {
+        [only] => Ok(only.address),
+        many => Err(format!("{} equally specific symbols contain line {line}", many.len())),
+    }
+}
+
+fn source_name(value: &codegenome_identity::graph::node::Source) -> String {
+    format!("{value:?}")
+}
+
+fn main() -> Result<(), String> {
+    let mut args = std::env::args().skip(1);
+    let store_dir = args.next().ok_or("usage: driver <store-dir> <file> <line>")?;
+    let file = args.next().ok_or("missing file")?;
+    let line: u32 = args
+        .next()
+        .ok_or("missing line")?
+        .parse()
+        .map_err(|_| "line must be an integer")?;
+
+    let store = OnDiskStore::new(&store_dir);
+    let (nodes, edges) = store
+        .read_overlay(&OverlayKind::Custom("fused".into()))
+        .map_err(|error| error.to_string())?
+        .ok_or("fused overlay unavailable")?;
+    let indexed_file = resolve_indexed_file(Path::new(&store_dir), &file)?;
+    let target = find_node_at(&nodes, &edges, &indexed_file, line)?;
+
+    let ctx = LocalQueryContext::new(&nodes, &edges);
+    let result = traversal::execute(&Query::downstream(target, 2), &ctx);
+    let relation = result
+        .edges
+        .iter()
+        .find(|edge| edge.source == target && edge.relation == Relation::Calls)
+        .ok_or("native downstream traversal produced no direct Calls relation")?;
+    let target_node = nodes
+        .iter()
+        .find(|node| node.address == target)
+        .ok_or("target node missing from fused overlay")?;
+
+    let payload = json!({
+        "schema_version": "1.0.0",
+        "provider": "codegenome",
+        "provider_version": PROVIDER_VERSION,
+        "operation": "code_graph_traversal",
+        "query": {
+            "file": file,
+            "line": line,
+            "direction": "downstream",
+            "max_depth": 2,
+            "native_result_confidence": result.confidence,
+            "path_count": result.paths.len(),
+            "edge_count": result.edges.len()
+        },
+        "target": {
+            "uor": target.to_string(),
+            "kind": format!("{:?}", target_node.kind),
+            "confidence": target_node.confidence,
+            "content_hash": target_node.content_hash.to_string()
+        },
+        "relation": {
+            "source_uor": relation.source.to_string(),
+            "target_uor": relation.target.to_string(),
+            "kind": format!("{:?}", relation.relation),
+            "confidence": relation.confidence,
+            "provenance": {
+                "source": source_name(&relation.provenance.source),
+                "actor": relation.provenance.actor,
+                "timestamp_ms": relation.provenance.timestamp.0,
+                "justification_uor": relation.provenance.justification.map(|value| value.to_string())
+            },
+            "evidence": relation.evidence.iter().map(ToString::to_string).collect::<Vec<_>>()
+        }
+    });
+    println!("{}", serde_json::to_string_pretty(&payload).map_err(|error| error.to_string())?);
+    Ok(())
+}

--- a/reference/run_codegenome_cognitive_mesh.py
+++ b/reference/run_codegenome_cognitive_mesh.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Carry pinned native CodeGenome Reality Graph evidence through the Cognitive Mesh."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext
+from agentmem_ref.cognitive_mesh import CognitiveMeshRuntime, MeshObject
+from agentmem_ref.codegenome_cognitive_mesh import (
+    ADAPTER_ID,
+    ADAPTER_VERSION,
+    CAPABILITY_ID,
+    cognitive_signal_from_native_relation,
+    experience_from_native_relation,
+    parse_native_relation_observation,
+)
+from agentmem_ref.codegenome_profile import COMPONENT_ID, QUALIFICATION_EVIDENCE_REF
+from agentmem_ref.code_graph_qualification import CODEGENOME_COMMIT
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+TENANT = "tenant:codegenome-native-mesh-evidence"
+PROJECT = "project:codegenome-native-mesh-evidence"
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def mesh_runtime() -> CognitiveMeshRuntime:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    return CognitiveMeshRuntime(adapter=adapter, available_components=(COMPONENT_ID,))
+
+
+def mesh_object(ref: str) -> MeshObject:
+    return MeshObject(
+        object_ref=ref,
+        object_type="code_relation_observation",
+        scope=TENANT,
+        isolation_domain_refs=(TENANT, PROJECT),
+        required_isolation_domain_refs=(TENANT, PROJECT),
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def recall_context() -> RecallContext:
+    return RecallContext(
+        target_domain_refs=(TENANT, PROJECT),
+        principal_ref="agent:codegenome-native-mesh-evidence",
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def run(raw_path: Path) -> dict:
+    raw = json.loads(raw_path.read_text(encoding="utf-8"))
+    raw_digest = sha256_file(raw_path)
+    raw_ref = f"artifact://codegenome-native-relation.json#sha256={raw_digest}"
+    observation = parse_native_relation_observation(raw, raw_evidence_ref=raw_ref)
+    signal = cognitive_signal_from_native_relation(observation)
+    experience = experience_from_native_relation(
+        observation,
+        experience_ref="episode:codegenome-native-relation",
+        observed_at="2026-01-01T00:00:00Z",
+    )
+
+    logical_ref = "reality:code:native-call-relation"
+    positive_mesh = mesh_runtime()
+    positive = positive_mesh.apply_signal(
+        experience=experience,
+        cognitive_object=mesh_object(logical_ref),
+        signal=signal,
+        actor_id="agent:codegenome-native-mesh-evidence",
+        requested_operation="promotion",
+        target_class=policy.M2,
+        downstream_authority=policy.A1,
+        risk_class="low",
+    )
+    active = positive_mesh.recall_active(
+        "CodeGenome observed code relation",
+        context=recall_context(),
+    )
+
+    authority_mesh = mesh_runtime()
+    authority = authority_mesh.apply_signal(
+        experience=experience_from_native_relation(
+            observation,
+            experience_ref="episode:codegenome-native-authority-challenge",
+            observed_at="2026-01-01T00:00:00Z",
+        ),
+        cognitive_object=mesh_object("reality:code:native-authority-challenge"),
+        signal=signal,
+        actor_id="agent:codegenome-native-mesh-evidence",
+        requested_operation="crystallization",
+        target_class=policy.M2,
+        downstream_authority=policy.A1,
+        risk_class="low",
+    )
+
+    return {
+        "profile": "adr-035-codegenome-native-reality-mesh-v1",
+        "provider": {
+            "component_id": COMPONENT_ID,
+            "component_version": observation.provider_version,
+            "expected_component_version": CODEGENOME_COMMIT,
+            "source_uor": observation.source_uor,
+            "target_uor": observation.target_uor,
+            "relation": observation.relation,
+            "confidence": observation.confidence,
+            "provenance_source": observation.provenance_source,
+            "provenance_actor": observation.provenance_actor,
+            "provenance_timestamp_ms": observation.provenance_timestamp_ms,
+            "evidence_uors": list(observation.evidence_uors),
+            "raw_evidence_ref": raw_ref,
+        },
+        "adapter": {
+            "adapter_id": ADAPTER_ID,
+            "adapter_version": ADAPTER_VERSION,
+            "capability_id": CAPABILITY_ID,
+            "qualification_evidence_ref": QUALIFICATION_EVIDENCE_REF,
+            "authority_effect": "none",
+            "maturity_change": "none",
+        },
+        "normalized_signal": {
+            "module_role": signal.module_role,
+            "source_component": signal.source_component,
+            "signal_type": signal.signal_type,
+            "estimator_ref": signal.estimator_ref,
+            "estimator_version": signal.estimator_version,
+            "confidence": signal.confidence,
+            "provider_verdict": signal.provider_verdict,
+            "evidence_refs": list(signal.evidence_refs),
+        },
+        "governed_positive_path": {
+            "logical_object_ref": positive.object_ref,
+            "provider_source_uor": observation.source_uor,
+            "provider_target_uor": observation.target_uor,
+            "provider_fact_uuid": positive.commit.fact_uuid,
+            "pama_outcome": positive.commit.decision.outcome,
+            "committed": positive.commit.committed,
+            "receipt_id": positive.commit.receipt["receipt_id"],
+            "active_object_refs": active.active_object_refs,
+            "identity_independent": positive.object_ref not in {
+                f"uor:{observation.source_uor}",
+                f"uor:{observation.target_uor}",
+            },
+        },
+        "authority_containment": {
+            "provider_confidence": signal.confidence,
+            "requested_operation": authority.proposal.operation,
+            "pama_outcome": authority.commit.decision.outcome,
+            "committed": authority.commit.committed,
+            "provider_verdict": signal.provider_verdict,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--raw", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    report = run(args.raw)
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_codegenome_cognitive_mesh.py
+++ b/reference/tests/test_codegenome_cognitive_mesh.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext
+from agentmem_ref.cognitive_mesh import CognitiveMeshRuntime, MeshObject
+from agentmem_ref.codegenome_cognitive_mesh import (
+    CAPABILITY_ID,
+    SIGNAL_TYPE,
+    CodeGenomeCognitiveMeshError,
+    cognitive_signal_from_native_relation,
+    experience_from_native_relation,
+    parse_native_relation_observation,
+)
+from agentmem_ref.codegenome_profile import COMPONENT_ID, QUALIFICATION_EVIDENCE_REF
+from agentmem_ref.code_graph_qualification import CODEGENOME_COMMIT
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+TENANT = "tenant:codegenome-native-mesh"
+PROJECT = "project:codegenome-native-mesh"
+RAW_REF = "artifact://codegenome-native-relation.json#sha256=fixture"
+SOURCE_UOR = "1" * 64
+TARGET_UOR = "2" * 64
+EVIDENCE_UOR = "3" * 64
+
+
+def raw_observation(*, confidence: float = 0.91) -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "provider": "codegenome",
+        "provider_version": CODEGENOME_COMMIT,
+        "operation": "code_graph_traversal",
+        "query": {
+            "file": "main.rs",
+            "line": 6,
+            "direction": "downstream",
+            "max_depth": 2,
+            "native_result_confidence": 1.0,
+            "path_count": 1,
+            "edge_count": 1,
+        },
+        "target": {"uor": SOURCE_UOR, "kind": "Symbol", "confidence": 1.0},
+        "relation": {
+            "source_uor": SOURCE_UOR,
+            "target_uor": TARGET_UOR,
+            "kind": "Calls",
+            "confidence": confidence,
+            "provenance": {
+                "source": "ToolOutput",
+                "actor": "rust-extractor",
+                "timestamp_ms": 123,
+                "justification_uor": None,
+            },
+            "evidence": [EVIDENCE_UOR],
+        },
+    }
+
+
+def mesh_object(ref: str = "reality:code:middle-calls-replacement") -> MeshObject:
+    return MeshObject(
+        object_ref=ref,
+        object_type="code_relation_observation",
+        scope=TENANT,
+        isolation_domain_refs=(TENANT, PROJECT),
+        required_isolation_domain_refs=(TENANT, PROJECT),
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def context() -> RecallContext:
+    return RecallContext(
+        target_domain_refs=(TENANT, PROJECT),
+        principal_ref="agent:codegenome-native-test",
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def runtime() -> CognitiveMeshRuntime:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    return CognitiveMeshRuntime(adapter=adapter, available_components=(COMPONENT_ID,))
+
+
+class CodeGenomeCognitiveMeshTests(unittest.TestCase):
+    def test_native_relation_preserves_provider_evidence_and_confidence(self) -> None:
+        observation = parse_native_relation_observation(raw_observation(), raw_evidence_ref=RAW_REF)
+        signal = cognitive_signal_from_native_relation(observation)
+
+        self.assertEqual(CODEGENOME_COMMIT, observation.provider_version)
+        self.assertEqual("Calls", observation.relation)
+        self.assertEqual(0.91, observation.confidence)
+        self.assertEqual((EVIDENCE_UOR,), observation.evidence_uors)
+        self.assertEqual("reality_graph", signal.module_role)
+        self.assertEqual(COMPONENT_ID, signal.source_component)
+        self.assertEqual(SIGNAL_TYPE, signal.signal_type)
+        self.assertEqual(0.91, signal.confidence)
+        self.assertEqual("", signal.provider_verdict)
+        self.assertIn(RAW_REF, signal.evidence_refs)
+        self.assertIn(f"uor:{SOURCE_UOR}", signal.evidence_refs)
+        self.assertIn(f"uor:{TARGET_UOR}", signal.evidence_refs)
+        self.assertIn(f"uor:{EVIDENCE_UOR}", signal.evidence_refs)
+        self.assertIn(QUALIFICATION_EVIDENCE_REF, signal.evidence_refs)
+        self.assertEqual("code_graph_traversal", CAPABILITY_ID)
+
+    def test_wrong_provider_version_or_operation_fails_closed(self) -> None:
+        wrong_provider = raw_observation()
+        wrong_provider["provider"] = "not-codegenome"
+        with self.assertRaises(CodeGenomeCognitiveMeshError):
+            parse_native_relation_observation(wrong_provider, raw_evidence_ref=RAW_REF)
+
+        wrong_version = raw_observation()
+        wrong_version["provider_version"] = "deadbeef"
+        with self.assertRaises(CodeGenomeCognitiveMeshError):
+            parse_native_relation_observation(wrong_version, raw_evidence_ref=RAW_REF)
+
+        wrong_operation = raw_observation()
+        wrong_operation["operation"] = "impact_propagation"
+        with self.assertRaises(CodeGenomeCognitiveMeshError):
+            parse_native_relation_observation(wrong_operation, raw_evidence_ref=RAW_REF)
+
+    def test_invalid_uor_or_confidence_fails_closed(self) -> None:
+        bad_uor = raw_observation()
+        bad_uor["relation"]["source_uor"] = "not-a-uor"
+        with self.assertRaises(CodeGenomeCognitiveMeshError):
+            parse_native_relation_observation(bad_uor, raw_evidence_ref=RAW_REF)
+
+        bad_confidence = raw_observation(confidence=1.1)
+        with self.assertRaises(CodeGenomeCognitiveMeshError):
+            parse_native_relation_observation(bad_confidence, raw_evidence_ref=RAW_REF)
+
+    def test_native_relation_flows_through_pama_and_recall_without_identity_laundering(self) -> None:
+        observation = parse_native_relation_observation(raw_observation(), raw_evidence_ref=RAW_REF)
+        signal = cognitive_signal_from_native_relation(observation)
+        experience = experience_from_native_relation(
+            observation,
+            experience_ref="episode:codegenome-native-relation",
+            observed_at="2026-01-01T00:00:00Z",
+        )
+        mesh = runtime()
+        logical_ref = "reality:code:middle-calls-replacement"
+
+        transition = mesh.apply_signal(
+            experience=experience,
+            cognitive_object=mesh_object(logical_ref),
+            signal=signal,
+            actor_id="agent:codegenome-native-test",
+            requested_operation="promotion",
+            target_class=policy.M2,
+            downstream_authority=policy.A1,
+            risk_class="low",
+        )
+
+        self.assertTrue(transition.commit.committed)
+        self.assertEqual(policy.ALLOW_WITH_LEDGER, transition.commit.decision.outcome)
+        self.assertEqual(logical_ref, transition.object_ref)
+        self.assertNotEqual(f"uor:{SOURCE_UOR}", transition.object_ref)
+        self.assertEqual(0.91, transition.proposal.confidence)
+        self.assertEqual(CODEGENOME_COMMIT, transition.proposal.estimator_versions[0])
+
+        active = mesh.recall_active("CodeGenome observed code relation Calls", context=context())
+        self.assertEqual([logical_ref], active.active_object_refs)
+
+    def test_perfect_native_graph_confidence_cannot_self_authorize_crystallization(self) -> None:
+        observation = parse_native_relation_observation(
+            raw_observation(confidence=1.0), raw_evidence_ref=RAW_REF
+        )
+        signal = cognitive_signal_from_native_relation(observation)
+        mesh = runtime()
+        transition = mesh.apply_signal(
+            experience=experience_from_native_relation(
+                observation,
+                experience_ref="episode:codegenome-native-authority-challenge",
+                observed_at="2026-01-01T00:00:00Z",
+            ),
+            cognitive_object=mesh_object("reality:code:authority-challenge"),
+            signal=signal,
+            actor_id="agent:codegenome-native-test",
+            requested_operation="crystallization",
+            target_class=policy.M2,
+            downstream_authority=policy.A1,
+            risk_class="low",
+        )
+
+        self.assertEqual(1.0, transition.proposal.confidence)
+        self.assertEqual(policy.REQUIRE_REVIEW, transition.commit.decision.outcome)
+        self.assertFalse(transition.commit.committed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the first native Code Reality Graph seam under Accepted ADR-035 without changing CodeGenome capability maturity.

### Native path

```text
CodeGenome@43a6b7147ec78ec5c616723fa1dd30f342174860
  -> native CLI index of existing qualification fixture
  -> fused on-disk overlay
  -> native symbol resolution
  -> LocalQueryContext
  -> graph::traversal::execute
  -> direct native Calls edge
       source/target UOR
       relation
       confidence
       provenance
       optional evidence UORs
  -> retained raw provider artifact
  -> codegenome-code-reality-mesh-adapter@1.0.0
  -> CognitiveSignal(module_role=reality_graph)
  -> CognitiveMeshRuntime
  -> PAMA
  -> governed durable commit/refusal
  -> governed recall
  -> active cognition
```

### Why this seam

The existing CodeGenome MCP `context` surface is too lossy for a canonical Reality Graph boundary because it reduces graph relations to aggregate context. Impact propagation is a derived score surface and is not used as the first Reality Plane observation.

The selected seam reuses CodeGenome's only currently `evidence_proven` Agent Memory capability: `code_graph_traversal`.

### Exact observed evidence

The native fixture produced a `Calls` relation with provider confidence `0.7`, stable source/target UORs, and provenance actor `heuristic-resolver` / source `Inferred`. The provider relation's `evidence` array was empty for this fixture. The contract therefore preserves provider evidence UORs when present but does not require or synthesize them when absent.

### Boundary preservation

- exact existing CodeGenome qualification pin retained;
- provider UOR remains provider/domain identity evidence, not Agent Memory logical identity;
- native relation confidence is preserved as proposal evidence only;
- provenance survives normalization and provider evidence UORs survive when supplied;
- empty provider evidence arrays remain empty rather than being fabricated;
- PAMA remains the only consequence-authority boundary;
- perfect provider confidence cannot self-authorize crystallization;
- no provider-native verdict becomes Agent Memory authority;
- CodeGenome capability maturity remains unchanged (`code_graph_traversal = evidence_proven`, zero `reference_qualified`).

## Non-claims

This PR does not qualify CodeGenome GraphRAG, impact propagation, deletion/rebuild completeness, or all graph overlays. It does not select physical monorepo/submodule/package composition and does not make CodeGenome's ontology canonical Cognitive Mesh semantics.

## Roadmap

Resolves P04 and provides the evidence needed to resolve D03: the first CodeGenome Reality Graph integration boundary is the provenance-bearing native relation/traversal seam carrying UOR identity, typed relation, confidence, provenance, and optional evidence references.