### PR TITLE
Qualify MemOS v2.0.17 and prove real resource-memory provider substitution

### DIFF
--- a/.github/workflows/memos-v2017-substitution.yml
+++ b/.github/workflows/memos-v2017-substitution.yml
@@ -97,6 +97,7 @@ jobs:
           npm install --no-audit --no-fund "$MEMOS_PACKAGE@$MEMOS_VERSION"
           PACKAGE_ROOT="/tmp/memos-runtime/node_modules/@memtensor/memos-local-plugin"
           test -f "$PACKAGE_ROOT/dist/core/index.js"
+          test -f "$PACKAGE_ROOT/core/pipeline/memory-core.ts"
           node - <<'NODE'
           const fs = require('fs');
           const pkg = JSON.parse(fs.readFileSync('/tmp/memos-runtime/node_modules/@memtensor/memos-local-plugin/package.json', 'utf8'));
@@ -104,6 +105,8 @@ jobs:
           if (pkg.version !== process.env.MEMOS_VERSION) throw new Error(`unexpected installed version: ${pkg.version}`);
           if (pkg.license !== 'MIT') throw new Error(`installed package license metadata drifted: ${pkg.license}`);
           NODE
+          cmp /tmp/memos-source/apps/memos-local-plugin/core/pipeline/memory-core.ts "$PACKAGE_ROOT/core/pipeline/memory-core.ts"
+          cmp /tmp/memos-source/apps/memos-local-plugin/agent-contract/memory-core.ts "$PACKAGE_ROOT/agent-contract/memory-core.ts"
           cp "$PACKAGE_ROOT/package.json" "$GITHUB_WORKSPACE/$RAW_ROOT/installed-package.json"
 
       - name: Execute focused qualification and substitution tests

--- a/.github/workflows/memos-v2017-substitution.yml
+++ b/.github/workflows/memos-v2017-substitution.yml
@@ -1,0 +1,221 @@
+name: MemOS v2.0.17 Provider Substitution
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/memos-v2017-substitution.yml"
+      - "reference/agentmem_ref/memos_qualification.py"
+      - "reference/agentmem_ref/resource_provider_substitution.py"
+      - "reference/run_memos_local_v2017_fixture.mjs"
+      - "reference/run_memos_local_v2017_qualification.py"
+      - "reference/run_resource_artifact_substitution.py"
+      - "reference/tests/test_memos_qualification.py"
+      - "reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json"
+      - "reference/fixtures/component-capabilities/hindsight-v0.9.0.json"
+      - "reference/fixtures/component-qualification/hindsight-v0.9.0-resource-artifact-qualified-v12.json"
+      - "reference/agentmem_ref/qualification.py"
+      - "reference/agentmem_ref/capabilities.py"
+      - "schemas/component-capability-profile.schema.json"
+      - "schemas/component-capability-qualification.schema.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  qualify-and-substitute:
+    name: qualify-and-substitute-memos-v2017
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      PYTHONPATH: reference
+      AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+      MEMOS_TAG: memos-local-plugin-v2.0.17
+      MEMOS_COMMIT: d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab
+      MEMOS_VERSION: 2.0.17
+      MEMOS_PACKAGE: "@memtensor/memos-local-plugin"
+      RAW_ROOT: artifacts/memos-v2017
+    steps:
+      - name: Checkout Agent Memory exact head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.AGENT_MEMORY_COMMIT }}
+
+      - name: Verify Agent Memory exact head
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$AGENT_MEMORY_COMMIT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Agent Memory validation dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Prepare evidence directories
+        shell: bash
+        run: mkdir -p "$RAW_ROOT" /tmp/memos-runtime /tmp/memos-qualification-home
+
+      - name: Verify exact MemOS source and preserve license discrepancy
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/memos-source
+          git init -q /tmp/memos-source
+          git -C /tmp/memos-source remote add origin https://github.com/MemTensor/MemOS.git
+          git -C /tmp/memos-source fetch -q --depth 1 origin "refs/tags/$MEMOS_TAG"
+          git -C /tmp/memos-source checkout -q FETCH_HEAD
+          test "$(git -C /tmp/memos-source rev-parse HEAD)" = "$MEMOS_COMMIT"
+          grep -q "Apache License" /tmp/memos-source/LICENSE
+          grep -q "Version 2.0" /tmp/memos-source/LICENSE
+          node - <<'NODE'
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('/tmp/memos-source/apps/memos-local-plugin/package.json', 'utf8'));
+          if (pkg.name !== process.env.MEMOS_PACKAGE) throw new Error(`unexpected package name: ${pkg.name}`);
+          if (pkg.version !== process.env.MEMOS_VERSION) throw new Error(`unexpected package version: ${pkg.version}`);
+          if (pkg.license !== 'MIT') throw new Error(`expected package metadata license discrepancy, got: ${pkg.license}`);
+          NODE
+          cp /tmp/memos-source/LICENSE "$RAW_ROOT/source-LICENSE"
+          cp /tmp/memos-source/apps/memos-local-plugin/package.json "$RAW_ROOT/source-package.json"
+
+      - name: Capture registry metadata and install exact MemOS package
+        working-directory: /tmp/memos-runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm init -y >/dev/null
+          npm view "$MEMOS_PACKAGE@$MEMOS_VERSION" version license dist.integrity dist.shasum --json > "$GITHUB_WORKSPACE/$RAW_ROOT/npm-registry-metadata.json"
+          npm install --no-audit --no-fund "$MEMOS_PACKAGE@$MEMOS_VERSION"
+          PACKAGE_ROOT="/tmp/memos-runtime/node_modules/@memtensor/memos-local-plugin"
+          test -f "$PACKAGE_ROOT/dist/core/index.js"
+          node - <<'NODE'
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('/tmp/memos-runtime/node_modules/@memtensor/memos-local-plugin/package.json', 'utf8'));
+          if (pkg.name !== process.env.MEMOS_PACKAGE) throw new Error(`unexpected installed package: ${pkg.name}`);
+          if (pkg.version !== process.env.MEMOS_VERSION) throw new Error(`unexpected installed version: ${pkg.version}`);
+          if (pkg.license !== 'MIT') throw new Error(`installed package license metadata drifted: ${pkg.license}`);
+          NODE
+          cp "$PACKAGE_ROOT/package.json" "$GITHUB_WORKSPACE/$RAW_ROOT/installed-package.json"
+
+      - name: Execute focused qualification and substitution tests
+        run: |
+          python -m unittest \
+            reference/tests/test_memos_qualification.py \
+            reference/tests/test_component_qualification_v12.py
+
+      - name: Execute exact MemOS SQLite lifecycle fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/memos-qualification-home
+          mkdir -p /tmp/memos-qualification-home
+          node reference/run_memos_local_v2017_fixture.mjs \
+            --package-root /tmp/memos-runtime/node_modules/@memtensor/memos-local-plugin \
+            --home /tmp/memos-qualification-home \
+            --source-commit "$MEMOS_COMMIT" \
+            --license-path /tmp/memos-source/LICENSE \
+            --output "$RAW_ROOT/raw-provider-evidence.json"
+
+      - name: Emit MemOS Capability Qualification v1.2 evidence
+        run: |
+          python reference/run_memos_local_v2017_qualification.py \
+            --agent-memory-commit "$AGENT_MEMORY_COMMIT" \
+            --raw-evidence "$RAW_ROOT/raw-provider-evidence.json" \
+            --component-profile reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json \
+            --output "$RAW_ROOT/qualification.json"
+
+      - name: Validate MemOS qualification schema and current declaration
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          import jsonschema
+          from agentmem_ref.memos_qualification import load_component_profile
+          from agentmem_ref.resource_provider_substitution import qualification_record_from_dict
+
+          root = Path('.')
+          report = json.loads((root / 'artifacts/memos-v2017/qualification.json').read_text())
+          assert report['eligible'] is True
+          qualification = report['qualification']
+          schema = json.loads((root / 'schemas/component-capability-qualification.schema.json').read_text())
+          jsonschema.Draft202012Validator(schema).validate(qualification)
+          record = qualification_record_from_dict(qualification)
+          component = load_component_profile(root / 'reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json')
+          record.assert_current_declaration(component)
+          assert record.use_posture == 'runtime_allowed'
+          assert record.license_id == 'Apache-2.0'
+          assert record.authority_effect == 'none'
+          PY
+
+      - name: Prove Hindsight to MemOS substitution against one requirement
+        run: |
+          python reference/run_resource_artifact_substitution.py \
+            --primary-component reference/fixtures/component-capabilities/hindsight-v0.9.0.json \
+            --primary-qualification reference/fixtures/component-qualification/hindsight-v0.9.0-resource-artifact-qualified-v12.json \
+            --replacement-component reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json \
+            --replacement-qualification "$RAW_ROOT/qualification.json" \
+            --output "$RAW_ROOT/substitution.json"
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          value = json.loads(Path('artifacts/memos-v2017/substitution.json').read_text())
+          assert value['authority_effect'] == 'none'
+          evidence = value['substitution']
+          assert evidence['primary_component'] == 'hindsight-v0.9.0'
+          assert evidence['replacement_component'] == 'memos-local-plugin-v2.0.17'
+          assert evidence['capability_id'] == 'resource_artifact_memory'
+          assert evidence['capability_version'] == '1.0'
+          assert evidence['authority_effect'] == 'none'
+          PY
+
+      - name: Publish qualification and substitution summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## MemOS v2.0.17 qualification and substitution"
+            echo
+            if [ -f "$RAW_ROOT/qualification.json" ]; then
+              python - <<'PY'
+          import json
+          from pathlib import Path
+          value = json.loads(Path('artifacts/memos-v2017/qualification.json').read_text())
+          print(f"- MemOS eligible: `{str(value.get('eligible')).lower()}`")
+          print(f"- authority effect: `{value.get('authority_effect')}`")
+          for observation in value.get('observations', []):
+              marker = 'PASS' if observation.get('passed') else 'FAIL'
+              print(f"- {marker}: `{observation.get('check_id')}`")
+          PY
+            else
+              echo "- MemOS qualification was not emitted"
+            fi
+            if [ -f "$RAW_ROOT/substitution.json" ]; then
+              python - <<'PY'
+          import json
+          from pathlib import Path
+          value = json.loads(Path('artifacts/memos-v2017/substitution.json').read_text())
+          sub = value['substitution']
+          print(f"- substitution: `{sub['primary_component']}` -> `{sub['replacement_component']}`")
+          print(f"- substitution authority: `{sub['authority_effect']}`")
+          PY
+            else
+              echo "- substitution evidence was not emitted"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw, qualification, and substitution evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: memos-v2017-substitution-${{ env.AGENT_MEMORY_COMMIT }}
+          path: artifacts/memos-v2017
+          if-no-files-found: warn

--- a/docs/programs/memory-modules/memos-v2017-provider-substitution.md
+++ b/docs/programs/memory-modules/memos-v2017-provider-substitution.md
@@ -1,0 +1,141 @@
+# MemOS v2.0.17 resource-memory qualification and provider substitution
+
+Issue: #354
+
+## Purpose
+
+This slice tests whether Agent Memory's Capability Contract v3 and Capability Qualification v1.2 can support real provider portability rather than provider-shaped abstractions.
+
+The exact replacement candidate is:
+
+- repository: `MemTensor/MemOS`
+- release tag: `memos-local-plugin-v2.0.17`
+- tag commit: `d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab`
+- package: `@memtensor/memos-local-plugin@2.0.17`
+- bounded capability: `resource_artifact_memory@1.0`
+
+The primary provider is the already-qualified Hindsight v0.9.0 resource-memory implementation merged in PR #353.
+
+Provider qualification and substitution have `authority_effect: none`. They establish provider eligibility only. They do not grant recall admission, mutation, structural, policy, or action authority.
+
+## Why the MemOS trace surface
+
+The local plugin exposes a direct, agent-agnostic `MemoryCore` backed by SQLite. Its tagged source provides a bounded resource lifecycle without requiring OpenClaw, Hermes Agent, DeepSeek Harness, a hosted MemOS service, or a hosted LLM:
+
+1. `importBundle()` accepts caller-supplied trace IDs.
+2. A colliding trace ID is skipped instead of being assigned a fresh provider ID.
+3. `getTrace()` provides direct readback.
+4. `listTraces(q=...)` provides deterministic text-filtered candidate retrieval without invoking semantic embedding/ranking.
+5. `updateTrace()` mutates user-facing content while retaining the same trace identity.
+6. shutdown plus bootstrap against the same runtime home reconstructs SQLite state.
+7. `deleteTrace()` hard-deletes the trace and removes its episode reference in a database transaction.
+
+The qualification therefore tests a stable provider-native trace ID as the durable key. It does **not** claim that MemOS conversational `onTurnEnd()` writes are idempotent.
+
+## Source-rights discrepancy
+
+The exact tagged repository root contains an Apache-2.0 license grant, while `apps/memos-local-plugin/package.json` declares `license: MIT`. The plugin directory does not provide a separate MIT license text in the examined tagged source.
+
+The qualification preserves both facts rather than choosing the more convenient label:
+
+- source-rights license used for runtime eligibility: `Apache-2.0`, bound to the exact root `LICENSE` at the tag commit;
+- package metadata recorded separately: `MIT`;
+- the discrepancy is an explicit qualification check and limitation.
+
+If the root Apache-2.0 grant cannot be verified at exact source, the provider cannot emit `runtime_allowed` qualification evidence.
+
+## Bounded v3 contract
+
+The MemOS candidate profile is deliberately narrower than the product:
+
+### Behavior
+
+- write: supported
+- read: supported
+- recall candidate: supported through deterministic `listTraces` filtering
+- currentness: `provider_revalidated`
+- invalidation: `explicit_signal`
+- correction: `provider_revalidation`
+- deletion: `provider_revalidation`
+- residue: `scan_required`
+- migration/rebuild: `requires_requalification`
+- structural mutation: `none`
+
+### Operational
+
+- write atomicity: `none`
+- concurrency control: `none`
+- idempotency: `durable_keyed`
+- restart recovery: `reconstructable`
+- reconciliation: `deterministic_readback`
+
+`handle.db.tx(...)` exists in MemOS tagged source, but this fixture does not inject transaction failures. Transactional atomicity is therefore not promoted into the qualification merely from source inspection.
+
+## Executable lifecycle
+
+The focused fixture uses a single stable trace/session/episode identity and two unique text markers. It proves:
+
+1. initial stable-ID import yields one trace;
+2. direct readback and deterministic candidate lookup see the initial content;
+3. repeating the same import is skipped and the trace count remains one;
+4. `updateTrace()` places replacement content on the same trace ID;
+5. old text is no longer returned by the candidate lookup;
+6. shutdown/bootstrap against the same SQLite home reconstructs the replacement state;
+7. retrying the original import after restart is still skipped and does not overwrite replacement state;
+8. hard delete removes direct readback and both old/new candidate residue.
+
+A failed check produces an explicit ineligible result rather than a weaker silently accepted qualification.
+
+## Durable Hindsight evidence
+
+PR #353's passing Hindsight v0.9.0 Qualification v1.2 record is persisted under `reference/fixtures/component-qualification/` with:
+
+- exact PR head `6274070fac248c38dc2b1a7c13fafab79881d681`;
+- merge `24707456a9bc89f50a49cb2a889aaeb6998ada54`;
+- workflow run `33341188586`;
+- artifact digest;
+- applicability digest.
+
+The substitution path reconstructs the record and recomputes its applicability digest before use. A modified snapshot cannot become substitution evidence by retaining the old digest string.
+
+## Common substitution requirement
+
+Hindsight and MemOS are compared against one caller requirement rather than against each other.
+
+Required:
+
+- `resource_artifact_memory@1.0`;
+- maturity at least `evidence_proven`;
+- state posture `derived`;
+- scope posture `external_scope_bridge`;
+- write/read/recall-candidate support;
+- provider-revalidated currentness, correction, and deletion;
+- invalidation by either provider revalidation or explicit signal;
+- residue scan required;
+- requalification after migration/rebuild;
+- no structural mutation requirement;
+- `durable_keyed` idempotency;
+- restart recovery `reconstructable` or stronger;
+- reconciliation `deterministic_readback` or stronger;
+- runtime-allowed source rights;
+- provider authority posture unchanged and non-authoritative.
+
+Atomicity and concurrency are intentionally unconstrained because neither bounded fixture earns stronger guarantees there.
+
+The two provider contracts do not need to be identical. In particular, Hindsight uses provider revalidation for invalidation while the MemOS stable trace surface uses an explicit update/delete signal. Both are eligible only because the caller's requirement explicitly permits those behaviors.
+
+## Negative proof
+
+Focused tests refuse substitution when:
+
+- a persisted qualification digest is tampered;
+- a v1.1 qualification is supplied in place of v1.2 contract-bound evidence;
+- current declarations drift from the qualified contract;
+- durable idempotency degrades to process-local;
+- restart recovery or reconciliation degrades to process-local;
+- source rights become comparator-only;
+- capability authority posture changes.
+
+## Explicit non-goals
+
+This slice does not qualify or import MemOS semantic ranking, learned L2 policies, L3 world models, skills, Hub behavior, disposition, epistemic state, predictive state, or agent integration semantics. It does not make MemOS architecture canonical. It tests whether a second implementation can satisfy one Agent Memory-owned capability boundary.

--- a/reference/agentmem_ref/memos_qualification.py
+++ b/reference/agentmem_ref/memos_qualification.py
@@ -1,0 +1,355 @@
+"""Exact-version qualification normalizer for MemOS local plugin v2.0.17.
+
+Consumes raw provider evidence from the pinned local SQLite-backed MemoryCore
+fixture. Qualification remains bounded to resource artifact memory and never
+promotes MemOS provider verdicts, learned policy, L2/L3 state, or skills into
+Agent Memory authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from .capabilities import ComponentDeclaration
+from .qualification import (
+    AdapterResult,
+    QualificationRuntime,
+    QualificationSubject,
+    QualifiedCapabilityContract,
+    qualification_from_adapter_results,
+)
+
+MEMOS_RELEASE = "memos-local-plugin-v2.0.17"
+MEMOS_VERSION = "2.0.17"
+MEMOS_COMMIT = "d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab"
+MEMOS_REPOSITORY = "MemTensor/MemOS"
+MEMOS_PACKAGE = "@memtensor/memos-local-plugin"
+SOURCE_LICENSE = "Apache-2.0"
+PACKAGE_LICENSE_METADATA = "MIT"
+CAPABILITY_ID = "resource_artifact_memory"
+CAPABILITY_VERSION = "1.0"
+PROFILE_ID = "memos-local-v2017-trace-resource-artifact"
+PROFILE_VERSION = "1.0.0"
+ADAPTER_ID = "memos-local-v2017-trace-bundle-adapter"
+ADAPTER_VERSION = "1.0.0"
+FIXTURE_ID = "memos-local-v2017-trace-lifecycle-v1"
+
+
+class MemOSQualificationError(ValueError):
+    """Raw MemOS evidence is incomplete or contradicts the claimed contract."""
+
+
+@dataclass(frozen=True)
+class MemOSObservation:
+    check_id: str
+    passed: bool
+    evidence_ref: str
+    detail: str = ""
+
+    def as_check(self) -> tuple[str, bool, str]:
+        return (self.check_id, self.passed, self.evidence_ref)
+
+
+@dataclass(frozen=True)
+class MemOSQualificationResult:
+    qualification: dict[str, object] | None
+    observations: tuple[MemOSObservation, ...]
+    eligible: bool
+    limitations: tuple[str, ...]
+
+    @property
+    def authority_effect(self) -> str:
+        return "none"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "provider": {
+                "repository": MEMOS_REPOSITORY,
+                "release": MEMOS_RELEASE,
+                "version": MEMOS_VERSION,
+                "commit": MEMOS_COMMIT,
+                "package": MEMOS_PACKAGE,
+                "source_license": SOURCE_LICENSE,
+                "package_license_metadata": PACKAGE_LICENSE_METADATA,
+            },
+            "capability": {
+                "capability_id": CAPABILITY_ID,
+                "capability_version": CAPABILITY_VERSION,
+            },
+            "eligible": self.eligible,
+            "authority_effect": "none",
+            "observations": [
+                {
+                    "check_id": item.check_id,
+                    "passed": item.passed,
+                    "evidence_ref": item.evidence_ref,
+                    "detail": item.detail,
+                }
+                for item in self.observations
+            ],
+            "limitations": list(self.limitations),
+            "qualification": self.qualification,
+        }
+
+
+def load_component_profile(path: Path) -> ComponentDeclaration:
+    return ComponentDeclaration.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def qualify_memos_local_v2017(
+    *,
+    raw_evidence: dict[str, Any],
+    component: ComponentDeclaration,
+    agent_memory_commit: str,
+    raw_evidence_ref: str,
+) -> MemOSQualificationResult:
+    _validate_component_identity(component)
+    observations = _observations(raw_evidence, raw_evidence_ref)
+    limitations = _limitations(raw_evidence, observations)
+    eligible = all(item.passed for item in observations)
+    if not eligible:
+        return MemOSQualificationResult(
+            qualification=None,
+            observations=tuple(observations),
+            eligible=False,
+            limitations=tuple(limitations),
+        )
+
+    subject = QualificationSubject(
+        component_id=component.component_id,
+        component_version=component.component_version,
+        implementation_ref=f"github:{MEMOS_REPOSITORY}@{MEMOS_COMMIT}:apps/memos-local-plugin",
+        capability_id=CAPABILITY_ID,
+        capability_version=CAPABILITY_VERSION,
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        qualification_profile_id=PROFILE_ID,
+        qualification_profile_version=PROFILE_VERSION,
+    )
+    runtime = QualificationRuntime(
+        configuration_digest=_sha256_json(
+            {
+                "agent_memory_commit": agent_memory_commit,
+                "provider_commit": MEMOS_COMMIT,
+                "provider_release": MEMOS_RELEASE,
+                "provider_version": MEMOS_VERSION,
+                "package": MEMOS_PACKAGE,
+                "adapter": "direct-memory-core",
+                "database": "sqlite",
+                "hosted_llm_credentials": False,
+                "fixture": FIXTURE_ID,
+            }
+        ),
+        fixture_id=FIXTURE_ID,
+        fixture_digest=_sha256_json(raw_evidence.get("fixture", {})),
+        dependency_refs=(
+            f"npm:{MEMOS_PACKAGE}@{MEMOS_VERSION}",
+            f"github:{MEMOS_REPOSITORY}@{MEMOS_COMMIT}",
+        ),
+        runtime_refs=(
+            "memos-local-plugin:MemoryCore",
+            "memos-local-plugin:importBundle",
+            "memos-local-plugin:updateTrace",
+            "memos-local-plugin:sqlite",
+        ),
+    )
+    common = dict(
+        subject=subject,
+        runtime_identity=f"memos-local-plugin:{MEMOS_VERSION}:sqlite",
+        input_refs=(FIXTURE_ID,),
+        raw_provider_refs=(raw_evidence_ref,),
+        normalized_refs=(f"qualification:{component.component_id}:{CAPABILITY_ID}",),
+        failure_result="none",
+    )
+    adapter_results = (
+        AdapterResult(
+            operation="stable_trace_import_read_candidate",
+            currentness="current",
+            trace_ref="qualification:memos:initial-import",
+            **common,
+        ),
+        AdapterResult(
+            operation="stable_key_repeat_and_update",
+            currentness="replacement_current",
+            trace_ref="qualification:memos:stable-key-update",
+            **common,
+        ),
+        AdapterResult(
+            operation="restart_readback",
+            currentness="reconstructed_current",
+            trace_ref="qualification:memos:restart-readback",
+            **common,
+        ),
+        AdapterResult(
+            operation="trace_delete_residue_scan",
+            currentness="deleted_no_candidate_residue",
+            trace_ref="qualification:memos:delete-residue",
+            **common,
+        ),
+    )
+    qualification = qualification_from_adapter_results(
+        subject=subject,
+        runtime=runtime,
+        license_id=SOURCE_LICENSE,
+        license_ref=f"github:{MEMOS_REPOSITORY}@{MEMOS_COMMIT}:LICENSE",
+        use_posture="runtime_allowed",
+        results=adapter_results,
+        checks=tuple(item.as_check() for item in observations),
+        artifact_digests=(_sha256_json(raw_evidence),),
+        maturity_before="runtime_wired",
+        profile_maturity_ceiling="evidence_proven",
+        earned_maturity="evidence_proven",
+        limitations=tuple(limitations),
+        qualified_contract=QualifiedCapabilityContract.from_component(
+            component,
+            capability_id=CAPABILITY_ID,
+            capability_version=CAPABILITY_VERSION,
+        ),
+    )
+    qualification.assert_current_declaration(component)
+    return MemOSQualificationResult(
+        qualification=qualification.to_dict(),
+        observations=tuple(observations),
+        eligible=True,
+        limitations=tuple(limitations),
+    )
+
+
+def _validate_component_identity(component: ComponentDeclaration) -> None:
+    if component.component_id != "memos-local-plugin-v2.0.17":
+        raise MemOSQualificationError("unexpected MemOS component identity")
+    if component.component_version != MEMOS_VERSION:
+        raise MemOSQualificationError("MemOS component version does not match pinned package")
+    matches = [
+        capability
+        for capability in component.capabilities
+        if capability.capability_id == CAPABILITY_ID
+        and capability.capability_version == CAPABILITY_VERSION
+    ]
+    if len(matches) != 1 or len(component.capabilities) != 1:
+        raise MemOSQualificationError("bounded profile must expose only resource_artifact_memory@1.0")
+    if matches[0].authority_effect != "none":
+        raise MemOSQualificationError("MemOS qualification cannot grant authority")
+
+
+def _observations(raw: dict[str, Any], evidence_ref: str) -> list[MemOSObservation]:
+    identity = raw.get("identity", {})
+    config = raw.get("configuration", {})
+    initial = raw.get("initial", {})
+    repeat = raw.get("same_key_repeat", {})
+    replacement = raw.get("replacement", {})
+    restart = raw.get("restart", {})
+    durable_repeat = raw.get("durable_repeat_after_restart", {})
+    deletion = raw.get("deletion", {})
+
+    def obs(check_id: str, passed: bool, detail: str) -> MemOSObservation:
+        return MemOSObservation(check_id, bool(passed), evidence_ref, detail)
+
+    return [
+        obs(
+            "exact-provider-identity",
+            identity.get("release") == MEMOS_RELEASE
+            and identity.get("version") == MEMOS_VERSION
+            and identity.get("commit") == MEMOS_COMMIT
+            and identity.get("package") == MEMOS_PACKAGE,
+            "tag/version/source commit/package must match the qualification pin",
+        ),
+        obs(
+            "source-rights-discrepancy-preserved",
+            identity.get("source_license") == SOURCE_LICENSE
+            and identity.get("source_license_verified") is True
+            and identity.get("package_license_metadata") == PACKAGE_LICENSE_METADATA
+            and identity.get("license_discrepancy_preserved") is True,
+            "root Apache-2.0 grant and package MIT metadata discrepancy must both be retained",
+        ),
+        obs(
+            "direct-local-core-no-hosted-secret",
+            config.get("adapter") == "direct-memory-core"
+            and config.get("database") == "sqlite"
+            and config.get("hosted_llm_api_key_present") is False
+            and config.get("hosted_embedding_api_key_present") is False,
+            "bounded fixture must use the direct local core and SQLite without hosted provider credentials",
+        ),
+        obs(
+            "initial-stable-trace-readback",
+            initial.get("imported") == 1
+            and initial.get("skipped") == 0
+            and initial.get("trace_count") == 1
+            and initial.get("get_matches_initial") is True
+            and initial.get("candidate_contains_initial") is True,
+            "caller-supplied trace identity must be imported once, directly readable, and query-visible",
+        ),
+        obs(
+            "stable-key-repeat-idempotency",
+            repeat.get("imported") == 0
+            and repeat.get("skipped") == 1
+            and repeat.get("trace_count") == 1
+            and repeat.get("get_matches_initial") is True,
+            "re-importing the same stable trace ID must skip rather than mint a duplicate",
+        ),
+        obs(
+            "stable-key-update-currentness",
+            replacement.get("updated_same_id") is True
+            and replacement.get("trace_count") == 1
+            and replacement.get("get_matches_replacement") is True
+            and replacement.get("candidate_contains_replacement") is True
+            and replacement.get("candidate_contains_initial") is False,
+            "updateTrace must replace user-facing content on the same durable provider ID",
+        ),
+        obs(
+            "restart-reconstruction",
+            restart.get("restart_succeeded") is True
+            and restart.get("trace_count") == 1
+            and restart.get("get_matches_replacement") is True
+            and restart.get("candidate_contains_replacement") is True,
+            "SQLite-backed trace state must reconstruct after MemoryCore shutdown/bootstrap",
+        ),
+        obs(
+            "durable-key-after-restart",
+            durable_repeat.get("imported") == 0
+            and durable_repeat.get("skipped") == 1
+            and durable_repeat.get("trace_count") == 1
+            and durable_repeat.get("get_matches_replacement") is True,
+            "the stable trace key must remain collision-detectable after restart",
+        ),
+        obs(
+            "delete-readback-and-candidate-residue",
+            deletion.get("delete_succeeded") is True
+            and deletion.get("get_after_delete_is_null") is True
+            and deletion.get("trace_count") == 0
+            and deletion.get("candidate_contains_initial") is False
+            and deletion.get("candidate_contains_replacement") is False,
+            "hard delete must remove direct readback and old/new listTraces query residue",
+        ),
+        obs(
+            "provider-identity-is-not-agent-memory-identity",
+            raw.get("identity_boundary_preserved") is True,
+            "MemOS trace/session/episode IDs remain provider-native evidence refs",
+        ),
+    ]
+
+
+def _limitations(raw: dict[str, Any], observations: list[MemOSObservation]) -> list[str]:
+    limitations = [
+        "Qualification is exact to @memtensor/memos-local-plugin v2.0.17 and tag commit d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab.",
+        "Only stable-ID trace bundle resource memory is qualified; conversational capture, semantic ranking, L2/L3 state, skills, Hub behavior, and agent adapters remain outside this evidence boundary.",
+        "Write atomicity and concurrent mutation ordering are not fault-injection qualified and remain declared none.",
+        "Candidate lookup uses deterministic listTraces text filtering and carries no Agent Memory recall-admission authority.",
+        "The tagged repository root grants Apache-2.0 while package metadata declares MIT; runtime posture relies on the exact root license grant and retains the metadata discrepancy rather than resolving it by convenience.",
+    ]
+    failed = [item.check_id for item in observations if not item.passed]
+    if failed:
+        limitations.append("Provider did not satisfy the candidate v3 contract: " + ", ".join(failed))
+    for note in raw.get("provider_notes", []):
+        if isinstance(note, str) and note:
+            limitations.append(note)
+    return limitations
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()

--- a/reference/agentmem_ref/resource_provider_substitution.py
+++ b/reference/agentmem_ref/resource_provider_substitution.py
@@ -1,0 +1,269 @@
+"""Real provider substitution proof for qualified resource artifact memory.
+
+This module consumes persisted Capability Qualification v1.2 records. It does
+not select providers by implementation resemblance and it never grants recall,
+mutation, or action authority. Each provider must independently satisfy the
+same explicit capability requirement before substitution evidence is emitted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+from typing import Mapping
+
+from .capabilities import (
+    CapabilityBehaviorContract,
+    CapabilityBehaviorRequirement,
+    CapabilityOperationalContract,
+    CapabilityOperationalRequirement,
+    CapabilityRequirement,
+    ComponentDeclaration,
+)
+from .qualification import (
+    AdapterResult,
+    QualificationError,
+    QualificationRecord,
+    QualificationRuntime,
+    QualificationSubject,
+    QualifiedCapabilityContract,
+    prove_provider_substitution,
+)
+
+RESOURCE_CAPABILITY_ID = "resource_artifact_memory"
+RESOURCE_CAPABILITY_VERSION = "1.0"
+
+
+def resource_artifact_substitution_requirement() -> CapabilityRequirement:
+    """Common boundary independently satisfied by Hindsight and MemOS.
+
+    Atomicity and concurrency are intentionally unconstrained. Neither provider
+    has earned stronger fault/concurrency evidence in the bounded fixtures.
+    """
+
+    return CapabilityRequirement(
+        capability_id=RESOURCE_CAPABILITY_ID,
+        capability_version=RESOURCE_CAPABILITY_VERSION,
+        minimum_maturity="evidence_proven",
+        required_state_postures=("derived",),
+        required_scope_postures=("external_scope_bridge",),
+        behavior_requirement=CapabilityBehaviorRequirement(
+            write=True,
+            read=True,
+            recall_candidate=True,
+            currentness_models=("provider_revalidated",),
+            invalidation_models=("provider_revalidation", "explicit_signal"),
+            correction_models=("provider_revalidation",),
+            deletion_models=("provider_revalidation",),
+            residue_models=("scan_required",),
+            migration_rebuild_models=("requires_requalification",),
+            structural_mutation_requirements=("none",),
+        ),
+        operational_requirement=CapabilityOperationalRequirement(
+            idempotency=("durable_keyed",),
+            restart_recovery=("reconstructable", "checkpoint_replay"),
+            reconciliation=("deterministic_readback", "authoritative_rebuild"),
+        ),
+    )
+
+
+def load_component(path: Path) -> ComponentDeclaration:
+    return ComponentDeclaration.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def load_qualification_snapshot(path: Path) -> QualificationRecord:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, Mapping):
+        raise QualificationError("qualification snapshot must be an object")
+    payload = value.get("qualification", value)
+    if not isinstance(payload, Mapping):
+        raise QualificationError("qualification snapshot does not contain a qualification object")
+    record = qualification_record_from_dict(payload)
+    source = value.get("source")
+    if isinstance(source, Mapping):
+        expected = source.get("applicability_digest")
+        if expected is not None and expected != record.applicability_digest:
+            raise QualificationError("qualification snapshot source applicability digest does not match record")
+    return record
+
+
+def qualification_record_from_dict(value: Mapping[str, object]) -> QualificationRecord:
+    """Strictly reconstruct one persisted v1.2 qualification record.
+
+    Recomputing the applicability digest makes persisted qualification evidence
+    tamper-evident at the semantic boundary used by provider substitution.
+    """
+
+    if value.get("schema_version") != "1.2.0":
+        raise QualificationError("real provider substitution requires Capability Qualification v1.2")
+
+    subject_raw = _mapping(value.get("subject"), "subject")
+    subject = QualificationSubject(
+        component_id=_string(subject_raw, "component_id"),
+        component_version=_string(subject_raw, "component_version"),
+        implementation_ref=_string(subject_raw, "implementation_ref"),
+        capability_id=_string(subject_raw, "capability_id"),
+        capability_version=_string(subject_raw, "capability_version"),
+        adapter_id=_string(subject_raw, "adapter_id"),
+        adapter_version=_string(subject_raw, "adapter_version"),
+        qualification_profile_id=_string(subject_raw, "qualification_profile_id"),
+        qualification_profile_version=_string(subject_raw, "qualification_profile_version"),
+    )
+
+    runtime_raw = _mapping(value.get("runtime"), "runtime")
+    runtime = QualificationRuntime(
+        configuration_digest=_string(runtime_raw, "configuration_digest"),
+        fixture_id=_string(runtime_raw, "fixture_id"),
+        fixture_digest=_string(runtime_raw, "fixture_digest"),
+        dependency_refs=_strings(runtime_raw.get("dependency_refs")),
+        runtime_refs=_strings(runtime_raw.get("runtime_refs")),
+    )
+
+    contract_raw = _mapping(value.get("qualified_contract"), "qualified_contract")
+    behavior_raw = _mapping(contract_raw.get("behavior_contract"), "qualified_contract.behavior_contract")
+    operational_raw = _mapping(contract_raw.get("operational_contract"), "qualified_contract.operational_contract")
+    contract = QualifiedCapabilityContract(
+        component_profile_version=_string(contract_raw, "component_profile_version"),
+        state_posture=_string(contract_raw, "state_posture"),
+        scope_posture=_string(contract_raw, "scope_posture"),
+        failure_posture=_string(contract_raw, "failure_posture"),
+        authority_effect=_string(contract_raw, "authority_effect"),
+        behavior_contract=CapabilityBehaviorContract.from_dict(behavior_raw),
+        operational_contract=CapabilityOperationalContract.from_dict(operational_raw),
+    )
+
+    source_rights = _mapping(value.get("source_rights"), "source_rights")
+    evidence = _mapping(value.get("evidence"), "evidence")
+    result = _mapping(value.get("result"), "result")
+    adapter_results = tuple(
+        _adapter_result_from_dict(subject, _mapping(item, "evidence.adapter_results[]"))
+        for item in _sequence(evidence.get("adapter_results"), "evidence.adapter_results")
+    )
+    checks = tuple(
+        (
+            _string(check, "check_id"),
+            _boolean(check, "passed"),
+            _string(check, "evidence_ref"),
+        )
+        for check in (
+            _mapping(item, "evidence.checks[]")
+            for item in _sequence(evidence.get("checks"), "evidence.checks")
+        )
+    )
+
+    record = QualificationRecord(
+        subject=subject,
+        runtime=runtime,
+        license_id=_string(source_rights, "license_id"),
+        license_ref=_string(source_rights, "license_ref"),
+        use_posture=_string(source_rights, "use_posture"),
+        operations=_strings(evidence.get("operations")),
+        raw_provider_refs=_strings(evidence.get("raw_provider_refs")),
+        normalized_refs=_strings(evidence.get("normalized_refs")),
+        checks=checks,
+        artifact_digests=_strings(evidence.get("artifact_digests")),
+        maturity_before=_string(result, "maturity_before"),
+        profile_maturity_ceiling=_string(result, "profile_maturity_ceiling"),
+        earned_maturity=_string(result, "earned_maturity"),
+        adapter_results=adapter_results,
+        limitations=_strings(result.get("limitations")),
+        qualification_current=_boolean(result, "qualification_current"),
+        qualified_contract=contract,
+    )
+    stored_digest = _string(result, "applicability_digest")
+    if record.applicability_digest != stored_digest:
+        raise QualificationError("persisted qualification applicability digest does not match reconstructed record")
+    if record.authority_effect != "none" or _string(result, "authority_effect") != "none":
+        raise QualificationError("persisted provider qualification cannot grant authority")
+    return record
+
+
+def prove_resource_artifact_substitution(
+    *,
+    primary_component: ComponentDeclaration,
+    primary_qualification: QualificationRecord,
+    replacement_component: ComponentDeclaration,
+    replacement_qualification: QualificationRecord,
+) -> dict[str, object]:
+    requirement = resource_artifact_substitution_requirement()
+    evidence = prove_provider_substitution(
+        primary_component=primary_component,
+        primary_qualification=primary_qualification,
+        replacement_component=replacement_component,
+        replacement_qualification=replacement_qualification,
+        requirement=requirement,
+    )
+    return {
+        "requirement": {
+            "capability_id": requirement.capability_id,
+            "capability_version": requirement.capability_version,
+            "minimum_maturity": requirement.minimum_maturity,
+            "required_state_postures": list(requirement.required_state_postures),
+            "required_scope_postures": list(requirement.required_scope_postures),
+            "behavior_requirement": requirement.behavior_requirement.to_dict()
+            if requirement.behavior_requirement
+            else None,
+            "operational_requirement": requirement.operational_requirement.to_dict()
+            if requirement.operational_requirement
+            else None,
+        },
+        "substitution": evidence.to_dict(),
+        "authority_effect": "none",
+    }
+
+
+def qualification_with_use_posture(record: QualificationRecord, use_posture: str) -> QualificationRecord:
+    """Test helper for adversarial source-rights substitution proofs."""
+    return replace(record, use_posture=use_posture)
+
+
+def _adapter_result_from_dict(subject: QualificationSubject, value: Mapping[str, object]) -> AdapterResult:
+    if _string(value, "authority_effect") != "none":
+        raise QualificationError("persisted adapter result cannot grant authority")
+    return AdapterResult(
+        subject=subject,
+        operation=_string(value, "operation"),
+        runtime_identity=_string(value, "runtime_identity"),
+        input_refs=_strings(value.get("input_refs")),
+        raw_provider_refs=_strings(value.get("raw_provider_refs")),
+        normalized_refs=_strings(value.get("normalized_refs")),
+        currentness=_string(value, "currentness"),
+        failure_result=_string(value, "failure_result"),
+        trace_ref=_string(value, "trace_ref"),
+    )
+
+
+def _mapping(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise QualificationError(f"{name} must be an object")
+    return value
+
+
+def _sequence(value: object, name: str) -> tuple[object, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise QualificationError(f"{name} must be an array")
+    return tuple(value)
+
+
+def _strings(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    items = _sequence(value, "string array")
+    if any(not isinstance(item, str) or not item for item in items):
+        raise QualificationError("string array values must be non-empty strings")
+    return tuple(items)  # type: ignore[return-value]
+
+
+def _string(value: Mapping[str, object], key: str) -> str:
+    raw = value.get(key)
+    if not isinstance(raw, str) or not raw:
+        raise QualificationError(f"{key} must be a non-empty string")
+    return raw
+
+
+def _boolean(value: Mapping[str, object], key: str) -> bool:
+    raw = value.get(key)
+    if not isinstance(raw, bool):
+        raise QualificationError(f"{key} must be boolean")
+    return raw

--- a/reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json
+++ b/reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json
@@ -29,7 +29,7 @@
         "Qualification is limited to @memtensor/memos-local-plugin v2.0.17 trace-bundle resource memory.",
         "Stable-key evidence uses caller-supplied trace IDs through importBundle plus updateTrace; conversational onTurnEnd writes are not claimed idempotent.",
         "Candidate retrieval is the deterministic listTraces query surface; semantic ranking, L2/L3 memory, skills, and agent adapters are outside this evidence boundary.",
-        "Concurrent mutation ordering is not qualified by this slice.",
+        "Write atomicity and concurrent mutation ordering are not fault-injection qualified and remain declared none.",
         "Repository root LICENSE is Apache-2.0 while the package manifest declares MIT; the discrepancy is retained as provenance and runtime rights rely on the exact tagged repository license grant."
       ],
       "behavior_contract": {
@@ -47,7 +47,7 @@
         "structural_mutation_requirement": "none"
       },
       "operational_contract": {
-        "write_atomicity": "transactional_multi_record",
+        "write_atomicity": "none",
         "concurrency_control": "none",
         "idempotency": "durable_keyed",
         "restart_recovery": "reconstructable",

--- a/reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json
+++ b/reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json
@@ -1,0 +1,58 @@
+{
+  "component_id": "memos-local-plugin-v2.0.17",
+  "component_version": "2.0.17",
+  "profile_version": "component-capability-v3",
+  "enabled": true,
+  "runtime_ref": "npm:@memtensor/memos-local-plugin@2.0.17",
+  "failure_posture": "fail_closed",
+  "provenance_refs": [
+    "https://github.com/MemTensor/MemOS/releases/tag/memos-local-plugin-v2.0.17",
+    "https://github.com/MemTensor/MemOS/commit/d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab",
+    "https://github.com/MythologIQ-Labs-LLC/agent-memory/issues/354"
+  ],
+  "capabilities": [
+    {
+      "capability_id": "resource_artifact_memory",
+      "capability_version": "1.0",
+      "maturity": "evidence_proven",
+      "state_posture": "derived",
+      "scope_posture": "external_scope_bridge",
+      "failure_posture": "fail_closed",
+      "authority_effect": "none",
+      "enabled": true,
+      "evidence_refs": [
+        "reference/agentmem_ref/memos_qualification.py",
+        "reference/tests/test_memos_qualification.py",
+        ".github/workflows/memos-v2017-substitution.yml"
+      ],
+      "limitations": [
+        "Qualification is limited to @memtensor/memos-local-plugin v2.0.17 trace-bundle resource memory.",
+        "Stable-key evidence uses caller-supplied trace IDs through importBundle plus updateTrace; conversational onTurnEnd writes are not claimed idempotent.",
+        "Candidate retrieval is the deterministic listTraces query surface; semantic ranking, L2/L3 memory, skills, and agent adapters are outside this evidence boundary.",
+        "Concurrent mutation ordering is not qualified by this slice.",
+        "Repository root LICENSE is Apache-2.0 while the package manifest declares MIT; the discrepancy is retained as provenance and runtime rights rely on the exact tagged repository license grant."
+      ],
+      "behavior_contract": {
+        "operation_support": {
+          "write": true,
+          "read": true,
+          "recall_candidate": true
+        },
+        "currentness_model": "provider_revalidated",
+        "invalidation_model": "explicit_signal",
+        "correction_model": "provider_revalidation",
+        "deletion_model": "provider_revalidation",
+        "residue_model": "scan_required",
+        "migration_rebuild_model": "requires_requalification",
+        "structural_mutation_requirement": "none"
+      },
+      "operational_contract": {
+        "write_atomicity": "transactional_multi_record",
+        "concurrency_control": "none",
+        "idempotency": "durable_keyed",
+        "restart_recovery": "reconstructable",
+        "reconciliation": "deterministic_readback"
+      }
+    }
+  ]
+}

--- a/reference/fixtures/component-qualification/hindsight-v0.9.0-resource-artifact-qualified-v12.json
+++ b/reference/fixtures/component-qualification/hindsight-v0.9.0-resource-artifact-qualified-v12.json
@@ -1,0 +1,154 @@
+{
+  "qualification": {
+    "evidence": {
+      "adapter_results": [
+        {
+          "authority_effect": "none",
+          "currentness": "current",
+          "failure_result": "none",
+          "input_refs": ["hindsight-v090-document-lifecycle-v1"],
+          "normalized_refs": ["qualification:hindsight-v0.9.0:resource_artifact_memory"],
+          "operation": "retain_read_recall",
+          "raw_provider_refs": ["artifacts/hindsight-v090/raw-provider-evidence.json"],
+          "runtime_identity": "hindsight-embed:0.9.0:pg0",
+          "trace_ref": "qualification:hindsight:initial-retain"
+        },
+        {
+          "authority_effect": "none",
+          "currentness": "replacement_current",
+          "failure_result": "none",
+          "input_refs": ["hindsight-v090-document-lifecycle-v1"],
+          "normalized_refs": ["qualification:hindsight-v0.9.0:resource_artifact_memory"],
+          "operation": "stable_key_replace",
+          "raw_provider_refs": ["artifacts/hindsight-v090/raw-provider-evidence.json"],
+          "runtime_identity": "hindsight-embed:0.9.0:pg0",
+          "trace_ref": "qualification:hindsight:stable-key-replace"
+        },
+        {
+          "authority_effect": "none",
+          "currentness": "reconstructed_current",
+          "failure_result": "none",
+          "input_refs": ["hindsight-v090-document-lifecycle-v1"],
+          "normalized_refs": ["qualification:hindsight-v0.9.0:resource_artifact_memory"],
+          "operation": "restart_readback",
+          "raw_provider_refs": ["artifacts/hindsight-v090/raw-provider-evidence.json"],
+          "runtime_identity": "hindsight-embed:0.9.0:pg0",
+          "trace_ref": "qualification:hindsight:restart-readback"
+        },
+        {
+          "authority_effect": "none",
+          "currentness": "deleted_no_recall_residue",
+          "failure_result": "none",
+          "input_refs": ["hindsight-v090-document-lifecycle-v1"],
+          "normalized_refs": ["qualification:hindsight-v0.9.0:resource_artifact_memory"],
+          "operation": "document_delete_residue_scan",
+          "raw_provider_refs": ["artifacts/hindsight-v090/raw-provider-evidence.json"],
+          "runtime_identity": "hindsight-embed:0.9.0:pg0",
+          "trace_ref": "qualification:hindsight:delete-residue"
+        }
+      ],
+      "artifact_digests": ["sha256:f27c544747033bd456e6b7c3e6d01dc1309731bce8e19130e20a5161d43bd04d"],
+      "checks": [
+        {"check_id":"exact-provider-identity","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true},
+        {"check_id":"mit-runtime-rights","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true},
+        {"check_id":"llm-free-chunk-path","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true},
+        {"check_id":"initial-document-readback","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true},
+        {"check_id":"stable-key-repeat-idempotency","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true},
+        {"check_id":"stable-key-replacement-currentness","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true},
+        {"check_id":"restart-reconstruction","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true},
+        {"check_id":"durable-key-after-restart","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true},
+        {"check_id":"delete-readback-and-recall-residue","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true},
+        {"check_id":"provider-identity-is-not-agent-memory-identity","evidence_ref":"artifacts/hindsight-v090/raw-provider-evidence.json","passed":true}
+      ],
+      "normalized_refs": [
+        "qualification:hindsight-v0.9.0:resource_artifact_memory",
+        "qualification:hindsight-v0.9.0:resource_artifact_memory",
+        "qualification:hindsight-v0.9.0:resource_artifact_memory",
+        "qualification:hindsight-v0.9.0:resource_artifact_memory"
+      ],
+      "operations": ["retain_read_recall","stable_key_replace","restart_readback","document_delete_residue_scan"],
+      "raw_provider_refs": [
+        "artifacts/hindsight-v090/raw-provider-evidence.json",
+        "artifacts/hindsight-v090/raw-provider-evidence.json",
+        "artifacts/hindsight-v090/raw-provider-evidence.json",
+        "artifacts/hindsight-v090/raw-provider-evidence.json"
+      ]
+    },
+    "qualified_contract": {
+      "authority_effect": "none",
+      "behavior_contract": {
+        "correction_model": "provider_revalidation",
+        "currentness_model": "provider_revalidated",
+        "deletion_model": "provider_revalidation",
+        "invalidation_model": "provider_revalidation",
+        "migration_rebuild_model": "requires_requalification",
+        "operation_support": {"read":true,"recall_candidate":true,"write":true},
+        "residue_model": "scan_required",
+        "structural_mutation_requirement": "none"
+      },
+      "component_profile_version": "component-capability-v3",
+      "failure_posture": "fail_closed",
+      "operational_contract": {
+        "concurrency_control": "none",
+        "idempotency": "durable_keyed",
+        "reconciliation": "deterministic_readback",
+        "restart_recovery": "reconstructable",
+        "write_atomicity": "none"
+      },
+      "scope_posture": "external_scope_bridge",
+      "state_posture": "derived"
+    },
+    "result": {
+      "applicability_digest": "sha256:a1776c55d7984706f75f429a605e13cd56e14cd02bfa334697e8509982bd7f5e",
+      "authority_effect": "none",
+      "earned_maturity": "evidence_proven",
+      "limitations": [
+        "Qualification is exact to Hindsight v0.9.0 and source commit b12646f49ec512136b9f709e608524ffed969668.",
+        "Only chunk-backed resource_artifact_memory is qualified; richer LLM-backed Hindsight modes are outside this evidence boundary.",
+        "Write atomicity and concurrent mutation ordering remain unqualified and are declared none.",
+        "Provider-native recall ranking remains candidate/relevance evidence and carries no Agent Memory authority.",
+        "The v0.9 prose documentation omitted chunks although the exact v0.9.0 source allowed it; source truth controls this fixture and the discrepancy is retained as provenance."
+      ],
+      "maturity_before": "runtime_wired",
+      "profile_maturity_ceiling": "evidence_proven",
+      "qualification_current": true
+    },
+    "runtime": {
+      "configuration_digest": "sha256:ea13f055644145f4dd74abc8ff02cb650963de0ea09a480746940eca8fefd8a3",
+      "dependency_refs": [
+        "pypi:hindsight-embed==0.9.0",
+        "github:vectorize-io/hindsight@b12646f49ec512136b9f709e608524ffed969668"
+      ],
+      "fixture_digest": "sha256:089ac14c1f9489864bb871055e8583475ac04c44022cf5994dd863fb68a8c3d4",
+      "fixture_id": "hindsight-v090-document-lifecycle-v1",
+      "runtime_refs": ["hindsight-embed:local-daemon","hindsight:chunk-extraction","hindsight:pg0"]
+    },
+    "schema_version": "1.2.0",
+    "source_rights": {
+      "license_id": "MIT",
+      "license_ref": "github:vectorize-io/hindsight@b12646f49ec512136b9f709e608524ffed969668:LICENSE",
+      "use_posture": "runtime_allowed"
+    },
+    "subject": {
+      "adapter_id": "hindsight-v090-chunk-document-adapter",
+      "adapter_version": "1.0.0",
+      "capability_id": "resource_artifact_memory",
+      "capability_version": "1.0",
+      "component_id": "hindsight-v0.9.0",
+      "component_version": "0.9.0",
+      "implementation_ref": "github:vectorize-io/hindsight@b12646f49ec512136b9f709e608524ffed969668",
+      "qualification_profile_id": "hindsight-v090-chunk-resource-artifact",
+      "qualification_profile_version": "1.0.0"
+    }
+  },
+  "source": {
+    "agent_memory_exact_head": "6274070fac248c38dc2b1a7c13fafab79881d681",
+    "agent_memory_merge": "24707456a9bc89f50a49cb2a889aaeb6998ada54",
+    "agent_memory_pr": 353,
+    "applicability_digest": "sha256:a1776c55d7984706f75f429a605e13cd56e14cd02bfa334697e8509982bd7f5e",
+    "artifact_digest": "sha256:f27c544747033bd456e6b7c3e6d01dc1309731bce8e19130e20a5161d43bd04d",
+    "provider": "vectorize-io/hindsight@v0.9.0",
+    "provider_commit": "b12646f49ec512136b9f709e608524ffed969668",
+    "workflow_run": 33341188586
+  }
+}

--- a/reference/run_memos_local_v2017_fixture.mjs
+++ b/reference/run_memos_local_v2017_fixture.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const MEMOS_RELEASE = "memos-local-plugin-v2.0.17";
+const MEMOS_VERSION = "2.0.17";
+const MEMOS_COMMIT = "d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab";
+const MEMOS_PACKAGE = "@memtensor/memos-local-plugin";
+const MEMOS_REPOSITORY = "MemTensor/MemOS";
+const INITIAL_MARKER = "silveroak317";
+const REPLACEMENT_MARKER = "violetstone624";
+const TRACE_ID = "agent-memory-resource-trace";
+const SESSION_ID = "agent-memory-resource-session";
+const EPISODE_ID = "agent-memory-resource-episode";
+const INITIAL_TEXT = `${INITIAL_MARKER} resource artifact state is initial and provider-bounded.`;
+const REPLACEMENT_TEXT = `${REPLACEMENT_MARKER} resource artifact state is replacement and provider-bounded.`;
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key?.startsWith("--") || value === undefined) throw new Error(`invalid argument near ${key}`);
+    out[key.slice(2)] = value;
+  }
+  for (const required of ["package-root", "home", "source-commit", "license-path", "output"]) {
+    if (!out[required]) throw new Error(`--${required} is required`);
+  }
+  return out;
+}
+
+async function mkdirHome(root) {
+  const dirs = [root, path.join(root, "data"), path.join(root, "skills"), path.join(root, "logs"), path.join(root, "daemon")];
+  for (const dir of dirs) await fs.mkdir(dir, { recursive: true });
+  return {
+    root,
+    configFile: path.join(root, "config.yaml"),
+    dataDir: path.join(root, "data"),
+    dbFile: path.join(root, "data", "memos.db"),
+    skillsDir: path.join(root, "skills"),
+    logsDir: path.join(root, "logs"),
+    daemonDir: path.join(root, "daemon"),
+  };
+}
+
+function containsMarker(rows, marker) {
+  return rows.some((row) => JSON.stringify(row).includes(marker));
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const packageJson = JSON.parse(await fs.readFile(path.join(args["package-root"], "package.json"), "utf8"));
+  const sourceLicense = await fs.readFile(args["license-path"], "utf8");
+  const coreUrl = pathToFileURL(path.join(args["package-root"], "dist", "core", "index.js")).href;
+  const coreModule = await import(coreUrl);
+  const { bootstrapMemoryCore, resolveConfig } = coreModule;
+  if (typeof bootstrapMemoryCore !== "function" || typeof resolveConfig !== "function") {
+    throw new Error("exact package does not expose bootstrapMemoryCore/resolveConfig from dist/core/index.js");
+  }
+
+  const home = await mkdirHome(path.resolve(args.home));
+  const config = resolveConfig({
+    viewer: { openOnFirstTurn: false },
+    llm: { provider: "", model: "", apiKey: "", fallbackToHost: false },
+    embedding: { provider: "local", apiKey: "", cache: { enabled: false, maxItems: 1 } },
+    algorithm: {
+      lightweightMemory: { enabled: true },
+      capture: { embedTraces: false, alphaScoring: false, synthReflections: false },
+      reward: { llmScoring: false },
+      l2Induction: { useLlm: false },
+      l3Abstraction: { useLlm: false },
+      skill: { useLlm: false }
+    }
+  }, [], "hermes");
+
+  const baseTrace = {
+    id: TRACE_ID,
+    episodeId: EPISODE_ID,
+    sessionId: SESSION_ID,
+    ts: 1735689600000,
+    turnId: 1735689600000,
+    userText: INITIAL_TEXT,
+    agentText: "fixture response",
+    summary: INITIAL_TEXT,
+    toolCalls: [],
+    reflection: null,
+    agentThinking: null,
+    value: 0,
+    alpha: 0,
+    rHuman: null,
+    priority: 0,
+    tags: ["agent-memory-qualification"]
+  };
+
+  const boot = async () => bootstrapMemoryCore({
+    agent: "hermes",
+    home,
+    config,
+    autoRecovery: false,
+    pkgVersion: MEMOS_VERSION,
+    initLogging: false,
+  });
+
+  let core = await boot();
+  const initialImport = await core.importBundle({ version: 1, traces: [baseTrace] });
+  const initialGet = await core.getTrace(TRACE_ID);
+  const initialCandidates = await core.listTraces({ q: INITIAL_MARKER, includeAllNamespaces: true });
+  const initialCount = await core.countTraces({ includeAllNamespaces: true });
+
+  const sameKey = await core.importBundle({ version: 1, traces: [baseTrace] });
+  const repeatGet = await core.getTrace(TRACE_ID);
+  const repeatCount = await core.countTraces({ includeAllNamespaces: true });
+
+  const updated = await core.updateTrace(TRACE_ID, {
+    userText: REPLACEMENT_TEXT,
+    summary: REPLACEMENT_TEXT,
+  });
+  const replacementGet = await core.getTrace(TRACE_ID);
+  const replacementCandidates = await core.listTraces({ q: REPLACEMENT_MARKER, includeAllNamespaces: true });
+  const oldCandidatesAfterReplacement = await core.listTraces({ q: INITIAL_MARKER, includeAllNamespaces: true });
+  const replacementCount = await core.countTraces({ includeAllNamespaces: true });
+
+  await core.shutdown();
+  core = await boot();
+  const restartGet = await core.getTrace(TRACE_ID);
+  const restartCandidates = await core.listTraces({ q: REPLACEMENT_MARKER, includeAllNamespaces: true });
+  const restartCount = await core.countTraces({ includeAllNamespaces: true });
+
+  const durableRepeat = await core.importBundle({ version: 1, traces: [baseTrace] });
+  const durableGet = await core.getTrace(TRACE_ID);
+  const durableCount = await core.countTraces({ includeAllNamespaces: true });
+
+  const deletionResult = await core.deleteTrace(TRACE_ID);
+  const deletedGet = await core.getTrace(TRACE_ID);
+  const oldCandidatesAfterDelete = await core.listTraces({ q: INITIAL_MARKER, includeAllNamespaces: true });
+  const replacementCandidatesAfterDelete = await core.listTraces({ q: REPLACEMENT_MARKER, includeAllNamespaces: true });
+  const deletionCount = await core.countTraces({ includeAllNamespaces: true });
+  await core.shutdown();
+
+  const raw = {
+    identity: {
+      repository: MEMOS_REPOSITORY,
+      package: packageJson.name,
+      release: MEMOS_RELEASE,
+      version: packageJson.version,
+      commit: args["source-commit"],
+      source_license: "Apache-2.0",
+      source_license_verified: sourceLicense.includes("Apache License") && sourceLicense.includes("Version 2.0"),
+      package_license_metadata: packageJson.license,
+      license_discrepancy_preserved: packageJson.license === "MIT",
+    },
+    configuration: {
+      adapter: "direct-memory-core",
+      database: "sqlite",
+      hosted_llm_api_key_present: Boolean(config.llm?.apiKey),
+      hosted_embedding_api_key_present: config.embedding?.provider !== "local" && Boolean(config.embedding?.apiKey),
+      semantic_search_exercised: false,
+    },
+    fixture: {
+      trace_id: TRACE_ID,
+      session_id: SESSION_ID,
+      episode_id: EPISODE_ID,
+      initial_marker: INITIAL_MARKER,
+      replacement_marker: REPLACEMENT_MARKER,
+      initial_text: INITIAL_TEXT,
+      replacement_text: REPLACEMENT_TEXT,
+    },
+    initial: {
+      ...initialImport,
+      trace_count: initialCount,
+      get_matches_initial: initialGet?.userText === INITIAL_TEXT,
+      candidate_contains_initial: containsMarker(initialCandidates, INITIAL_MARKER),
+    },
+    same_key_repeat: {
+      ...sameKey,
+      trace_count: repeatCount,
+      get_matches_initial: repeatGet?.userText === INITIAL_TEXT,
+    },
+    replacement: {
+      updated_same_id: updated?.id === TRACE_ID,
+      trace_count: replacementCount,
+      get_matches_replacement: replacementGet?.userText === REPLACEMENT_TEXT,
+      candidate_contains_replacement: containsMarker(replacementCandidates, REPLACEMENT_MARKER),
+      candidate_contains_initial: containsMarker(oldCandidatesAfterReplacement, INITIAL_MARKER),
+    },
+    restart: {
+      restart_succeeded: true,
+      trace_count: restartCount,
+      get_matches_replacement: restartGet?.userText === REPLACEMENT_TEXT,
+      candidate_contains_replacement: containsMarker(restartCandidates, REPLACEMENT_MARKER),
+    },
+    durable_repeat_after_restart: {
+      ...durableRepeat,
+      trace_count: durableCount,
+      get_matches_replacement: durableGet?.userText === REPLACEMENT_TEXT,
+    },
+    deletion: {
+      delete_succeeded: deletionResult.deleted === true,
+      get_after_delete_is_null: deletedGet === null,
+      trace_count: deletionCount,
+      candidate_contains_initial: containsMarker(oldCandidatesAfterDelete, INITIAL_MARKER),
+      candidate_contains_replacement: containsMarker(replacementCandidatesAfterDelete, REPLACEMENT_MARKER),
+    },
+    identity_boundary_preserved: ![TRACE_ID, SESSION_ID, EPISODE_ID].includes("agentmem:resource-artifact:qualification"),
+    provider_notes: [
+      "MemOS importBundle collision behavior is idempotent skip, not replacement; replacement is intentionally exercised through updateTrace on the same stable provider-native ID.",
+      "The fixture uses listTraces text filtering as deterministic recall-candidate evidence and does not exercise semantic embedding/ranking."
+    ]
+  };
+
+  await fs.mkdir(path.dirname(path.resolve(args.output)), { recursive: true });
+  await fs.writeFile(path.resolve(args.output), JSON.stringify(raw, null, 2) + "\n", "utf8");
+}
+
+main().catch(async (err) => {
+  const args = (() => { try { return parseArgs(process.argv); } catch { return {}; } })();
+  const failure = { execution_error: err instanceof Error ? `${err.name}: ${err.message}` : String(err), authority_effect: "none" };
+  if (args.output) {
+    await fs.mkdir(path.dirname(path.resolve(args.output)), { recursive: true });
+    await fs.writeFile(path.resolve(args.output), JSON.stringify(failure, null, 2) + "\n", "utf8");
+  }
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/reference/run_memos_local_v2017_qualification.py
+++ b/reference/run_memos_local_v2017_qualification.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Emit bounded Capability Qualification v1.2 evidence for MemOS local v2.0.17."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref.memos_qualification import (
+    load_component_profile,
+    qualify_memos_local_v2017,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-memory-commit", required=True)
+    parser.add_argument("--raw-evidence", type=Path, required=True)
+    parser.add_argument("--component-profile", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    raw_evidence = json.loads(args.raw_evidence.read_text(encoding="utf-8"))
+    component = load_component_profile(args.component_profile)
+    result = qualify_memos_local_v2017(
+        raw_evidence=raw_evidence,
+        component=component,
+        agent_memory_commit=args.agent_memory_commit,
+        raw_evidence_ref=str(args.raw_evidence),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if result.eligible else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/run_resource_artifact_substitution.py
+++ b/reference/run_resource_artifact_substitution.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Emit real resource_artifact_memory provider substitution evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from agentmem_ref.resource_provider_substitution import (
+    load_component,
+    load_qualification_snapshot,
+    prove_resource_artifact_substitution,
+    qualification_record_from_dict,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--primary-component", type=Path, required=True)
+    parser.add_argument("--primary-qualification", type=Path, required=True)
+    parser.add_argument("--replacement-component", type=Path, required=True)
+    parser.add_argument("--replacement-qualification", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    primary_component = load_component(args.primary_component)
+    primary_qualification = load_qualification_snapshot(args.primary_qualification)
+    replacement_component = load_component(args.replacement_component)
+    replacement_report = json.loads(args.replacement_qualification.read_text(encoding="utf-8"))
+    if not replacement_report.get("eligible"):
+        raise SystemExit("replacement provider qualification is explicitly ineligible")
+    replacement_payload = replacement_report.get("qualification")
+    if not isinstance(replacement_payload, dict):
+        raise SystemExit("replacement provider did not emit a qualification record")
+    replacement_qualification = qualification_record_from_dict(replacement_payload)
+
+    result = prove_resource_artifact_substitution(
+        primary_component=primary_component,
+        primary_qualification=primary_qualification,
+        replacement_component=replacement_component,
+        replacement_qualification=replacement_qualification,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tests/test_memos_qualification.py
+++ b/reference/tests/test_memos_qualification.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+from agentmem_ref.memos_qualification import (
+    MEMOS_COMMIT,
+    MEMOS_PACKAGE,
+    MEMOS_RELEASE,
+    MEMOS_VERSION,
+    load_component_profile,
+    qualify_memos_local_v2017,
+)
+from agentmem_ref.qualification import QualificationError
+from agentmem_ref.resource_provider_substitution import (
+    load_component,
+    load_qualification_snapshot,
+    prove_resource_artifact_substitution,
+    qualification_record_from_dict,
+    qualification_with_use_posture,
+    resource_artifact_substitution_requirement,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+MEMOS_PROFILE = ROOT / "reference" / "fixtures" / "component-capabilities" / "memos-local-plugin-v2.0.17.json"
+HINDSIGHT_PROFILE = ROOT / "reference" / "fixtures" / "component-capabilities" / "hindsight-v0.9.0.json"
+HINDSIGHT_QUALIFICATION = (
+    ROOT
+    / "reference"
+    / "fixtures"
+    / "component-qualification"
+    / "hindsight-v0.9.0-resource-artifact-qualified-v12.json"
+)
+PROFILE_SCHEMA = ROOT / "schemas" / "component-capability-profile.schema.json"
+QUALIFICATION_SCHEMA = ROOT / "schemas" / "component-capability-qualification.schema.json"
+
+
+def passing_raw() -> dict:
+    return {
+        "identity": {
+            "repository": "MemTensor/MemOS",
+            "package": MEMOS_PACKAGE,
+            "release": MEMOS_RELEASE,
+            "version": MEMOS_VERSION,
+            "commit": MEMOS_COMMIT,
+            "source_license": "Apache-2.0",
+            "source_license_verified": True,
+            "package_license_metadata": "MIT",
+            "license_discrepancy_preserved": True,
+        },
+        "configuration": {
+            "adapter": "direct-memory-core",
+            "database": "sqlite",
+            "hosted_llm_api_key_present": False,
+            "hosted_embedding_api_key_present": False,
+            "semantic_search_exercised": False,
+        },
+        "fixture": {
+            "trace_id": "agent-memory-resource-trace",
+            "session_id": "agent-memory-resource-session",
+            "episode_id": "agent-memory-resource-episode",
+            "initial_marker": "silveroak317",
+            "replacement_marker": "violetstone624",
+        },
+        "initial": {
+            "imported": 1,
+            "skipped": 0,
+            "trace_count": 1,
+            "get_matches_initial": True,
+            "candidate_contains_initial": True,
+        },
+        "same_key_repeat": {
+            "imported": 0,
+            "skipped": 1,
+            "trace_count": 1,
+            "get_matches_initial": True,
+        },
+        "replacement": {
+            "updated_same_id": True,
+            "trace_count": 1,
+            "get_matches_replacement": True,
+            "candidate_contains_replacement": True,
+            "candidate_contains_initial": False,
+        },
+        "restart": {
+            "restart_succeeded": True,
+            "trace_count": 1,
+            "get_matches_replacement": True,
+            "candidate_contains_replacement": True,
+        },
+        "durable_repeat_after_restart": {
+            "imported": 0,
+            "skipped": 1,
+            "trace_count": 1,
+            "get_matches_replacement": True,
+        },
+        "deletion": {
+            "delete_succeeded": True,
+            "get_after_delete_is_null": True,
+            "trace_count": 0,
+            "candidate_contains_initial": False,
+            "candidate_contains_replacement": False,
+        },
+        "identity_boundary_preserved": True,
+        "provider_notes": [],
+    }
+
+
+def memos_qualification_record():
+    component = load_component_profile(MEMOS_PROFILE)
+    result = qualify_memos_local_v2017(
+        raw_evidence=passing_raw(),
+        component=component,
+        agent_memory_commit="agent-memory-exact-head",
+        raw_evidence_ref="raw/memos-v2017.json",
+    )
+    assert result.qualification is not None
+    return component, qualification_record_from_dict(result.qualification)
+
+
+class MemOSQualificationTests(unittest.TestCase):
+    def test_component_profile_is_schema_valid_and_bounded(self) -> None:
+        value = json.loads(MEMOS_PROFILE.read_text(encoding="utf-8"))
+        schema = json.loads(PROFILE_SCHEMA.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(value)
+
+        component = load_component_profile(MEMOS_PROFILE)
+        self.assertEqual("component-capability-v3", component.profile_version)
+        self.assertEqual(1, len(component.capabilities))
+        capability = component.capabilities[0]
+        self.assertEqual("resource_artifact_memory", capability.capability_id)
+        self.assertEqual("evidence_proven", capability.maturity)
+        self.assertEqual("derived", capability.state_posture)
+        self.assertEqual("external_scope_bridge", capability.scope_posture)
+        self.assertEqual("none", capability.authority_effect)
+        self.assertEqual("none", capability.operational_contract.write_atomicity)
+        self.assertEqual("none", capability.operational_contract.concurrency_control)
+        self.assertEqual("durable_keyed", capability.operational_contract.idempotency)
+        self.assertEqual("reconstructable", capability.operational_contract.restart_recovery)
+        self.assertEqual("deterministic_readback", capability.operational_contract.reconciliation)
+
+    def test_passing_raw_evidence_emits_v12_contract_bound_qualification(self) -> None:
+        component = load_component_profile(MEMOS_PROFILE)
+        result = qualify_memos_local_v2017(
+            raw_evidence=passing_raw(),
+            component=component,
+            agent_memory_commit="agent-memory-exact-head",
+            raw_evidence_ref="raw/memos-v2017.json",
+        )
+        self.assertTrue(result.eligible)
+        self.assertEqual("none", result.authority_effect)
+        self.assertIsNotNone(result.qualification)
+        qualification = result.qualification
+        self.assertEqual("1.2.0", qualification["schema_version"])
+        self.assertEqual("Apache-2.0", qualification["source_rights"]["license_id"])
+        self.assertEqual("runtime_allowed", qualification["source_rights"]["use_posture"])
+        self.assertEqual("evidence_proven", qualification["result"]["earned_maturity"])
+        self.assertEqual("none", qualification["result"]["authority_effect"])
+        self.assertTrue(any("MIT" in item for item in qualification["result"]["limitations"]))
+        schema = json.loads(QUALIFICATION_SCHEMA.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(qualification)
+
+    def test_license_discrepancy_must_be_preserved(self) -> None:
+        raw = passing_raw()
+        raw["identity"]["license_discrepancy_preserved"] = False
+        result = qualify_memos_local_v2017(
+            raw_evidence=raw,
+            component=load_component_profile(MEMOS_PROFILE),
+            agent_memory_commit="head",
+            raw_evidence_ref="raw.json",
+        )
+        self.assertFalse(result.eligible)
+        self.assertIsNone(result.qualification)
+        failed = {item.check_id for item in result.observations if not item.passed}
+        self.assertIn("source-rights-discrepancy-preserved", failed)
+
+    def test_stable_key_collision_must_skip_not_duplicate(self) -> None:
+        raw = passing_raw()
+        raw["same_key_repeat"].update(imported=1, skipped=0, trace_count=2)
+        result = qualify_memos_local_v2017(
+            raw_evidence=raw,
+            component=load_component_profile(MEMOS_PROFILE),
+            agent_memory_commit="head",
+            raw_evidence_ref="raw.json",
+        )
+        self.assertFalse(result.eligible)
+        failed = {item.check_id for item in result.observations if not item.passed}
+        self.assertIn("stable-key-repeat-idempotency", failed)
+
+    def test_same_id_update_must_remove_old_candidate_text(self) -> None:
+        raw = passing_raw()
+        raw["replacement"]["candidate_contains_initial"] = True
+        result = qualify_memos_local_v2017(
+            raw_evidence=raw,
+            component=load_component_profile(MEMOS_PROFILE),
+            agent_memory_commit="head",
+            raw_evidence_ref="raw.json",
+        )
+        self.assertFalse(result.eligible)
+        failed = {item.check_id for item in result.observations if not item.passed}
+        self.assertIn("stable-key-update-currentness", failed)
+
+    def test_restart_and_post_restart_collision_are_required(self) -> None:
+        for section, key, value, expected in (
+            ("restart", "restart_succeeded", False, "restart-reconstruction"),
+            ("durable_repeat_after_restart", "imported", 1, "durable-key-after-restart"),
+        ):
+            raw = passing_raw()
+            raw[section][key] = value
+            result = qualify_memos_local_v2017(
+                raw_evidence=raw,
+                component=load_component_profile(MEMOS_PROFILE),
+                agent_memory_commit="head",
+                raw_evidence_ref="raw.json",
+            )
+            self.assertFalse(result.eligible)
+            failed = {item.check_id for item in result.observations if not item.passed}
+            self.assertIn(expected, failed)
+
+    def test_delete_residue_refuses_candidate_contract(self) -> None:
+        raw = passing_raw()
+        raw["deletion"]["candidate_contains_replacement"] = True
+        result = qualify_memos_local_v2017(
+            raw_evidence=raw,
+            component=load_component_profile(MEMOS_PROFILE),
+            agent_memory_commit="head",
+            raw_evidence_ref="raw.json",
+        )
+        self.assertFalse(result.eligible)
+        failed = {item.check_id for item in result.observations if not item.passed}
+        self.assertIn("delete-readback-and-candidate-residue", failed)
+
+    def test_profile_does_not_promote_learned_memos_surfaces(self) -> None:
+        component = load_component_profile(MEMOS_PROFILE)
+        self.assertEqual({"resource_artifact_memory"}, {item.capability_id for item in component.capabilities})
+        for forbidden in (
+            "semantic_fact_memory",
+            "epistemic_belief_memory",
+            "predictive_counterfactual_memory",
+            "procedural_memory",
+            "graph_state",
+            "policy_memory",
+        ):
+            self.assertNotIn(forbidden, {item.capability_id for item in component.capabilities})
+
+    def test_persisted_hindsight_snapshot_reconstructs_exact_applicability(self) -> None:
+        record = load_qualification_snapshot(HINDSIGHT_QUALIFICATION)
+        self.assertEqual(
+            "sha256:a1776c55d7984706f75f429a605e13cd56e14cd02bfa334697e8509982bd7f5e",
+            record.applicability_digest,
+        )
+        record.assert_current_declaration(load_component(HINDSIGHT_PROFILE))
+
+    def test_real_provider_contracts_satisfy_same_requirement_without_internal_equality(self) -> None:
+        hindsight_component = load_component(HINDSIGHT_PROFILE)
+        hindsight_qualification = load_qualification_snapshot(HINDSIGHT_QUALIFICATION)
+        memos_component, memos_qualification = memos_qualification_record()
+
+        result = prove_resource_artifact_substitution(
+            primary_component=hindsight_component,
+            primary_qualification=hindsight_qualification,
+            replacement_component=memos_component,
+            replacement_qualification=memos_qualification,
+        )
+        self.assertEqual("none", result["authority_effect"])
+        self.assertEqual("hindsight-v0.9.0", result["substitution"]["primary_component"])
+        self.assertEqual("memos-local-plugin-v2.0.17", result["substitution"]["replacement_component"])
+        self.assertNotEqual(
+            hindsight_component.capabilities[0].behavior_contract.invalidation_model,
+            memos_component.capabilities[0].behavior_contract.invalidation_model,
+        )
+        requirement = resource_artifact_substitution_requirement()
+        self.assertEqual(("durable_keyed",), requirement.operational_requirement.idempotency)
+
+    def test_weaker_durable_contract_is_not_substitutable(self) -> None:
+        hindsight_component = load_component(HINDSIGHT_PROFILE)
+        hindsight_qualification = load_qualification_snapshot(HINDSIGHT_QUALIFICATION)
+        memos_component, memos_qualification = memos_qualification_record()
+        capability = memos_component.capabilities[0]
+        weaker_operational = replace(capability.operational_contract, idempotency="process_local")
+        weaker_capability = replace(capability, operational_contract=weaker_operational)
+        weaker_component = replace(memos_component, capabilities=(weaker_capability,))
+        weaker_contract = replace(
+            memos_qualification.qualified_contract,
+            operational_contract=weaker_operational,
+        )
+        weaker_qualification = replace(memos_qualification, qualified_contract=weaker_contract)
+
+        with self.assertRaisesRegex(QualificationError, "operational contract"):
+            prove_resource_artifact_substitution(
+                primary_component=hindsight_component,
+                primary_qualification=hindsight_qualification,
+                replacement_component=weaker_component,
+                replacement_qualification=weaker_qualification,
+            )
+
+    def test_process_local_restart_or_reconciliation_is_not_substitutable(self) -> None:
+        for field_name in ("restart_recovery", "reconciliation"):
+            hindsight_component = load_component(HINDSIGHT_PROFILE)
+            hindsight_qualification = load_qualification_snapshot(HINDSIGHT_QUALIFICATION)
+            memos_component, memos_qualification = memos_qualification_record()
+            capability = memos_component.capabilities[0]
+            replacement_value = "process_local_only"
+            weaker_operational = replace(capability.operational_contract, **{field_name: replacement_value})
+            weaker_component = replace(
+                memos_component,
+                capabilities=(replace(capability, operational_contract=weaker_operational),),
+            )
+            weaker_qualification = replace(
+                memos_qualification,
+                qualified_contract=replace(
+                    memos_qualification.qualified_contract,
+                    operational_contract=weaker_operational,
+                ),
+            )
+            with self.assertRaisesRegex(QualificationError, "operational contract"):
+                prove_resource_artifact_substitution(
+                    primary_component=hindsight_component,
+                    primary_qualification=hindsight_qualification,
+                    replacement_component=weaker_component,
+                    replacement_qualification=weaker_qualification,
+                )
+
+    def test_comparator_only_source_rights_cannot_enter_runtime_substitution(self) -> None:
+        hindsight_component = load_component(HINDSIGHT_PROFILE)
+        hindsight_qualification = load_qualification_snapshot(HINDSIGHT_QUALIFICATION)
+        memos_component, memos_qualification = memos_qualification_record()
+        with self.assertRaisesRegex(QualificationError, "runtime-allowed"):
+            prove_resource_artifact_substitution(
+                primary_component=hindsight_component,
+                primary_qualification=hindsight_qualification,
+                replacement_component=memos_component,
+                replacement_qualification=qualification_with_use_posture(memos_qualification, "comparator_only"),
+            )
+
+    def test_authority_posture_change_cannot_hide_inside_substitution(self) -> None:
+        hindsight_component = load_component(HINDSIGHT_PROFILE)
+        hindsight_qualification = load_qualification_snapshot(HINDSIGHT_QUALIFICATION)
+        memos_component, memos_qualification = memos_qualification_record()
+        capability = memos_component.capabilities[0]
+        authority_component = replace(memos_component, capabilities=(replace(capability, authority_effect="proposal_only"),))
+        with self.assertRaises(QualificationError):
+            prove_resource_artifact_substitution(
+                primary_component=hindsight_component,
+                primary_qualification=hindsight_qualification,
+                replacement_component=authority_component,
+                replacement_qualification=memos_qualification,
+            )
+
+    def test_legacy_v11_record_cannot_be_deserialized_for_real_substitution(self) -> None:
+        snapshot = json.loads(HINDSIGHT_QUALIFICATION.read_text(encoding="utf-8"))["qualification"]
+        snapshot["schema_version"] = "1.1.0"
+        snapshot.pop("qualified_contract")
+        with self.assertRaisesRegex(QualificationError, "v1.2"):
+            qualification_record_from_dict(snapshot)
+
+    def test_tampered_snapshot_digest_is_rejected(self) -> None:
+        snapshot = json.loads(HINDSIGHT_QUALIFICATION.read_text(encoding="utf-8"))["qualification"]
+        snapshot["runtime"]["fixture_id"] = "tampered-fixture"
+        with self.assertRaisesRegex(QualificationError, "applicability digest"):
+            qualification_record_from_dict(snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #354.

## Summary

Adds a second real external `resource_artifact_memory@1.0` qualification through Capability Qualification v1.2 and proves provider substitution against the already-qualified Hindsight v0.9.0 provider if, and only if, both independently satisfy one explicit Capability Contract v3 requirement.

Target provider is exact `@memtensor/memos-local-plugin@2.0.17`, tag `memos-local-plugin-v2.0.17`, commit `d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab`.

## Bounded lifecycle

The MemOS fixture uses the agent-agnostic local SQLite core and deterministic trace identity:

- caller-supplied stable trace ID import;
- repeated import collision skip;
- same-ID `updateTrace()` replacement;
- direct read/list candidate visibility;
- shutdown and reconstruction from the same SQLite home;
- repeated stable-key retry after restart;
- hard delete;
- direct read and candidate residue scan.

It does not require OpenClaw, Hermes, DeepSeek Harness, a hosted MemOS service, or an external LLM/API credential. L2/L3 learned memory, skills, semantic ranking, Hub behavior, and adapter-specific semantics are outside this qualification.

## Operational posture

The candidate profile is deliberately conservative:

- write atomicity: `none`
- concurrency control: `none`
- idempotency: `durable_keyed`
- restart recovery: `reconstructable`
- reconciliation: `deterministic_readback`
- authority effect: `none`

The durable/restart/reconciliation claims must be earned by executable evidence. Tagged-source transaction implementation details are not promoted into an atomicity claim without fault-injection evidence.

## Source-rights evidence

The exact repository root grants Apache-2.0 while the local-plugin package manifest declares MIT. The workflow preserves that discrepancy, verifies the exact tagged root license and package metadata, compares critical installed package files with the pinned tag, and relies on the exact Apache-2.0 source grant for runtime rights rather than selecting whichever permissive identifier is convenient.

## Real substitution proof

The slice persists the exact passing Hindsight #353 qualification evidence and reconstructs it with strict applicability-digest validation. MemOS may substitute for Hindsight only if both satisfy the same requirement for:

- `resource_artifact_memory@1.0`;
- `evidence_proven` maturity;
- derived state and external scope bridge;
- write/read/recall-candidate support;
- compatible provider-revalidated lifecycle behavior;
- `durable_keyed` idempotency;
- restart recovery `reconstructable`;
- reconciliation `deterministic_readback`;
- runtime-allowed source rights;
- authority posture `none`.

Atomicity and concurrency are intentionally unconstrained by the common requirement because neither bounded provider qualification has earned stronger guarantees there.

## Adversarial cases

Focused tests fail substitution for stale/tampered qualification evidence, weakened durable/restart/reconciliation posture, comparator-only rights, authority drift, or legacy v1.1 evidence.

## Validation

Required repository `validate` plus the dedicated MemOS v2.0.17 qualification/substitution workflow must pass on the exact PR head before merge. If the provider cannot satisfy the common requirement, the result must remain explicitly incompatible rather than weakening Agent Memory semantics.