### PR TITLE
Qualify Hindsight v0.9.0 memory lifecycle against Capability Contract v3

### DIFF
--- a/.github/workflows/hindsight-v090-qualification.yml
+++ b/.github/workflows/hindsight-v090-qualification.yml
@@ -63,19 +63,28 @@ jobs:
           test "$ACTUAL_COMMIT" = "$EXPECTED_COMMIT"
           grep -q "MIT License" /tmp/hindsight-source/LICENSE
           grep -q 'version = "0.9.0"' /tmp/hindsight-source/hindsight-embed/pyproject.toml
+          grep -q 'version = "0.9.0"' /tmp/hindsight-source/hindsight-api/pyproject.toml
           grep -q '"chunks"' /tmp/hindsight-source/hindsight-api-slim/hindsight_api/config.py
           grep -q 'ENV_RETAIN_EXTRACTION_MODE = "HINDSIGHT_API_RETAIN_EXTRACTION_MODE"' /tmp/hindsight-source/hindsight-api-slim/hindsight_api/config.py
           printf '%s\n' "$ACTUAL_COMMIT" > /tmp/hindsight-source-commit.txt
 
-      - name: Install exact Hindsight embedded package
+      - name: Install exact Hindsight embedded runtime
         run: |
-          python -m pip install --disable-pip-version-check "hindsight-embed==0.9.0"
+          python -m pip install --disable-pip-version-check \
+            "hindsight-embed==0.9.0" \
+            "hindsight-api==0.9.0"
           python - <<'PY'
           from importlib import metadata
-          version = metadata.version("hindsight-embed")
-          if version != "0.9.0":
-              raise SystemExit(f"unexpected hindsight-embed version: {version}")
-          print(version)
+          expected = {
+              "hindsight-embed": "0.9.0",
+              "hindsight-api": "0.9.0",
+              "hindsight-api-slim": "0.9.0",
+          }
+          for package, wanted in expected.items():
+              actual = metadata.version(package)
+              if actual != wanted:
+                  raise SystemExit(f"unexpected {package} version: {actual}")
+              print(f"{package}={actual}")
           PY
 
       - name: Execute focused Agent Memory qualification tests

--- a/.github/workflows/hindsight-v090-qualification.yml
+++ b/.github/workflows/hindsight-v090-qualification.yml
@@ -24,12 +24,21 @@ jobs:
     timeout-minutes: 35
     env:
       PYTHONPATH: reference
+      AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
       HINDSIGHT_QUALIFICATION_HOME: /tmp/hindsight-qualification-home
       HF_HOME: /tmp/hindsight-qualification-hf
       TRANSFORMERS_CACHE: /tmp/hindsight-qualification-hf
     steps:
       - name: Checkout Agent Memory exact head
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.AGENT_MEMORY_COMMIT }}
+
+      - name: Verify Agent Memory exact head
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$AGENT_MEMORY_COMMIT"
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -71,7 +80,7 @@ jobs:
 
       - name: Execute focused Agent Memory qualification tests
         run: |
-          python -m pytest -q \
+          python -m unittest \
             reference/tests/test_hindsight_qualification.py \
             reference/tests/test_component_qualification_v12.py
 
@@ -91,7 +100,7 @@ jobs:
       - name: Emit Capability Qualification v1.2 evidence
         run: |
           python reference/run_hindsight_v090_qualification.py \
-            --agent-memory-commit "$GITHUB_SHA" \
+            --agent-memory-commit "$AGENT_MEMORY_COMMIT" \
             --raw-evidence artifacts/hindsight-v090/raw-provider-evidence.json \
             --component-profile reference/fixtures/component-capabilities/hindsight-v0.9.0.json \
             --output artifacts/hindsight-v090/qualification.json
@@ -157,6 +166,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: hindsight-v090-qualification-${{ github.sha }}
+          name: hindsight-v090-qualification-${{ env.AGENT_MEMORY_COMMIT }}
           path: artifacts/hindsight-v090
           if-no-files-found: warn

--- a/.github/workflows/hindsight-v090-qualification.yml
+++ b/.github/workflows/hindsight-v090-qualification.yml
@@ -1,0 +1,162 @@
+name: Hindsight v0.9.0 Qualification
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/hindsight-v090-qualification.yml"
+      - "reference/agentmem_ref/hindsight_qualification.py"
+      - "reference/run_hindsight_v090_fixture.py"
+      - "reference/run_hindsight_v090_qualification.py"
+      - "reference/tests/test_hindsight_qualification.py"
+      - "reference/fixtures/component-capabilities/hindsight-v0.9.0.json"
+      - "reference/agentmem_ref/qualification.py"
+      - "schemas/component-capability-profile.schema.json"
+      - "schemas/component-capability-qualification.schema.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  qualify-hindsight-v090:
+    name: qualify-hindsight-v090
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      PYTHONPATH: reference
+      HINDSIGHT_QUALIFICATION_HOME: /tmp/hindsight-qualification-home
+      HF_HOME: /tmp/hindsight-qualification-hf
+      TRANSFORMERS_CACHE: /tmp/hindsight-qualification-hf
+    steps:
+      - name: Checkout Agent Memory exact head
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Agent Memory validation dependencies
+        run: |
+          python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Verify exact Hindsight v0.9.0 source and MIT license
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/hindsight-source
+          git init -q /tmp/hindsight-source
+          git -C /tmp/hindsight-source remote add origin https://github.com/vectorize-io/hindsight.git
+          git -C /tmp/hindsight-source fetch -q --depth 1 origin refs/tags/v0.9.0
+          git -C /tmp/hindsight-source checkout -q FETCH_HEAD
+          ACTUAL_COMMIT="$(git -C /tmp/hindsight-source rev-parse HEAD)"
+          EXPECTED_COMMIT="b12646f49ec512136b9f709e608524ffed969668"
+          test "$ACTUAL_COMMIT" = "$EXPECTED_COMMIT"
+          grep -q "MIT License" /tmp/hindsight-source/LICENSE
+          grep -q 'version = "0.9.0"' /tmp/hindsight-source/hindsight-embed/pyproject.toml
+          grep -q '"chunks"' /tmp/hindsight-source/hindsight-api-slim/hindsight_api/config.py
+          grep -q 'ENV_RETAIN_EXTRACTION_MODE = "HINDSIGHT_API_RETAIN_EXTRACTION_MODE"' /tmp/hindsight-source/hindsight-api-slim/hindsight_api/config.py
+          printf '%s\n' "$ACTUAL_COMMIT" > /tmp/hindsight-source-commit.txt
+
+      - name: Install exact Hindsight embedded package
+        run: |
+          python -m pip install --disable-pip-version-check "hindsight-embed==0.9.0"
+          python - <<'PY'
+          from importlib import metadata
+          version = metadata.version("hindsight-embed")
+          if version != "0.9.0":
+              raise SystemExit(f"unexpected hindsight-embed version: {version}")
+          print(version)
+          PY
+
+      - name: Execute focused Agent Memory qualification tests
+        run: |
+          python -m pytest -q \
+            reference/tests/test_hindsight_qualification.py \
+            reference/tests/test_component_qualification_v12.py
+
+      - name: Execute exact Hindsight document lifecycle fixture
+        shell: bash
+        env:
+          HOME: /tmp/hindsight-qualification-home
+        run: |
+          set -euo pipefail
+          rm -rf "$HOME" /tmp/hindsight-qualification-hf
+          mkdir -p "$HOME" /tmp/hindsight-qualification-hf artifacts/hindsight-v090
+          python reference/run_hindsight_v090_fixture.py \
+            --source-commit "$(cat /tmp/hindsight-source-commit.txt)" \
+            --license-path /tmp/hindsight-source/LICENSE \
+            --output artifacts/hindsight-v090/raw-provider-evidence.json
+
+      - name: Emit Capability Qualification v1.2 evidence
+        run: |
+          python reference/run_hindsight_v090_qualification.py \
+            --agent-memory-commit "$GITHUB_SHA" \
+            --raw-evidence artifacts/hindsight-v090/raw-provider-evidence.json \
+            --component-profile reference/fixtures/component-capabilities/hindsight-v0.9.0.json \
+            --output artifacts/hindsight-v090/qualification.json
+
+      - name: Validate qualification schema and exact current declaration
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          import jsonschema
+          from agentmem_ref.hindsight_qualification import load_component_profile
+          from agentmem_ref.qualification import QualifiedCapabilityContract
+
+          root = Path('.')
+          report = json.loads((root / 'artifacts/hindsight-v090/qualification.json').read_text())
+          if not report.get('eligible'):
+              raise SystemExit('Hindsight qualification is explicitly ineligible')
+          qualification = report.get('qualification')
+          if not qualification:
+              raise SystemExit('eligible Hindsight result did not emit a qualification record')
+          schema = json.loads((root / 'schemas/component-capability-qualification.schema.json').read_text())
+          jsonschema.Draft202012Validator(schema).validate(qualification)
+          if qualification['schema_version'] != '1.2.0':
+              raise SystemExit('Hindsight must emit qualification schema v1.2.0')
+          if qualification['result']['authority_effect'] != 'none':
+              raise SystemExit('provider qualification cannot grant authority')
+          if qualification['source_rights']['use_posture'] != 'runtime_allowed':
+              raise SystemExit('MIT-qualified runtime must preserve runtime_allowed source-rights posture')
+          component = load_component_profile(root / 'reference/fixtures/component-capabilities/hindsight-v0.9.0.json')
+          contract = QualifiedCapabilityContract.from_component(
+              component,
+              capability_id='resource_artifact_memory',
+              capability_version='1.0',
+          )
+          if qualification['qualified_contract'] != contract.to_dict():
+              raise SystemExit('serialized Hindsight qualification contract drifted from current declaration')
+          PY
+
+      - name: Publish Hindsight qualification summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Hindsight v0.9.0 qualification"
+            echo
+            if [ -f artifacts/hindsight-v090/qualification.json ]; then
+              python - <<'PY'
+          import json
+          from pathlib import Path
+          value = json.loads(Path('artifacts/hindsight-v090/qualification.json').read_text())
+          print(f"- eligible: `{str(value.get('eligible')).lower()}`")
+          print(f"- authority effect: `{value.get('authority_effect')}`")
+          for observation in value.get('observations', []):
+              marker = 'PASS' if observation.get('passed') else 'FAIL'
+              print(f"- {marker}: `{observation.get('check_id')}`")
+          PY
+            else
+              echo "- qualification report was not emitted"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw and normalized qualification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hindsight-v090-qualification-${{ github.sha }}
+          path: artifacts/hindsight-v090
+          if-no-files-found: warn

--- a/docs/programs/memory-modules/hindsight-v090-qualification.md
+++ b/docs/programs/memory-modules/hindsight-v090-qualification.md
@@ -1,0 +1,209 @@
+# Hindsight v0.9.0 Qualification
+
+Status: **candidate external-provider qualification for issue #352**
+
+Provider boundary:
+
+```text
+repository: vectorize-io/hindsight
+release: v0.9.0
+source commit: b12646f49ec512136b9f709e608524ffed969668
+published: 2026-08-07
+license: MIT
+runtime package: hindsight-embed==0.9.0
+```
+
+## Qualification target
+
+This slice does not qualify Hindsight as a product. It qualifies one exact provider/version/runtime path against one Agent Memory capability contract:
+
+```text
+Hindsight v0.9.0
++ embedded pg0 runtime
++ LLM provider disabled
++ retain extraction mode = chunks
++ stable document identity
+-> resource_artifact_memory@1.0 candidate qualification
+```
+
+No richer Hindsight capability is inherited merely because the provider also contains fact extraction, entities, observations, graph relationships, causal links, reflect, mental models, or other features.
+
+The bounded profile therefore declares only:
+
+```text
+resource_artifact_memory@1.0
+```
+
+It does not earn `semantic_fact_memory`, `epistemic_belief_memory`, `predictive_counterfactual_memory`, `graph_state`, `causal_model_memory`, or `policy_memory` from this run.
+
+## Exact source and rights boundary
+
+The qualification workflow fetches tag `v0.9.0` and requires the checked-out commit to equal:
+
+```text
+b12646f49ec512136b9f709e608524ffed969668
+```
+
+It also verifies the exact source license contains the MIT license text and verifies `hindsight-embed` reports version `0.9.0` before any behavioral evidence is accepted.
+
+That exact MIT evidence supports `runtime_allowed` source-rights posture for this pinned runtime. A future Hindsight release must be evaluated independently.
+
+## Documentation/source discrepancy
+
+The versioned v0.9 retain prose documents extraction modes `concise`, `verbose`, and `custom`, but the exact v0.9.0 source defines:
+
+```python
+RETAIN_EXTRACTION_MODES = (
+    "concise",
+    "verbose",
+    "custom",
+    "verbatim",
+    "chunks",
+)
+```
+
+The same pinned source defines `HINDSIGHT_API_RETAIN_EXTRACTION_MODE` and explicitly discusses a `chunk-extraction bank` in recall configuration comments.
+
+The executable fixture therefore uses `chunks`, but its provenance is the exact source revision rather than the stale versioned prose page. The discrepancy is preserved as a qualification limitation instead of silently rewriting the historical documentation.
+
+## LLM-free fixture
+
+The fixture disables the provider LLM and the Hindsight features that would otherwise introduce unrelated inference behavior:
+
+```text
+HINDSIGHT_API_LLM_PROVIDER=none
+HINDSIGHT_API_SKIP_LLM_VERIFICATION=true
+HINDSIGHT_API_RETAIN_EXTRACTION_MODE=chunks
+HINDSIGHT_API_ENABLE_OBSERVATIONS=false
+HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION=false
+HINDSIGHT_API_ENABLE_RERANKING=false
+HINDSIGHT_API_ENABLE_GRAPH_RETRIEVAL=false
+HINDSIGHT_API_ENABLE_TEMPORAL_RETRIEVAL=false
+HINDSIGHT_API_MCP_ENABLED=false
+```
+
+No external model API key is permitted in the qualification environment.
+
+This does not prove Hindsight's richer LLM-backed memory behavior. It isolates provider storage/currentness/retrieval mechanics so the evidence is repeatable and attributable.
+
+## Lifecycle fixture
+
+One isolated bank and one stable provider-native document ID are exercised through:
+
+```text
+initial retain
+-> exact document readback
+-> recall visibility
+
+same-key repeat
+-> one current document
+
+same-key replacement
+-> replacement document current
+-> replacement recall visible
+-> initial marker no longer recallable
+
+daemon stop/start
+-> document reconstructs
+-> replacement remains recallable
+
+same-key retry after restart
+-> one current document
+
+document delete
+-> direct get fails
+-> document list is empty
+-> initial marker absent from recall
+-> replacement marker absent from recall
+```
+
+Every provider command, return code, stdout, and stderr is retained in the raw evidence artifact before Agent Memory normalizes any conclusion.
+
+## Candidate behavior contract
+
+The profile uses provider revalidation rather than pretending Hindsight implements Agent Memory-native lifecycle semantics:
+
+```text
+currentness_model: provider_revalidated
+invalidation_model: provider_revalidation
+correction_model: provider_revalidation
+deletion_model: provider_revalidation
+residue_model: scan_required
+migration_rebuild_model: requires_requalification
+```
+
+Stable Hindsight document identity is provider-native identity. It never becomes Agent Memory logical memory identity or authority.
+
+## Candidate operational contract
+
+Only properties directly exercised by the fixture may survive qualification:
+
+```text
+write_atomicity: none
+concurrency_control: none
+idempotency: durable_keyed
+restart_recovery: reconstructable
+reconciliation: deterministic_readback
+```
+
+`none` for atomicity and concurrency is deliberate. PostgreSQL underneath Hindsight is not evidence that the Hindsight operation exposed to Agent Memory has a particular atomic or concurrency guarantee.
+
+The stronger three claims have executable gates:
+
+- `durable_keyed` requires the same document ID to remain singular across repeat, replacement, restart, and retry;
+- `reconstructable` requires an actual daemon stop/start followed by successful state/recall recovery;
+- `deterministic_readback` requires exact document readback and lifecycle comparison rather than inference from a successful write command.
+
+If the exact runtime fails one of these checks, the candidate qualification is rejected. Agent Memory does not weaken the test to make the provider appear compatible.
+
+## Deletion and residue
+
+Hindsight documentation says deleting a document removes the document and associated memories. Agent Memory treats that as a claim to test, not as proof.
+
+The qualification requires all of the following after deletion:
+
+```text
+delete reports success
+direct document read fails
+document list contains no current document
+old marker is not recallable
+replacement marker is not recallable
+```
+
+A stale recall result is therefore sufficient to fail the candidate contract even when Hindsight's direct document endpoint reports deletion success.
+
+This remains provider-local deletion evidence. It is not a claim of transitive forgetting completeness across external systems or arbitrary derived artifacts.
+
+## Maturity and authority
+
+The profile may land at `evidence_proven` only when the exact-head provider workflow proves every required check and the resulting Qualification v1.2 record validates against the current component declaration.
+
+```text
+provider success != Agent Memory authority
+provider recall score != recall admission
+provider document ID != Agent Memory logical identity
+provider qualification != PAMA permission
+```
+
+The qualification record and normalized result always carry:
+
+```text
+authority_effect: none
+```
+
+## Failure is a valid result
+
+The qualification harness is intentionally capable of producing an explicit ineligible result. Examples include:
+
+- the pinned source/package identity does not match;
+- an external LLM credential is required;
+- replacement leaves the old document recallable;
+- restart loses current state;
+- stable document identity duplicates across retries;
+- deletion leaves direct or recall residue.
+
+Such a result is evidence about the exact provider version, not a reason to modify Agent Memory's canonical semantics.
+
+## Stop condition
+
+Issue #352 stops after Hindsight v0.9.0 has one exact, bounded qualification result for chunk-backed `resource_artifact_memory`. It does not integrate a second external provider and does not begin cross-substrate consolidation.

--- a/reference/agentmem_ref/hindsight_qualification.py
+++ b/reference/agentmem_ref/hindsight_qualification.py
@@ -1,0 +1,341 @@
+"""Exact-version qualification normalizer for Hindsight v0.9.0.
+
+This module does not execute Hindsight and does not grant authority. It consumes
+raw evidence captured from the pinned provider runtime, checks the bounded
+resource-artifact lifecycle contract, and emits a Capability Qualification v1.2
+record only when the exact observed behavior supports the declared v3 contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from .capabilities import ComponentDeclaration
+from .qualification import (
+    AdapterResult,
+    QualificationRuntime,
+    QualificationSubject,
+    QualifiedCapabilityContract,
+    qualification_from_adapter_results,
+)
+
+HINDSIGHT_RELEASE = "v0.9.0"
+HINDSIGHT_VERSION = "0.9.0"
+HINDSIGHT_COMMIT = "b12646f49ec512136b9f709e608524ffed969668"
+HINDSIGHT_REPOSITORY = "vectorize-io/hindsight"
+HINDSIGHT_LICENSE = "MIT"
+CAPABILITY_ID = "resource_artifact_memory"
+CAPABILITY_VERSION = "1.0"
+PROFILE_ID = "hindsight-v090-chunk-resource-artifact"
+PROFILE_VERSION = "1.0.0"
+ADAPTER_ID = "hindsight-v090-chunk-document-adapter"
+ADAPTER_VERSION = "1.0.0"
+FIXTURE_ID = "hindsight-v090-document-lifecycle-v1"
+
+
+class HindsightQualificationError(ValueError):
+    """Raw Hindsight evidence is incomplete or contradicts the claimed contract."""
+
+
+@dataclass(frozen=True)
+class HindsightObservation:
+    check_id: str
+    passed: bool
+    evidence_ref: str
+    detail: str = ""
+
+    def as_check(self) -> tuple[str, bool, str]:
+        return (self.check_id, self.passed, self.evidence_ref)
+
+
+@dataclass(frozen=True)
+class HindsightQualificationResult:
+    qualification: dict[str, object] | None
+    observations: tuple[HindsightObservation, ...]
+    eligible: bool
+    limitations: tuple[str, ...]
+
+    @property
+    def authority_effect(self) -> str:
+        return "none"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "provider": {
+                "repository": HINDSIGHT_REPOSITORY,
+                "release": HINDSIGHT_RELEASE,
+                "version": HINDSIGHT_VERSION,
+                "commit": HINDSIGHT_COMMIT,
+                "license": HINDSIGHT_LICENSE,
+            },
+            "capability": {
+                "capability_id": CAPABILITY_ID,
+                "capability_version": CAPABILITY_VERSION,
+            },
+            "eligible": self.eligible,
+            "authority_effect": "none",
+            "observations": [
+                {
+                    "check_id": item.check_id,
+                    "passed": item.passed,
+                    "evidence_ref": item.evidence_ref,
+                    "detail": item.detail,
+                }
+                for item in self.observations
+            ],
+            "limitations": list(self.limitations),
+            "qualification": self.qualification,
+        }
+
+
+def load_component_profile(path: Path) -> ComponentDeclaration:
+    return ComponentDeclaration.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def qualify_hindsight_v090(
+    *,
+    raw_evidence: dict[str, Any],
+    component: ComponentDeclaration,
+    agent_memory_commit: str,
+    raw_evidence_ref: str,
+) -> HindsightQualificationResult:
+    """Normalize one exact Hindsight run into bounded qualification evidence."""
+    _validate_component_identity(component)
+    observations = _observations(raw_evidence, raw_evidence_ref)
+    limitations = _limitations(raw_evidence, observations)
+    eligible = all(item.passed for item in observations)
+    if not eligible:
+        return HindsightQualificationResult(
+            qualification=None,
+            observations=tuple(observations),
+            eligible=False,
+            limitations=tuple(limitations),
+        )
+
+    subject = QualificationSubject(
+        component_id=component.component_id,
+        component_version=component.component_version,
+        implementation_ref=f"github:{HINDSIGHT_REPOSITORY}@{HINDSIGHT_COMMIT}",
+        capability_id=CAPABILITY_ID,
+        capability_version=CAPABILITY_VERSION,
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        qualification_profile_id=PROFILE_ID,
+        qualification_profile_version=PROFILE_VERSION,
+    )
+    runtime = QualificationRuntime(
+        configuration_digest=_sha256_json(
+            {
+                "agent_memory_commit": agent_memory_commit,
+                "provider_commit": HINDSIGHT_COMMIT,
+                "provider_release": HINDSIGHT_RELEASE,
+                "provider_version": HINDSIGHT_VERSION,
+                "llm_provider": "none",
+                "retain_extraction_mode": "chunks",
+                "database": "pg0",
+                "fixture": FIXTURE_ID,
+            }
+        ),
+        fixture_id=FIXTURE_ID,
+        fixture_digest=_sha256_json(raw_evidence.get("fixture", {})),
+        dependency_refs=(
+            f"pypi:hindsight-embed=={HINDSIGHT_VERSION}",
+            f"github:{HINDSIGHT_REPOSITORY}@{HINDSIGHT_COMMIT}",
+        ),
+        runtime_refs=(
+            "hindsight-embed:local-daemon",
+            "hindsight:chunk-extraction",
+            "hindsight:pg0",
+        ),
+    )
+    common = dict(
+        subject=subject,
+        runtime_identity=f"hindsight-embed:{HINDSIGHT_VERSION}:pg0",
+        input_refs=(FIXTURE_ID,),
+        raw_provider_refs=(raw_evidence_ref,),
+        normalized_refs=(f"qualification:{component.component_id}:{CAPABILITY_ID}",),
+        failure_result="none",
+    )
+    adapter_results = (
+        AdapterResult(
+            operation="retain_read_recall",
+            currentness="current",
+            trace_ref="qualification:hindsight:initial-retain",
+            **common,
+        ),
+        AdapterResult(
+            operation="stable_key_replace",
+            currentness="replacement_current",
+            trace_ref="qualification:hindsight:stable-key-replace",
+            **common,
+        ),
+        AdapterResult(
+            operation="restart_readback",
+            currentness="reconstructed_current",
+            trace_ref="qualification:hindsight:restart-readback",
+            **common,
+        ),
+        AdapterResult(
+            operation="document_delete_residue_scan",
+            currentness="deleted_no_recall_residue",
+            trace_ref="qualification:hindsight:delete-residue",
+            **common,
+        ),
+    )
+    qualification = qualification_from_adapter_results(
+        subject=subject,
+        runtime=runtime,
+        license_id=HINDSIGHT_LICENSE,
+        license_ref=f"github:{HINDSIGHT_REPOSITORY}@{HINDSIGHT_COMMIT}:LICENSE",
+        use_posture="runtime_allowed",
+        results=adapter_results,
+        checks=tuple(item.as_check() for item in observations),
+        artifact_digests=(_sha256_json(raw_evidence),),
+        maturity_before="runtime_wired",
+        profile_maturity_ceiling="evidence_proven",
+        earned_maturity="evidence_proven",
+        limitations=tuple(limitations),
+        qualified_contract=QualifiedCapabilityContract.from_component(
+            component,
+            capability_id=CAPABILITY_ID,
+            capability_version=CAPABILITY_VERSION,
+        ),
+    )
+    qualification.assert_current_declaration(component)
+    return HindsightQualificationResult(
+        qualification=qualification.to_dict(),
+        observations=tuple(observations),
+        eligible=True,
+        limitations=tuple(limitations),
+    )
+
+
+def _validate_component_identity(component: ComponentDeclaration) -> None:
+    if component.component_id != "hindsight-v0.9.0":
+        raise HindsightQualificationError("unexpected Hindsight component identity")
+    if component.component_version != HINDSIGHT_VERSION:
+        raise HindsightQualificationError("Hindsight component version does not match pinned provider")
+    matches = [
+        capability
+        for capability in component.capabilities
+        if capability.capability_id == CAPABILITY_ID
+        and capability.capability_version == CAPABILITY_VERSION
+    ]
+    if len(matches) != 1:
+        raise HindsightQualificationError("profile must expose exactly one bounded resource_artifact_memory capability")
+    if len(component.capabilities) != 1:
+        raise HindsightQualificationError("bounded Hindsight qualification must not promote unrelated capabilities")
+    if matches[0].authority_effect != "none":
+        raise HindsightQualificationError("Hindsight qualification cannot grant authority")
+
+
+def _observations(raw: dict[str, Any], evidence_ref: str) -> list[HindsightObservation]:
+    identity = raw.get("identity", {})
+    config = raw.get("configuration", {})
+    initial = raw.get("initial", {})
+    repeat = raw.get("same_key_repeat", {})
+    replacement = raw.get("replacement", {})
+    restart = raw.get("restart", {})
+    durable_repeat = raw.get("durable_repeat_after_restart", {})
+    deletion = raw.get("deletion", {})
+
+    def obs(check_id: str, passed: bool, detail: str) -> HindsightObservation:
+        return HindsightObservation(check_id, bool(passed), evidence_ref, detail)
+
+    return [
+        obs(
+            "exact-provider-identity",
+            identity.get("release") == HINDSIGHT_RELEASE
+            and identity.get("version") == HINDSIGHT_VERSION
+            and identity.get("commit") == HINDSIGHT_COMMIT,
+            "release/version/source commit must match the qualification pin",
+        ),
+        obs(
+            "mit-runtime-rights",
+            identity.get("license") == HINDSIGHT_LICENSE and identity.get("license_verified") is True,
+            "exact pinned source must carry MIT license evidence",
+        ),
+        obs(
+            "llm-free-chunk-path",
+            config.get("llm_provider") == "none"
+            and config.get("retain_extraction_mode") == "chunks"
+            and config.get("external_llm_api_key_present") is False,
+            "qualification must execute chunks mode without an external LLM credential",
+        ),
+        obs(
+            "initial-document-readback",
+            initial.get("document_count") == 1
+            and initial.get("document_text_matches") is True
+            and initial.get("recall_contains_initial") is True,
+            "retained document must be readable and recall-visible",
+        ),
+        obs(
+            "stable-key-repeat-idempotency",
+            repeat.get("document_count") == 1
+            and repeat.get("document_text_matches") is True,
+            "repeating the same durable document key must not create a second current document",
+        ),
+        obs(
+            "stable-key-replacement-currentness",
+            replacement.get("document_count") == 1
+            and replacement.get("document_text_matches_replacement") is True
+            and replacement.get("recall_contains_replacement") is True
+            and replacement.get("recall_contains_initial") is False,
+            "replacement must make the new document current without old-content recall residue",
+        ),
+        obs(
+            "restart-reconstruction",
+            restart.get("daemon_restart_succeeded") is True
+            and restart.get("document_count") == 1
+            and restart.get("document_text_matches_replacement") is True
+            and restart.get("recall_contains_replacement") is True,
+            "document state and recall visibility must survive daemon restart",
+        ),
+        obs(
+            "durable-key-after-restart",
+            durable_repeat.get("document_count") == 1
+            and durable_repeat.get("document_text_matches_replacement") is True,
+            "the stable document key must remain singular after restart and retry",
+        ),
+        obs(
+            "delete-readback-and-recall-residue",
+            deletion.get("delete_succeeded") is True
+            and deletion.get("get_after_delete_failed") is True
+            and deletion.get("document_count") == 0
+            and deletion.get("recall_contains_initial") is False
+            and deletion.get("recall_contains_replacement") is False,
+            "document deletion must remove current readback and both old/new recall residue",
+        ),
+        obs(
+            "provider-identity-is-not-agent-memory-identity",
+            raw.get("identity_boundary_preserved") is True,
+            "provider bank/document IDs remain evidence refs rather than Agent Memory logical IDs",
+        ),
+    ]
+
+
+def _limitations(raw: dict[str, Any], observations: list[HindsightObservation]) -> list[str]:
+    limitations = [
+        "Qualification is exact to Hindsight v0.9.0 and source commit b12646f49ec512136b9f709e608524ffed969668.",
+        "Only chunk-backed resource_artifact_memory is qualified; richer LLM-backed Hindsight modes are outside this evidence boundary.",
+        "Write atomicity and concurrent mutation ordering remain unqualified and are declared none.",
+        "Provider-native recall ranking remains candidate/relevance evidence and carries no Agent Memory authority.",
+        "The v0.9 prose documentation omitted chunks although the exact v0.9.0 source allowed it; source truth controls this fixture and the discrepancy is retained as provenance.",
+    ]
+    failed = [item.check_id for item in observations if not item.passed]
+    if failed:
+        limitations.append("Provider did not satisfy the candidate v3 contract: " + ", ".join(failed))
+    provider_notes = raw.get("provider_notes", [])
+    for note in provider_notes:
+        if isinstance(note, str) and note:
+            limitations.append(note)
+    return limitations
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()

--- a/reference/fixtures/component-capabilities/hindsight-v0.9.0.json
+++ b/reference/fixtures/component-capabilities/hindsight-v0.9.0.json
@@ -16,7 +16,7 @@
       "capability_version": "1.0",
       "maturity": "evidence_proven",
       "state_posture": "derived",
-      "scope_posture": "bridged_scope",
+      "scope_posture": "external_scope_bridge",
       "failure_posture": "fail_closed",
       "authority_effect": "none",
       "enabled": true,

--- a/reference/fixtures/component-capabilities/hindsight-v0.9.0.json
+++ b/reference/fixtures/component-capabilities/hindsight-v0.9.0.json
@@ -1,0 +1,58 @@
+{
+  "component_id": "hindsight-v0.9.0",
+  "component_version": "0.9.0",
+  "profile_version": "component-capability-v3",
+  "enabled": true,
+  "runtime_ref": "pypi:hindsight-embed==0.9.0",
+  "failure_posture": "fail_closed",
+  "provenance_refs": [
+    "https://github.com/vectorize-io/hindsight/releases/tag/v0.9.0",
+    "https://github.com/vectorize-io/hindsight/commit/b12646f49ec512136b9f709e608524ffed969668",
+    "https://github.com/MythologIQ-Labs-LLC/agent-memory/issues/352"
+  ],
+  "capabilities": [
+    {
+      "capability_id": "resource_artifact_memory",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "bridged_scope",
+      "failure_posture": "fail_closed",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "reference/agentmem_ref/hindsight_qualification.py",
+        "reference/tests/test_hindsight_qualification.py",
+        ".github/workflows/hindsight-v090-qualification.yml"
+      ],
+      "limitations": [
+        "Qualification is limited to Hindsight v0.9.0 chunk-backed document memory with LLM provider disabled.",
+        "Provider bank/document identities are provider-native and do not become Agent Memory logical identity.",
+        "Write atomicity and concurrent mutation ordering are not qualified by this slice.",
+        "Deletion completeness is accepted only when exact-head document readback and recall residue scans pass.",
+        "No semantic-fact, epistemic-belief, predictive, graph, causal, or policy-memory capability is earned by this profile."
+      ],
+      "behavior_contract": {
+        "operation_support": {
+          "write": true,
+          "read": true,
+          "recall_candidate": true
+        },
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "provider_revalidation",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "scan_required",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      },
+      "operational_contract": {
+        "write_atomicity": "none",
+        "concurrency_control": "none",
+        "idempotency": "durable_keyed",
+        "restart_recovery": "reconstructable",
+        "reconciliation": "deterministic_readback"
+      }
+    }
+  ]
+}

--- a/reference/run_hindsight_v090_fixture.py
+++ b/reference/run_hindsight_v090_fixture.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Execute the exact Hindsight v0.9.0 chunk/document lifecycle fixture for #352.
+
+The script preserves every provider command result before deriving a small set
+of factual observations. It intentionally treats provider IDs as provider
+identity only; Agent Memory logical identity is never created here.
+"""
+
+from __future__ import annotations
+
+import argparse
+from importlib import metadata
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+HINDSIGHT_RELEASE = "v0.9.0"
+HINDSIGHT_VERSION = "0.9.0"
+HINDSIGHT_COMMIT = "b12646f49ec512136b9f709e608524ffed969668"
+PROFILE = "agent-memory-qualification"
+BANK = "agent-memory-hindsight-v090"
+DOCUMENT = "agent-memory-stable-document"
+INITIAL_MARKER = "alphacedar731"
+REPLACEMENT_MARKER = "omegamaple842"
+INITIAL_TEXT = f"{INITIAL_MARKER} retained document state is blue and belongs only to the initial fixture."
+REPLACEMENT_TEXT = f"{REPLACEMENT_MARKER} retained document state is green and supersedes the initial fixture."
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--license-path", type=Path, required=True)
+    parser.add_argument("--source-commit", default=HINDSIGHT_COMMIT)
+    parser.add_argument("--port", type=int, default=18888)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    commands: list[dict[str, Any]] = []
+    notes: list[str] = []
+    package_version = metadata.version("hindsight-embed")
+    license_text = args.license_path.read_text(encoding="utf-8")
+
+    raw: dict[str, Any] = {
+        "identity": {
+            "repository": "vectorize-io/hindsight",
+            "release": HINDSIGHT_RELEASE,
+            "version": package_version,
+            "commit": args.source_commit,
+            "license": "MIT" if "MIT License" in license_text else "unverified",
+            "license_verified": "MIT License" in license_text,
+        },
+        "configuration": {
+            "llm_provider": "none",
+            "retain_extraction_mode": "chunks",
+            "external_llm_api_key_present": any(
+                bool(os.environ.get(name))
+                for name in (
+                    "HINDSIGHT_API_LLM_API_KEY",
+                    "OPENAI_API_KEY",
+                    "ANTHROPIC_API_KEY",
+                    "GROQ_API_KEY",
+                    "GEMINI_API_KEY",
+                )
+            ),
+            "database": "pg0",
+        },
+        "fixture": {
+            "bank_id": BANK,
+            "document_id": DOCUMENT,
+            "initial_marker": INITIAL_MARKER,
+            "replacement_marker": REPLACEMENT_MARKER,
+            "initial_text": INITIAL_TEXT,
+            "replacement_text": REPLACEMENT_TEXT,
+        },
+        "identity_boundary_preserved": True,
+        "commands": commands,
+        "provider_notes": notes,
+    }
+
+    try:
+        _create_profile(args.port, commands)
+        _run(["hindsight-embed", "-p", PROFILE, "daemon", "start"], commands, "daemon-start")
+        _cli(["bank", "create", BANK], commands, "bank-create")
+
+        _retain(INITIAL_TEXT, commands, "initial-retain")
+        initial_doc = _cli_json(["document", "get", BANK, DOCUMENT], commands, "initial-document-get")
+        initial_list = _cli_json(["document", "list", BANK], commands, "initial-document-list")
+        initial_recall = _cli_json(
+            ["memory", "recall", BANK, INITIAL_MARKER, "--include-chunks", "--budget", "low"],
+            commands,
+            "initial-recall",
+        )
+        raw["initial"] = {
+            "document_count": _document_count(initial_list),
+            "document_text_matches": _document_text(initial_doc) == INITIAL_TEXT,
+            "recall_contains_initial": _contains_provider_content(initial_recall, INITIAL_MARKER),
+        }
+
+        _retain(INITIAL_TEXT, commands, "same-key-repeat")
+        repeat_doc = _cli_json(["document", "get", BANK, DOCUMENT], commands, "repeat-document-get")
+        repeat_list = _cli_json(["document", "list", BANK], commands, "repeat-document-list")
+        raw["same_key_repeat"] = {
+            "document_count": _document_count(repeat_list),
+            "document_text_matches": _document_text(repeat_doc) == INITIAL_TEXT,
+        }
+
+        _retain(REPLACEMENT_TEXT, commands, "replacement-retain")
+        replacement_doc = _cli_json(
+            ["document", "get", BANK, DOCUMENT], commands, "replacement-document-get"
+        )
+        replacement_list = _cli_json(["document", "list", BANK], commands, "replacement-document-list")
+        replacement_recall = _cli_json(
+            ["memory", "recall", BANK, REPLACEMENT_MARKER, "--include-chunks", "--budget", "low"],
+            commands,
+            "replacement-recall",
+        )
+        old_recall = _cli_json(
+            ["memory", "recall", BANK, INITIAL_MARKER, "--include-chunks", "--budget", "low"],
+            commands,
+            "old-marker-after-replacement",
+        )
+        raw["replacement"] = {
+            "document_count": _document_count(replacement_list),
+            "document_text_matches_replacement": _document_text(replacement_doc) == REPLACEMENT_TEXT,
+            "recall_contains_replacement": _contains_provider_content(replacement_recall, REPLACEMENT_MARKER),
+            "recall_contains_initial": _contains_provider_content(old_recall, INITIAL_MARKER),
+        }
+
+        _run(["hindsight-embed", "-p", PROFILE, "daemon", "stop"], commands, "daemon-stop-before-restart")
+        _run(["hindsight-embed", "-p", PROFILE, "daemon", "start"], commands, "daemon-restart")
+        restart_doc = _cli_json(["document", "get", BANK, DOCUMENT], commands, "restart-document-get")
+        restart_list = _cli_json(["document", "list", BANK], commands, "restart-document-list")
+        restart_recall = _cli_json(
+            ["memory", "recall", BANK, REPLACEMENT_MARKER, "--include-chunks", "--budget", "low"],
+            commands,
+            "restart-recall",
+        )
+        raw["restart"] = {
+            "daemon_restart_succeeded": True,
+            "document_count": _document_count(restart_list),
+            "document_text_matches_replacement": _document_text(restart_doc) == REPLACEMENT_TEXT,
+            "recall_contains_replacement": _contains_provider_content(restart_recall, REPLACEMENT_MARKER),
+        }
+
+        _retain(REPLACEMENT_TEXT, commands, "durable-key-repeat-after-restart")
+        durable_doc = _cli_json(["document", "get", BANK, DOCUMENT], commands, "durable-repeat-document-get")
+        durable_list = _cli_json(["document", "list", BANK], commands, "durable-repeat-document-list")
+        raw["durable_repeat_after_restart"] = {
+            "document_count": _document_count(durable_list),
+            "document_text_matches_replacement": _document_text(durable_doc) == REPLACEMENT_TEXT,
+        }
+
+        delete_result = _cli_json(["document", "delete", BANK, DOCUMENT], commands, "document-delete")
+        get_after_delete = _run(
+            _cli_command(["document", "get", BANK, DOCUMENT]),
+            commands,
+            "document-get-after-delete",
+            expect_success=False,
+        )
+        delete_list = _cli_json(["document", "list", BANK], commands, "document-list-after-delete")
+        old_after_delete = _cli_json(
+            ["memory", "recall", BANK, INITIAL_MARKER, "--include-chunks", "--budget", "low"],
+            commands,
+            "old-marker-after-delete",
+        )
+        replacement_after_delete = _cli_json(
+            ["memory", "recall", BANK, REPLACEMENT_MARKER, "--include-chunks", "--budget", "low"],
+            commands,
+            "replacement-marker-after-delete",
+        )
+        raw["deletion"] = {
+            "delete_succeeded": _delete_succeeded(delete_result),
+            "get_after_delete_failed": get_after_delete.returncode != 0,
+            "document_count": _document_count(delete_list),
+            "recall_contains_initial": _contains_provider_content(old_after_delete, INITIAL_MARKER),
+            "recall_contains_replacement": _contains_provider_content(
+                replacement_after_delete, REPLACEMENT_MARKER
+            ),
+        }
+
+        _run(
+            _cli_command(["bank", "delete", BANK, "--yes"]),
+            commands,
+            "bank-delete",
+            expect_success=False,
+        )
+    except Exception as exc:
+        notes.append(f"fixture execution stopped with {type(exc).__name__}: {exc}")
+        raw["execution_error"] = {"type": type(exc).__name__, "message": str(exc)}
+    finally:
+        _run(
+            ["hindsight-embed", "-p", PROFILE, "daemon", "stop"],
+            commands,
+            "final-daemon-stop",
+            expect_success=False,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(raw, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return 0
+
+
+def _create_profile(port: int, commands: list[dict[str, Any]]) -> None:
+    env_values = [
+        "HINDSIGHT_API_LLM_PROVIDER=none",
+        "HINDSIGHT_API_SKIP_LLM_VERIFICATION=true",
+        "HINDSIGHT_API_RETAIN_EXTRACTION_MODE=chunks",
+        "HINDSIGHT_API_ENABLE_OBSERVATIONS=false",
+        "HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION=false",
+        "HINDSIGHT_API_ENABLE_RERANKING=false",
+        "HINDSIGHT_API_ENABLE_GRAPH_RETRIEVAL=false",
+        "HINDSIGHT_API_ENABLE_TEMPORAL_RETRIEVAL=false",
+        "HINDSIGHT_API_MCP_ENABLED=false",
+        "HINDSIGHT_EMBED_API_DATABASE_URL=pg0://agent-memory-hindsight-v090",
+        "HINDSIGHT_API_DATABASE_URL=pg0://agent-memory-hindsight-v090",
+        "HINDSIGHT_EMBED_API_VERSION=0.9.0",
+        "HINDSIGHT_EMBED_CLI_VERSION=0.9.0",
+    ]
+    command = ["hindsight-embed", "profile", "create", PROFILE, "--port", str(port)]
+    for value in env_values:
+        command.extend(["--env", value])
+    _run(command, commands, "profile-create")
+
+
+def _retain(content: str, commands: list[dict[str, Any]], name: str) -> None:
+    _cli_json(
+        ["memory", "retain", BANK, content, "--doc-id", DOCUMENT, "--timestamp", "unset"],
+        commands,
+        name,
+    )
+
+
+def _cli(args: list[str], commands: list[dict[str, Any]], name: str) -> subprocess.CompletedProcess[str]:
+    return _run(_cli_command(args), commands, name)
+
+
+def _cli_json(args: list[str], commands: list[dict[str, Any]], name: str) -> Any:
+    result = _run(_cli_command(args), commands, name)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{name} did not emit JSON: {result.stdout[:500]!r}") from exc
+
+
+def _cli_command(args: list[str]) -> list[str]:
+    return ["hindsight-embed", "-p", PROFILE, "-o", "json", *args]
+
+
+def _run(
+    command: list[str],
+    commands: list[dict[str, Any]],
+    name: str,
+    *,
+    expect_success: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(command, text=True, capture_output=True, timeout=240)
+    except Exception as exc:
+        commands.append(
+            {
+                "name": name,
+                "command": command,
+                "returncode": None,
+                "stdout": "",
+                "stderr": "",
+                "exception": f"{type(exc).__name__}: {exc}",
+            }
+        )
+        if expect_success:
+            raise
+        return subprocess.CompletedProcess(command, 255, "", str(exc))
+    commands.append(
+        {
+            "name": name,
+            "command": command,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+    )
+    if expect_success and result.returncode != 0:
+        raise RuntimeError(
+            f"{name} failed with exit {result.returncode}: {result.stderr[-1000:]}"
+        )
+    return result
+
+
+def _document_count(value: Any) -> int:
+    if isinstance(value, dict):
+        total = value.get("total")
+        if isinstance(total, int):
+            return total
+        items = value.get("items")
+        if isinstance(items, list):
+            return len(items)
+    if isinstance(value, list):
+        return len(value)
+    return -1
+
+
+def _document_text(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    for key in ("original_text", "text", "content"):
+        candidate = value.get(key)
+        if isinstance(candidate, str):
+            return candidate
+    return None
+
+
+def _delete_succeeded(value: Any) -> bool:
+    if isinstance(value, dict):
+        result = value.get("success")
+        if isinstance(result, bool):
+            return result
+        status = value.get("status")
+        if isinstance(status, str):
+            return status.lower() in {"ok", "success", "deleted"}
+    return False
+
+
+def _contains_provider_content(value: Any, marker: str) -> bool:
+    marker = marker.lower()
+
+    def walk(item: Any, *, parent_key: str = "") -> bool:
+        if isinstance(item, str):
+            # Avoid treating echoed request/query fields as retrieved content.
+            if parent_key in {"query", "request", "input", "search_query"}:
+                return False
+            return marker in item.lower()
+        if isinstance(item, list):
+            return any(walk(child, parent_key=parent_key) for child in item)
+        if isinstance(item, dict):
+            return any(walk(child, parent_key=str(key).lower()) for key, child in item.items())
+        return False
+
+    return walk(value)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/run_hindsight_v090_qualification.py
+++ b/reference/run_hindsight_v090_qualification.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Emit contract-bound Hindsight v0.9.0 qualification evidence for #352."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref.hindsight_qualification import (
+    load_component_profile,
+    qualify_hindsight_v090,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--raw-evidence", type=Path, required=True)
+    parser.add_argument("--component-profile", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    raw = json.loads(args.raw_evidence.read_text(encoding="utf-8"))
+    component = load_component_profile(args.component_profile)
+    result = qualify_hindsight_v090(
+        raw_evidence=raw,
+        component=component,
+        agent_memory_commit=args.agent_memory_commit,
+        raw_evidence_ref=str(args.raw_evidence),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if result.eligible else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_hindsight_qualification.py
+++ b/reference/tests/test_hindsight_qualification.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+from agentmem_ref.hindsight_qualification import (
+    CAPABILITY_ID,
+    HINDSIGHT_COMMIT,
+    HINDSIGHT_RELEASE,
+    HINDSIGHT_VERSION,
+    load_component_profile,
+    qualify_hindsight_v090,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE = ROOT / "reference" / "fixtures" / "component-capabilities" / "hindsight-v0.9.0.json"
+PROFILE_SCHEMA = ROOT / "schemas" / "component-capability-profile.schema.json"
+QUALIFICATION_SCHEMA = ROOT / "schemas" / "component-capability-qualification.schema.json"
+
+
+def passing_raw() -> dict:
+    return {
+        "identity": {
+            "repository": "vectorize-io/hindsight",
+            "release": HINDSIGHT_RELEASE,
+            "version": HINDSIGHT_VERSION,
+            "commit": HINDSIGHT_COMMIT,
+            "license": "MIT",
+            "license_verified": True,
+        },
+        "configuration": {
+            "llm_provider": "none",
+            "retain_extraction_mode": "chunks",
+            "external_llm_api_key_present": False,
+            "database": "pg0",
+        },
+        "fixture": {
+            "bank_id": "agent-memory-hindsight-v090",
+            "document_id": "agent-memory-stable-document",
+            "initial_marker": "alphacedar731",
+            "replacement_marker": "omegamaple842",
+        },
+        "identity_boundary_preserved": True,
+        "initial": {
+            "document_count": 1,
+            "document_text_matches": True,
+            "recall_contains_initial": True,
+        },
+        "same_key_repeat": {
+            "document_count": 1,
+            "document_text_matches": True,
+        },
+        "replacement": {
+            "document_count": 1,
+            "document_text_matches_replacement": True,
+            "recall_contains_replacement": True,
+            "recall_contains_initial": False,
+        },
+        "restart": {
+            "daemon_restart_succeeded": True,
+            "document_count": 1,
+            "document_text_matches_replacement": True,
+            "recall_contains_replacement": True,
+        },
+        "durable_repeat_after_restart": {
+            "document_count": 1,
+            "document_text_matches_replacement": True,
+        },
+        "deletion": {
+            "delete_succeeded": True,
+            "get_after_delete_failed": True,
+            "document_count": 0,
+            "recall_contains_initial": False,
+            "recall_contains_replacement": False,
+        },
+        "commands": [],
+        "provider_notes": [],
+    }
+
+
+class HindsightQualificationTests(unittest.TestCase):
+    def test_component_profile_is_schema_valid_and_bounded(self) -> None:
+        value = json.loads(PROFILE.read_text(encoding="utf-8"))
+        schema = json.loads(PROFILE_SCHEMA.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(value)
+
+        component = load_component_profile(PROFILE)
+        self.assertEqual("component-capability-v3", component.profile_version)
+        self.assertEqual(1, len(component.capabilities))
+        capability = component.capabilities[0]
+        self.assertEqual(CAPABILITY_ID, capability.capability_id)
+        self.assertEqual("evidence_proven", capability.maturity)
+        self.assertEqual("external_scope_bridge", capability.scope_posture)
+        self.assertEqual("none", capability.authority_effect)
+        self.assertEqual("none", capability.operational_contract.write_atomicity)
+        self.assertEqual("none", capability.operational_contract.concurrency_control)
+        self.assertEqual("durable_keyed", capability.operational_contract.idempotency)
+        self.assertEqual("reconstructable", capability.operational_contract.restart_recovery)
+        self.assertEqual("deterministic_readback", capability.operational_contract.reconciliation)
+
+    def test_passing_raw_evidence_emits_v12_contract_bound_qualification(self) -> None:
+        component = load_component_profile(PROFILE)
+        result = qualify_hindsight_v090(
+            raw_evidence=passing_raw(),
+            component=component,
+            agent_memory_commit="agent-memory-exact-head",
+            raw_evidence_ref="raw/hindsight-v090.json",
+        )
+
+        self.assertTrue(result.eligible)
+        self.assertEqual("none", result.authority_effect)
+        self.assertIsNotNone(result.qualification)
+        qualification = result.qualification
+        self.assertEqual("1.2.0", qualification["schema_version"])
+        self.assertEqual("evidence_proven", qualification["result"]["earned_maturity"])
+        self.assertEqual("none", qualification["result"]["authority_effect"])
+        self.assertEqual("runtime_allowed", qualification["source_rights"]["use_posture"])
+        self.assertEqual(
+            "reconstructable",
+            qualification["qualified_contract"]["operational_contract"]["restart_recovery"],
+        )
+
+        schema = json.loads(QUALIFICATION_SCHEMA.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(qualification)
+
+    def test_replacement_recall_residue_refuses_candidate_contract(self) -> None:
+        raw = passing_raw()
+        raw["replacement"]["recall_contains_initial"] = True
+        result = qualify_hindsight_v090(
+            raw_evidence=raw,
+            component=load_component_profile(PROFILE),
+            agent_memory_commit="head",
+            raw_evidence_ref="raw.json",
+        )
+
+        self.assertFalse(result.eligible)
+        self.assertIsNone(result.qualification)
+        failed = {item.check_id for item in result.observations if not item.passed}
+        self.assertIn("stable-key-replacement-currentness", failed)
+
+    def test_restart_failure_refuses_reconstructable_claim(self) -> None:
+        raw = passing_raw()
+        raw["restart"]["daemon_restart_succeeded"] = False
+        result = qualify_hindsight_v090(
+            raw_evidence=raw,
+            component=load_component_profile(PROFILE),
+            agent_memory_commit="head",
+            raw_evidence_ref="raw.json",
+        )
+
+        self.assertFalse(result.eligible)
+        self.assertIsNone(result.qualification)
+        failed = {item.check_id for item in result.observations if not item.passed}
+        self.assertIn("restart-reconstruction", failed)
+
+    def test_delete_residue_refuses_provider_deletion_contract(self) -> None:
+        raw = passing_raw()
+        raw["deletion"]["recall_contains_replacement"] = True
+        result = qualify_hindsight_v090(
+            raw_evidence=raw,
+            component=load_component_profile(PROFILE),
+            agent_memory_commit="head",
+            raw_evidence_ref="raw.json",
+        )
+
+        self.assertFalse(result.eligible)
+        self.assertIsNone(result.qualification)
+        failed = {item.check_id for item in result.observations if not item.passed}
+        self.assertIn("delete-readback-and-recall-residue", failed)
+
+    def test_wrong_release_or_source_cannot_be_qualified(self) -> None:
+        raw = passing_raw()
+        raw["identity"]["commit"] = "0" * 40
+        result = qualify_hindsight_v090(
+            raw_evidence=raw,
+            component=load_component_profile(PROFILE),
+            agent_memory_commit="head",
+            raw_evidence_ref="raw.json",
+        )
+        self.assertFalse(result.eligible)
+        failed = {item.check_id for item in result.observations if not item.passed}
+        self.assertIn("exact-provider-identity", failed)
+
+    def test_llm_key_or_non_chunk_mode_cannot_satisfy_bounded_fixture(self) -> None:
+        for mutation in (
+            ("external_llm_api_key_present", True),
+            ("retain_extraction_mode", "concise"),
+            ("llm_provider", "openai"),
+        ):
+            raw = passing_raw()
+            raw["configuration"][mutation[0]] = mutation[1]
+            result = qualify_hindsight_v090(
+                raw_evidence=raw,
+                component=load_component_profile(PROFILE),
+                agent_memory_commit="head",
+                raw_evidence_ref="raw.json",
+            )
+            self.assertFalse(result.eligible)
+            failed = {item.check_id for item in result.observations if not item.passed}
+            self.assertIn("llm-free-chunk-path", failed)
+
+    def test_profile_does_not_promote_richer_hindsight_capabilities(self) -> None:
+        component = load_component_profile(PROFILE)
+        declared = {capability.capability_id for capability in component.capabilities}
+        self.assertEqual({"resource_artifact_memory"}, declared)
+        for forbidden in (
+            "semantic_fact_memory",
+            "epistemic_belief_memory",
+            "predictive_counterfactual_memory",
+            "graph_state",
+            "causal_model_memory",
+            "policy_memory",
+        ):
+            self.assertNotIn(forbidden, declared)
+
+    def test_provider_native_identity_never_creates_authority(self) -> None:
+        raw = passing_raw()
+        raw["identity_boundary_preserved"] = False
+        result = qualify_hindsight_v090(
+            raw_evidence=raw,
+            component=load_component_profile(PROFILE),
+            agent_memory_commit="head",
+            raw_evidence_ref="raw.json",
+        )
+        self.assertFalse(result.eligible)
+        self.assertEqual("none", result.authority_effect)
+        failed = {item.check_id for item in result.observations if not item.passed}
+        self.assertIn("provider-identity-is-not-agent-memory-identity", failed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #352.

## Summary

Adds the first real external general-memory qualification through the Capability Qualification v1.2 admission gate.

Target is exact Hindsight v0.9.0 at source commit `b12646f49ec512136b9f709e608524ffed969668`, MIT licensed, using the embedded local runtime and LLM-free `chunks` retention path.

The slice is intentionally bounded to `resource_artifact_memory@1.0`. It does not promote Hindsight's richer semantic, graph, causal, epistemic, or predictive surfaces.

## Evidence boundary

The dedicated workflow verifies exact release/source/license/package identity, runs without external model credentials, and exercises:

- stable document identity;
- initial retain and readback;
- repeat retain/idempotent replacement behavior;
- replacement currentness;
- daemon restart reconstruction;
- post-restart retry behavior;
- document deletion;
- direct readback after deletion;
- recall residue scanning.

Raw provider output is retained before provider-neutral normalization.

## Contract posture

The candidate v3 profile is deliberately conservative:

- write atomicity: `none`
- concurrency control: `none`
- idempotency: `durable_keyed`
- restart recovery: `reconstructable`
- reconciliation: `deterministic_readback`
- authority effect: `none`

The latter operational claims are accepted only if the exact runtime workflow proves them. No PostgreSQL implementation detail is used to infer stronger transaction or concurrency guarantees.

## Documentation discrepancy

The versioned v0.9 prose docs omit `chunks` from the listed extraction modes, while the exact v0.9.0 source explicitly includes it in `RETAIN_EXTRACTION_MODES`. The qualification records that discrepancy and treats exact tagged source as controlling evidence.

## Validation

Required repository validation plus the focused Hindsight v0.9.0 qualification workflow must pass on the exact PR head before merge.