### PR TITLE
Implement native epistemic belief memory reference substrate

### DIFF
--- a/docs/programs/memory-modules/epistemic-belief-memory-reference.md
+++ b/docs/programs/memory-modules/epistemic-belief-memory-reference.md
@@ -1,0 +1,108 @@
+# Epistemic Belief Memory Reference
+
+Status: **bounded runtime reference for issue #346**
+
+Capability: `epistemic_belief_memory@1.0`
+
+Component: `agent-memory-epistemic-reference@0.1.0`
+
+## Purpose
+
+Capability Contract v3 introduced an explicit retained-memory capability for claims, beliefs, hypotheses, confidence, supporting/contradicting evidence, and revision state. This reference makes that semantic boundary executable without creating a second memory engine or treating belief as fact.
+
+The path is:
+
+```text
+claim / belief / hypothesis revision
+        |
+        v
+stable belief identity + directional evidence
+        |
+        v
+CognitiveSignal(module_role=epistemic_memory)
+        |
+        v
+Cognitive Mesh
+        |
+        v
+PAMA authority evaluation
+        |
+        +-- refused -> proposal evidence only
+        |
+        +-- committed -> append-only epistemic revision
+        |
+        v
+governed recall
+        |
+        +-- active belief -> eligible active cognition
+        +-- disputed belief -> retained, not active cognition
+        +-- retracted belief -> historical only, no current claim
+```
+
+## Semantics
+
+Each belief has one stable `belief_ref` and an append-only sequence of explicit `revision_ref` values. A revision records:
+
+- epistemic kind: `claim`, `belief`, or `hypothesis`;
+- claim text for active/disputed revisions;
+- confidence when supplied;
+- supporting evidence refs;
+- contradicting evidence refs;
+- prior revision ref;
+- revision reason;
+- governed scope/isolation/project/task/purpose;
+- source component and optional estimator identity/version;
+- epistemic status: `active`, `disputed`, or `retracted`.
+
+Supporting and contradicting evidence are retained as separate directional sets. They are flattened only when the generic PAMA proposal requires an evidence list; the epistemic record does not erase which evidence supported or contradicted the claim.
+
+## Revision and authority boundary
+
+Initial retention uses the existing `promotion` operation. A later belief revision uses the existing `correction` operation, so the current PAMA correction policy remains controlling. Confidence is carried as estimator evidence and cannot satisfy review or external-verification requirements.
+
+A refused correction is never appended to current epistemic state.
+
+The reference also rejects stale lineage and silent scope movement before substrate mutation. A revision must extend the exact current revision and retain the same governed scope.
+
+## Dispute and retraction
+
+A disputed belief remains retained epistemic state but the epistemic recall layer removes it from active cognition with an explicit `epistemic_disputed` refusal. It is not relabeled as a fact simply because it was committed.
+
+Retraction uses the existing governed `pruning` consequence. The prior fact remains historically attributable in the permissive substrate, but Agent Memory records a tombstone, clears the current recall fact, and appends a retraction revision with no replacement claim text. This avoids inventing a current pseudo-fact whose content is merely “this belief was retracted.”
+
+## Capability maturity and operational honesty
+
+The reference component declares:
+
+```text
+profile_version: component-capability-v3
+maturity: runtime_wired
+authority_effect: none
+```
+
+Its operational contract is intentionally process-local:
+
+```text
+write_atomicity: process_local
+concurrency_control: process_local
+idempotency: process_local
+restart_recovery: process_local_only
+reconciliation: process_local_only
+```
+
+That means this slice proves semantic composition and governance, not restart reconstruction or production substrate portability. Capability Contract v3 can later require stronger operational properties and exclude this reference provider when the operation demands them.
+
+## Non-claims
+
+This implementation does not:
+
+- certify epistemic state as `semantic_fact_memory`;
+- automatically derive confidence from evidence;
+- treat confidence `1.0` as authority;
+- implement predictive/counterfactual memory or world modeling;
+- provide cross-process restart reconstruction;
+- claim durable idempotency or reconciliation;
+- add an external provider dependency;
+- create a new PAMA authority class.
+
+The next predictive/world-model slice should consume this distinction rather than collapse predicted outcomes, beliefs, and observed history into one record type.

--- a/reference/agentmem_ref/epistemic_memory.py
+++ b/reference/agentmem_ref/epistemic_memory.py
@@ -1,0 +1,457 @@
+"""Governed reference implementation of epistemic belief memory.
+
+This module implements the first bounded ``epistemic_belief_memory`` runtime
+surface introduced by Capability Contract v3. It intentionally does not decide
+truth. Claims, beliefs, and hypotheses remain epistemic state with explicit
+confidence, directional evidence, and append-only revision lineage.
+
+The module composes existing Agent Memory primitives:
+
+epistemic revision
+  -> Cognitive Mesh signal
+  -> PAMA authority envelope
+  -> governed commit/refusal
+  -> governed recall
+
+Retraction uses the existing governed pruning consequence so historical content
+remains attributable while no replacement claim becomes current recall state.
+
+The reference implementation is process-local. Its v3 capability profile says
+so explicitly; restart/reconciliation portability is future work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from . import policy
+from .adapter import CommitResult, GovernedMemoryAdapter, RecallContext
+from .cognitive_mesh import (
+    ActiveCognition,
+    CognitiveExperience,
+    CognitiveMeshRuntime,
+    CognitiveSignal,
+    MeshObject,
+)
+from .contextual_recall import DeterministicContextualRecallPolicy
+
+EPISTEMIC_COMPONENT_ID = "agent-memory-epistemic-reference"
+CAPABILITY_ID = "epistemic_belief_memory"
+
+EPISTEMIC_KINDS = frozenset({"claim", "belief", "hypothesis"})
+EPISTEMIC_STATUSES = frozenset({"active", "disputed", "retracted"})
+
+
+class EpistemicRevisionError(ValueError):
+    """Base error for an invalid epistemic revision."""
+
+
+class StaleEpistemicRevision(EpistemicRevisionError):
+    """A revision did not extend the current append-only lineage."""
+
+
+class RetractedBeliefError(EpistemicRevisionError):
+    """A retracted belief requires an explicit future readmission path."""
+
+
+@dataclass(frozen=True)
+class EpistemicScope:
+    """Governed scope carried by every revision of one belief."""
+
+    scope: str
+    isolation_domain_refs: tuple[str, ...] = ()
+    required_isolation_domain_refs: tuple[str, ...] = ()
+    project_ref: str = ""
+    task_ref: str = ""
+    purpose: str = "reasoning"
+
+    def __post_init__(self) -> None:
+        if not self.scope:
+            raise EpistemicRevisionError("epistemic scope is required")
+        required = set(self.required_isolation_domain_refs)
+        bound = set(self.isolation_domain_refs)
+        if required and not required.issubset(bound):
+            raise EpistemicRevisionError(
+                "required isolation domains must be present in isolation_domain_refs"
+            )
+
+
+@dataclass(frozen=True)
+class BeliefRevision:
+    """One immutable epistemic revision.
+
+    ``epistemic_kind`` describes the retained epistemic object, not truth.
+    ``epistemic_status`` is the status of this revision when it becomes current.
+    Historical current/superseded posture is computed from append-only lineage.
+    """
+
+    belief_ref: str
+    revision_ref: str
+    epistemic_kind: str
+    claim_text: str
+    confidence: float | None
+    scope: EpistemicScope
+    source_component: str
+    observed_at: str
+    supporting_evidence_refs: tuple[str, ...] = ()
+    contradicting_evidence_refs: tuple[str, ...] = ()
+    revision_reason: str = ""
+    prior_revision_ref: str = ""
+    epistemic_status: str = "active"
+    estimator_ref: str = ""
+    estimator_version: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.belief_ref or not self.revision_ref:
+            raise EpistemicRevisionError("belief_ref and revision_ref are required")
+        if self.epistemic_kind not in EPISTEMIC_KINDS:
+            raise EpistemicRevisionError(
+                f"unsupported epistemic_kind: {self.epistemic_kind}"
+            )
+        if self.epistemic_status not in EPISTEMIC_STATUSES:
+            raise EpistemicRevisionError(
+                f"unsupported epistemic_status: {self.epistemic_status}"
+            )
+        if not self.source_component or not self.observed_at:
+            raise EpistemicRevisionError(
+                "source_component and observed_at are required"
+            )
+        if self.epistemic_status == "retracted":
+            if self.claim_text:
+                raise EpistemicRevisionError(
+                    "retracted revision must not carry replacement claim_text"
+                )
+        elif not self.claim_text:
+            raise EpistemicRevisionError(
+                "active/disputed epistemic revision requires claim_text"
+            )
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise EpistemicRevisionError("confidence must be between 0 and 1")
+        if self.prior_revision_ref and not self.revision_reason:
+            raise EpistemicRevisionError(
+                "non-initial revision requires revision_reason"
+            )
+        for name, refs in (
+            ("supporting_evidence_refs", self.supporting_evidence_refs),
+            ("contradicting_evidence_refs", self.contradicting_evidence_refs),
+        ):
+            if len(set(refs)) != len(refs):
+                raise EpistemicRevisionError(f"{name} must not contain duplicates")
+
+    @property
+    def evidence_refs(self) -> tuple[str, ...]:
+        """Directional evidence flattened only for the generic PAMA evidence list."""
+        return tuple(
+            dict.fromkeys(
+                self.supporting_evidence_refs + self.contradicting_evidence_refs
+            )
+        )
+
+
+@dataclass(frozen=True)
+class EpistemicRevisionResult:
+    """Governed consequence of one attempted epistemic revision."""
+
+    revision: BeliefRevision
+    commit: CommitResult
+    fact_uuid: str | None
+    lineage_state: str
+
+
+@dataclass
+class EpistemicBeliefMemory:
+    """Process-local reference runtime for governed epistemic belief state."""
+
+    adapter: GovernedMemoryAdapter
+    available_components: tuple[str, ...]
+    recall_policy: DeterministicContextualRecallPolicy | None = None
+    _mesh: CognitiveMeshRuntime = field(init=False, repr=False)
+    _history: dict[str, list[BeliefRevision]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _fact_by_revision: dict[str, str] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        self._mesh = CognitiveMeshRuntime(
+            adapter=self.adapter,
+            available_components=self.available_components,
+            recall_policy=self.recall_policy,
+        )
+
+    def apply_revision(
+        self,
+        revision: BeliefRevision,
+        *,
+        actor_id: str,
+        target_class: str = policy.M2,
+        downstream_authority: str = policy.A1,
+        risk_class: str = "low",
+        review_satisfied: bool = False,
+        approval_refs: tuple[str, ...] = (),
+    ) -> EpistemicRevisionResult:
+        """Retain or revise a belief through Cognitive Mesh and PAMA.
+
+        A refused proposal is returned to the caller but is never appended to
+        current/history state. Confidence is carried as estimator evidence only.
+        """
+        if revision.epistemic_status == "retracted":
+            return self.retract(
+                revision,
+                actor_id=actor_id,
+                target_class=target_class,
+                downstream_authority=downstream_authority,
+                risk_class=risk_class,
+                review_satisfied=review_satisfied,
+                approval_refs=approval_refs,
+            )
+
+        current = self.current(revision.belief_ref)
+        self._ensure_new_revision_ref(revision)
+        self._validate_lineage(revision, current)
+        if current is not None and current.epistemic_status == "retracted":
+            raise RetractedBeliefError(
+                "retracted belief requires an explicit readmission path"
+            )
+
+        operation = "promotion" if current is None else "correction"
+        experience = CognitiveExperience(
+            experience_ref=revision.revision_ref,
+            content=revision.claim_text,
+            source_description=(
+                f"epistemic {revision.epistemic_kind} revision "
+                f"from {revision.source_component}"
+            ),
+            observed_at=revision.observed_at,
+        )
+        cognitive_object = MeshObject(
+            object_ref=revision.belief_ref,
+            object_type=CAPABILITY_ID,
+            scope=revision.scope.scope,
+            evidence_refs=revision.evidence_refs,
+            isolation_domain_refs=revision.scope.isolation_domain_refs,
+            required_isolation_domain_refs=(
+                revision.scope.required_isolation_domain_refs
+            ),
+            project_ref=revision.scope.project_ref,
+            task_ref=revision.scope.task_ref,
+            purpose=revision.scope.purpose,
+        )
+        signal = CognitiveSignal(
+            module_role="epistemic_memory",
+            source_component=revision.source_component,
+            signal_type="epistemic_revision",
+            evidence_refs=revision.evidence_refs,
+            estimator_ref=revision.estimator_ref,
+            estimator_version=revision.estimator_version,
+            confidence=revision.confidence,
+        )
+        transition = self._mesh.apply_signal(
+            experience=experience,
+            cognitive_object=cognitive_object,
+            signal=signal,
+            actor_id=actor_id,
+            requested_operation=operation,
+            target_class=target_class,
+            downstream_authority=downstream_authority,
+            risk_class=risk_class,
+            current_strength="observed" if current is None else "promoted",
+            proposed_strength=(
+                "disputed"
+                if revision.epistemic_status == "disputed"
+                else "promoted"
+            ),
+            charter_version="epistemic-belief-memory-ref-v1",
+            proposal_id=f"proposal:{revision.revision_ref}",
+            review_satisfied=review_satisfied,
+            approval_refs=approval_refs,
+        )
+
+        if transition.commit.committed:
+            self._history.setdefault(revision.belief_ref, []).append(revision)
+            if transition.commit.fact_uuid is None:
+                raise RuntimeError("committed epistemic revision requires fact_uuid")
+            self._fact_by_revision[revision.revision_ref] = (
+                transition.commit.fact_uuid
+            )
+
+        return EpistemicRevisionResult(
+            revision=revision,
+            commit=transition.commit,
+            fact_uuid=transition.commit.fact_uuid,
+            lineage_state=(
+                self.revision_state(revision.belief_ref, revision.revision_ref)
+                if transition.commit.committed
+                else "refused"
+            ),
+        )
+
+    def retract(
+        self,
+        revision: BeliefRevision,
+        *,
+        actor_id: str,
+        target_class: str = policy.M2,
+        downstream_authority: str = policy.A1,
+        risk_class: str = "low",
+        review_satisfied: bool = False,
+        approval_refs: tuple[str, ...] = (),
+    ) -> EpistemicRevisionResult:
+        """Append a retraction while pruning the current claim from active recall."""
+        if revision.epistemic_status != "retracted":
+            raise EpistemicRevisionError(
+                "retract() requires epistemic_status='retracted'"
+            )
+        current = self.current(revision.belief_ref)
+        self._ensure_new_revision_ref(revision)
+        if current is None:
+            raise EpistemicRevisionError("cannot retract an unknown belief")
+        self._validate_lineage(revision, current)
+        if current.epistemic_status == "retracted":
+            raise RetractedBeliefError("belief is already retracted")
+
+        current_fact_uuid = self.adapter.current_fact_uuid(revision.belief_ref)
+        if current_fact_uuid is None:
+            raise EpistemicRevisionError(
+                "current belief has no governed recall fact to retract"
+            )
+
+        evidence_refs = tuple(
+            dict.fromkeys(
+                revision.evidence_refs
+                + (revision.prior_revision_ref,)
+            )
+        )
+        proposal = policy.Proposal(
+            proposal_id=f"proposal:{revision.revision_ref}",
+            actor_id=actor_id,
+            charter_version="epistemic-belief-memory-ref-v1",
+            target_reference=revision.belief_ref,
+            target_class=target_class,
+            scope=revision.scope.scope,
+            operation="pruning",
+            current_strength="promoted",
+            proposed_strength="retracted",
+            downstream_authority=downstream_authority,
+            reversibility="reversible",
+            risk_class=risk_class,
+            evidence_refs=evidence_refs,
+            estimator_refs=(
+                (revision.estimator_ref,) if revision.estimator_ref else ()
+            ),
+            estimator_versions=(
+                (revision.estimator_version,)
+                if revision.estimator_version
+                else ()
+            ),
+            confidence=revision.confidence,
+            review_satisfied=review_satisfied,
+            approval_refs=approval_refs,
+            purpose=revision.scope.purpose,
+            isolation_domain_refs=revision.scope.isolation_domain_refs,
+            required_isolation_domain_refs=(
+                revision.scope.required_isolation_domain_refs
+            ),
+            project_ref=revision.scope.project_ref,
+            task_ref=revision.scope.task_ref,
+        )
+        commit = self.adapter.governed_delete(
+            proposal,
+            current_fact_uuid,
+        )
+        if commit.committed:
+            self._history.setdefault(revision.belief_ref, []).append(revision)
+
+        return EpistemicRevisionResult(
+            revision=revision,
+            commit=commit,
+            fact_uuid=current_fact_uuid if commit.committed else None,
+            lineage_state=(
+                self.revision_state(revision.belief_ref, revision.revision_ref)
+                if commit.committed
+                else "refused"
+            ),
+        )
+
+    def current(self, belief_ref: str) -> BeliefRevision | None:
+        history = self._history.get(belief_ref, ())
+        return history[-1] if history else None
+
+    def current_claim(self, belief_ref: str) -> str | None:
+        current = self.current(belief_ref)
+        if current is None or current.epistemic_status == "retracted":
+            return None
+        return current.claim_text
+
+    def history(self, belief_ref: str) -> tuple[BeliefRevision, ...]:
+        return tuple(self._history.get(belief_ref, ()))
+
+    def revision_state(self, belief_ref: str, revision_ref: str) -> str:
+        history = self._history.get(belief_ref, ())
+        matches = [item for item in history if item.revision_ref == revision_ref]
+        if not matches:
+            raise KeyError(revision_ref)
+        current = history[-1]
+        if current.revision_ref != revision_ref:
+            return "superseded"
+        if current.epistemic_status == "disputed":
+            return "disputed"
+        if current.epistemic_status == "retracted":
+            return "retracted"
+        return "current"
+
+    def fact_uuid(self, revision_ref: str) -> str | None:
+        return self._fact_by_revision.get(revision_ref)
+
+    def recall_active(
+        self,
+        query: str,
+        *,
+        context: RecallContext,
+    ) -> ActiveCognition:
+        result = self._mesh.recall_active(query, context=context)
+        for object_ref in tuple(result.active_object_refs):
+            current = self.current(object_ref)
+            if current is None or current.epistemic_status != "disputed":
+                continue
+            result.active_object_refs.remove(object_ref)
+            fact_uuid = self._fact_by_revision.get(current.revision_ref)
+            if fact_uuid:
+                result.refusals[fact_uuid] = "epistemic_disputed"
+        return result
+
+    def replace_component(self, *, old_component: str, new_component: str) -> None:
+        self._mesh.replace_component(
+            old_component=old_component,
+            new_component=new_component,
+        )
+
+    def _ensure_new_revision_ref(self, revision: BeliefRevision) -> None:
+        if any(
+            item.revision_ref == revision.revision_ref
+            for item in self._history.get(revision.belief_ref, ())
+        ):
+            raise EpistemicRevisionError(
+                f"revision_ref already exists for belief: {revision.revision_ref}"
+            )
+
+    @staticmethod
+    def _validate_lineage(
+        revision: BeliefRevision,
+        current: BeliefRevision | None,
+    ) -> None:
+        if current is None:
+            if revision.prior_revision_ref:
+                raise StaleEpistemicRevision(
+                    "initial belief revision must not declare prior_revision_ref"
+                )
+            return
+        if revision.prior_revision_ref != current.revision_ref:
+            raise StaleEpistemicRevision(
+                "revision must extend the current revision_ref"
+            )
+        if revision.scope != current.scope:
+            raise EpistemicRevisionError(
+                "belief revision cannot silently change governed scope"
+            )

--- a/reference/agentmem_ref/epistemic_memory.py
+++ b/reference/agentmem_ref/epistemic_memory.py
@@ -256,9 +256,17 @@ class EpistemicBeliefMemory:
             target_class=target_class,
             downstream_authority=downstream_authority,
             risk_class=risk_class,
-            current_strength="observed" if current is None else "promoted",
+            current_strength=(
+                "observed"
+                if current is None
+                else (
+                    "tentative"
+                    if current.epistemic_status == "disputed"
+                    else "promoted"
+                )
+            ),
             proposed_strength=(
-                "disputed"
+                "tentative"
                 if revision.epistemic_status == "disputed"
                 else "promoted"
             ),
@@ -331,8 +339,12 @@ class EpistemicBeliefMemory:
             target_class=target_class,
             scope=revision.scope.scope,
             operation="pruning",
-            current_strength="promoted",
-            proposed_strength="retracted",
+            current_strength=(
+                "tentative"
+                if current.epistemic_status == "disputed"
+                else "promoted"
+            ),
+            proposed_strength="archived",
             downstream_authority=downstream_authority,
             reversibility="reversible",
             risk_class=risk_class,

--- a/reference/fixtures/component-capabilities/epistemic-reference-v3.json
+++ b/reference/fixtures/component-capabilities/epistemic-reference-v3.json
@@ -1,0 +1,55 @@
+{
+  "component_id": "agent-memory-epistemic-reference",
+  "component_version": "0.1.0",
+  "profile_version": "component-capability-v3",
+  "enabled": true,
+  "runtime_ref": "reference/agentmem_ref/epistemic_memory.py",
+  "failure_posture": "fail_closed",
+  "provenance_refs": [
+    "https://github.com/MythologIQ-Labs-LLC/agent-memory/issues/346",
+    "https://github.com/MythologIQ-Labs-LLC/agent-memory/pull/345"
+  ],
+  "capabilities": [
+    {
+      "capability_id": "epistemic_belief_memory",
+      "capability_version": "1.0",
+      "maturity": "runtime_wired",
+      "state_posture": "derived",
+      "scope_posture": "enforces_agent_memory_scope",
+      "failure_posture": "fail_closed",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "reference/agentmem_ref/epistemic_memory.py",
+        "reference/tests/test_epistemic_memory.py"
+      ],
+      "limitations": [
+        "Reference revision index is process-local and is not restart reconstructable.",
+        "Belief confidence is retained as epistemic evidence and is not fact certification or authority.",
+        "No automatic promotion from epistemic belief memory to semantic fact memory.",
+        "No predictive/counterfactual world-model behavior is implemented by this component."
+      ],
+      "behavior_contract": {
+        "operation_support": {
+          "write": true,
+          "read": true,
+          "recall_candidate": true
+        },
+        "currentness_model": "basis_versioned",
+        "invalidation_model": "version_relation",
+        "correction_model": "invalidate_derived",
+        "deletion_model": "derived_residue_then_purge",
+        "residue_model": "scan_required",
+        "migration_rebuild_model": "unsupported",
+        "structural_mutation_requirement": "none"
+      },
+      "operational_contract": {
+        "write_atomicity": "process_local",
+        "concurrency_control": "process_local",
+        "idempotency": "process_local",
+        "restart_recovery": "process_local_only",
+        "reconciliation": "process_local_only"
+      }
+    }
+  ]
+}

--- a/reference/fixtures/component-capabilities/epistemic-reference-v3.json
+++ b/reference/fixtures/component-capabilities/epistemic-reference-v3.json
@@ -21,7 +21,8 @@
       "enabled": true,
       "evidence_refs": [
         "reference/agentmem_ref/epistemic_memory.py",
-        "reference/tests/test_epistemic_memory.py"
+        "reference/tests/test_epistemic_memory.py",
+        "docs/programs/memory-modules/epistemic-belief-memory-reference.md"
       ],
       "limitations": [
         "Reference revision index is process-local and is not restart reconstructable.",

--- a/reference/tests/test_epistemic_memory.py
+++ b/reference/tests/test_epistemic_memory.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext
+from agentmem_ref.capabilities import ComponentDeclaration
+from agentmem_ref.epistemic_memory import (
+    CAPABILITY_ID,
+    BeliefRevision,
+    EpistemicBeliefMemory,
+    EpistemicRevisionError,
+    EpistemicScope,
+    StaleEpistemicRevision,
+)
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE = (
+    ROOT
+    / "reference"
+    / "fixtures"
+    / "component-capabilities"
+    / "epistemic-reference-v3.json"
+)
+SCHEMA = ROOT / "schemas" / "component-capability-profile.schema.json"
+
+TENANT = "tenant:epistemic"
+PROJECT = "project:epistemic"
+
+
+def governed_scope() -> EpistemicScope:
+    return EpistemicScope(
+        scope=TENANT,
+        isolation_domain_refs=(TENANT, PROJECT),
+        required_isolation_domain_refs=(TENANT, PROJECT),
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def context() -> RecallContext:
+    return RecallContext(
+        target_domain_refs=(TENANT, PROJECT),
+        principal_ref="agent:epistemic-test",
+        project_ref=PROJECT,
+        purpose="reasoning",
+    )
+
+
+def revision(
+    revision_ref: str,
+    *,
+    belief_ref: str = "belief:deployment-safety",
+    claim_text: str = "Staged deployment is likely safe for this service",
+    confidence: float | None = 0.7,
+    source_component: str = "EpistemicReference",
+    epistemic_kind: str = "belief",
+    epistemic_status: str = "active",
+    supporting: tuple[str, ...] = ("evidence:canary-success",),
+    contradicting: tuple[str, ...] = (),
+    prior_revision_ref: str = "",
+    revision_reason: str = "",
+    scope: EpistemicScope | None = None,
+) -> BeliefRevision:
+    return BeliefRevision(
+        belief_ref=belief_ref,
+        revision_ref=revision_ref,
+        epistemic_kind=epistemic_kind,
+        claim_text=claim_text,
+        confidence=confidence,
+        scope=scope or governed_scope(),
+        source_component=source_component,
+        observed_at="2026-01-01T00:00:00Z",
+        supporting_evidence_refs=supporting,
+        contradicting_evidence_refs=contradicting,
+        prior_revision_ref=prior_revision_ref,
+        revision_reason=revision_reason,
+        epistemic_status=epistemic_status,
+        estimator_ref=f"estimator:{source_component}",
+        estimator_version="1.0.0",
+    )
+
+
+def runtime(*components: str) -> tuple[
+    EpistemicBeliefMemory,
+    GovernedMemoryAdapter,
+    InMemoryTemporalGraph,
+]:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    memory = EpistemicBeliefMemory(
+        adapter=adapter,
+        available_components=tuple(components),
+    )
+    return memory, adapter, substrate
+
+
+class EpistemicBeliefMemoryTests(unittest.TestCase):
+    def test_v3_profile_is_honest_process_local_epistemic_capability(self) -> None:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        value = json.loads(PROFILE.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(value)
+        component = ComponentDeclaration.from_dict(value)
+
+        self.assertEqual("component-capability-v3", component.profile_version)
+        self.assertEqual(1, len(component.capabilities))
+        capability = component.capabilities[0]
+        self.assertEqual(CAPABILITY_ID, capability.capability_id)
+        self.assertEqual("runtime_wired", capability.maturity)
+        self.assertEqual("none", capability.authority_effect)
+        self.assertEqual(
+            "process_local_only",
+            capability.operational_contract.restart_recovery,
+        )
+        self.assertEqual(
+            "process_local_only",
+            capability.operational_contract.reconciliation,
+        )
+
+    def test_initial_belief_retains_epistemic_state_through_existing_governance(self) -> None:
+        memory, adapter, substrate = runtime("EpistemicReference")
+        first = revision("belief-rev:001", epistemic_kind="hypothesis")
+
+        result = memory.apply_revision(first, actor_id="agent:epistemic-test")
+
+        self.assertTrue(result.commit.committed)
+        self.assertEqual(policy.ALLOW_WITH_LEDGER, result.commit.decision.outcome)
+        self.assertEqual("current", result.lineage_state)
+        self.assertEqual(first, memory.current(first.belief_ref))
+        self.assertEqual(first.claim_text, memory.current_claim(first.belief_ref))
+        self.assertEqual((first,), memory.history(first.belief_ref))
+        self.assertEqual(result.fact_uuid, adapter.current_fact_uuid(first.belief_ref))
+        self.assertEqual(first.claim_text, substrate.get_fact(result.fact_uuid).fact_text)
+        self.assertEqual(0.7, result.commit.pama_decision["basis"]["confidence"])
+
+        active = memory.recall_active(
+            "staged deployment safe service",
+            context=context(),
+        )
+        self.assertIn(first.belief_ref, active.active_object_refs)
+
+    def test_confidence_one_cannot_bypass_review_and_refused_revision_is_not_current(self) -> None:
+        memory, adapter, _ = runtime("EpistemicReference")
+        first = revision("belief-rev:001")
+        committed = memory.apply_revision(first, actor_id="agent:epistemic-test")
+        first_fact = committed.fact_uuid
+
+        proposed = revision(
+            "belief-rev:002",
+            claim_text="Staged deployment is unsafe for this service",
+            confidence=1.0,
+            supporting=("evidence:incident",),
+            contradicting=("evidence:canary-success",),
+            prior_revision_ref=first.revision_ref,
+            revision_reason="new incident contradicts the earlier belief",
+        )
+        refused = memory.apply_revision(
+            proposed,
+            actor_id="agent:epistemic-test",
+        )
+
+        self.assertFalse(refused.commit.committed)
+        self.assertEqual(policy.REQUIRE_REVIEW, refused.commit.decision.outcome)
+        self.assertEqual("refused", refused.lineage_state)
+        self.assertEqual(first, memory.current(first.belief_ref))
+        self.assertEqual((first,), memory.history(first.belief_ref))
+        self.assertEqual(first_fact, adapter.current_fact_uuid(first.belief_ref))
+        self.assertIn("correction", refused.commit.decision.prohibited_actions)
+
+    def test_approved_revision_is_append_only_and_preserves_directional_evidence(self) -> None:
+        memory, adapter, substrate = runtime("EpistemicReference")
+        first = revision("belief-rev:001")
+        first_result = memory.apply_revision(first, actor_id="agent:epistemic-test")
+
+        second = revision(
+            "belief-rev:002",
+            claim_text="Staged deployment is risky until the incident is explained",
+            confidence=0.45,
+            supporting=("evidence:incident",),
+            contradicting=("evidence:canary-success", "evidence:load-test"),
+            prior_revision_ref=first.revision_ref,
+            revision_reason="contradictory production evidence",
+        )
+        second_result = memory.apply_revision(
+            second,
+            actor_id="agent:epistemic-test",
+            review_satisfied=True,
+            approval_refs=("approval:epistemic-review",),
+        )
+
+        self.assertTrue(second_result.commit.committed)
+        self.assertEqual(policy.ALLOW_WITH_LEDGER, second_result.commit.decision.outcome)
+        self.assertEqual((first, second), memory.history(first.belief_ref))
+        self.assertEqual("superseded", memory.revision_state(first.belief_ref, first.revision_ref))
+        self.assertEqual("current", memory.revision_state(first.belief_ref, second.revision_ref))
+        self.assertEqual(("evidence:incident",), second.supporting_evidence_refs)
+        self.assertEqual(
+            ("evidence:canary-success", "evidence:load-test"),
+            second.contradicting_evidence_refs,
+        )
+        self.assertTrue(substrate.get_fact(first_result.fact_uuid).is_event_invalid)
+        self.assertEqual(
+            second_result.fact_uuid,
+            adapter.current_fact_uuid(first.belief_ref),
+        )
+
+    def test_disputed_belief_remains_epistemic_but_is_not_active_cognition(self) -> None:
+        memory, _, _ = runtime("EpistemicReference")
+        first = revision("belief-rev:001")
+        memory.apply_revision(first, actor_id="agent:epistemic-test")
+
+        disputed = revision(
+            "belief-rev:002",
+            claim_text="Deployment safety remains unresolved",
+            confidence=0.5,
+            supporting=("evidence:canary-success",),
+            contradicting=("evidence:incident",),
+            prior_revision_ref=first.revision_ref,
+            revision_reason="evidence is materially conflicting",
+            epistemic_status="disputed",
+        )
+        result = memory.apply_revision(
+            disputed,
+            actor_id="agent:epistemic-test",
+            review_satisfied=True,
+            approval_refs=("approval:dispute-review",),
+        )
+
+        self.assertTrue(result.commit.committed)
+        self.assertEqual("disputed", result.lineage_state)
+        self.assertEqual(disputed, memory.current(disputed.belief_ref))
+        active = memory.recall_active(
+            "deployment safety unresolved",
+            context=context(),
+        )
+        self.assertIn(result.fact_uuid, active.admitted_fact_uuids)
+        self.assertNotIn(disputed.belief_ref, active.active_object_refs)
+        self.assertEqual("epistemic_disputed", active.refusals[result.fact_uuid])
+
+    def test_retraction_preserves_history_and_removes_current_claim_from_recall(self) -> None:
+        memory, adapter, substrate = runtime("EpistemicReference")
+        first = revision("belief-rev:001")
+        first_result = memory.apply_revision(first, actor_id="agent:epistemic-test")
+
+        retracted = revision(
+            "belief-rev:002",
+            claim_text="",
+            confidence=None,
+            supporting=("evidence:withdrawal",),
+            prior_revision_ref=first.revision_ref,
+            revision_reason="source withdrew the underlying observation",
+            epistemic_status="retracted",
+        )
+        result = memory.apply_revision(
+            retracted,
+            actor_id="agent:epistemic-test",
+        )
+
+        self.assertTrue(result.commit.committed)
+        self.assertEqual("retracted", result.lineage_state)
+        self.assertEqual((first, retracted), memory.history(first.belief_ref))
+        self.assertEqual("superseded", memory.revision_state(first.belief_ref, first.revision_ref))
+        self.assertIsNone(memory.current_claim(first.belief_ref))
+        self.assertIsNone(adapter.current_fact_uuid(first.belief_ref))
+        self.assertIsNotNone(substrate.get_fact(first_result.fact_uuid))
+        self.assertIsNotNone(adapter.tombstone(first_result.fact_uuid))
+
+        active = memory.recall_active(
+            "staged deployment safe service",
+            context=context(),
+        )
+        self.assertEqual([], active.active_object_refs)
+        self.assertEqual(
+            "tombstoned",
+            active.refusals[first_result.fact_uuid],
+        )
+
+    def test_stale_revision_and_scope_change_fail_before_substrate_mutation(self) -> None:
+        memory, _, substrate = runtime("EpistemicReference")
+        first = revision("belief-rev:001")
+        memory.apply_revision(first, actor_id="agent:epistemic-test")
+        before = tuple(substrate.write_log)
+
+        stale = revision(
+            "belief-rev:002",
+            prior_revision_ref="belief-rev:000",
+            revision_reason="stale writer",
+        )
+        with self.assertRaises(StaleEpistemicRevision):
+            memory.apply_revision(stale, actor_id="agent:epistemic-test")
+        self.assertEqual(before, tuple(substrate.write_log))
+
+        foreign_scope = EpistemicScope(
+            scope=TENANT,
+            isolation_domain_refs=(TENANT, "project:other"),
+            required_isolation_domain_refs=(TENANT, "project:other"),
+            project_ref="project:other",
+        )
+        changed_scope = revision(
+            "belief-rev:003",
+            prior_revision_ref=first.revision_ref,
+            revision_reason="attempted scope movement",
+            scope=foreign_scope,
+        )
+        with self.assertRaises(EpistemicRevisionError):
+            memory.apply_revision(changed_scope, actor_id="agent:epistemic-test")
+        self.assertEqual(before, tuple(substrate.write_log))
+
+    def test_provider_replacement_does_not_change_belief_identity_or_authority(self) -> None:
+        memory, _, _ = runtime("EstimatorA")
+        first = revision(
+            "belief-rev:001",
+            source_component="EstimatorA",
+        )
+        first_result = memory.apply_revision(first, actor_id="agent:epistemic-test")
+        self.assertNotIn("authority_effect", first_result.commit.pama_decision)
+
+        memory.replace_component(
+            old_component="EstimatorA",
+            new_component="EstimatorB",
+        )
+        second = revision(
+            "belief-rev:002",
+            source_component="EstimatorB",
+            claim_text="Staged deployment safety estimate has changed",
+            supporting=("evidence:new-run",),
+            prior_revision_ref=first.revision_ref,
+            revision_reason="replacement estimator produced new evidence",
+        )
+        second_result = memory.apply_revision(
+            second,
+            actor_id="agent:epistemic-test",
+            review_satisfied=True,
+            approval_refs=("approval:provider-change-review",),
+        )
+
+        self.assertTrue(second_result.commit.committed)
+        self.assertEqual(first.belief_ref, second.belief_ref)
+        self.assertEqual(first.belief_ref, second_result.commit.pama_decision["target"]["reference"])
+        self.assertEqual("EstimatorB", memory.current(first.belief_ref).source_component)
+        self.assertNotIn("authority_effect", second_result.commit.pama_decision)
+
+    def test_profile_declares_only_epistemic_not_semantic_fact_or_predictive_capability(self) -> None:
+        value = json.loads(PROFILE.read_text(encoding="utf-8"))
+        declared = {
+            item["capability_id"]
+            for item in value["capabilities"]
+        }
+        self.assertEqual({CAPABILITY_ID}, declared)
+        self.assertNotIn("semantic_fact_memory", declared)
+        self.assertNotIn("predictive_counterfactual_memory", declared)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #346

## Summary

Implements the first bounded native `epistemic_belief_memory` reference substrate on top of Accepted ADR-035 and Capability Contract v3.

The implementation composes existing Agent Memory primitives rather than creating a parallel memory engine:

```text
claim / belief / hypothesis revision
  -> stable belief identity + directional evidence
  -> CognitiveSignal(module_role=epistemic_memory)
  -> Cognitive Mesh
  -> PAMA authority evaluation
  -> governed commit/refusal
  -> governed recall
```

## Epistemic semantics

- explicit `claim`, `belief`, and `hypothesis` kinds;
- stable `belief_ref` across append-only `revision_ref` lineage;
- per-revision confidence, supporting evidence, contradicting evidence, prior revision, and revision reason;
- explicit active, disputed, retracted, current, and superseded epistemic posture;
- supporting and contradicting evidence remain directionally distinct in the epistemic record;
- no automatic conversion to `semantic_fact_memory`;
- provider replacement preserves belief identity and does not change authority.

## Governance consequences

Initial retention uses the existing `promotion` operation. Later belief revision uses the existing `correction` operation, so current PAMA review requirements remain controlling. A refused correction never becomes current state, including at confidence `1.0`.

Retraction uses existing governed `pruning`: history remains attributable, the current fact is tombstoned/removed from active recall, and no replacement pseudo-fact is created merely to say that the belief was retracted.

A disputed belief can remain retained/admitted epistemic evidence while the epistemic recall layer refuses it from active cognition with an explicit `epistemic_disputed` reason.

## Ontology boundary

Epistemic status and PAMA strength remain separate vocabularies. The implementation maps:

- disputed epistemic posture -> PAMA `tentative` strength;
- retraction consequence -> PAMA `archived` strength.

It does not add `disputed` or `retracted` to the closed PAMA strength vocabulary.

## Capability Contract v3 profile

Adds `agent-memory-epistemic-reference@0.1.0` with:

- `epistemic_belief_memory@1.0`;
- maturity `runtime_wired`;
- `authority_effect: none`;
- explicit behavior contract;
- intentionally process-local operational contract for atomicity, concurrency, idempotency, restart recovery, and reconciliation.

This profile does not claim restart reconstruction or production substrate portability that the reference implementation has not earned.

## Acceptance evidence

Focused tests cover:

- schema-valid v3 profile and honest operational posture;
- initial governed belief retention;
- confidence `1.0` unable to bypass correction review;
- refused revisions never becoming current;
- append-only approved revision lineage;
- directional supporting/contradicting evidence preservation;
- disputed state excluded from active cognition;
- retraction preserving history while removing the current claim from recall;
- stale revisions and silent scope movement failing before substrate mutation;
- provider replacement preserving belief identity and authority boundaries;
- profile declaring neither `semantic_fact_memory` nor `predictive_counterfactual_memory`.

The repository's required `validate` lane remains the repository-level evidence boundary and includes the full reference regression suite.

## Explicit non-goals / stop condition

This PR does **not** implement predictive/counterfactual world modeling, external memory provider SDKs, restart-safe epistemic reconstruction, new PAMA operations, or new authority semantics. Those remain later bounded slices.