### PR TITLE
Capability Contract v3: frontier semantics and substrate portability

### DIFF
--- a/docs/programs/memory-modules/capability-vocabulary.md
+++ b/docs/programs/memory-modules/capability-vocabulary.md
@@ -2,7 +2,7 @@
 
 Status: **research conclusion / implementation vocabulary candidate**
 
-Issues: #274, #284, #286, #287, #290, #291
+Issues: #274, #284, #286, #287, #290, #291, #343
 
 ## Purpose
 
@@ -16,6 +16,8 @@ capability presence != capability maturity
 candidate retrieval != recall admission
 memory representation != memory truth
 memory procedure != execution permission
+behavioral compatibility != operational compatibility
+operational quality != authority
 ```
 
 ## Capability maturity
@@ -43,11 +45,15 @@ These describe what kind of retained state a component can materially represent.
 | `transient_memory` | Retained state expected to be short-lived or cheaply disposable. | Transience is lifecycle posture, not a storage technology. |
 | `episodic_event_memory` | Event/interaction traces preserving time, sequence, source, or episode context. | An event may be historically true without remaining current guidance. |
 | `semantic_fact_memory` | Retained declarative facts, assertions, concepts, or stable summaries. | Consolidated meaning remains derived from evidence unless independently established. |
+| `epistemic_belief_memory` | Retained claims, beliefs, hypotheses, confidence, supporting/contradicting evidence, and revision state. | Belief remains distinct from fact, observed history, and authority even when confidence is high. |
+| `predictive_counterfactual_memory` | Retained predictions, simulations, expected outcomes, counterfactual trajectories, and later outcome comparisons. | Predicted or simulated history must not become observed history by storage accident. |
 | `procedural_skill_memory` | Retained reusable procedures, skills, playbooks, strategies, or action guidance. | Retention/retrieval is not activation or execution authority. |
 | `resource_artifact_memory` | Retained files, documents, media, tool outputs, templates, or other reusable artifacts. | Artifact availability does not imply admissibility or execution permission. |
 | `negative_failure_memory` | Retained failures, anti-patterns, rejected paths, hazards, or negative precedents. | Similarity to a failure is risk evidence, not an autonomous block/allow verdict. |
 | `policy_memory` | Retained policy or policy-like state whose currentness materially affects permitted behavior. | Governed separately by high-authority policy-memory doctrine. |
 | `metamemory_policy` | Retained/evolved procedures for how future memory should be extracted, consolidated, routed, retrieved, ranked, pruned, or forgotten. | This changes the memory system's future behavior and is not ordinary procedural memory authority. |
+
+`epistemic_belief_memory` exists because a belief or hypothesis needs revision and contradiction semantics without being laundered into `semantic_fact_memory`. `predictive_counterfactual_memory` exists because simulated or expected trajectories need later comparison with outcomes while retaining an explicit boundary from observation.
 
 `metamemory_policy` is intentionally named as a capability surface rather than a new authority class. MemSkill-style memory skills and EvolveMem-style retrieval evolution demonstrate that memory systems can learn *how to remember* independently from what they remember. Under Agent Memory, those learned outputs remain proposals to a governed configuration/maintenance path.
 
@@ -180,6 +186,61 @@ These capabilities are constrained by ADR-022 isolation and governed boundary cr
 
 Multimodal support is not one yes/no capability because ingestion, representation, and retrieval may mature independently.
 
+## Capability Contract v3: behavior and operation remain separate
+
+`component-capability-v2` made lifecycle behavior explicit. `component-capability-v3` preserves that contract and adds a separate substrate operational contract.
+
+```text
+behavior_contract
+  operation support
+  currentness
+  invalidation
+  correction
+  deletion
+  residue
+  migration / rebuild
+  structural mutation requirement
+
+!=
+
+operational_contract
+  write atomicity
+  concurrency control
+  idempotency
+  restart recovery
+  reconciliation
+```
+
+This distinction is required for replaceability. Two providers can both expose `graph_state`, `epistemic_belief_memory`, or another identical capability while having materially different transaction, replay, and recovery guarantees.
+
+A v3 provider therefore declares both contracts. A routing requirement may constrain operational properties in addition to capability identity, maturity, state/scope posture, and behavior. If a provider cannot satisfy the required operational posture, it is ineligible even when it exposes the requested capability.
+
+An explicitly preferred provider that is operationally ineligible fails resolution. Agent Memory does not silently fall back merely to make a configuration appear successful. Equally qualified providers remain ambiguous unless an explicit preference resolves the choice.
+
+Operational quality remains non-authoritative:
+
+```text
+atomic write != permission
+idempotent replay != permission
+restart recovery != correctness
+reconciliation != lifecycle completion
+provider selection != PAMA authority
+```
+
+Persistent state is not sufficient evidence that governance-critical interpretation survived reconstruction. Likewise, successful readback or reconciliation is evidence about substrate behavior, not proof that a memory consequence was authorized or that its lifecycle completed correctly.
+
+### Operational contract vocabulary
+
+| Dimension | Values | Meaning |
+|---|---|---|
+| `write_atomicity` | `none`, `process_local`, `single_record_atomic`, `transactional_multi_record` | What atomic write boundary the provider can establish. |
+| `concurrency_control` | `none`, `process_local`, `optimistic_revision`, `pessimistic_lock`, `serializable` | How conflicting concurrent mutations are detected or ordered. |
+| `idempotency` | `none`, `process_local`, `durable_keyed` | Whether repeated operations can be recognized safely across the relevant persistence boundary. |
+| `restart_recovery` | `none`, `process_local_only`, `reconstructable`, `checkpoint_replay` | Whether governance-relevant runtime state can be reconstructed after process loss. |
+| `reconciliation` | `none`, `process_local_only`, `deterministic_readback`, `authoritative_rebuild` | Whether persisted/materialized state can be independently checked and repaired against its authority/source basis. |
+
+A process-local-only provider cannot satisfy a requirement for durable restart reconstruction or independent reconciliation simply because its in-process tests are tidy. Processes, regrettably, do eventually stop.
+
 ### Operational/evidence capabilities
 
 These help qualify components but are not themselves memory authority:
@@ -192,6 +253,8 @@ These help qualify components but are not themselves memory authority:
 | `provenance_binding` | Bind retained/derived state to source/evidence identities. |
 | `evaluation_harness` | Execute repeatable quality/fitness experiments against a component or memory strategy. |
 | `agent_protocol_exposure` | Expose component operations through MCP or equivalent agent-facing protocol. |
+
+These capability names remain useful for describing supplied functions. The v3 `operational_contract` is different: it describes execution guarantees that may make a provider eligible or ineligible for a requested capability operation.
 
 ## Core responsibilities that are not delegated capabilities
 
@@ -221,7 +284,7 @@ One memory operation may legitimately use several capabilities:
 source episode
   -> episodic_event_memory
   -> consolidation_synthesis
-  -> semantic_fact_memory + procedural_skill_memory
+  -> semantic_fact_memory + epistemic_belief_memory + procedural_skill_memory
   -> vector_representation
   -> graph_state
   -> lexical/vector/graph candidate retrieval
@@ -229,7 +292,9 @@ source episode
   -> Agent Memory recall admission
 ```
 
-Each stage must retain enough provenance/currentness information that stale, superseded, foreign-scope, or deleted source state cannot be laundered through a later representation.
+Predictive/counterfactual state may participate in planning or comparison, but it remains explicitly typed as predictive/counterfactual until later evidence records an observed outcome.
+
+Each stage must retain enough provenance/currentness information that stale, superseded, foreign-scope, deleted, hypothetical, or predicted source state cannot be laundered through a later representation.
 
 ## Implications for current first-party systems
 
@@ -243,4 +308,6 @@ CodeGenome spans code-domain graph state/query/traversal, structural reasoning, 
 
 ## Research implication
 
-Future comparisons should score **capability behavior and maturity**, not whole products. A system can outperform another in vector candidate retrieval while underperforming it in lifecycle correction or procedural memory. A single product leaderboard erases exactly the architectural information this program needs.
+Future comparisons should score **capability behavior, operational posture, and maturity**, not whole products. A system can outperform another in vector candidate retrieval while underperforming it in lifecycle correction, restart recovery, idempotency, or procedural memory. A single product leaderboard erases exactly the architectural information this program needs.
+
+External providers should be qualified against this contract in later adaptor slices. No external SDK is required to prove v3 itself.

--- a/reference/agentmem_ref/capabilities.py
+++ b/reference/agentmem_ref/capabilities.py
@@ -1,13 +1,15 @@
 """Capability declarations and deterministic component resolution.
 
-This module is the narrow executable surface for ADR-033 and issues #287/#290/#280.
+This module is the narrow executable surface for ADR-033 and issues #287/#290/#280/#343.
 It deliberately does not know about PAMA, recall admission, or memory mutation.
 Selecting a component says only which configured implementation may supply a
 capability. It never grants authority to use the resulting memory consequence.
 
 ``component-capability-v2`` adds machine-readable behavior metadata for the
-lifecycle dimensions required by #280. Those fields describe what a capability
-supports and how its state relates to canonical memory; they are not authority.
+lifecycle dimensions required by #280. ``component-capability-v3`` preserves
+that behavior contract and adds a separate operational contract so substrate
+mechanics can constrain provider eligibility without becoming memory semantics
+or authority.
 """
 
 from __future__ import annotations
@@ -83,6 +85,47 @@ STRUCTURAL_MUTATION_REQUIREMENTS = frozenset(
         "proposal_only",
         "pama_required",
         "external_authorization_required",
+    }
+)
+
+WRITE_ATOMICITY_MODELS = frozenset(
+    {
+        "none",
+        "process_local",
+        "single_record_atomic",
+        "transactional_multi_record",
+    }
+)
+CONCURRENCY_CONTROL_MODELS = frozenset(
+    {
+        "none",
+        "process_local",
+        "optimistic_revision",
+        "pessimistic_lock",
+        "serializable",
+    }
+)
+IDEMPOTENCY_MODELS = frozenset(
+    {
+        "none",
+        "process_local",
+        "durable_keyed",
+    }
+)
+RESTART_RECOVERY_MODELS = frozenset(
+    {
+        "none",
+        "process_local_only",
+        "reconstructable",
+        "checkpoint_replay",
+    }
+)
+RECONCILIATION_MODELS = frozenset(
+    {
+        "none",
+        "process_local_only",
+        "deterministic_readback",
+        "authoritative_rebuild",
     }
 )
 
@@ -270,6 +313,105 @@ class CapabilityBehaviorRequirement:
 
 
 @dataclass(frozen=True)
+class CapabilityOperationalContract:
+    """Substrate mechanics that affect provider eligibility, not memory meaning.
+
+    Operational quality cannot grant authority. It only describes whether a
+    provider can safely satisfy a caller's explicit execution/recovery posture.
+    """
+
+    write_atomicity: str
+    concurrency_control: str
+    idempotency: str
+    restart_recovery: str
+    reconciliation: str
+
+    def __post_init__(self) -> None:
+        checks = (
+            ("write_atomicity", self.write_atomicity, WRITE_ATOMICITY_MODELS),
+            ("concurrency_control", self.concurrency_control, CONCURRENCY_CONTROL_MODELS),
+            ("idempotency", self.idempotency, IDEMPOTENCY_MODELS),
+            ("restart_recovery", self.restart_recovery, RESTART_RECOVERY_MODELS),
+            ("reconciliation", self.reconciliation, RECONCILIATION_MODELS),
+        )
+        for name, value, allowed in checks:
+            if value not in allowed:
+                raise ValueError(f"unknown {name}: {value}")
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "CapabilityOperationalContract":
+        return cls(
+            write_atomicity=str(value["write_atomicity"]),
+            concurrency_control=str(value["concurrency_control"]),
+            idempotency=str(value["idempotency"]),
+            restart_recovery=str(value["restart_recovery"]),
+            reconciliation=str(value["reconciliation"]),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "write_atomicity": self.write_atomicity,
+            "concurrency_control": self.concurrency_control,
+            "idempotency": self.idempotency,
+            "restart_recovery": self.restart_recovery,
+            "reconciliation": self.reconciliation,
+        }
+
+
+@dataclass(frozen=True)
+class CapabilityOperationalRequirement:
+    """Optional routing constraints over substrate operational guarantees."""
+
+    write_atomicity: tuple[str, ...] = ()
+    concurrency_control: tuple[str, ...] = ()
+    idempotency: tuple[str, ...] = ()
+    restart_recovery: tuple[str, ...] = ()
+    reconciliation: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        checks = (
+            ("write_atomicity", self.write_atomicity, WRITE_ATOMICITY_MODELS),
+            ("concurrency_control", self.concurrency_control, CONCURRENCY_CONTROL_MODELS),
+            ("idempotency", self.idempotency, IDEMPOTENCY_MODELS),
+            ("restart_recovery", self.restart_recovery, RESTART_RECOVERY_MODELS),
+            ("reconciliation", self.reconciliation, RECONCILIATION_MODELS),
+        )
+        for name, values, allowed in checks:
+            unknown = sorted(set(values).difference(allowed))
+            if unknown:
+                raise ValueError(f"unknown operational requirement {name}: {unknown}")
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "CapabilityOperationalRequirement":
+        return cls(
+            write_atomicity=tuple(str(item) for item in value.get("write_atomicity", ())),
+            concurrency_control=tuple(str(item) for item in value.get("concurrency_control", ())),
+            idempotency=tuple(str(item) for item in value.get("idempotency", ())),
+            restart_recovery=tuple(str(item) for item in value.get("restart_recovery", ())),
+            reconciliation=tuple(str(item) for item in value.get("reconciliation", ())),
+        )
+
+    def matches(self, contract: CapabilityOperationalContract) -> bool:
+        checks = (
+            (self.write_atomicity, contract.write_atomicity),
+            (self.concurrency_control, contract.concurrency_control),
+            (self.idempotency, contract.idempotency),
+            (self.restart_recovery, contract.restart_recovery),
+            (self.reconciliation, contract.reconciliation),
+        )
+        return all(not allowed or actual in allowed for allowed, actual in checks)
+
+    def to_dict(self) -> dict:
+        return {
+            "write_atomicity": list(self.write_atomicity),
+            "concurrency_control": list(self.concurrency_control),
+            "idempotency": list(self.idempotency),
+            "restart_recovery": list(self.restart_recovery),
+            "reconciliation": list(self.reconciliation),
+        }
+
+
+@dataclass(frozen=True)
 class CapabilityDeclaration:
     capability_id: str
     capability_version: str
@@ -282,6 +424,7 @@ class CapabilityDeclaration:
     limitations: tuple[str, ...] = ()
     enabled: bool = True
     behavior_contract: CapabilityBehaviorContract | None = None
+    operational_contract: CapabilityOperationalContract | None = None
 
     def __post_init__(self) -> None:
         if not self.capability_id or not self.capability_version:
@@ -299,6 +442,14 @@ class CapabilityDeclaration:
             if not isinstance(behavior_raw, Mapping):
                 raise ValueError("capability behavior_contract must be an object")
             behavior = CapabilityBehaviorContract.from_dict(behavior_raw)
+
+        operational_raw = value.get("operational_contract")
+        operational = None
+        if operational_raw is not None:
+            if not isinstance(operational_raw, Mapping):
+                raise ValueError("capability operational_contract must be an object")
+            operational = CapabilityOperationalContract.from_dict(operational_raw)
+
         return cls(
             capability_id=str(value["capability_id"]),
             capability_version=str(value["capability_version"]),
@@ -311,6 +462,7 @@ class CapabilityDeclaration:
             limitations=tuple(str(item) for item in value.get("limitations", ())),
             enabled=bool(value.get("enabled", True)),
             behavior_contract=behavior,
+            operational_contract=operational,
         )
 
     def to_dict(self) -> dict:
@@ -328,6 +480,8 @@ class CapabilityDeclaration:
         }
         if self.behavior_contract is not None:
             payload["behavior_contract"] = self.behavior_contract.to_dict()
+        if self.operational_contract is not None:
+            payload["operational_contract"] = self.operational_contract.to_dict()
         return payload
 
 
@@ -351,15 +505,29 @@ class ComponentDeclaration:
             if identity in seen:
                 raise ValueError(f"duplicate capability declaration: {identity}")
             seen.add(identity)
-        if self.profile_version == "component-capability-v2":
-            missing = [
+
+        if self.profile_version in {"component-capability-v2", "component-capability-v3"}:
+            missing_behavior = [
                 capability.capability_id
                 for capability in self.capabilities
                 if capability.behavior_contract is None
             ]
-            if missing:
+            if missing_behavior:
                 raise ValueError(
-                    f"component-capability-v2 requires behavior_contract for every capability: {missing}"
+                    f"{self.profile_version} requires behavior_contract for every capability: "
+                    f"{missing_behavior}"
+                )
+
+        if self.profile_version == "component-capability-v3":
+            missing_operational = [
+                capability.capability_id
+                for capability in self.capabilities
+                if capability.operational_contract is None
+            ]
+            if missing_operational:
+                raise ValueError(
+                    "component-capability-v3 requires operational_contract for every capability: "
+                    f"{missing_operational}"
                 )
 
     @classmethod
@@ -401,6 +569,7 @@ class CapabilityRequirement:
     allowed_components: tuple[str, ...] = ()
     preferred_component: str = ""
     behavior_requirement: CapabilityBehaviorRequirement | None = None
+    operational_requirement: CapabilityOperationalRequirement | None = None
 
     def __post_init__(self) -> None:
         if self.minimum_maturity not in _MATURITY_RANK:
@@ -422,6 +591,7 @@ class ResolvedCapability:
     evidence_refs: tuple[str, ...] = ()
     limitations: tuple[str, ...] = ()
     behavior_contract: CapabilityBehaviorContract | None = None
+    operational_contract: CapabilityOperationalContract | None = None
 
     def to_dict(self) -> dict:
         payload = {
@@ -440,6 +610,8 @@ class ResolvedCapability:
         }
         if self.behavior_contract is not None:
             payload["behavior_contract"] = self.behavior_contract.to_dict()
+        if self.operational_contract is not None:
+            payload["operational_contract"] = self.operational_contract.to_dict()
         return payload
 
 
@@ -490,6 +662,11 @@ class ComponentRegistry:
                     if capability.behavior_contract is None:
                         continue
                     if not requirement.behavior_requirement.matches(capability.behavior_contract):
+                        continue
+                if requirement.operational_requirement is not None:
+                    if capability.operational_contract is None:
+                        continue
+                    if not requirement.operational_requirement.matches(capability.operational_contract):
                         continue
                 eligible.append((component, capability))
 
@@ -544,4 +721,5 @@ def _resolved(component: ComponentDeclaration, capability: CapabilityDeclaration
         evidence_refs=capability.evidence_refs,
         limitations=capability.limitations,
         behavior_contract=capability.behavior_contract,
+        operational_contract=capability.operational_contract,
     )

--- a/reference/fixtures/component-capabilities/frontier-v3-reference.json
+++ b/reference/fixtures/component-capabilities/frontier-v3-reference.json
@@ -1,0 +1,69 @@
+{
+  "component_id": "synthetic-frontier-store",
+  "component_version": "1.0.0",
+  "profile_version": "component-capability-v3",
+  "enabled": true,
+  "failure_posture": "fail_closed",
+  "runtime_ref": "reference.synthetic.frontier",
+  "provenance_refs": ["issue:#343"],
+  "capabilities": [
+    {
+      "capability_id": "epistemic_belief_memory",
+      "capability_version": "1.0",
+      "maturity": "implemented",
+      "state_posture": "derived",
+      "scope_posture": "enforces_agent_memory_scope",
+      "failure_posture": "fail_closed",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": ["issue:#343"],
+      "limitations": ["synthetic contract proof only"],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": true},
+        "currentness_model": "basis_versioned",
+        "invalidation_model": "version_relation",
+        "correction_model": "invalidate_derived",
+        "deletion_model": "derived_residue_then_purge",
+        "residue_model": "scan_required",
+        "migration_rebuild_model": "rebuild_from_canonical",
+        "structural_mutation_requirement": "pama_required"
+      },
+      "operational_contract": {
+        "write_atomicity": "single_record_atomic",
+        "concurrency_control": "optimistic_revision",
+        "idempotency": "durable_keyed",
+        "restart_recovery": "reconstructable",
+        "reconciliation": "deterministic_readback"
+      }
+    },
+    {
+      "capability_id": "predictive_counterfactual_memory",
+      "capability_version": "1.0",
+      "maturity": "declared",
+      "state_posture": "derived",
+      "scope_posture": "enforces_agent_memory_scope",
+      "failure_posture": "explicit_unavailable",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": ["issue:#343"],
+      "limitations": ["prediction and simulation remain distinct from observed history"],
+      "behavior_contract": {
+        "operation_support": {"write": true, "read": true, "recall_candidate": true},
+        "currentness_model": "basis_versioned",
+        "invalidation_model": "version_relation",
+        "correction_model": "invalidate_derived",
+        "deletion_model": "derived_residue_then_purge",
+        "residue_model": "scan_required",
+        "migration_rebuild_model": "rebuild_from_canonical",
+        "structural_mutation_requirement": "pama_required"
+      },
+      "operational_contract": {
+        "write_atomicity": "single_record_atomic",
+        "concurrency_control": "optimistic_revision",
+        "idempotency": "durable_keyed",
+        "restart_recovery": "reconstructable",
+        "reconciliation": "deterministic_readback"
+      }
+    }
+  ]
+}

--- a/reference/tests/test_component_capabilities_v3.py
+++ b/reference/tests/test_component_capabilities_v3.py
@@ -1,0 +1,293 @@
+"""Capability Contract v3 tests for issue #343."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agentmem_ref.capabilities import (  # noqa: E402
+    AmbiguousCapabilityError,
+    CapabilityBehaviorContract,
+    CapabilityDeclaration,
+    CapabilityOperationalContract,
+    CapabilityOperationalRequirement,
+    CapabilityRequirement,
+    CapabilityResolutionError,
+    ComponentDeclaration,
+    ComponentRegistry,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = ROOT / "schemas" / "component-capability-profile.schema.json"
+FIXTURE = ROOT / "reference" / "fixtures" / "component-capabilities" / "frontier-v3-reference.json"
+
+
+def behavior() -> CapabilityBehaviorContract:
+    return CapabilityBehaviorContract(
+        write=True,
+        read=True,
+        recall_candidate=True,
+        currentness_model="basis_versioned",
+        invalidation_model="version_relation",
+        correction_model="invalidate_derived",
+        deletion_model="derived_residue_then_purge",
+        residue_model="scan_required",
+        migration_rebuild_model="rebuild_from_canonical",
+        structural_mutation_requirement="pama_required",
+    )
+
+
+def operational(*, durable: bool = True) -> CapabilityOperationalContract:
+    if durable:
+        return CapabilityOperationalContract(
+            write_atomicity="single_record_atomic",
+            concurrency_control="optimistic_revision",
+            idempotency="durable_keyed",
+            restart_recovery="reconstructable",
+            reconciliation="deterministic_readback",
+        )
+    return CapabilityOperationalContract(
+        write_atomicity="process_local",
+        concurrency_control="process_local",
+        idempotency="process_local",
+        restart_recovery="process_local_only",
+        reconciliation="process_local_only",
+    )
+
+
+def component(
+    component_id: str,
+    capability_id: str = "epistemic_belief_memory",
+    *,
+    maturity: str = "runtime_wired",
+    durable: bool = True,
+    authority_effect: str = "none",
+    profile_version: str = "component-capability-v3",
+) -> ComponentDeclaration:
+    capability = CapabilityDeclaration(
+        capability_id=capability_id,
+        capability_version="1.0",
+        maturity=maturity,
+        state_posture="derived",
+        scope_posture="enforces_agent_memory_scope",
+        failure_posture="fail_closed",
+        authority_effect=authority_effect,
+        behavior_contract=behavior(),
+        operational_contract=operational(durable=durable),
+    )
+    return ComponentDeclaration(
+        component_id=component_id,
+        component_version="1.0.0",
+        profile_version=profile_version,
+        failure_posture="fail_closed",
+        capabilities=(capability,),
+    )
+
+
+class ComponentCapabilityV3Tests(unittest.TestCase):
+    def test_v3_fixture_validates_and_frontier_capabilities_are_independent(self):
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        value = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(value)
+        parsed = ComponentDeclaration.from_dict(value)
+        self.assertEqual(
+            [item.capability_id for item in parsed.capabilities],
+            ["epistemic_belief_memory", "predictive_counterfactual_memory"],
+        )
+        self.assertNotEqual(parsed.capabilities[0].maturity, parsed.capabilities[1].maturity)
+
+    def test_v1_and_v2_remain_backwards_compatible(self):
+        v1 = ComponentDeclaration(
+            component_id="legacy-v1",
+            component_version="9.0.0",
+            profile_version="component-capability-v1",
+            failure_posture="fail_closed",
+            capabilities=(
+                CapabilityDeclaration(
+                    "procedural_skill_memory",
+                    "1.0",
+                    "declared",
+                    "canonical",
+                    "enforces_agent_memory_scope",
+                    "fail_closed",
+                ),
+            ),
+        )
+        v2 = ComponentDeclaration(
+            component_id="legacy-v2",
+            component_version="1.0.0",
+            profile_version="component-capability-v2",
+            failure_posture="fail_closed",
+            capabilities=(
+                CapabilityDeclaration(
+                    "procedural_skill_memory",
+                    "1.0",
+                    "implemented",
+                    "canonical",
+                    "enforces_agent_memory_scope",
+                    "fail_closed",
+                    behavior_contract=behavior(),
+                ),
+            ),
+        )
+        self.assertIsNone(v1.capabilities[0].behavior_contract)
+        self.assertIsNone(v2.capabilities[0].operational_contract)
+
+    def test_v3_requires_behavior_and_operational_contracts(self):
+        with self.assertRaisesRegex(ValueError, "behavior_contract"):
+            ComponentDeclaration(
+                component_id="bad-v3-behavior",
+                component_version="1.0.0",
+                profile_version="component-capability-v3",
+                failure_posture="fail_closed",
+                capabilities=(
+                    CapabilityDeclaration(
+                        "epistemic_belief_memory",
+                        "1.0",
+                        "declared",
+                        "derived",
+                        "enforces_agent_memory_scope",
+                        "fail_closed",
+                        operational_contract=operational(),
+                    ),
+                ),
+            )
+        with self.assertRaisesRegex(ValueError, "operational_contract"):
+            ComponentDeclaration(
+                component_id="bad-v3-operational",
+                component_version="1.0.0",
+                profile_version="component-capability-v3",
+                failure_posture="fail_closed",
+                capabilities=(
+                    CapabilityDeclaration(
+                        "epistemic_belief_memory",
+                        "1.0",
+                        "declared",
+                        "derived",
+                        "enforces_agent_memory_scope",
+                        "fail_closed",
+                        behavior_contract=behavior(),
+                    ),
+                ),
+            )
+
+    def test_operational_requirement_filters_otherwise_valid_provider(self):
+        requirement = CapabilityRequirement(
+            "epistemic_belief_memory",
+            "runtime_wired",
+            operational_requirement=CapabilityOperationalRequirement(
+                idempotency=("durable_keyed",),
+                restart_recovery=("reconstructable", "checkpoint_replay"),
+                reconciliation=("deterministic_readback", "authoritative_rebuild"),
+            ),
+        )
+        registry = ComponentRegistry()
+        registry.register(component("durable"))
+        registry.register(component("process-local", durable=False))
+        resolved = registry.resolve(requirement)
+        self.assertEqual(resolved.component_id, "durable")
+
+    def test_preferred_operationally_ineligible_provider_does_not_fallback(self):
+        registry = ComponentRegistry(preferences={"epistemic_belief_memory": "preferred"})
+        registry.register(component("preferred", durable=False))
+        registry.register(component("eligible"))
+        requirement = CapabilityRequirement(
+            "epistemic_belief_memory",
+            "runtime_wired",
+            operational_requirement=CapabilityOperationalRequirement(
+                restart_recovery=("reconstructable", "checkpoint_replay"),
+            ),
+        )
+        with self.assertRaises(CapabilityResolutionError) as context:
+            registry.resolve(requirement)
+        self.assertIn("preferred provider", str(context.exception))
+
+    def test_equally_qualified_providers_remain_explicitly_ambiguous(self):
+        registry = ComponentRegistry()
+        registry.register_many((component("a"), component("b")))
+        requirement = CapabilityRequirement(
+            "epistemic_belief_memory",
+            "runtime_wired",
+            operational_requirement=CapabilityOperationalRequirement(
+                idempotency=("durable_keyed",),
+            ),
+        )
+        with self.assertRaises(AmbiguousCapabilityError):
+            registry.resolve(requirement)
+
+    def test_process_local_provider_cannot_satisfy_restart_or_reconciliation_requirement(self):
+        registry = ComponentRegistry()
+        registry.register(component("process-local", durable=False))
+        for operational_requirement in (
+            CapabilityOperationalRequirement(restart_recovery=("reconstructable",)),
+            CapabilityOperationalRequirement(reconciliation=("deterministic_readback",)),
+        ):
+            with self.assertRaises(CapabilityResolutionError):
+                registry.resolve(
+                    CapabilityRequirement(
+                        "epistemic_belief_memory",
+                        "runtime_wired",
+                        operational_requirement=operational_requirement,
+                    )
+                )
+
+    def test_provider_substitution_preserves_requested_semantics_and_authority(self):
+        requirement = CapabilityRequirement(
+            "epistemic_belief_memory",
+            "runtime_wired",
+            operational_requirement=CapabilityOperationalRequirement(
+                idempotency=("durable_keyed",),
+                restart_recovery=("reconstructable",),
+            ),
+        )
+        first = ComponentRegistry()
+        first.register(component("provider-a"))
+        second = ComponentRegistry()
+        second.register(component("provider-b"))
+
+        resolved_a = first.resolve(requirement)
+        resolved_b = second.resolve(requirement)
+        self.assertEqual(resolved_a.capability_id, resolved_b.capability_id)
+        self.assertEqual(resolved_a.capability_version, resolved_b.capability_version)
+        self.assertEqual(resolved_a.state_posture, resolved_b.state_posture)
+        self.assertEqual(resolved_a.scope_posture, resolved_b.scope_posture)
+        self.assertEqual(resolved_a.behavior_contract, resolved_b.behavior_contract)
+        self.assertTrue(requirement.operational_requirement.matches(resolved_a.operational_contract))
+        self.assertTrue(requirement.operational_requirement.matches(resolved_b.operational_contract))
+        self.assertEqual(resolved_a.authority_effect, "none")
+        self.assertEqual(resolved_b.authority_effect, "none")
+        self.assertNotEqual(resolved_a.component_id, resolved_b.component_id)
+
+    def test_operational_quality_does_not_change_declared_authority_effect(self):
+        registry = ComponentRegistry()
+        registry.register(component("high-quality", authority_effect="proposal_only"))
+        resolved = registry.resolve(
+            CapabilityRequirement(
+                "epistemic_belief_memory",
+                "runtime_wired",
+                operational_requirement=CapabilityOperationalRequirement(
+                    write_atomicity=("single_record_atomic",),
+                    concurrency_control=("optimistic_revision",),
+                    idempotency=("durable_keyed",),
+                    restart_recovery=("reconstructable",),
+                    reconciliation=("deterministic_readback",),
+                ),
+            )
+        )
+        self.assertEqual(resolved.authority_effect, "proposal_only")
+
+    def test_component_version_does_not_upgrade_capability_maturity(self):
+        registry = ComponentRegistry()
+        registry.register(component("new-component", maturity="declared"))
+        with self.assertRaises(CapabilityResolutionError):
+            registry.resolve(CapabilityRequirement("epistemic_belief_memory", "runtime_wired"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference/tests/test_component_capabilities_v3.py
+++ b/reference/tests/test_component_capabilities_v3.py
@@ -102,6 +102,19 @@ class ComponentCapabilityV3Tests(unittest.TestCase):
         )
         self.assertNotEqual(parsed.capabilities[0].maturity, parsed.capabilities[1].maturity)
 
+    def test_schema_rejects_v3_without_behavior_or_operational_contract(self):
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        source = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        validator = jsonschema.Draft202012Validator(schema)
+        for required_contract in ("behavior_contract", "operational_contract"):
+            value = json.loads(json.dumps(source))
+            value["capabilities"][0].pop(required_contract)
+            errors = list(validator.iter_errors(value))
+            self.assertTrue(
+                errors,
+                f"component-capability-v3 unexpectedly accepted missing {required_contract}",
+            )
+
     def test_v1_and_v2_remain_backwards_compatible(self):
         v1 = ComponentDeclaration(
             component_id="legacy-v1",

--- a/schemas/component-capability-profile.schema.json
+++ b/schemas/component-capability-profile.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/component-capability-profile.schema.json",
   "title": "Agent Memory Component Capability Profile",
-  "description": "Machine-readable reference contract for independently matured component capabilities. component-capability-v2 requires explicit lifecycle behavior metadata. Capability selection and behavior declarations do not create memory authority.",
+  "description": "Machine-readable reference contract for independently matured component capabilities. component-capability-v2 requires explicit lifecycle behavior metadata; component-capability-v3 additionally requires an operational substrate contract. Capability selection and contract declarations do not create memory authority.",
   "type": "object",
   "required": [
     "component_id",
@@ -37,7 +37,7 @@
     {
       "if": {
         "properties": {
-          "profile_version": { "const": "component-capability-v2" }
+          "profile_version": { "enum": ["component-capability-v2", "component-capability-v3"] }
         },
         "required": ["profile_version"]
       },
@@ -48,6 +48,26 @@
               "allOf": [
                 { "$ref": "#/$defs/capability" },
                 { "required": ["behavior_contract"] }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "profile_version": { "const": "component-capability-v3" }
+        },
+        "required": ["profile_version"]
+      },
+      "then": {
+        "properties": {
+          "capabilities": {
+            "items": {
+              "allOf": [
+                { "$ref": "#/$defs/capability" },
+                { "required": ["operational_contract"] }
               ]
             }
           }
@@ -151,6 +171,55 @@
       },
       "additionalProperties": false
     },
+    "operationalContract": {
+      "type": "object",
+      "required": [
+        "write_atomicity",
+        "concurrency_control",
+        "idempotency",
+        "restart_recovery",
+        "reconciliation"
+      ],
+      "properties": {
+        "write_atomicity": {
+          "type": "string",
+          "enum": [
+            "none",
+            "process_local",
+            "single_record_atomic",
+            "transactional_multi_record"
+          ]
+        },
+        "concurrency_control": {
+          "type": "string",
+          "enum": [
+            "none",
+            "process_local",
+            "optimistic_revision",
+            "pessimistic_lock",
+            "serializable"
+          ]
+        },
+        "idempotency": {
+          "type": "string",
+          "enum": ["none", "process_local", "durable_keyed"]
+        },
+        "restart_recovery": {
+          "type": "string",
+          "enum": ["none", "process_local_only", "reconstructable", "checkpoint_replay"]
+        },
+        "reconciliation": {
+          "type": "string",
+          "enum": [
+            "none",
+            "process_local_only",
+            "deterministic_readback",
+            "authoritative_rebuild"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "capability": {
       "type": "object",
       "required": [
@@ -207,7 +276,8 @@
           "items": { "type": "string", "minLength": 1 },
           "uniqueItems": true
         },
-        "behavior_contract": { "$ref": "#/$defs/behaviorContract" }
+        "behavior_contract": { "$ref": "#/$defs/behaviorContract" },
+        "operational_contract": { "$ref": "#/$defs/operationalContract" }
       },
       "additionalProperties": false
     }


### PR DESCRIPTION
Closes #343

## What this changes

Extends the existing capability contract rather than adding a parallel provider abstraction.

- adds `epistemic_belief_memory`
- adds `predictive_counterfactual_memory`
- introduces `component-capability-v3`
- keeps `behavior_contract` and new `operational_contract` separate
- adds operational routing constraints for write atomicity, concurrency control, idempotency, restart recovery, and reconciliation
- makes operationally ineligible providers fail deterministic resolution, including explicitly preferred providers
- returns operational metadata in resolved capability evidence without changing `authority_effect`
- proves synthetic provider substitution against the requested contract

## Compatibility

- v1 behavior remains unchanged
- v2 still requires `behavior_contract` but does not require `operational_contract`
- capability maturity remains independent of component version
- ambiguous eligible providers still fail explicitly

## Evidence

Focused local reference proof covered compatibility plus the v3 acceptance surface before push. The PR workflow additionally executes targeted capability-contract tests and the full reference regression suite against the exact head.

The repository CI remains the authoritative repository-level validation boundary.

## Governance boundaries

`durable_keyed` idempotency describes a substrate guarantee that durable idempotency-key state can be retained/read. It does **not** transfer ownership of idempotency semantics, receipt interpretation, or replay authority to the provider. Those remain Agent Memory responsibilities, consistent with the #336 ownership correction.

Operational quality is eligibility evidence only. Provider selection, atomicity, replay safety, restart recovery, and reconciliation do not create PAMA authority or prove lifecycle completion.

## Explicit non-goals / stop condition

No Neo4j, Supermemory, GitNexus, MemOS, Cloudflare, or other provider SDK is added. This PR stops at the synthetic/reference contract proof. Later provider qualification/adaptor work must target this contract rather than become architecture by installation.