### PR TITLE
Implement native predictive and counterfactual memory reference substrate

### DIFF
--- a/docs/programs/memory-modules/predictive-counterfactual-memory-reference.md
+++ b/docs/programs/memory-modules/predictive-counterfactual-memory-reference.md
@@ -1,0 +1,117 @@
+# Predictive and Counterfactual Memory Reference
+
+Status: **bounded runtime reference for issue #348**
+
+Capability: `predictive_counterfactual_memory@1.0`
+
+Component: `agent-memory-predictive-reference@0.1.0`
+
+## Purpose
+
+Capability Contract v3 introduced an explicit retained-memory capability for predictions, simulations, expected outcomes, counterfactual trajectories, and later outcome comparison. This reference makes that boundary executable without embedding a simulation engine or allowing predicted state to become observed history by storage accident.
+
+The retained paths are deliberately separate:
+
+```text
+prediction revision
+  -> stable prediction identity
+  -> explicitly predictive kind
+  -> Cognitive Mesh
+  -> PAMA
+  -> governed predictive memory
+
+observed outcome evidence
+  -> separate comparison artifact
+  -> exact prediction revision reference
+  -> descriptive disposition
+  -> Cognitive Mesh
+  -> PAMA
+  -> governed comparison memory
+```
+
+The second path does not overwrite the first.
+
+## Predictive state
+
+Each prediction has one stable `prediction_ref` and append-only `revision_ref` lineage. A revision records:
+
+- predictive kind: `forecast`, `simulation`, or `counterfactual`;
+- expected outcome;
+- confidence when supplied;
+- target window / horizon description;
+- basis evidence refs;
+- assumptions;
+- prior revision ref and revision reason;
+- governed scope/isolation/project/task/purpose;
+- source component and optional estimator identity/version.
+
+Predictive revisions use PAMA `tentative` strength. Retention therefore does not imply observation, truth, or authority. A later revision must extend the exact current revision, keep the same predictive kind, and retain the same governed scope.
+
+Initial retention uses the existing `promotion` operation. Later revision uses the existing `correction` operation, preserving current review requirements. Confidence is estimator evidence only and cannot discharge an authority requirement.
+
+## Outcome comparison
+
+`PredictionOutcomeComparison` is a distinct derived artifact. It records:
+
+- a stable comparison ref;
+- exact `prediction_ref` and `prediction_revision_ref`;
+- observed outcome summary;
+- observed evidence refs;
+- observation time;
+- comparison disposition: `matched`, `contradicted`, `partial`, or `unresolved`;
+- optional comparison evidence and estimator metadata.
+
+The comparison retains a reference to observed evidence. It is not itself promoted to `semantic_fact_memory` or `episodic_event_memory` by this module.
+
+The comparison disposition is provider/estimator output. `matched` does not authorize action, `contradicted` does not autonomously block action, and a confidence of `1.0` does not alter PAMA outcome.
+
+## Counterfactual boundary
+
+Counterfactual history is intentionally sticky:
+
+```text
+counterfactual prediction
+  + later actual outcome
+  + comparison
+  != observed counterfactual history
+```
+
+The actual outcome can be compared with the counterfactual, but `prediction_kind` remains `counterfactual`. The original expected outcome remains historically attributable as the modelled branch that was considered, not as an event that happened.
+
+## Capability maturity and operational honesty
+
+The reference component declares:
+
+```text
+profile_version: component-capability-v3
+maturity: runtime_wired
+authority_effect: none
+```
+
+Its operational contract is intentionally process-local:
+
+```text
+write_atomicity: process_local
+concurrency_control: process_local
+idempotency: process_local
+restart_recovery: process_local_only
+reconciliation: process_local_only
+```
+
+This slice proves predictive semantics, governed retention/revision, and the observed-outcome comparison boundary. It does not prove restart reconstruction, cross-process reconciliation, or production world-model execution.
+
+## Non-claims
+
+This implementation does not:
+
+- execute forecasts, simulations, or counterfactual models;
+- certify a prediction as fact;
+- treat an observed outcome summary as canonical observed history;
+- promote comparison disposition to authority;
+- treat confidence `1.0` as permission;
+- provide cross-process restart reconstruction;
+- claim durable idempotency or reconciliation;
+- add an external world-model/provider SDK;
+- create a new PAMA operation or authority class.
+
+External predictive providers can later be qualified against Capability Contract v3 without changing these canonical semantic boundaries.

--- a/reference/agentmem_ref/predictive_memory.py
+++ b/reference/agentmem_ref/predictive_memory.py
@@ -1,0 +1,552 @@
+"""Governed reference implementation of predictive and counterfactual memory.
+
+This module implements the first bounded ``predictive_counterfactual_memory``
+runtime surface introduced by Capability Contract v3. Forecasts, simulations,
+and counterfactual trajectories remain explicitly predictive state. Later
+observations are retained as evidence for a separate comparison artifact; they
+do not rewrite the prediction into observed history.
+
+The module composes existing Agent Memory primitives:
+
+prediction revision
+  -> Cognitive Mesh signal
+  -> PAMA authority envelope
+  -> governed commit/refusal
+  -> predictive recall
+
+observed outcome evidence
+  -> separate comparison artifact
+  -> Cognitive Mesh signal
+  -> PAMA authority envelope
+  -> governed commit/refusal
+
+The reference implementation is process-local. Its v3 capability profile says
+so explicitly; restart/reconciliation portability and actual simulation/model
+execution are future work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from . import policy
+from .adapter import CommitResult, GovernedMemoryAdapter, RecallContext
+from .cognitive_mesh import (
+    ActiveCognition,
+    CognitiveExperience,
+    CognitiveMeshRuntime,
+    CognitiveSignal,
+    MeshObject,
+)
+from .contextual_recall import DeterministicContextualRecallPolicy
+
+PREDICTIVE_COMPONENT_ID = "agent-memory-predictive-reference"
+CAPABILITY_ID = "predictive_counterfactual_memory"
+
+PREDICTION_KINDS = frozenset({"forecast", "simulation", "counterfactual"})
+COMPARISON_DISPOSITIONS = frozenset(
+    {"matched", "contradicted", "partial", "unresolved"}
+)
+
+
+class PredictiveRevisionError(ValueError):
+    """Base error for invalid predictive state or comparison."""
+
+
+class StalePredictionRevision(PredictiveRevisionError):
+    """A prediction revision did not extend the current append-only lineage."""
+
+
+@dataclass(frozen=True)
+class PredictiveScope:
+    """Governed scope carried by every revision of one prediction."""
+
+    scope: str
+    isolation_domain_refs: tuple[str, ...] = ()
+    required_isolation_domain_refs: tuple[str, ...] = ()
+    project_ref: str = ""
+    task_ref: str = ""
+    purpose: str = "planning"
+
+    def __post_init__(self) -> None:
+        if not self.scope:
+            raise PredictiveRevisionError("predictive scope is required")
+        required = set(self.required_isolation_domain_refs)
+        bound = set(self.isolation_domain_refs)
+        if required and not required.issubset(bound):
+            raise PredictiveRevisionError(
+                "required isolation domains must be present in isolation_domain_refs"
+            )
+
+
+@dataclass(frozen=True)
+class PredictionRevision:
+    """One immutable forecast/simulation/counterfactual revision.
+
+    ``prediction_kind`` remains predictive metadata for the lifetime of the
+    revision. Outcome comparison never mutates it into an observation.
+    """
+
+    prediction_ref: str
+    revision_ref: str
+    prediction_kind: str
+    expected_outcome: str
+    confidence: float | None
+    scope: PredictiveScope
+    source_component: str
+    created_at: str
+    target_window: str
+    basis_evidence_refs: tuple[str, ...] = ()
+    assumptions: tuple[str, ...] = ()
+    prior_revision_ref: str = ""
+    revision_reason: str = ""
+    estimator_ref: str = ""
+    estimator_version: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.prediction_ref or not self.revision_ref:
+            raise PredictiveRevisionError(
+                "prediction_ref and revision_ref are required"
+            )
+        if self.prediction_kind not in PREDICTION_KINDS:
+            raise PredictiveRevisionError(
+                f"unsupported prediction_kind: {self.prediction_kind}"
+            )
+        if not self.expected_outcome:
+            raise PredictiveRevisionError("expected_outcome is required")
+        if not self.source_component or not self.created_at or not self.target_window:
+            raise PredictiveRevisionError(
+                "source_component, created_at, and target_window are required"
+            )
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise PredictiveRevisionError("confidence must be between 0 and 1")
+        if self.prior_revision_ref and not self.revision_reason:
+            raise PredictiveRevisionError(
+                "non-initial prediction revision requires revision_reason"
+            )
+        if len(set(self.basis_evidence_refs)) != len(self.basis_evidence_refs):
+            raise PredictiveRevisionError(
+                "basis_evidence_refs must not contain duplicates"
+            )
+        if len(set(self.assumptions)) != len(self.assumptions):
+            raise PredictiveRevisionError("assumptions must not contain duplicates")
+
+
+@dataclass(frozen=True)
+class PredictionOutcomeComparison:
+    """Separate derived comparison between prediction and observed evidence.
+
+    The comparison is not the observation itself and does not change the
+    prediction's kind. ``disposition`` is descriptive and never authority.
+    """
+
+    comparison_ref: str
+    prediction_ref: str
+    prediction_revision_ref: str
+    observed_outcome_summary: str
+    observed_evidence_refs: tuple[str, ...]
+    observed_at: str
+    disposition: str
+    source_component: str
+    comparison_evidence_refs: tuple[str, ...] = ()
+    confidence: float | None = None
+    estimator_ref: str = ""
+    estimator_version: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.comparison_ref or not self.prediction_ref:
+            raise PredictiveRevisionError(
+                "comparison_ref and prediction_ref are required"
+            )
+        if not self.prediction_revision_ref:
+            raise PredictiveRevisionError(
+                "prediction_revision_ref is required"
+            )
+        if not self.observed_outcome_summary or not self.observed_at:
+            raise PredictiveRevisionError(
+                "observed_outcome_summary and observed_at are required"
+            )
+        if not self.observed_evidence_refs:
+            raise PredictiveRevisionError(
+                "observed_evidence_refs are required for outcome comparison"
+            )
+        if self.disposition not in COMPARISON_DISPOSITIONS:
+            raise PredictiveRevisionError(
+                f"unsupported comparison disposition: {self.disposition}"
+            )
+        if not self.source_component:
+            raise PredictiveRevisionError(
+                "comparison source_component is required"
+            )
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise PredictiveRevisionError("confidence must be between 0 and 1")
+        for name, refs in (
+            ("observed_evidence_refs", self.observed_evidence_refs),
+            ("comparison_evidence_refs", self.comparison_evidence_refs),
+        ):
+            if len(set(refs)) != len(refs):
+                raise PredictiveRevisionError(f"{name} must not contain duplicates")
+
+    @property
+    def evidence_refs(self) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                self.observed_evidence_refs + self.comparison_evidence_refs
+            )
+        )
+
+
+@dataclass(frozen=True)
+class PredictionRevisionResult:
+    """Governed consequence of one attempted prediction revision."""
+
+    revision: PredictionRevision
+    commit: CommitResult
+    fact_uuid: str | None
+    lineage_state: str
+
+
+@dataclass(frozen=True)
+class PredictionComparisonResult:
+    """Governed consequence of retaining one outcome comparison."""
+
+    comparison: PredictionOutcomeComparison
+    commit: CommitResult
+    fact_uuid: str | None
+
+
+@dataclass
+class PredictiveCounterfactualMemory:
+    """Process-local reference runtime for governed predictive state."""
+
+    adapter: GovernedMemoryAdapter
+    available_components: tuple[str, ...]
+    recall_policy: DeterministicContextualRecallPolicy | None = None
+    _mesh: CognitiveMeshRuntime = field(init=False, repr=False)
+    _history: dict[str, list[PredictionRevision]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _fact_by_revision: dict[str, str] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _comparisons: dict[str, PredictionOutcomeComparison] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _comparison_refs_by_prediction: dict[str, list[str]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _fact_by_comparison: dict[str, str] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        self._mesh = CognitiveMeshRuntime(
+            adapter=self.adapter,
+            available_components=self.available_components,
+            recall_policy=self.recall_policy,
+        )
+
+    def apply_revision(
+        self,
+        revision: PredictionRevision,
+        *,
+        actor_id: str,
+        target_class: str = policy.M2,
+        downstream_authority: str = policy.A1,
+        risk_class: str = "low",
+        review_satisfied: bool = False,
+        approval_refs: tuple[str, ...] = (),
+    ) -> PredictionRevisionResult:
+        """Retain/revise predictive state through Cognitive Mesh and PAMA."""
+        current = self.current(revision.prediction_ref)
+        self._ensure_new_revision_ref(revision)
+        self._validate_lineage(revision, current)
+
+        operation = "promotion" if current is None else "correction"
+        experience = CognitiveExperience(
+            experience_ref=revision.revision_ref,
+            content=self._prediction_fact_text(revision),
+            source_description=(
+                f"predictive {revision.prediction_kind} revision "
+                f"from {revision.source_component}"
+            ),
+            observed_at=revision.created_at,
+        )
+        cognitive_object = MeshObject(
+            object_ref=revision.prediction_ref,
+            object_type=CAPABILITY_ID,
+            scope=revision.scope.scope,
+            evidence_refs=revision.basis_evidence_refs,
+            isolation_domain_refs=revision.scope.isolation_domain_refs,
+            required_isolation_domain_refs=(
+                revision.scope.required_isolation_domain_refs
+            ),
+            project_ref=revision.scope.project_ref,
+            task_ref=revision.scope.task_ref,
+            purpose=revision.scope.purpose,
+        )
+        signal = CognitiveSignal(
+            module_role="predictive_world_model",
+            source_component=revision.source_component,
+            signal_type=f"{revision.prediction_kind}_revision",
+            evidence_refs=revision.basis_evidence_refs,
+            estimator_ref=revision.estimator_ref,
+            estimator_version=revision.estimator_version,
+            confidence=revision.confidence,
+        )
+        transition = self._mesh.apply_signal(
+            experience=experience,
+            cognitive_object=cognitive_object,
+            signal=signal,
+            actor_id=actor_id,
+            requested_operation=operation,
+            target_class=target_class,
+            downstream_authority=downstream_authority,
+            risk_class=risk_class,
+            current_strength="observed" if current is None else "tentative",
+            proposed_strength="tentative",
+            charter_version="predictive-counterfactual-memory-ref-v1",
+            proposal_id=f"proposal:{revision.revision_ref}",
+            review_satisfied=review_satisfied,
+            approval_refs=approval_refs,
+        )
+
+        if transition.commit.committed:
+            self._history.setdefault(revision.prediction_ref, []).append(revision)
+            if transition.commit.fact_uuid is None:
+                raise RuntimeError("committed prediction revision requires fact_uuid")
+            self._fact_by_revision[revision.revision_ref] = (
+                transition.commit.fact_uuid
+            )
+
+        return PredictionRevisionResult(
+            revision=revision,
+            commit=transition.commit,
+            fact_uuid=transition.commit.fact_uuid,
+            lineage_state=(
+                self.revision_state(
+                    revision.prediction_ref,
+                    revision.revision_ref,
+                )
+                if transition.commit.committed
+                else "refused"
+            ),
+        )
+
+    def record_outcome_comparison(
+        self,
+        comparison: PredictionOutcomeComparison,
+        *,
+        actor_id: str,
+        scope: PredictiveScope | None = None,
+        target_class: str = policy.M2,
+        downstream_authority: str = policy.A1,
+        risk_class: str = "low",
+        review_satisfied: bool = False,
+        approval_refs: tuple[str, ...] = (),
+    ) -> PredictionComparisonResult:
+        """Retain a derived comparison without rewriting prediction history."""
+        if comparison.comparison_ref in self._comparisons:
+            raise PredictiveRevisionError(
+                f"comparison_ref already exists: {comparison.comparison_ref}"
+            )
+        prediction_revision = self._revision(
+            comparison.prediction_ref,
+            comparison.prediction_revision_ref,
+        )
+        effective_scope = scope or prediction_revision.scope
+        if effective_scope != prediction_revision.scope:
+            raise PredictiveRevisionError(
+                "outcome comparison cannot silently change governed prediction scope"
+            )
+
+        content = self._comparison_fact_text(
+            prediction_revision,
+            comparison,
+        )
+        experience = CognitiveExperience(
+            experience_ref=comparison.comparison_ref,
+            content=content,
+            source_description=(
+                "prediction/outcome comparison; observed evidence remains "
+                "separate from predictive state"
+            ),
+            observed_at=comparison.observed_at,
+        )
+        cognitive_object = MeshObject(
+            object_ref=comparison.comparison_ref,
+            object_type="prediction_outcome_comparison",
+            scope=effective_scope.scope,
+            evidence_refs=tuple(
+                dict.fromkeys(
+                    (comparison.prediction_revision_ref,)
+                    + comparison.evidence_refs
+                )
+            ),
+            isolation_domain_refs=effective_scope.isolation_domain_refs,
+            required_isolation_domain_refs=(
+                effective_scope.required_isolation_domain_refs
+            ),
+            project_ref=effective_scope.project_ref,
+            task_ref=effective_scope.task_ref,
+            purpose=effective_scope.purpose,
+        )
+        signal = CognitiveSignal(
+            module_role="predictive_world_model",
+            source_component=comparison.source_component,
+            signal_type="prediction_outcome_comparison",
+            evidence_refs=tuple(
+                dict.fromkeys(
+                    (comparison.prediction_revision_ref,)
+                    + comparison.evidence_refs
+                )
+            ),
+            estimator_ref=comparison.estimator_ref,
+            estimator_version=comparison.estimator_version,
+            confidence=comparison.confidence,
+            provider_verdict=comparison.disposition,
+        )
+        transition = self._mesh.apply_signal(
+            experience=experience,
+            cognitive_object=cognitive_object,
+            signal=signal,
+            actor_id=actor_id,
+            requested_operation="promotion",
+            target_class=target_class,
+            downstream_authority=downstream_authority,
+            risk_class=risk_class,
+            current_strength="observed",
+            proposed_strength="tentative",
+            charter_version="predictive-counterfactual-memory-ref-v1",
+            proposal_id=f"proposal:{comparison.comparison_ref}",
+            review_satisfied=review_satisfied,
+            approval_refs=approval_refs,
+        )
+
+        if transition.commit.committed:
+            self._comparisons[comparison.comparison_ref] = comparison
+            self._comparison_refs_by_prediction.setdefault(
+                comparison.prediction_ref,
+                [],
+            ).append(comparison.comparison_ref)
+            if transition.commit.fact_uuid is None:
+                raise RuntimeError("committed comparison requires fact_uuid")
+            self._fact_by_comparison[comparison.comparison_ref] = (
+                transition.commit.fact_uuid
+            )
+
+        return PredictionComparisonResult(
+            comparison=comparison,
+            commit=transition.commit,
+            fact_uuid=transition.commit.fact_uuid,
+        )
+
+    def current(self, prediction_ref: str) -> PredictionRevision | None:
+        history = self._history.get(prediction_ref, ())
+        return history[-1] if history else None
+
+    def history(self, prediction_ref: str) -> tuple[PredictionRevision, ...]:
+        return tuple(self._history.get(prediction_ref, ()))
+
+    def revision_state(self, prediction_ref: str, revision_ref: str) -> str:
+        history = self._history.get(prediction_ref, ())
+        matches = [item for item in history if item.revision_ref == revision_ref]
+        if not matches:
+            raise KeyError(revision_ref)
+        return "current" if history[-1].revision_ref == revision_ref else "superseded"
+
+    def comparison(self, comparison_ref: str) -> PredictionOutcomeComparison | None:
+        return self._comparisons.get(comparison_ref)
+
+    def comparisons_for(
+        self,
+        prediction_ref: str,
+    ) -> tuple[PredictionOutcomeComparison, ...]:
+        return tuple(
+            self._comparisons[ref]
+            for ref in self._comparison_refs_by_prediction.get(prediction_ref, ())
+        )
+
+    def fact_uuid(self, revision_ref: str) -> str | None:
+        return self._fact_by_revision.get(revision_ref)
+
+    def comparison_fact_uuid(self, comparison_ref: str) -> str | None:
+        return self._fact_by_comparison.get(comparison_ref)
+
+    def recall_active(
+        self,
+        query: str,
+        *,
+        context: RecallContext,
+    ) -> ActiveCognition:
+        return self._mesh.recall_active(query, context=context)
+
+    def replace_component(self, *, old_component: str, new_component: str) -> None:
+        self._mesh.replace_component(
+            old_component=old_component,
+            new_component=new_component,
+        )
+
+    def _ensure_new_revision_ref(self, revision: PredictionRevision) -> None:
+        if any(
+            item.revision_ref == revision.revision_ref
+            for item in self._history.get(revision.prediction_ref, ())
+        ):
+            raise PredictiveRevisionError(
+                f"revision_ref already exists for prediction: {revision.revision_ref}"
+            )
+
+    @staticmethod
+    def _validate_lineage(
+        revision: PredictionRevision,
+        current: PredictionRevision | None,
+    ) -> None:
+        if current is None:
+            if revision.prior_revision_ref:
+                raise StalePredictionRevision(
+                    "initial prediction revision must not declare prior_revision_ref"
+                )
+            return
+        if revision.prior_revision_ref != current.revision_ref:
+            raise StalePredictionRevision(
+                "prediction revision must extend the current revision_ref"
+            )
+        if revision.scope != current.scope:
+            raise PredictiveRevisionError(
+                "prediction revision cannot silently change governed scope"
+            )
+        if revision.prediction_kind != current.prediction_kind:
+            raise PredictiveRevisionError(
+                "prediction revision cannot silently change prediction_kind"
+            )
+
+    def _revision(
+        self,
+        prediction_ref: str,
+        revision_ref: str,
+    ) -> PredictionRevision:
+        for revision in self._history.get(prediction_ref, ()):
+            if revision.revision_ref == revision_ref:
+                return revision
+        raise PredictiveRevisionError(
+            f"unknown prediction revision: {prediction_ref}/{revision_ref}"
+        )
+
+    @staticmethod
+    def _prediction_fact_text(revision: PredictionRevision) -> str:
+        return (
+            f"PREDICTIVE[{revision.prediction_kind}] target={revision.target_window}: "
+            f"{revision.expected_outcome}"
+        )
+
+    @staticmethod
+    def _comparison_fact_text(
+        revision: PredictionRevision,
+        comparison: PredictionOutcomeComparison,
+    ) -> str:
+        return (
+            f"PREDICTION_COMPARISON[{comparison.disposition}] "
+            f"prediction_kind={revision.prediction_kind}; "
+            f"predicted={revision.expected_outcome}; "
+            f"observed_summary={comparison.observed_outcome_summary}"
+        )

--- a/reference/fixtures/component-capabilities/predictive-reference-v3.json
+++ b/reference/fixtures/component-capabilities/predictive-reference-v3.json
@@ -1,0 +1,57 @@
+{
+  "component_id": "agent-memory-predictive-reference",
+  "component_version": "0.1.0",
+  "profile_version": "component-capability-v3",
+  "enabled": true,
+  "runtime_ref": "reference/agentmem_ref/predictive_memory.py",
+  "failure_posture": "fail_closed",
+  "provenance_refs": [
+    "https://github.com/MythologIQ-Labs-LLC/agent-memory/issues/348",
+    "https://github.com/MythologIQ-Labs-LLC/agent-memory/pull/345",
+    "https://github.com/MythologIQ-Labs-LLC/agent-memory/pull/347"
+  ],
+  "capabilities": [
+    {
+      "capability_id": "predictive_counterfactual_memory",
+      "capability_version": "1.0",
+      "maturity": "runtime_wired",
+      "state_posture": "derived",
+      "scope_posture": "enforces_agent_memory_scope",
+      "failure_posture": "fail_closed",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "reference/agentmem_ref/predictive_memory.py",
+        "reference/tests/test_predictive_memory.py",
+        "docs/programs/memory-modules/predictive-counterfactual-memory-reference.md"
+      ],
+      "limitations": [
+        "Reference prediction and comparison indexes are process-local and are not restart reconstructable.",
+        "Prediction confidence and outcome-comparison disposition are descriptive evidence and not authority.",
+        "Observed outcome summaries remain comparison evidence and are not promoted to semantic fact memory by this component.",
+        "This component stores predictive artifacts; it does not execute a simulation engine or external world model."
+      ],
+      "behavior_contract": {
+        "operation_support": {
+          "write": true,
+          "read": true,
+          "recall_candidate": true
+        },
+        "currentness_model": "basis_versioned",
+        "invalidation_model": "version_relation",
+        "correction_model": "invalidate_derived",
+        "deletion_model": "candidate_drop",
+        "residue_model": "scan_required",
+        "migration_rebuild_model": "unsupported",
+        "structural_mutation_requirement": "none"
+      },
+      "operational_contract": {
+        "write_atomicity": "process_local",
+        "concurrency_control": "process_local",
+        "idempotency": "process_local",
+        "restart_recovery": "process_local_only",
+        "reconciliation": "process_local_only"
+      }
+    }
+  ]
+}

--- a/reference/fixtures/component-capabilities/predictive-reference-v3.json
+++ b/reference/fixtures/component-capabilities/predictive-reference-v3.json
@@ -29,6 +29,7 @@
         "Reference prediction and comparison indexes are process-local and are not restart reconstructable.",
         "Prediction confidence and outcome-comparison disposition are descriptive evidence and not authority.",
         "Observed outcome summaries remain comparison evidence and are not promoted to semantic fact memory by this component.",
+        "Predictive deletion/residue behavior is outside this bounded runtime slice.",
         "This component stores predictive artifacts; it does not execute a simulation engine or external world model."
       ],
       "behavior_contract": {
@@ -40,8 +41,8 @@
         "currentness_model": "basis_versioned",
         "invalidation_model": "version_relation",
         "correction_model": "invalidate_derived",
-        "deletion_model": "candidate_drop",
-        "residue_model": "scan_required",
+        "deletion_model": "not_applicable",
+        "residue_model": "not_applicable",
         "migration_rebuild_model": "unsupported",
         "structural_mutation_requirement": "none"
       },

--- a/reference/tests/test_predictive_memory.py
+++ b/reference/tests/test_predictive_memory.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+from agentmem_ref import policy
+from agentmem_ref.adapter import Clock, GovernedMemoryAdapter, RecallContext
+from agentmem_ref.capabilities import ComponentDeclaration
+from agentmem_ref.predictive_memory import (
+    CAPABILITY_ID,
+    PredictionOutcomeComparison,
+    PredictionRevision,
+    PredictiveCounterfactualMemory,
+    PredictiveRevisionError,
+    PredictiveScope,
+    StalePredictionRevision,
+)
+from agentmem_ref.substrate import InMemoryTemporalGraph
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE = (
+    ROOT
+    / "reference"
+    / "fixtures"
+    / "component-capabilities"
+    / "predictive-reference-v3.json"
+)
+SCHEMA = ROOT / "schemas" / "component-capability-profile.schema.json"
+
+TENANT = "tenant:predictive"
+PROJECT = "project:predictive"
+
+
+def governed_scope() -> PredictiveScope:
+    return PredictiveScope(
+        scope=TENANT,
+        isolation_domain_refs=(TENANT, PROJECT),
+        required_isolation_domain_refs=(TENANT, PROJECT),
+        project_ref=PROJECT,
+        purpose="planning",
+    )
+
+
+def context() -> RecallContext:
+    return RecallContext(
+        target_domain_refs=(TENANT, PROJECT),
+        principal_ref="agent:predictive-test",
+        project_ref=PROJECT,
+        purpose="planning",
+    )
+
+
+def prediction(
+    revision_ref: str,
+    *,
+    prediction_ref: str = "prediction:deployment",
+    prediction_kind: str = "forecast",
+    expected_outcome: str = "Staged deployment completes without elevated errors",
+    confidence: float | None = 0.72,
+    source_component: str = "PredictorA",
+    basis: tuple[str, ...] = ("evidence:canary",),
+    assumptions: tuple[str, ...] = ("traffic mix remains stable",),
+    prior_revision_ref: str = "",
+    revision_reason: str = "",
+    scope: PredictiveScope | None = None,
+) -> PredictionRevision:
+    return PredictionRevision(
+        prediction_ref=prediction_ref,
+        revision_ref=revision_ref,
+        prediction_kind=prediction_kind,
+        expected_outcome=expected_outcome,
+        confidence=confidence,
+        scope=scope or governed_scope(),
+        source_component=source_component,
+        created_at="2026-01-01T00:00:00Z",
+        target_window="next deployment window",
+        basis_evidence_refs=basis,
+        assumptions=assumptions,
+        prior_revision_ref=prior_revision_ref,
+        revision_reason=revision_reason,
+        estimator_ref=f"estimator:{source_component}",
+        estimator_version="1.0.0",
+    )
+
+
+def comparison(
+    comparison_ref: str,
+    *,
+    prediction_ref: str = "prediction:deployment",
+    prediction_revision_ref: str = "prediction-rev:001",
+    disposition: str = "matched",
+    source_component: str = "ComparatorA",
+    observed_summary: str = "Deployment completed without elevated errors",
+    observed_refs: tuple[str, ...] = ("observation:deploy-run-42",),
+) -> PredictionOutcomeComparison:
+    return PredictionOutcomeComparison(
+        comparison_ref=comparison_ref,
+        prediction_ref=prediction_ref,
+        prediction_revision_ref=prediction_revision_ref,
+        observed_outcome_summary=observed_summary,
+        observed_evidence_refs=observed_refs,
+        observed_at="2026-01-01T01:00:00Z",
+        disposition=disposition,
+        source_component=source_component,
+        comparison_evidence_refs=("comparison:method-v1",),
+        confidence=0.9,
+        estimator_ref=f"estimator:{source_component}",
+        estimator_version="1.0.0",
+    )
+
+
+def runtime(*components: str) -> tuple[
+    PredictiveCounterfactualMemory,
+    GovernedMemoryAdapter,
+    InMemoryTemporalGraph,
+]:
+    substrate = InMemoryTemporalGraph()
+    adapter = GovernedMemoryAdapter(substrate, tenant=TENANT, clock=Clock())
+    memory = PredictiveCounterfactualMemory(
+        adapter=adapter,
+        available_components=tuple(components),
+    )
+    return memory, adapter, substrate
+
+
+class PredictiveCounterfactualMemoryTests(unittest.TestCase):
+    def test_v3_profile_is_honest_process_local_predictive_capability(self) -> None:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        value = json.loads(PROFILE.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(value)
+        component = ComponentDeclaration.from_dict(value)
+
+        self.assertEqual("component-capability-v3", component.profile_version)
+        self.assertEqual(1, len(component.capabilities))
+        capability = component.capabilities[0]
+        self.assertEqual(CAPABILITY_ID, capability.capability_id)
+        self.assertEqual("runtime_wired", capability.maturity)
+        self.assertEqual("none", capability.authority_effect)
+        self.assertEqual(
+            "process_local_only",
+            capability.operational_contract.restart_recovery,
+        )
+        self.assertEqual(
+            "process_local_only",
+            capability.operational_contract.reconciliation,
+        )
+
+    def test_forecast_simulation_and_counterfactual_remain_independently_typed(self) -> None:
+        memory, _, _ = runtime("PredictorA")
+        for index, kind in enumerate(
+            ("forecast", "simulation", "counterfactual"),
+            start=1,
+        ):
+            item = prediction(
+                f"prediction-rev:{index:03d}",
+                prediction_ref=f"prediction:{kind}",
+                prediction_kind=kind,
+            )
+            result = memory.apply_revision(
+                item,
+                actor_id="agent:predictive-test",
+            )
+            self.assertTrue(result.commit.committed)
+            self.assertEqual(kind, memory.current(item.prediction_ref).prediction_kind)
+            self.assertEqual("tentative", result.commit.pama_decision["mutation"]["proposed_strength"])
+
+    def test_initial_forecast_is_retained_as_predictive_not_observed_history(self) -> None:
+        memory, adapter, substrate = runtime("PredictorA")
+        first = prediction("prediction-rev:001")
+
+        result = memory.apply_revision(first, actor_id="agent:predictive-test")
+
+        self.assertTrue(result.commit.committed)
+        self.assertEqual(policy.ALLOW_WITH_LEDGER, result.commit.decision.outcome)
+        self.assertEqual("current", result.lineage_state)
+        self.assertEqual(first, memory.current(first.prediction_ref))
+        fact = substrate.get_fact(result.fact_uuid)
+        self.assertTrue(fact.fact_text.startswith("PREDICTIVE[forecast]"))
+        self.assertEqual(result.fact_uuid, adapter.current_fact_uuid(first.prediction_ref))
+        self.assertEqual(0.72, result.commit.pama_decision["basis"]["confidence"])
+
+        active = memory.recall_active(
+            "staged deployment elevated errors",
+            context=context(),
+        )
+        self.assertIn(first.prediction_ref, active.active_object_refs)
+
+    def test_confidence_one_cannot_grant_external_action_authority(self) -> None:
+        memory, adapter, substrate = runtime("PredictorA")
+        high_confidence = prediction(
+            "prediction-rev:001",
+            confidence=1.0,
+        )
+
+        result = memory.apply_revision(
+            high_confidence,
+            actor_id="agent:predictive-test",
+            downstream_authority=policy.A4,
+        )
+
+        self.assertFalse(result.commit.committed)
+        self.assertEqual(policy.REQUIRE_REVIEW, result.commit.decision.outcome)
+        self.assertEqual("refused", result.lineage_state)
+        self.assertEqual((), memory.history(high_confidence.prediction_ref))
+        self.assertIsNone(adapter.current_fact_uuid(high_confidence.prediction_ref))
+        self.assertNotIn("write_fact", [entry[0] for entry in substrate.write_log])
+        self.assertIn("promotion", result.commit.decision.prohibited_actions)
+
+    def test_prediction_revision_is_append_only_and_refused_revision_is_not_current(self) -> None:
+        memory, adapter, substrate = runtime("PredictorA")
+        first = prediction("prediction-rev:001")
+        first_result = memory.apply_revision(first, actor_id="agent:predictive-test")
+
+        second = prediction(
+            "prediction-rev:002",
+            expected_outcome="Staged deployment causes a transient error increase",
+            confidence=0.55,
+            basis=("evidence:new-load-test",),
+            prior_revision_ref=first.revision_ref,
+            revision_reason="new load test changes expected outcome",
+        )
+        refused = memory.apply_revision(second, actor_id="agent:predictive-test")
+        self.assertFalse(refused.commit.committed)
+        self.assertEqual(first, memory.current(first.prediction_ref))
+        self.assertEqual((first,), memory.history(first.prediction_ref))
+        self.assertEqual(first_result.fact_uuid, adapter.current_fact_uuid(first.prediction_ref))
+
+        approved = memory.apply_revision(
+            second,
+            actor_id="agent:predictive-test",
+            review_satisfied=True,
+            approval_refs=("approval:prediction-revision",),
+        )
+        self.assertTrue(approved.commit.committed)
+        self.assertEqual((first, second), memory.history(first.prediction_ref))
+        self.assertEqual("superseded", memory.revision_state(first.prediction_ref, first.revision_ref))
+        self.assertEqual("current", memory.revision_state(first.prediction_ref, second.revision_ref))
+        self.assertTrue(substrate.get_fact(first_result.fact_uuid).is_event_invalid)
+
+    def test_outcome_comparison_is_separate_and_does_not_rewrite_prediction(self) -> None:
+        memory, _, substrate = runtime("PredictorA", "ComparatorA")
+        first = prediction("prediction-rev:001")
+        first_result = memory.apply_revision(first, actor_id="agent:predictive-test")
+        observed = comparison("comparison:001")
+
+        result = memory.record_outcome_comparison(
+            observed,
+            actor_id="agent:predictive-test",
+        )
+
+        self.assertTrue(result.commit.committed)
+        self.assertEqual(first, memory.current(first.prediction_ref))
+        self.assertEqual((first,), memory.history(first.prediction_ref))
+        self.assertEqual(observed, memory.comparison(observed.comparison_ref))
+        self.assertEqual((observed,), memory.comparisons_for(first.prediction_ref))
+        self.assertEqual(first.revision_ref, observed.prediction_revision_ref)
+        self.assertEqual(("observation:deploy-run-42",), observed.observed_evidence_refs)
+        self.assertEqual("forecast", memory.current(first.prediction_ref).prediction_kind)
+        prediction_fact = substrate.get_fact(first_result.fact_uuid)
+        comparison_fact = substrate.get_fact(result.fact_uuid)
+        self.assertTrue(prediction_fact.fact_text.startswith("PREDICTIVE[forecast]"))
+        self.assertTrue(comparison_fact.fact_text.startswith("PREDICTION_COMPARISON[matched]"))
+        self.assertNotEqual(first_result.fact_uuid, result.fact_uuid)
+
+    def test_comparison_disposition_is_descriptive_not_authority(self) -> None:
+        memory, _, _ = runtime("PredictorA", "ComparatorA")
+        first = prediction("prediction-rev:001")
+        memory.apply_revision(first, actor_id="agent:predictive-test")
+
+        outcomes = []
+        for disposition in ("matched", "contradicted", "partial", "unresolved"):
+            item = comparison(
+                f"comparison:{disposition}",
+                disposition=disposition,
+                observed_summary=f"Observed outcome for {disposition}",
+                observed_refs=(f"observation:{disposition}",),
+            )
+            result = memory.record_outcome_comparison(
+                item,
+                actor_id="agent:predictive-test",
+            )
+            self.assertTrue(result.commit.committed)
+            self.assertEqual(disposition, result.comparison.disposition)
+            self.assertEqual(disposition, result.commit.pama_decision.get("provider_verdict", disposition))
+            outcomes.append(result.commit.decision.outcome)
+
+        self.assertEqual([policy.ALLOW_WITH_LEDGER] * 4, outcomes)
+
+    def test_counterfactual_remains_counterfactual_after_actual_outcome_comparison(self) -> None:
+        memory, _, _ = runtime("PredictorA", "ComparatorA")
+        counterfactual = prediction(
+            "prediction-rev:001",
+            prediction_ref="prediction:counterfactual-no-cache",
+            prediction_kind="counterfactual",
+            expected_outcome="Without caching, latency would exceed the target",
+        )
+        memory.apply_revision(counterfactual, actor_id="agent:predictive-test")
+        outcome = comparison(
+            "comparison:counterfactual",
+            prediction_ref=counterfactual.prediction_ref,
+            prediction_revision_ref=counterfactual.revision_ref,
+            disposition="partial",
+            observed_summary="Actual cached deployment met latency target",
+            observed_refs=("observation:cached-deployment",),
+        )
+        memory.record_outcome_comparison(
+            outcome,
+            actor_id="agent:predictive-test",
+        )
+
+        current = memory.current(counterfactual.prediction_ref)
+        self.assertEqual("counterfactual", current.prediction_kind)
+        self.assertEqual(counterfactual.expected_outcome, current.expected_outcome)
+        self.assertEqual(
+            counterfactual.revision_ref,
+            memory.comparison(outcome.comparison_ref).prediction_revision_ref,
+        )
+
+    def test_stale_revision_scope_change_and_kind_change_fail_before_mutation(self) -> None:
+        memory, _, substrate = runtime("PredictorA")
+        first = prediction("prediction-rev:001")
+        memory.apply_revision(first, actor_id="agent:predictive-test")
+        before = tuple(substrate.write_log)
+
+        stale = prediction(
+            "prediction-rev:002",
+            prior_revision_ref="prediction-rev:000",
+            revision_reason="stale writer",
+        )
+        with self.assertRaises(StalePredictionRevision):
+            memory.apply_revision(stale, actor_id="agent:predictive-test")
+        self.assertEqual(before, tuple(substrate.write_log))
+
+        foreign_scope = PredictiveScope(
+            scope=TENANT,
+            isolation_domain_refs=(TENANT, "project:other"),
+            required_isolation_domain_refs=(TENANT, "project:other"),
+            project_ref="project:other",
+        )
+        changed_scope = prediction(
+            "prediction-rev:003",
+            prior_revision_ref=first.revision_ref,
+            revision_reason="attempted scope movement",
+            scope=foreign_scope,
+        )
+        with self.assertRaises(PredictiveRevisionError):
+            memory.apply_revision(changed_scope, actor_id="agent:predictive-test")
+        self.assertEqual(before, tuple(substrate.write_log))
+
+        changed_kind = prediction(
+            "prediction-rev:004",
+            prediction_kind="simulation",
+            prior_revision_ref=first.revision_ref,
+            revision_reason="attempted type mutation",
+        )
+        with self.assertRaises(PredictiveRevisionError):
+            memory.apply_revision(changed_kind, actor_id="agent:predictive-test")
+        self.assertEqual(before, tuple(substrate.write_log))
+
+    def test_provider_replacement_preserves_prediction_identity_and_authority_boundary(self) -> None:
+        memory, _, _ = runtime("PredictorA", "ComparatorA")
+        first = prediction("prediction-rev:001", source_component="PredictorA")
+        memory.apply_revision(first, actor_id="agent:predictive-test")
+
+        memory.replace_component(old_component="PredictorA", new_component="PredictorB")
+        second = prediction(
+            "prediction-rev:002",
+            source_component="PredictorB",
+            expected_outcome="Replacement predictor expects a small error increase",
+            basis=("evidence:replacement-model",),
+            prior_revision_ref=first.revision_ref,
+            revision_reason="replacement provider produced revised forecast",
+        )
+        result = memory.apply_revision(
+            second,
+            actor_id="agent:predictive-test",
+            review_satisfied=True,
+            approval_refs=("approval:provider-revision",),
+        )
+
+        self.assertTrue(result.commit.committed)
+        self.assertEqual(first.prediction_ref, second.prediction_ref)
+        self.assertEqual(
+            first.prediction_ref,
+            result.commit.pama_decision["target"]["reference"],
+        )
+        self.assertEqual("PredictorB", memory.current(first.prediction_ref).source_component)
+        self.assertNotIn("authority_effect", result.commit.pama_decision)
+
+    def test_profile_declares_only_predictive_capability(self) -> None:
+        value = json.loads(PROFILE.read_text(encoding="utf-8"))
+        declared = {item["capability_id"] for item in value["capabilities"]}
+        self.assertEqual({CAPABILITY_ID}, declared)
+        self.assertNotIn("semantic_fact_memory", declared)
+        self.assertNotIn("episodic_event_memory", declared)
+        self.assertNotIn("epistemic_belief_memory", declared)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #348

## Summary

Implements the first bounded native `predictive_counterfactual_memory` reference substrate on top of Accepted ADR-035, Capability Contract v3, and the merged epistemic belief-memory boundary.

The implementation deliberately stores and governs predictive artifacts; it does **not** become a simulation engine.

```text
prediction revision
  -> stable predictive identity + explicit kind
  -> Cognitive Mesh
  -> PAMA
  -> governed predictive memory

observed outcome evidence
  -> separate comparison artifact
  -> exact prediction revision ref
  -> descriptive comparison disposition
  -> Cognitive Mesh
  -> PAMA
  -> governed comparison memory
```

The second path never overwrites the first.

## Predictive semantics

- explicit `forecast`, `simulation`, and `counterfactual` kinds;
- stable `prediction_ref` with append-only prediction revisions;
- expected outcome, confidence, target window, basis evidence, assumptions, revision lineage, governed scope, and estimator provenance;
- predictive revisions remain PAMA `tentative`, including confidence `1.0`;
- revision cannot silently change predictive kind or governed scope;
- refused revisions never become current.

## Outcome-comparison boundary

Adds a separate `PredictionOutcomeComparison` artifact with:

- exact prediction and revision refs;
- observed outcome summary and observed evidence refs;
- observation time;
- disposition: `matched`, `contradicted`, `partial`, or `unresolved`;
- optional comparison evidence and estimator metadata.

Observed evidence is therefore linked to a prediction rather than mutating the prediction into observed history. A counterfactual remains `counterfactual` after actual-outcome comparison.

Comparison disposition is passed only as descriptive provider output. It does not enter the PAMA proposal as a decision shortcut and does not create authority.

## Authority boundaries

- initial prediction retention uses existing `promotion`;
- later prediction revision uses existing `correction`, preserving review requirements;
- confidence `1.0` cannot grant external-action authority;
- `matched` does not authorize action;
- `contradicted` does not autonomously block action;
- no new PAMA operation or authority class is added.

## Capability Contract v3 profile

Adds `agent-memory-predictive-reference@0.1.0` with:

- `predictive_counterfactual_memory@1.0`;
- maturity `runtime_wired`;
- `authority_effect: none`;
- explicit behavior contract;
- process-local operational guarantees only;
- deletion/residue marked `not_applicable` because this bounded slice does not implement predictive forgetting.

## Acceptance evidence

Focused tests cover:

- schema-valid honest v3 profile;
- independent forecast/simulation/counterfactual typing;
- predictive rather than observed storage posture;
- confidence `1.0` unable to grant external-action authority;
- append-only revisions and correction review;
- separate outcome comparison without prediction rewrite;
- all comparison dispositions remaining descriptive/non-authoritative;
- counterfactual type preservation after actual-outcome comparison;
- stale revision, scope change, and kind mutation failing before substrate mutation;
- provider replacement preserving logical prediction identity and authority boundaries;
- profile declaring only predictive/counterfactual memory, not semantic fact, episodic history, or epistemic belief memory.

The repository's required `validate` lane remains the repository-level evidence boundary and includes the full reference regression suite.

## Explicit non-goals / stop condition

This PR does **not** integrate an external world-model SDK, execute simulations, create canonical observed history, implement predictive deletion/restart reconstruction, or add new authority semantics.