### PR TITLE
Prove bidirectional federated resource exchange across qualified providers

### DIFF
--- a/.github/workflows/federated-resource-exchange.yml
+++ b/.github/workflows/federated-resource-exchange.yml
@@ -1,0 +1,243 @@
+name: Federated Resource Exchange
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/federated-resource-exchange.yml"
+      - "reference/agentmem_ref/resource_exchange.py"
+      - "reference/agentmem_ref/resource_provider_substitution.py"
+      - "reference/run_federated_resource_exchange_fixture.py"
+      - "reference/run_federated_resource_exchange.py"
+      - "reference/run_memos_local_v2017_exchange_endpoint.mjs"
+      - "reference/tests/test_resource_exchange.py"
+      - "reference/fixtures/component-capabilities/hindsight-v0.9.0.json"
+      - "reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json"
+      - "reference/fixtures/component-qualification/hindsight-v0.9.0-resource-artifact-qualified-v12.json"
+      - "reference/fixtures/component-qualification/memos-local-plugin-v2.0.17-resource-artifact-qualified-v12.json"
+      - "schemas/resource-exchange-receipt.schema.json"
+      - "schemas/boundary-crossing-receipt.schema.json"
+      - "schemas/component-capability-qualification.schema.json"
+      - "docs/programs/memory-modules/federated-resource-exchange.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  federated-resource-exchange:
+    name: prove-bidirectional-resource-exchange
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      PYTHONPATH: reference
+      AGENT_MEMORY_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+      HINDSIGHT_COMMIT: b12646f49ec512136b9f709e608524ffed969668
+      HINDSIGHT_VERSION: 0.9.0
+      MEMOS_TAG: memos-local-plugin-v2.0.17
+      MEMOS_COMMIT: d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab
+      MEMOS_VERSION: 2.0.17
+      MEMOS_PACKAGE: "@memtensor/memos-local-plugin"
+      RAW_ROOT: artifacts/federated-resource-exchange
+    steps:
+      - name: Checkout Agent Memory exact head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.AGENT_MEMORY_COMMIT }}
+
+      - name: Verify Agent Memory exact head
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$AGENT_MEMORY_COMMIT"
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Agent Memory validation dependencies
+        run: python -m pip install --disable-pip-version-check -r reference/requirements.txt
+
+      - name: Prepare isolated evidence directories
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/federated-hindsight-home /tmp/federated-memos-h2m /tmp/federated-memos-m2h /tmp/memos-runtime
+          mkdir -p "$RAW_ROOT" /tmp/federated-hindsight-home /tmp/federated-memos-h2m /tmp/federated-memos-m2h /tmp/memos-runtime
+
+      - name: Verify exact Hindsight v0.9.0 source
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/hindsight-source
+          git init -q /tmp/hindsight-source
+          git -C /tmp/hindsight-source remote add origin https://github.com/vectorize-io/hindsight.git
+          git -C /tmp/hindsight-source fetch -q --depth 1 origin refs/tags/v0.9.0
+          git -C /tmp/hindsight-source checkout -q FETCH_HEAD
+          test "$(git -C /tmp/hindsight-source rev-parse HEAD)" = "$HINDSIGHT_COMMIT"
+          grep -q "MIT License" /tmp/hindsight-source/LICENSE
+          grep -q 'version = "0.9.0"' /tmp/hindsight-source/hindsight-embed/pyproject.toml
+          grep -q 'version = "0.9.0"' /tmp/hindsight-source/hindsight-api/pyproject.toml
+          grep -q '"chunks"' /tmp/hindsight-source/hindsight-api-slim/hindsight_api/config.py
+
+      - name: Verify exact MemOS v2.0.17 source
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/memos-source
+          git init -q /tmp/memos-source
+          git -C /tmp/memos-source remote add origin https://github.com/MemTensor/MemOS.git
+          git -C /tmp/memos-source fetch -q --depth 1 origin "refs/tags/$MEMOS_TAG"
+          git -C /tmp/memos-source checkout -q FETCH_HEAD
+          test "$(git -C /tmp/memos-source rev-parse HEAD)" = "$MEMOS_COMMIT"
+          grep -q "Apache License" /tmp/memos-source/LICENSE
+          grep -q "Version 2.0" /tmp/memos-source/LICENSE
+          node - <<'NODE'
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('/tmp/memos-source/apps/memos-local-plugin/package.json', 'utf8'));
+          if (pkg.name !== process.env.MEMOS_PACKAGE) throw new Error(`unexpected package name: ${pkg.name}`);
+          if (pkg.version !== process.env.MEMOS_VERSION) throw new Error(`unexpected package version: ${pkg.version}`);
+          if (pkg.license !== 'MIT') throw new Error(`expected retained package metadata discrepancy, got ${pkg.license}`);
+          NODE
+
+      - name: Install exact Hindsight embedded runtime
+        run: |
+          python -m pip install --disable-pip-version-check \
+            "hindsight-embed==$HINDSIGHT_VERSION" \
+            "hindsight-api==$HINDSIGHT_VERSION"
+          python - <<'PY'
+          from importlib import metadata
+          for package in ('hindsight-embed', 'hindsight-api', 'hindsight-api-slim'):
+              actual = metadata.version(package)
+              if actual != '0.9.0':
+                  raise SystemExit(f'unexpected {package} version: {actual}')
+              print(f'{package}={actual}')
+          PY
+
+      - name: Install exact MemOS package and bind installed source
+        working-directory: /tmp/memos-runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm init -y >/dev/null
+          npm view "$MEMOS_PACKAGE@$MEMOS_VERSION" version license dist.integrity dist.shasum --json > "$GITHUB_WORKSPACE/$RAW_ROOT/memos-registry-metadata.json"
+          npm install --no-audit --no-fund "$MEMOS_PACKAGE@$MEMOS_VERSION"
+          PACKAGE_ROOT="/tmp/memos-runtime/node_modules/@memtensor/memos-local-plugin"
+          test -f "$PACKAGE_ROOT/dist/core/index.js"
+          test -f "$PACKAGE_ROOT/core/pipeline/memory-core.ts"
+          cmp /tmp/memos-source/apps/memos-local-plugin/core/pipeline/memory-core.ts "$PACKAGE_ROOT/core/pipeline/memory-core.ts"
+          cmp /tmp/memos-source/apps/memos-local-plugin/agent-contract/memory-core.ts "$PACKAGE_ROOT/agent-contract/memory-core.ts"
+
+      - name: Execute focused exchange and qualification tests
+        run: |
+          python -m unittest \
+            reference/tests/test_resource_exchange.py \
+            reference/tests/test_component_qualification_v12.py
+
+      - name: Execute exact bidirectional provider fixture
+        shell: bash
+        env:
+          HOME: /tmp/federated-hindsight-home
+          HF_HOME: /tmp/federated-hindsight-home/hf
+          TRANSFORMERS_CACHE: /tmp/federated-hindsight-home/hf
+        run: |
+          set -euo pipefail
+          python reference/run_federated_resource_exchange_fixture.py \
+            --memos-package-root /tmp/memos-runtime/node_modules/@memtensor/memos-local-plugin \
+            --memos-h2m-home /tmp/federated-memos-h2m \
+            --memos-m2h-home /tmp/federated-memos-m2h \
+            --hindsight-source-commit "$HINDSIGHT_COMMIT" \
+            --memos-source-commit "$MEMOS_COMMIT" \
+            --output "$RAW_ROOT/raw-provider-exchange.json"
+
+      - name: Emit invariant-bound exchange receipts
+        run: |
+          python reference/run_federated_resource_exchange.py \
+            --raw-evidence "$RAW_ROOT/raw-provider-exchange.json" \
+            --hindsight-component reference/fixtures/component-capabilities/hindsight-v0.9.0.json \
+            --hindsight-qualification reference/fixtures/component-qualification/hindsight-v0.9.0-resource-artifact-qualified-v12.json \
+            --memos-component reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json \
+            --memos-qualification reference/fixtures/component-qualification/memos-local-plugin-v2.0.17-resource-artifact-qualified-v12.json \
+            --output "$RAW_ROOT/exchange.json"
+
+      - name: Validate exact qualifications and exchange receipts
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          import jsonschema
+          from agentmem_ref.resource_provider_substitution import load_component, load_qualification_snapshot
+
+          root = Path('.')
+          h_component = load_component(root / 'reference/fixtures/component-capabilities/hindsight-v0.9.0.json')
+          m_component = load_component(root / 'reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json')
+          hq = load_qualification_snapshot(root / 'reference/fixtures/component-qualification/hindsight-v0.9.0-resource-artifact-qualified-v12.json')
+          mq = load_qualification_snapshot(root / 'reference/fixtures/component-qualification/memos-local-plugin-v2.0.17-resource-artifact-qualified-v12.json')
+          hq.assert_current_declaration(h_component)
+          mq.assert_current_declaration(m_component)
+          assert hq.use_posture == mq.use_posture == 'runtime_allowed'
+          assert hq.authority_effect == mq.authority_effect == 'none'
+
+          value = json.loads((root / 'artifacts/federated-resource-exchange/exchange.json').read_text())
+          assert value['eligible'] is True
+          assert value['authority_effect'] == 'none'
+          assert value['invariants']['bidirectional'] is True
+          assert value['invariants']['source_retained'] is True
+          assert value['invariants']['destructive_cutover'] is False
+          schema = json.loads((root / 'schemas/resource-exchange-receipt.schema.json').read_text())
+          validator = jsonschema.Draft202012Validator(schema)
+          directions = value['directions']
+          for name in ('hindsight_to_memos', 'memos_to_hindsight'):
+              receipt = directions[name]
+              validator.validate(receipt)
+              assert receipt['content_digest'] == receipt['target_readback_digest']
+              assert receipt['source_retained'] is True
+              assert receipt['destructive_cutover'] is False
+              assert receipt['authority_effect'] == 'none'
+              assert receipt['logical_resource_id'] not in {
+                  receipt['source_provider']['native_resource_id'],
+                  receipt['target_provider']['native_resource_id'],
+              }
+          assert directions['hindsight_to_memos']['source_provider']['component_id'] == 'hindsight-v0.9.0'
+          assert directions['hindsight_to_memos']['target_provider']['component_id'] == 'memos-local-plugin-v2.0.17'
+          assert directions['memos_to_hindsight']['source_provider']['component_id'] == 'memos-local-plugin-v2.0.17'
+          assert directions['memos_to_hindsight']['target_provider']['component_id'] == 'hindsight-v0.9.0'
+          PY
+
+      - name: Publish federated exchange summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Federated resource exchange"
+            echo
+            if [ -f "$RAW_ROOT/exchange.json" ]; then
+              python - <<'PY'
+          import json
+          from pathlib import Path
+          value = json.loads(Path('artifacts/federated-resource-exchange/exchange.json').read_text())
+          print(f"- eligible: `{str(value.get('eligible')).lower()}`")
+          print(f"- authority effect: `{value.get('authority_effect')}`")
+          for name, receipt in value.get('directions', {}).items():
+              print(f"- {name}: `{receipt.get('source_provider', {}).get('component_id')}` -> `{receipt.get('target_provider', {}).get('component_id')}`")
+              print(f"  - target digest equals source: `{receipt.get('target_readback_digest') == receipt.get('content_digest')}`")
+              print(f"  - source retained: `{receipt.get('source_retained')}`")
+          PY
+            else
+              echo "- exchange evidence was not emitted"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw and normalized exchange evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: federated-resource-exchange-${{ env.AGENT_MEMORY_COMMIT }}
+          path: artifacts/federated-resource-exchange
+          if-no-files-found: warn

--- a/docs/programs/memory-modules/federated-resource-exchange.md
+++ b/docs/programs/memory-modules/federated-resource-exchange.md
@@ -1,0 +1,157 @@
+# Federated Resource Exchange
+
+Status: **bounded implementation for issue #358**
+
+This slice implements the first executable `federated_memory_exchange` path over two independently qualified external `resource_artifact_memory@1.0` providers:
+
+- Hindsight v0.9.0;
+- `@memtensor/memos-local-plugin@2.0.17`.
+
+It follows #276's `no_new_algebra` conclusion. Agent Memory does not create a new universal state algebra or consolidate the providers into one physical store.
+
+## Architecture boundary
+
+The capability vocabulary defines federated memory exchange as exchange across independent stores without requiring one physical store.
+
+The bounded path is therefore:
+
+```text
+current Capability Qualification v1.2 evidence
+        |
+        v
+common resource_artifact_memory requirement
+        |
+        v
+logical resource snapshot
+  Agent Memory logical ID
+  exact content + digest
+  representation kind
+  source domain refs
+  provenance refs
+        |
+        v
+provider-native copy
+        |
+        v
+direct target readback
+        |
+        v
+invariant-bound exchange receipt
+```
+
+Provider-native object IDs are mappings only. They do not become Agent Memory logical IDs.
+
+## Relationship to provider substitution
+
+PR #357 proved that Hindsight and MemOS independently satisfy the same durable resource-memory requirement.
+
+Exchange reuses that gate. It does not infer compatibility from similar APIs, SQLite/PostgreSQL durability, or provider marketing language.
+
+Every exchange receipt binds:
+
+- source qualification applicability digest;
+- target qualification applicability digest;
+- common requirement digest;
+- exact provider identities and versions.
+
+A changed provider declaration or stale qualification therefore cannot silently inherit old exchange evidence.
+
+## Resource snapshot
+
+`LogicalResourceSnapshot` is intentionally narrow:
+
+```text
+logical_resource_id
+representation_kind
+content
+content_digest
+source_domain_refs
+provenance_refs
+```
+
+The snapshot is not a new lifecycle object. It is the exact provider-neutral payload needed to prove a copy while preserving existing Agent Memory identity, scope, and provenance semantics.
+
+## Exchange receipt
+
+`ResourceExchangeReceipt` records:
+
+```text
+snapshot_digest
+logical_resource_id
+content_digest
+source / target provider binding
+source / target qualification digests
+common requirement digest
+target direct-readback digest
+source / destination domain refs
+provenance refs
+source_retained = true
+destructive_cutover = false
+crossing_receipt_ref, when applicable
+outcome = copied_verified
+authority_effect = none
+```
+
+The receipt proves a bounded copy and direct-readback equality. It does not grant recall admission, action authority, durable mutation authority, source deletion, or destructive cutover.
+
+## Isolation-domain crossing
+
+ADR-022 and `docs/41-memory-isolation-domains-and-governed-crossing.md` remain controlling.
+
+For a same-domain provider copy, the exchange receipt records the unchanged domain and no separate boundary-crossing receipt is required.
+
+For a domain-changing transfer, the exchange layer requires an already-committed canonical `boundary-crossing-receipt` whose:
+
+- operation is compatible with copy/export/import;
+- source and destination domains exactly match;
+- logical resource reference matches;
+- representation kind and content digest match;
+- PAMA disposition allows the consequence.
+
+The exchange module does not mint that authority itself.
+
+## Exact runtime proof
+
+The dedicated workflow exercises both directions in one isolated job.
+
+### Hindsight -> MemOS
+
+1. create one exact Hindsight chunk-backed document under a provider-native document ID;
+2. direct-read the source;
+3. write those bytes to a distinct MemOS stable trace ID;
+4. direct-read the MemOS target;
+5. direct-read the Hindsight source again;
+6. require source-before, target, and source-after bytes to match exactly.
+
+### MemOS -> Hindsight
+
+1. create one MemOS trace under a provider-native stable trace ID;
+2. direct-read the source;
+3. write those bytes to a distinct Hindsight document ID;
+4. direct-read the Hindsight target;
+5. reopen the same MemOS SQLite home and direct-read the source again;
+6. require source-before, target, and source-after bytes to match exactly.
+
+Bidirectionality prevents either provider representation from becoming an implicit canonical format.
+
+## Deliberate non-goals
+
+This slice does not implement:
+
+- destructive migration or cutover;
+- source deletion;
+- replication or synchronization daemons;
+- conflict resolution between concurrently changing replicas;
+- third-provider federation;
+- semantic-memory conversion;
+- L2/L3/skill/graph transfer;
+- automatic scope promotion;
+- a new logical-state algebra.
+
+Those are separate consequences and require separate evidence.
+
+## Failure is meaningful
+
+The exchange fails closed for content mismatch, provider/logical identity collapse, missing provenance, qualification drift, source-rights downgrade, provider-version drift, destructive-cutover claims, or an invalid/missing cross-domain boundary receipt.
+
+A failed provider copy is not repaired by weakening the common qualification requirement or by treating serialization success as semantic compatibility.

--- a/reference/agentmem_ref/resource_exchange.py
+++ b/reference/agentmem_ref/resource_exchange.py
@@ -1,0 +1,357 @@
+"""Provider-neutral evidence for bounded resource exchange across qualified stores.
+
+The exchange layer does not define a second memory lifecycle and does not grant
+copy, export, deletion, recall-admission, or mutation authority. It binds one
+logical Agent Memory resource to exact provider-native representations and
+proves target readback equality after both providers independently satisfy the
+same Capability Contract v3 requirement.
+
+Isolation-domain crossing authority remains owned by ADR-022 and the canonical
+boundary-crossing receipt. This module only verifies that a supplied committed
+crossing receipt matches the exchange it is being used to justify.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Mapping, Sequence
+
+from .capabilities import ComponentDeclaration
+from .qualification import QualificationError, QualificationRecord
+from .resource_provider_substitution import prove_resource_artifact_substitution
+
+RESOURCE_EXCHANGE_SCHEMA_VERSION = "1.0.0"
+EXCHANGE_OUTCOME = "copied_verified"
+
+
+class ResourceExchangeError(ValueError):
+    """Federated resource exchange evidence is invalid or insufficient."""
+
+
+@dataclass(frozen=True)
+class ProviderResourceBinding:
+    component_id: str
+    component_version: str
+    native_resource_id: str
+    runtime_ref: str = ""
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("component_id", self.component_id),
+            ("component_version", self.component_version),
+            ("native_resource_id", self.native_resource_id),
+        ):
+            if not value:
+                raise ResourceExchangeError(f"provider binding {name} is required")
+
+    def to_dict(self) -> dict[str, str]:
+        value = {
+            "component_id": self.component_id,
+            "component_version": self.component_version,
+            "native_resource_id": self.native_resource_id,
+        }
+        if self.runtime_ref:
+            value["runtime_ref"] = self.runtime_ref
+        return value
+
+
+@dataclass(frozen=True)
+class LogicalResourceSnapshot:
+    """Exact logical payload crossing provider boundaries.
+
+    The logical ID is Agent Memory identity. Provider-native IDs belong only in
+    ProviderResourceBinding and must never replace this identity.
+    """
+
+    logical_resource_id: str
+    representation_kind: str
+    content: str
+    source_domain_refs: tuple[str, ...]
+    provenance_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.logical_resource_id:
+            raise ResourceExchangeError("logical_resource_id is required")
+        if not self.representation_kind:
+            raise ResourceExchangeError("representation_kind is required")
+        if not self.content:
+            raise ResourceExchangeError("resource content is required")
+        _nonempty_unique(self.source_domain_refs, "source_domain_refs")
+        _nonempty_unique(self.provenance_refs, "provenance_refs")
+
+    @property
+    def content_digest(self) -> str:
+        return _sha256_text(self.content)
+
+    @property
+    def snapshot_digest(self) -> str:
+        return _sha256_json(self.to_dict())
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "logical_resource_id": self.logical_resource_id,
+            "representation_kind": self.representation_kind,
+            "content": self.content,
+            "content_digest": self.content_digest,
+            "source_domain_refs": list(self.source_domain_refs),
+            "provenance_refs": list(self.provenance_refs),
+        }
+
+
+@dataclass(frozen=True)
+class ResourceExchangeReceipt:
+    exchange_id: str
+    snapshot_digest: str
+    logical_resource_id: str
+    representation_kind: str
+    content_digest: str
+    source_domain_refs: tuple[str, ...]
+    destination_domain_refs: tuple[str, ...]
+    provenance_refs: tuple[str, ...]
+    source_provider: ProviderResourceBinding
+    target_provider: ProviderResourceBinding
+    source_qualification_digest: str
+    target_qualification_digest: str
+    requirement_digest: str
+    target_readback_digest: str
+    source_retained: bool
+    destructive_cutover: bool
+    crossing_receipt_ref: str = ""
+    outcome: str = EXCHANGE_OUTCOME
+
+    @property
+    def authority_effect(self) -> str:
+        return "none"
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("exchange_id", self.exchange_id),
+            ("snapshot_digest", self.snapshot_digest),
+            ("logical_resource_id", self.logical_resource_id),
+            ("representation_kind", self.representation_kind),
+            ("content_digest", self.content_digest),
+            ("source_qualification_digest", self.source_qualification_digest),
+            ("target_qualification_digest", self.target_qualification_digest),
+            ("requirement_digest", self.requirement_digest),
+            ("target_readback_digest", self.target_readback_digest),
+        ):
+            if not value:
+                raise ResourceExchangeError(f"exchange receipt {name} is required")
+        _nonempty_unique(self.source_domain_refs, "source_domain_refs")
+        _nonempty_unique(self.destination_domain_refs, "destination_domain_refs")
+        _nonempty_unique(self.provenance_refs, "provenance_refs")
+        if not self.source_retained:
+            raise ResourceExchangeError("bounded resource exchange requires source_retained=true")
+        if self.destructive_cutover:
+            raise ResourceExchangeError("bounded resource exchange cannot claim destructive cutover authority")
+        if self.outcome != EXCHANGE_OUTCOME:
+            raise ResourceExchangeError(f"unsupported exchange outcome: {self.outcome}")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": RESOURCE_EXCHANGE_SCHEMA_VERSION,
+            "exchange_id": self.exchange_id,
+            "snapshot_digest": self.snapshot_digest,
+            "logical_resource_id": self.logical_resource_id,
+            "representation_kind": self.representation_kind,
+            "content_digest": self.content_digest,
+            "source_domain_refs": list(self.source_domain_refs),
+            "destination_domain_refs": list(self.destination_domain_refs),
+            "provenance_refs": list(self.provenance_refs),
+            "source_provider": self.source_provider.to_dict(),
+            "target_provider": self.target_provider.to_dict(),
+            "source_qualification_digest": self.source_qualification_digest,
+            "target_qualification_digest": self.target_qualification_digest,
+            "requirement_digest": self.requirement_digest,
+            "target_readback_digest": self.target_readback_digest,
+            "source_retained": self.source_retained,
+            "destructive_cutover": self.destructive_cutover,
+            "crossing_receipt_ref": self.crossing_receipt_ref or None,
+            "outcome": self.outcome,
+            "authority_effect": "none",
+        }
+
+
+def prove_resource_exchange(
+    *,
+    snapshot: LogicalResourceSnapshot,
+    source_component: ComponentDeclaration,
+    source_qualification: QualificationRecord,
+    source_binding: ProviderResourceBinding,
+    target_component: ComponentDeclaration,
+    target_qualification: QualificationRecord,
+    target_binding: ProviderResourceBinding,
+    target_readback: str,
+    destination_domain_refs: Sequence[str],
+    source_retained: bool,
+    crossing_receipt: Mapping[str, object] | None = None,
+    crossing_receipt_ref: str = "",
+    destructive_cutover: bool = False,
+) -> ResourceExchangeReceipt:
+    """Prove one copy between qualified resource-memory providers.
+
+    This validates provider eligibility with the existing real-substitution
+    gate, then binds exact source and target bytes. Same-domain copies need no
+    authority receipt. A domain-changing copy requires an already-committed
+    ADR-022 boundary-crossing receipt whose source/destination domains match.
+    """
+
+    _assert_binding_matches_component(source_binding, source_component, "source")
+    _assert_binding_matches_component(target_binding, target_component, "target")
+    if source_binding.component_id == target_binding.component_id:
+        raise ResourceExchangeError("federated exchange requires distinct provider components")
+    if snapshot.logical_resource_id in {
+        source_binding.native_resource_id,
+        target_binding.native_resource_id,
+    }:
+        raise ResourceExchangeError(
+            "provider-native identity must remain distinct from Agent Memory logical identity"
+        )
+
+    substitution = prove_resource_artifact_substitution(
+        primary_component=source_component,
+        primary_qualification=source_qualification,
+        replacement_component=target_component,
+        replacement_qualification=target_qualification,
+    )["substitution"]
+    if not isinstance(substitution, Mapping):
+        raise ResourceExchangeError("provider substitution did not emit evidence")
+
+    destination_domains = tuple(destination_domain_refs)
+    _nonempty_unique(destination_domains, "destination_domain_refs")
+    if target_readback != snapshot.content:
+        raise ResourceExchangeError("target direct readback differs from source logical resource content")
+    target_digest = _sha256_text(target_readback)
+    if target_digest != snapshot.content_digest:
+        raise ResourceExchangeError("target content digest differs from source snapshot digest")
+    if not source_retained:
+        raise ResourceExchangeError("copy evidence cannot claim success after deleting the source")
+    if destructive_cutover:
+        raise ResourceExchangeError("resource exchange does not authorize destructive cutover")
+
+    domain_changed = tuple(snapshot.source_domain_refs) != destination_domains
+    if domain_changed:
+        _validate_crossing_receipt(
+            crossing_receipt,
+            source_domain_refs=snapshot.source_domain_refs,
+            destination_domain_refs=destination_domains,
+            logical_resource_id=snapshot.logical_resource_id,
+            representation_kind=snapshot.representation_kind,
+            content_digest=snapshot.content_digest,
+        )
+        if not crossing_receipt_ref:
+            raise ResourceExchangeError("cross-domain exchange requires a crossing_receipt_ref")
+    elif crossing_receipt is not None:
+        _validate_crossing_receipt(
+            crossing_receipt,
+            source_domain_refs=snapshot.source_domain_refs,
+            destination_domain_refs=destination_domains,
+            logical_resource_id=snapshot.logical_resource_id,
+            representation_kind=snapshot.representation_kind,
+            content_digest=snapshot.content_digest,
+        )
+
+    source_q = str(substitution.get("primary_qualification_digest", ""))
+    target_q = str(substitution.get("replacement_qualification_digest", ""))
+    requirement_digest = str(substitution.get("requirement_digest", ""))
+    if source_q != source_qualification.applicability_digest:
+        raise QualificationError("source substitution qualification digest drifted")
+    if target_q != target_qualification.applicability_digest:
+        raise QualificationError("target substitution qualification digest drifted")
+
+    exchange_basis = {
+        "snapshot_digest": snapshot.snapshot_digest,
+        "source_provider": source_binding.to_dict(),
+        "target_provider": target_binding.to_dict(),
+        "source_qualification_digest": source_q,
+        "target_qualification_digest": target_q,
+        "requirement_digest": requirement_digest,
+        "destination_domain_refs": list(destination_domains),
+        "target_readback_digest": target_digest,
+        "source_retained": True,
+        "destructive_cutover": False,
+        "crossing_receipt_ref": crossing_receipt_ref,
+    }
+    return ResourceExchangeReceipt(
+        exchange_id="resource-exchange:" + _sha256_json(exchange_basis).removeprefix("sha256:"),
+        snapshot_digest=snapshot.snapshot_digest,
+        logical_resource_id=snapshot.logical_resource_id,
+        representation_kind=snapshot.representation_kind,
+        content_digest=snapshot.content_digest,
+        source_domain_refs=snapshot.source_domain_refs,
+        destination_domain_refs=destination_domains,
+        provenance_refs=snapshot.provenance_refs,
+        source_provider=source_binding,
+        target_provider=target_binding,
+        source_qualification_digest=source_q,
+        target_qualification_digest=target_q,
+        requirement_digest=requirement_digest,
+        target_readback_digest=target_digest,
+        source_retained=True,
+        destructive_cutover=False,
+        crossing_receipt_ref=crossing_receipt_ref,
+    )
+
+
+def _validate_crossing_receipt(
+    receipt: Mapping[str, object] | None,
+    *,
+    source_domain_refs: Sequence[str],
+    destination_domain_refs: Sequence[str],
+    logical_resource_id: str,
+    representation_kind: str,
+    content_digest: str,
+) -> None:
+    if receipt is None:
+        raise ResourceExchangeError("cross-domain exchange requires an ADR-022 boundary-crossing receipt")
+    if receipt.get("operation") not in {"copy", "export", "import"}:
+        raise ResourceExchangeError("crossing receipt operation is not compatible with resource exchange")
+    if receipt.get("outcome") != "committed":
+        raise ResourceExchangeError("cross-domain exchange requires a committed crossing receipt")
+    if receipt.get("pama_disposition") not in {"allow", "allow_with_ledger"}:
+        raise ResourceExchangeError("committed crossing receipt lacks an allowing PAMA disposition")
+    if tuple(receipt.get("source_domain_refs", ())) != tuple(source_domain_refs):
+        raise ResourceExchangeError("crossing receipt source domains do not match resource snapshot")
+    if tuple(receipt.get("destination_domain_refs", ())) != tuple(destination_domain_refs):
+        raise ResourceExchangeError("crossing receipt destination domains do not match exchange target")
+    source_refs = receipt.get("source_refs")
+    if not isinstance(source_refs, (list, tuple)) or logical_resource_id not in source_refs:
+        raise ResourceExchangeError("crossing receipt does not bind the logical resource identity")
+    representation = receipt.get("representation")
+    if not isinstance(representation, Mapping):
+        raise ResourceExchangeError("crossing receipt representation is required")
+    if representation.get("kind") != representation_kind:
+        raise ResourceExchangeError("crossing receipt representation kind does not match resource")
+    if representation.get("content_ref") != content_digest:
+        raise ResourceExchangeError("crossing receipt content reference does not match resource digest")
+    if not isinstance(receipt.get("receipt_id"), str) or not receipt.get("receipt_id"):
+        raise ResourceExchangeError("crossing receipt identity is required")
+
+
+def _assert_binding_matches_component(
+    binding: ProviderResourceBinding,
+    component: ComponentDeclaration,
+    label: str,
+) -> None:
+    if binding.component_id != component.component_id:
+        raise ResourceExchangeError(f"{label} provider binding component identity drifted")
+    if binding.component_version != component.component_version:
+        raise ResourceExchangeError(f"{label} provider binding component version drifted")
+
+
+def _nonempty_unique(values: Sequence[str], name: str) -> None:
+    if not values or any(not isinstance(item, str) or not item for item in values):
+        raise ResourceExchangeError(f"{name} must contain non-empty strings")
+    if len(set(values)) != len(values):
+        raise ResourceExchangeError(f"{name} must be unique")
+
+
+def _sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()

--- a/reference/fixtures/component-qualification/memos-local-plugin-v2.0.17-resource-artifact-qualified-v12.json
+++ b/reference/fixtures/component-qualification/memos-local-plugin-v2.0.17-resource-artifact-qualified-v12.json
@@ -1,0 +1,153 @@
+{
+  "qualification": {
+    "evidence": {
+      "adapter_results": [
+        {
+          "authority_effect": "none",
+          "currentness": "current",
+          "failure_result": "none",
+          "input_refs": ["memos-local-v2017-trace-lifecycle-v1"],
+          "normalized_refs": ["qualification:memos-local-plugin-v2.0.17:resource_artifact_memory"],
+          "operation": "stable_trace_import_read_candidate",
+          "raw_provider_refs": ["artifacts/memos-v2017/raw-provider-evidence.json"],
+          "runtime_identity": "memos-local-plugin:2.0.17:sqlite",
+          "trace_ref": "qualification:memos:initial-import"
+        },
+        {
+          "authority_effect": "none",
+          "currentness": "replacement_current",
+          "failure_result": "none",
+          "input_refs": ["memos-local-v2017-trace-lifecycle-v1"],
+          "normalized_refs": ["qualification:memos-local-plugin-v2.0.17:resource_artifact_memory"],
+          "operation": "stable_key_repeat_and_update",
+          "raw_provider_refs": ["artifacts/memos-v2017/raw-provider-evidence.json"],
+          "runtime_identity": "memos-local-plugin:2.0.17:sqlite",
+          "trace_ref": "qualification:memos:stable-key-update"
+        },
+        {
+          "authority_effect": "none",
+          "currentness": "reconstructed_current",
+          "failure_result": "none",
+          "input_refs": ["memos-local-v2017-trace-lifecycle-v1"],
+          "normalized_refs": ["qualification:memos-local-plugin-v2.0.17:resource_artifact_memory"],
+          "operation": "restart_readback",
+          "raw_provider_refs": ["artifacts/memos-v2017/raw-provider-evidence.json"],
+          "runtime_identity": "memos-local-plugin:2.0.17:sqlite",
+          "trace_ref": "qualification:memos:restart-readback"
+        },
+        {
+          "authority_effect": "none",
+          "currentness": "deleted_no_candidate_residue",
+          "failure_result": "none",
+          "input_refs": ["memos-local-v2017-trace-lifecycle-v1"],
+          "normalized_refs": ["qualification:memos-local-plugin-v2.0.17:resource_artifact_memory"],
+          "operation": "trace_delete_residue_scan",
+          "raw_provider_refs": ["artifacts/memos-v2017/raw-provider-evidence.json"],
+          "runtime_identity": "memos-local-plugin:2.0.17:sqlite",
+          "trace_ref": "qualification:memos:delete-residue"
+        }
+      ],
+      "artifact_digests": ["sha256:000ff1afa0b499447d3b65d7e62f6d81bee3a157ed84be7abe3e12d847329f4b"],
+      "checks": [
+        {"check_id":"exact-provider-identity","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true},
+        {"check_id":"source-rights-discrepancy-preserved","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true},
+        {"check_id":"direct-local-core-no-hosted-secret","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true},
+        {"check_id":"initial-stable-trace-readback","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true},
+        {"check_id":"stable-key-repeat-idempotency","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true},
+        {"check_id":"stable-key-update-currentness","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true},
+        {"check_id":"restart-reconstruction","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true},
+        {"check_id":"durable-key-after-restart","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true},
+        {"check_id":"delete-readback-and-candidate-residue","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true},
+        {"check_id":"provider-identity-is-not-agent-memory-identity","evidence_ref":"artifacts/memos-v2017/raw-provider-evidence.json","passed":true}
+      ],
+      "normalized_refs": [
+        "qualification:memos-local-plugin-v2.0.17:resource_artifact_memory",
+        "qualification:memos-local-plugin-v2.0.17:resource_artifact_memory",
+        "qualification:memos-local-plugin-v2.0.17:resource_artifact_memory",
+        "qualification:memos-local-plugin-v2.0.17:resource_artifact_memory"
+      ],
+      "operations": ["stable_trace_import_read_candidate","stable_key_repeat_and_update","restart_readback","trace_delete_residue_scan"],
+      "raw_provider_refs": [
+        "artifacts/memos-v2017/raw-provider-evidence.json",
+        "artifacts/memos-v2017/raw-provider-evidence.json",
+        "artifacts/memos-v2017/raw-provider-evidence.json",
+        "artifacts/memos-v2017/raw-provider-evidence.json"
+      ]
+    },
+    "qualified_contract": {
+      "authority_effect": "none",
+      "behavior_contract": {
+        "correction_model": "provider_revalidation",
+        "currentness_model": "provider_revalidated",
+        "deletion_model": "provider_revalidation",
+        "invalidation_model": "explicit_signal",
+        "migration_rebuild_model": "requires_requalification",
+        "operation_support": {"read":true,"recall_candidate":true,"write":true},
+        "residue_model": "scan_required",
+        "structural_mutation_requirement": "none"
+      },
+      "component_profile_version": "component-capability-v3",
+      "failure_posture": "fail_closed",
+      "operational_contract": {
+        "concurrency_control": "none",
+        "idempotency": "durable_keyed",
+        "reconciliation": "deterministic_readback",
+        "restart_recovery": "reconstructable",
+        "write_atomicity": "none"
+      },
+      "scope_posture": "external_scope_bridge",
+      "state_posture": "derived"
+    },
+    "result": {
+      "applicability_digest": "sha256:e8596721e6d31f75233af03db6c624fc501bc39593cc9c247cd6e7a4d1299dad",
+      "authority_effect": "none",
+      "earned_maturity": "evidence_proven",
+      "limitations": [
+        "Qualification is exact to @memtensor/memos-local-plugin v2.0.17 and tag commit d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab.",
+        "Only stable-ID trace bundle resource memory is qualified; conversational capture, semantic ranking, L2/L3 state, skills, Hub behavior, and agent adapters remain outside this evidence boundary.",
+        "Write atomicity and concurrent mutation ordering are not fault-injection qualified and remain declared none.",
+        "Candidate lookup uses deterministic listTraces text filtering and carries no Agent Memory recall-admission authority.",
+        "The tagged repository root grants Apache-2.0 while package metadata declares MIT; runtime posture relies on the exact root license grant and retains the metadata discrepancy rather than resolving it by convenience.",
+        "MemOS importBundle collision behavior is idempotent skip, not replacement; replacement is intentionally exercised through updateTrace on the same stable provider-native ID.",
+        "The fixture uses listTraces text filtering as deterministic recall-candidate evidence and does not exercise semantic embedding/ranking."
+      ],
+      "maturity_before": "runtime_wired",
+      "profile_maturity_ceiling": "evidence_proven",
+      "qualification_current": true
+    },
+    "runtime": {
+      "configuration_digest": "sha256:04f039fd3c20c62df4472ef9982d8ef3ac0b97a5c5abcaeb48194c953c711725",
+      "dependency_refs": ["npm:@memtensor/memos-local-plugin@2.0.17","github:MemTensor/MemOS@d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab"],
+      "fixture_digest": "sha256:3772a883f31a69d3945820ffe6d273e2b663d8cbc6ceddff2b9bb68bd4134889",
+      "fixture_id": "memos-local-v2017-trace-lifecycle-v1",
+      "runtime_refs": ["memos-local-plugin:MemoryCore","memos-local-plugin:importBundle","memos-local-plugin:updateTrace","memos-local-plugin:sqlite"]
+    },
+    "schema_version": "1.2.0",
+    "source_rights": {
+      "license_id": "Apache-2.0",
+      "license_ref": "github:MemTensor/MemOS@d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab:LICENSE",
+      "use_posture": "runtime_allowed"
+    },
+    "subject": {
+      "adapter_id": "memos-local-v2017-trace-bundle-adapter",
+      "adapter_version": "1.0.0",
+      "capability_id": "resource_artifact_memory",
+      "capability_version": "1.0",
+      "component_id": "memos-local-plugin-v2.0.17",
+      "component_version": "2.0.17",
+      "implementation_ref": "github:MemTensor/MemOS@d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab:apps/memos-local-plugin",
+      "qualification_profile_id": "memos-local-v2017-trace-resource-artifact",
+      "qualification_profile_version": "1.0.0"
+    }
+  },
+  "source": {
+    "agent_memory_exact_head": "5a87f929ef9a63e212865dbf73b9f7c659dc3a93",
+    "agent_memory_merge": "3c532c1f74492ca86334db25b8fb4c000c7f53be",
+    "agent_memory_pr": 357,
+    "applicability_digest": "sha256:e8596721e6d31f75233af03db6c624fc501bc39593cc9c247cd6e7a4d1299dad",
+    "artifact_digest": "sha256:ae8b766861bec57183918887616391348018c5aeb43f884a29fd9b2b2e53ee25",
+    "provider": "MemTensor/MemOS@memos-local-plugin-v2.0.17",
+    "provider_commit": "d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab",
+    "workflow_run": 33343316829
+  }
+}

--- a/reference/run_federated_resource_exchange.py
+++ b/reference/run_federated_resource_exchange.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Normalize exact-provider copy evidence into federated resource receipts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+from agentmem_ref.resource_exchange import (
+    LogicalResourceSnapshot,
+    ProviderResourceBinding,
+    ResourceExchangeError,
+    prove_resource_exchange,
+)
+from agentmem_ref.resource_provider_substitution import load_component, load_qualification_snapshot
+
+HINDSIGHT_COMPONENT_ID = "hindsight-v0.9.0"
+HINDSIGHT_VERSION = "0.9.0"
+MEMOS_COMPONENT_ID = "memos-local-plugin-v2.0.17"
+MEMOS_VERSION = "2.0.17"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--raw-evidence", type=Path, required=True)
+    parser.add_argument("--hindsight-component", type=Path, required=True)
+    parser.add_argument("--hindsight-qualification", type=Path, required=True)
+    parser.add_argument("--memos-component", type=Path, required=True)
+    parser.add_argument("--memos-qualification", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    raw = json.loads(args.raw_evidence.read_text(encoding="utf-8"))
+    if raw.get("execution_error"):
+        raise ResourceExchangeError(f"provider fixture failed: {raw['execution_error']}")
+    if raw.get("authority_effect") != "none":
+        raise ResourceExchangeError("provider fixture cannot grant authority")
+
+    identity = _mapping(raw.get("identity"), "identity")
+    hindsight_identity = _mapping(identity.get("hindsight"), "identity.hindsight")
+    memos_identity = _mapping(identity.get("memos"), "identity.memos")
+    if hindsight_identity.get("component_id") != HINDSIGHT_COMPONENT_ID or hindsight_identity.get("version") != HINDSIGHT_VERSION:
+        raise ResourceExchangeError("raw Hindsight provider identity drifted")
+    if memos_identity.get("component_id") != MEMOS_COMPONENT_ID or memos_identity.get("version") != MEMOS_VERSION:
+        raise ResourceExchangeError("raw MemOS provider identity drifted")
+
+    boundary = _mapping(raw.get("exchange_boundary"), "exchange_boundary")
+    if boundary.get("cross_domain_authority_exercised") is not False:
+        raise ResourceExchangeError("bounded runtime fixture must not synthesize cross-domain authority")
+    if boundary.get("destructive_cutover_exercised") is not False:
+        raise ResourceExchangeError("bounded runtime fixture cannot exercise destructive cutover")
+
+    hindsight_component = load_component(args.hindsight_component)
+    memos_component = load_component(args.memos_component)
+    hindsight_qualification = load_qualification_snapshot(args.hindsight_qualification)
+    memos_qualification = load_qualification_snapshot(args.memos_qualification)
+
+    h2m = _direction(_mapping(raw.get("hindsight_to_memos"), "hindsight_to_memos"))
+    m2h = _direction(_mapping(raw.get("memos_to_hindsight"), "memos_to_hindsight"))
+
+    if h2m["source"].component_id != HINDSIGHT_COMPONENT_ID or h2m["target"].component_id != MEMOS_COMPONENT_ID:
+        raise ResourceExchangeError("Hindsight-to-MemOS fixture provider direction drifted")
+    if m2h["source"].component_id != MEMOS_COMPONENT_ID or m2h["target"].component_id != HINDSIGHT_COMPONENT_ID:
+        raise ResourceExchangeError("MemOS-to-Hindsight fixture provider direction drifted")
+
+    h2m_receipt = prove_resource_exchange(
+        snapshot=h2m["snapshot"],
+        source_component=hindsight_component,
+        source_qualification=hindsight_qualification,
+        source_binding=h2m["source"],
+        target_component=memos_component,
+        target_qualification=memos_qualification,
+        target_binding=h2m["target"],
+        target_readback=h2m["target_readback"],
+        destination_domain_refs=h2m["destination_domain_refs"],
+        source_retained=h2m["source_retained"],
+    )
+    m2h_receipt = prove_resource_exchange(
+        snapshot=m2h["snapshot"],
+        source_component=memos_component,
+        source_qualification=memos_qualification,
+        source_binding=m2h["source"],
+        target_component=hindsight_component,
+        target_qualification=hindsight_qualification,
+        target_binding=m2h["target"],
+        target_readback=m2h["target_readback"],
+        destination_domain_refs=m2h["destination_domain_refs"],
+        source_retained=m2h["source_retained"],
+    )
+
+    output = {
+        "schema_version": "1.0.0",
+        "capability": "federated_memory_exchange",
+        "eligible": True,
+        "directions": {
+            "hindsight_to_memos": h2m_receipt.to_dict(),
+            "memos_to_hindsight": m2h_receipt.to_dict(),
+        },
+        "invariants": {
+            "bidirectional": True,
+            "logical_identity_provider_independent": True,
+            "exact_target_readback": True,
+            "source_retained": True,
+            "source_scope_provenance_preserved": True,
+            "destructive_cutover": False,
+            "cross_domain_authority_exercised": False,
+            "authority_effect": "none",
+        },
+        "authority_effect": "none",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+def _direction(value: Mapping[str, object]) -> dict[str, Any]:
+    content = _string(value, "content")
+    snapshot = LogicalResourceSnapshot(
+        logical_resource_id=_string(value, "logical_resource_id"),
+        representation_kind=_string(value, "representation_kind"),
+        content=content,
+        source_domain_refs=_strings(value.get("source_domain_refs"), "source_domain_refs"),
+        provenance_refs=_strings(value.get("provenance_refs"), "provenance_refs"),
+    )
+    destination = _strings(value.get("destination_domain_refs"), "destination_domain_refs")
+    source_raw = _mapping(value.get("source"), "source")
+    target_raw = _mapping(value.get("target"), "target")
+    source = _binding(source_raw)
+    target = _binding(target_raw)
+    source_before = source_raw.get("readback_before")
+    source_after = source_raw.get("readback_after_target")
+    target_readback = target_raw.get("readback")
+    if source_before != content:
+        raise ResourceExchangeError("source direct readback before copy differs from logical snapshot")
+    if source_after != content:
+        raise ResourceExchangeError("source direct readback after copy does not prove source retention")
+    if target_readback != content:
+        raise ResourceExchangeError("target direct readback differs from logical snapshot")
+    if value.get("source_retained") is not True:
+        raise ResourceExchangeError("provider fixture did not prove source retention")
+    if value.get("target_readback_matches") is not True:
+        raise ResourceExchangeError("provider fixture did not prove exact target readback")
+    return {
+        "snapshot": snapshot,
+        "source": source,
+        "target": target,
+        "target_readback": str(target_readback),
+        "destination_domain_refs": destination,
+        "source_retained": True,
+    }
+
+
+def _binding(value: Mapping[str, object]) -> ProviderResourceBinding:
+    return ProviderResourceBinding(
+        component_id=_string(value, "component_id"),
+        component_version=_string(value, "component_version"),
+        native_resource_id=_string(value, "native_resource_id"),
+        runtime_ref=str(value.get("runtime_ref") or ""),
+    )
+
+
+def _mapping(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ResourceExchangeError(f"{name} must be an object")
+    return value
+
+
+def _string(value: Mapping[str, object], key: str) -> str:
+    raw = value.get(key)
+    if not isinstance(raw, str) or not raw:
+        raise ResourceExchangeError(f"{key} must be a non-empty string")
+    return raw
+
+
+def _strings(value: object, name: str) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)) or not value:
+        raise ResourceExchangeError(f"{name} must be a non-empty array")
+    if any(not isinstance(item, str) or not item for item in value):
+        raise ResourceExchangeError(f"{name} values must be non-empty strings")
+    return tuple(value)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/run_federated_resource_exchange_fixture.py
+++ b/reference/run_federated_resource_exchange_fixture.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Execute bidirectional Hindsight v0.9.0 <-> MemOS v2.0.17 resource copies.
+
+This fixture captures provider-native direct readback before and after each copy.
+It deliberately retains the source resource and does not exercise cross-domain
+authority; cross-domain receipt composition is covered by the reference contract
+tests against the canonical ADR-022 schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+from importlib import metadata
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+HINDSIGHT_VERSION = "0.9.0"
+HINDSIGHT_COMMIT = "b12646f49ec512136b9f709e608524ffed969668"
+MEMOS_VERSION = "2.0.17"
+MEMOS_COMMIT = "d3d1bcfaff65f31b621d58bc236ece6d1e0da5ab"
+DOMAIN = "memory-domain:project:federated-exchange-fixture"
+PROVENANCE = [
+    "source:fixture:federated-resource-exchange-v1",
+    "issue:https://github.com/MythologIQ-Labs-LLC/agent-memory/issues/358",
+]
+H2M_LOGICAL_ID = "agent-memory:resource:federated-hindsight-to-memos"
+M2H_LOGICAL_ID = "agent-memory:resource:federated-memos-to-hindsight"
+H2M_CONTENT = "amber-river-481 exact resource bytes move from Hindsight to MemOS without becoming provider identity."
+M2H_CONTENT = "cobalt-grove-592 exact resource bytes move from MemOS to Hindsight without becoming provider identity."
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--memos-package-root", type=Path, required=True)
+    parser.add_argument("--memos-h2m-home", type=Path, required=True)
+    parser.add_argument("--memos-m2h-home", type=Path, required=True)
+    parser.add_argument("--hindsight-source-commit", default=HINDSIGHT_COMMIT)
+    parser.add_argument("--memos-source-commit", default=MEMOS_COMMIT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    commands: list[dict[str, Any]] = []
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    temp_dir = args.output.parent / "endpoint-evidence"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+
+    raw: dict[str, Any] = {
+        "identity": {
+            "hindsight": {
+                "component_id": "hindsight-v0.9.0",
+                "version": metadata.version("hindsight-embed"),
+                "source_commit": args.hindsight_source_commit,
+            },
+            "memos": {
+                "component_id": "memos-local-plugin-v2.0.17",
+                "version": MEMOS_VERSION,
+                "source_commit": args.memos_source_commit,
+            },
+        },
+        "exchange_boundary": {
+            "source_domain_refs": [DOMAIN],
+            "destination_domain_refs": [DOMAIN],
+            "provenance_refs": PROVENANCE,
+            "cross_domain_authority_exercised": False,
+            "destructive_cutover_exercised": False,
+        },
+        "commands": commands,
+        "authority_effect": "none",
+    }
+
+    try:
+        if raw["identity"]["hindsight"]["version"] != HINDSIGHT_VERSION:
+            raise RuntimeError("unexpected installed Hindsight version")
+        memos_pkg = json.loads((args.memos_package_root / "package.json").read_text(encoding="utf-8"))
+        if memos_pkg.get("name") != "@memtensor/memos-local-plugin" or memos_pkg.get("version") != MEMOS_VERSION:
+            raise RuntimeError("unexpected installed MemOS package identity")
+
+        # Direction 1: Hindsight source -> MemOS target.
+        h2m_profile = "agent-memory-exchange-h2m-source"
+        h2m_bank = "agent-memory-exchange-h2m-source"
+        h2m_doc = "hindsight-native-h2m-source-document"
+        _create_profile(h2m_profile, 18890, "agent-memory-exchange-h2m-source", commands)
+        _daemon(h2m_profile, "start", commands, "h2m-source-daemon-start")
+        _h_cli_json(h2m_profile, ["bank", "create", h2m_bank], commands, "h2m-source-bank-create")
+        _h_cli_json(
+            h2m_profile,
+            ["memory", "retain", h2m_bank, H2M_CONTENT, "--doc-id", h2m_doc, "--timestamp", "unset"],
+            commands,
+            "h2m-source-retain",
+        )
+        h2m_source_before = _h_cli_json(
+            h2m_profile, ["document", "get", h2m_bank, h2m_doc], commands, "h2m-source-read-before"
+        )
+        h2m_source_text = _document_text(h2m_source_before)
+        h2m_target_trace = "memos-native-h2m-target-trace"
+        h2m_target_file = temp_dir / "memos-h2m-target.json"
+        _memos_endpoint(
+            args,
+            action="write-read",
+            home=args.memos_h2m_home,
+            trace_id=h2m_target_trace,
+            content=h2m_source_text or "",
+            output=h2m_target_file,
+            commands=commands,
+            name="h2m-target-memos-write-read",
+        )
+        h2m_target = json.loads(h2m_target_file.read_text(encoding="utf-8"))
+        h2m_source_after = _h_cli_json(
+            h2m_profile, ["document", "get", h2m_bank, h2m_doc], commands, "h2m-source-read-after-target"
+        )
+        _daemon(h2m_profile, "stop", commands, "h2m-source-daemon-stop", expect_success=False)
+
+        raw["hindsight_to_memos"] = {
+            "logical_resource_id": H2M_LOGICAL_ID,
+            "representation_kind": "text/plain; charset=utf-8",
+            "content": H2M_CONTENT,
+            "source_domain_refs": [DOMAIN],
+            "destination_domain_refs": [DOMAIN],
+            "provenance_refs": PROVENANCE,
+            "source": {
+                "component_id": "hindsight-v0.9.0",
+                "component_version": HINDSIGHT_VERSION,
+                "native_resource_id": f"hindsight-document:{h2m_bank}/{h2m_doc}",
+                "runtime_ref": "hindsight-embed:0.9.0:pg0",
+                "readback_before": h2m_source_text,
+                "readback_after_target": _document_text(h2m_source_after),
+            },
+            "target": {
+                **h2m_target.get("provider", {}),
+                "readback": h2m_target.get("readback"),
+                "write_import_result": h2m_target.get("import_result"),
+            },
+            "source_retained": _document_text(h2m_source_after) == H2M_CONTENT,
+            "target_readback_matches": h2m_target.get("readback") == H2M_CONTENT,
+        }
+
+        # Direction 2: MemOS source -> Hindsight target.
+        m2h_source_trace = "memos-native-m2h-source-trace"
+        m2h_source_file = temp_dir / "memos-m2h-source.json"
+        _memos_endpoint(
+            args,
+            action="write-read",
+            home=args.memos_m2h_home,
+            trace_id=m2h_source_trace,
+            content=M2H_CONTENT,
+            output=m2h_source_file,
+            commands=commands,
+            name="m2h-source-memos-write-read",
+        )
+        m2h_source = json.loads(m2h_source_file.read_text(encoding="utf-8"))
+        m2h_profile = "agent-memory-exchange-m2h-target"
+        m2h_bank = "agent-memory-exchange-m2h-target"
+        m2h_doc = "hindsight-native-m2h-target-document"
+        _create_profile(m2h_profile, 18891, "agent-memory-exchange-m2h-target", commands)
+        _daemon(m2h_profile, "start", commands, "m2h-target-daemon-start")
+        _h_cli_json(m2h_profile, ["bank", "create", m2h_bank], commands, "m2h-target-bank-create")
+        _h_cli_json(
+            m2h_profile,
+            [
+                "memory",
+                "retain",
+                m2h_bank,
+                str(m2h_source.get("readback") or ""),
+                "--doc-id",
+                m2h_doc,
+                "--timestamp",
+                "unset",
+            ],
+            commands,
+            "m2h-target-retain",
+        )
+        m2h_target = _h_cli_json(
+            m2h_profile, ["document", "get", m2h_bank, m2h_doc], commands, "m2h-target-read"
+        )
+        m2h_target_text = _document_text(m2h_target)
+        m2h_source_after_file = temp_dir / "memos-m2h-source-after.json"
+        _memos_endpoint(
+            args,
+            action="read",
+            home=args.memos_m2h_home,
+            trace_id=m2h_source_trace,
+            content=None,
+            output=m2h_source_after_file,
+            commands=commands,
+            name="m2h-source-memos-read-after-target",
+        )
+        m2h_source_after = json.loads(m2h_source_after_file.read_text(encoding="utf-8"))
+        _daemon(m2h_profile, "stop", commands, "m2h-target-daemon-stop", expect_success=False)
+
+        raw["memos_to_hindsight"] = {
+            "logical_resource_id": M2H_LOGICAL_ID,
+            "representation_kind": "text/plain; charset=utf-8",
+            "content": M2H_CONTENT,
+            "source_domain_refs": [DOMAIN],
+            "destination_domain_refs": [DOMAIN],
+            "provenance_refs": PROVENANCE,
+            "source": {
+                **m2h_source.get("provider", {}),
+                "readback_before": m2h_source.get("readback"),
+                "readback_after_target": m2h_source_after.get("readback"),
+            },
+            "target": {
+                "component_id": "hindsight-v0.9.0",
+                "component_version": HINDSIGHT_VERSION,
+                "native_resource_id": f"hindsight-document:{m2h_bank}/{m2h_doc}",
+                "runtime_ref": "hindsight-embed:0.9.0:pg0",
+                "readback": m2h_target_text,
+            },
+            "source_retained": m2h_source_after.get("readback") == M2H_CONTENT,
+            "target_readback_matches": m2h_target_text == M2H_CONTENT,
+        }
+    except Exception as exc:
+        raw["execution_error"] = {"type": type(exc).__name__, "message": str(exc)}
+    finally:
+        # Best effort cleanup of possible running profiles. Data is intentionally
+        # not deleted because source-retention is part of the bounded evidence.
+        for profile in (
+            "agent-memory-exchange-h2m-source",
+            "agent-memory-exchange-m2h-target",
+        ):
+            _daemon(profile, "stop", commands, f"final-stop:{profile}", expect_success=False)
+        args.output.write_text(json.dumps(raw, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return 0 if "execution_error" not in raw else 1
+
+
+def _create_profile(profile: str, port: int, database_name: str, commands: list[dict[str, Any]]) -> None:
+    env_values = [
+        "HINDSIGHT_API_LLM_PROVIDER=none",
+        "HINDSIGHT_API_SKIP_LLM_VERIFICATION=true",
+        "HINDSIGHT_API_RETAIN_EXTRACTION_MODE=chunks",
+        "HINDSIGHT_API_ENABLE_OBSERVATIONS=false",
+        "HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION=false",
+        "HINDSIGHT_API_ENABLE_RERANKING=false",
+        "HINDSIGHT_API_ENABLE_GRAPH_RETRIEVAL=false",
+        "HINDSIGHT_API_ENABLE_TEMPORAL_RETRIEVAL=false",
+        "HINDSIGHT_API_MCP_ENABLED=false",
+        f"HINDSIGHT_EMBED_API_DATABASE_URL=pg0://{database_name}",
+        f"HINDSIGHT_API_DATABASE_URL=pg0://{database_name}",
+        "HINDSIGHT_EMBED_API_VERSION=0.9.0",
+        "HINDSIGHT_EMBED_CLI_VERSION=0.9.0",
+    ]
+    command = ["hindsight-embed", "profile", "create", profile, "--port", str(port)]
+    for item in env_values:
+        command.extend(["--env", item])
+    _run(command, commands, f"profile-create:{profile}")
+
+
+def _daemon(
+    profile: str,
+    action: str,
+    commands: list[dict[str, Any]],
+    name: str,
+    *,
+    expect_success: bool = True,
+) -> None:
+    _run(["hindsight-embed", "-p", profile, "daemon", action], commands, name, expect_success=expect_success)
+
+
+def _h_cli_json(profile: str, args: list[str], commands: list[dict[str, Any]], name: str) -> Any:
+    result = _run(["hindsight-embed", "-p", profile, "-o", "json", *args], commands, name)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{name} did not emit JSON: {result.stdout[:500]!r}") from exc
+
+
+def _memos_endpoint(
+    args: argparse.Namespace,
+    *,
+    action: str,
+    home: Path,
+    trace_id: str,
+    content: str | None,
+    output: Path,
+    commands: list[dict[str, Any]],
+    name: str,
+) -> None:
+    command = [
+        "node",
+        "reference/run_memos_local_v2017_exchange_endpoint.mjs",
+        "--action",
+        action,
+        "--package-root",
+        str(args.memos_package_root),
+        "--home",
+        str(home),
+        "--trace-id",
+        trace_id,
+        "--output",
+        str(output),
+    ]
+    if content is not None:
+        command.extend(["--content", content])
+    _run(command, commands, name)
+
+
+def _run(
+    command: list[str],
+    commands: list[dict[str, Any]],
+    name: str,
+    *,
+    expect_success: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    try:
+        result = subprocess.run(command, text=True, capture_output=True, timeout=300, env=env)
+    except Exception as exc:
+        commands.append({
+            "name": name,
+            "command": command,
+            "returncode": None,
+            "stdout": "",
+            "stderr": "",
+            "exception": f"{type(exc).__name__}: {exc}",
+        })
+        if expect_success:
+            raise
+        return subprocess.CompletedProcess(command, 255, "", str(exc))
+    commands.append({
+        "name": name,
+        "command": command,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    })
+    if expect_success and result.returncode != 0:
+        raise RuntimeError(f"{name} failed with exit {result.returncode}: {result.stderr[-1200:]}")
+    return result
+
+
+def _document_text(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    for key in ("original_text", "text", "content"):
+        candidate = value.get(key)
+        if isinstance(candidate, str):
+            return candidate
+    return None
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/run_federated_resource_exchange_fixture.py
+++ b/reference/run_federated_resource_exchange_fixture.py
@@ -266,10 +266,23 @@ def _daemon(
 
 def _h_cli_json(profile: str, args: list[str], commands: list[dict[str, Any]], name: str) -> Any:
     result = _run(["hindsight-embed", "-p", profile, "-o", "json", *args], commands, name)
+    return _decode_json_prefix(result.stdout, name)
+
+
+def _decode_json_prefix(stdout: str, name: str) -> Any:
+    """Decode the provider JSON value while preserving launcher chatter separately.
+
+    Hindsight Embed v0.9.0 may lazily install its exact CLI on the first
+    forwarded command and append installer status text to stdout after the JSON
+    response. Raw stdout remains captured in command evidence; qualification
+    uses only the first syntactically valid JSON value.
+    """
+    text = stdout.lstrip()
     try:
-        return json.loads(result.stdout)
+        value, _end = json.JSONDecoder().raw_decode(text)
     except json.JSONDecodeError as exc:
-        raise RuntimeError(f"{name} did not emit JSON: {result.stdout[:500]!r}") from exc
+        raise RuntimeError(f"{name} did not begin with JSON: {stdout[:500]!r}") from exc
+    return value
 
 
 def _memos_endpoint(

--- a/reference/run_memos_local_v2017_exchange_endpoint.mjs
+++ b/reference/run_memos_local_v2017_exchange_endpoint.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const MEMOS_VERSION = "2.0.17";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key?.startsWith("--") || value === undefined) throw new Error(`invalid argument near ${key}`);
+    out[key.slice(2)] = value;
+  }
+  for (const required of ["action", "package-root", "home", "trace-id", "output"]) {
+    if (!out[required]) throw new Error(`--${required} is required`);
+  }
+  if (!["write-read", "read"].includes(out.action)) throw new Error(`unsupported --action ${out.action}`);
+  if (out.action === "write-read" && !out.content) throw new Error("--content is required for write-read");
+  return out;
+}
+
+async function mkdirHome(root) {
+  const dirs = [root, path.join(root, "data"), path.join(root, "skills"), path.join(root, "logs"), path.join(root, "daemon")];
+  for (const dir of dirs) await fs.mkdir(dir, { recursive: true });
+  return {
+    root,
+    configFile: path.join(root, "config.yaml"),
+    dataDir: path.join(root, "data"),
+    dbFile: path.join(root, "data", "memos.db"),
+    skillsDir: path.join(root, "skills"),
+    logsDir: path.join(root, "logs"),
+    daemonDir: path.join(root, "daemon"),
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const packageJson = JSON.parse(await fs.readFile(path.join(args["package-root"], "package.json"), "utf8"));
+  if (packageJson.name !== "@memtensor/memos-local-plugin" || packageJson.version !== MEMOS_VERSION) {
+    throw new Error(`unexpected MemOS package identity ${packageJson.name}@${packageJson.version}`);
+  }
+
+  const coreUrl = pathToFileURL(path.join(args["package-root"], "dist", "core", "index.js")).href;
+  const coreModule = await import(coreUrl);
+  const { bootstrapMemoryCore, resolveConfig } = coreModule;
+  if (typeof bootstrapMemoryCore !== "function" || typeof resolveConfig !== "function") {
+    throw new Error("exact package does not expose bootstrapMemoryCore/resolveConfig");
+  }
+
+  const home = await mkdirHome(path.resolve(args.home));
+  const config = resolveConfig({
+    viewer: { openOnFirstTurn: false },
+    llm: { provider: "", model: "", apiKey: "", fallbackToHost: false },
+    embedding: { provider: "local", apiKey: "", cache: { enabled: false, maxItems: 1 } },
+    algorithm: {
+      lightweightMemory: { enabled: true },
+      capture: { embedTraces: false, alphaScoring: false, synthReflections: false },
+      reward: { llmScoring: false },
+      l2Induction: { useLlm: false },
+      l3Abstraction: { useLlm: false },
+      skill: { useLlm: false }
+    }
+  }, [], "hermes");
+
+  const core = await bootstrapMemoryCore({
+    agent: "hermes",
+    home,
+    config,
+    autoRecovery: false,
+    pkgVersion: MEMOS_VERSION,
+    initLogging: false,
+  });
+
+  let importResult = null;
+  if (args.action === "write-read") {
+    const trace = {
+      id: args["trace-id"],
+      episodeId: `${args["trace-id"]}:episode`,
+      sessionId: `${args["trace-id"]}:session`,
+      ts: 1735689600000,
+      turnId: 1735689600000,
+      userText: args.content,
+      agentText: "federated exchange fixture",
+      summary: args.content,
+      toolCalls: [],
+      reflection: null,
+      agentThinking: null,
+      value: 0,
+      alpha: 0,
+      rHuman: null,
+      priority: 0,
+      tags: ["agent-memory-federated-exchange"]
+    };
+    importResult = await core.importBundle({ version: 1, traces: [trace] });
+  }
+
+  const trace = await core.getTrace(args["trace-id"]);
+  const count = await core.countTraces({ includeAllNamespaces: true });
+  await core.shutdown();
+
+  const result = {
+    provider: {
+      component_id: "memos-local-plugin-v2.0.17",
+      component_version: MEMOS_VERSION,
+      package: packageJson.name,
+      package_version: packageJson.version,
+      native_resource_id: args["trace-id"],
+      runtime_ref: "memos-local-plugin:2.0.17:sqlite"
+    },
+    action: args.action,
+    import_result: importResult,
+    readback: trace?.userText ?? null,
+    current_resource_count: count,
+    native_id_matches: trace?.id === args["trace-id"],
+    authority_effect: "none"
+  };
+
+  await fs.mkdir(path.dirname(path.resolve(args.output)), { recursive: true });
+  await fs.writeFile(path.resolve(args.output), JSON.stringify(result, null, 2) + "\n", "utf8");
+}
+
+main().catch(async (err) => {
+  const args = (() => { try { return parseArgs(process.argv); } catch { return {}; } })();
+  if (args.output) {
+    await fs.mkdir(path.dirname(path.resolve(args.output)), { recursive: true });
+    await fs.writeFile(path.resolve(args.output), JSON.stringify({
+      execution_error: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      authority_effect: "none"
+    }, null, 2) + "\n", "utf8");
+  }
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/reference/tests/test_resource_exchange.py
+++ b/reference/tests/test_resource_exchange.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+from agentmem_ref.resource_exchange import (
+    LogicalResourceSnapshot,
+    ProviderResourceBinding,
+    ResourceExchangeError,
+    prove_resource_exchange,
+)
+from agentmem_ref.resource_provider_substitution import (
+    load_component,
+    load_qualification_snapshot,
+    qualification_with_use_posture,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+HINDSIGHT_COMPONENT = ROOT / "reference/fixtures/component-capabilities/hindsight-v0.9.0.json"
+MEMOS_COMPONENT = ROOT / "reference/fixtures/component-capabilities/memos-local-plugin-v2.0.17.json"
+HINDSIGHT_QUALIFICATION = ROOT / "reference/fixtures/component-qualification/hindsight-v0.9.0-resource-artifact-qualified-v12.json"
+MEMOS_QUALIFICATION = ROOT / "reference/fixtures/component-qualification/memos-local-plugin-v2.0.17-resource-artifact-qualified-v12.json"
+EXCHANGE_SCHEMA = ROOT / "schemas/resource-exchange-receipt.schema.json"
+CROSSING_SCHEMA = ROOT / "schemas/boundary-crossing-receipt.schema.json"
+
+LOGICAL_ID = "agent-memory:resource:exchange-fixture-001"
+CONTENT = "Federated resource exchange preserves exact bytes across qualified substrates."
+DOMAIN = "memory-domain:project:exchange-fixture"
+PROVENANCE = (
+    "source:fixture:federated-resource-exchange-v1",
+    "issue:https://github.com/MythologIQ-Labs-LLC/agent-memory/issues/358",
+)
+
+
+class ResourceExchangeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.hindsight_component = load_component(HINDSIGHT_COMPONENT)
+        self.memos_component = load_component(MEMOS_COMPONENT)
+        self.hindsight_qualification = load_qualification_snapshot(HINDSIGHT_QUALIFICATION)
+        self.memos_qualification = load_qualification_snapshot(MEMOS_QUALIFICATION)
+        self.snapshot = LogicalResourceSnapshot(
+            logical_resource_id=LOGICAL_ID,
+            representation_kind="text/plain; charset=utf-8",
+            content=CONTENT,
+            source_domain_refs=(DOMAIN,),
+            provenance_refs=PROVENANCE,
+        )
+        self.hindsight_binding = ProviderResourceBinding(
+            component_id=self.hindsight_component.component_id,
+            component_version=self.hindsight_component.component_version,
+            native_resource_id="hindsight-document:exchange-source",
+            runtime_ref="hindsight-embed:0.9.0:pg0",
+        )
+        self.memos_binding = ProviderResourceBinding(
+            component_id=self.memos_component.component_id,
+            component_version=self.memos_component.component_version,
+            native_resource_id="memos-trace:exchange-target",
+            runtime_ref="memos-local-plugin:2.0.17:sqlite",
+        )
+
+    def test_hindsight_to_memos_same_domain_exchange_is_schema_valid(self) -> None:
+        receipt = prove_resource_exchange(
+            snapshot=self.snapshot,
+            source_component=self.hindsight_component,
+            source_qualification=self.hindsight_qualification,
+            source_binding=self.hindsight_binding,
+            target_component=self.memos_component,
+            target_qualification=self.memos_qualification,
+            target_binding=self.memos_binding,
+            target_readback=CONTENT,
+            destination_domain_refs=(DOMAIN,),
+            source_retained=True,
+        )
+        value = receipt.to_dict()
+        schema = json.loads(EXCHANGE_SCHEMA.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(value)
+        self.assertEqual(LOGICAL_ID, value["logical_resource_id"])
+        self.assertEqual(self.snapshot.content_digest, value["content_digest"])
+        self.assertEqual(value["content_digest"], value["target_readback_digest"])
+        self.assertEqual(list(PROVENANCE), value["provenance_refs"])
+        self.assertTrue(value["source_retained"])
+        self.assertFalse(value["destructive_cutover"])
+        self.assertEqual("none", value["authority_effect"])
+        self.assertIsNone(value["crossing_receipt_ref"])
+
+    def test_memos_to_hindsight_proves_direction_is_not_canonicalized(self) -> None:
+        receipt = prove_resource_exchange(
+            snapshot=self.snapshot,
+            source_component=self.memos_component,
+            source_qualification=self.memos_qualification,
+            source_binding=self.memos_binding,
+            target_component=self.hindsight_component,
+            target_qualification=self.hindsight_qualification,
+            target_binding=self.hindsight_binding,
+            target_readback=CONTENT,
+            destination_domain_refs=(DOMAIN,),
+            source_retained=True,
+        )
+        value = receipt.to_dict()
+        self.assertEqual("memos-local-plugin-v2.0.17", value["source_provider"]["component_id"])
+        self.assertEqual("hindsight-v0.9.0", value["target_provider"]["component_id"])
+        self.assertEqual("none", value["authority_effect"])
+
+    def test_target_content_mismatch_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ResourceExchangeError, "direct readback differs"):
+            self._hindsight_to_memos(target_readback=CONTENT + " drift")
+
+    def test_provider_native_id_cannot_replace_logical_identity(self) -> None:
+        bad_snapshot = LogicalResourceSnapshot(
+            logical_resource_id=self.memos_binding.native_resource_id,
+            representation_kind=self.snapshot.representation_kind,
+            content=CONTENT,
+            source_domain_refs=(DOMAIN,),
+            provenance_refs=PROVENANCE,
+        )
+        with self.assertRaisesRegex(ResourceExchangeError, "provider-native identity"):
+            prove_resource_exchange(
+                snapshot=bad_snapshot,
+                source_component=self.hindsight_component,
+                source_qualification=self.hindsight_qualification,
+                source_binding=self.hindsight_binding,
+                target_component=self.memos_component,
+                target_qualification=self.memos_qualification,
+                target_binding=self.memos_binding,
+                target_readback=CONTENT,
+                destination_domain_refs=(DOMAIN,),
+                source_retained=True,
+            )
+
+    def test_missing_provenance_is_rejected_before_exchange(self) -> None:
+        with self.assertRaisesRegex(ResourceExchangeError, "provenance_refs"):
+            LogicalResourceSnapshot(
+                logical_resource_id=LOGICAL_ID,
+                representation_kind="text/plain",
+                content=CONTENT,
+                source_domain_refs=(DOMAIN,),
+                provenance_refs=(),
+            )
+
+    def test_comparator_only_target_qualification_cannot_receive_runtime_copy(self) -> None:
+        with self.assertRaises(Exception):
+            prove_resource_exchange(
+                snapshot=self.snapshot,
+                source_component=self.hindsight_component,
+                source_qualification=self.hindsight_qualification,
+                source_binding=self.hindsight_binding,
+                target_component=self.memos_component,
+                target_qualification=qualification_with_use_posture(
+                    self.memos_qualification, "comparator_only"
+                ),
+                target_binding=self.memos_binding,
+                target_readback=CONTENT,
+                destination_domain_refs=(DOMAIN,),
+                source_retained=True,
+            )
+
+    def test_provider_version_drift_invalidates_binding_or_qualification(self) -> None:
+        drifted = replace(self.memos_component, component_version="2.0.18")
+        with self.assertRaises(Exception):
+            prove_resource_exchange(
+                snapshot=self.snapshot,
+                source_component=self.hindsight_component,
+                source_qualification=self.hindsight_qualification,
+                source_binding=self.hindsight_binding,
+                target_component=drifted,
+                target_qualification=self.memos_qualification,
+                target_binding=self.memos_binding,
+                target_readback=CONTENT,
+                destination_domain_refs=(DOMAIN,),
+                source_retained=True,
+            )
+
+    def test_exchange_cannot_claim_source_deletion_or_cutover(self) -> None:
+        with self.assertRaisesRegex(ResourceExchangeError, "deleting the source"):
+            self._hindsight_to_memos(source_retained=False)
+        with self.assertRaisesRegex(ResourceExchangeError, "destructive cutover"):
+            self._hindsight_to_memos(destructive_cutover=True)
+
+    def test_cross_domain_exchange_requires_existing_committed_crossing_receipt(self) -> None:
+        with self.assertRaisesRegex(ResourceExchangeError, "boundary-crossing receipt"):
+            self._hindsight_to_memos(destination_domain_refs=("memory-domain:other",))
+
+    def test_valid_cross_domain_receipt_is_composed_not_redefined(self) -> None:
+        destination = "memory-domain:shared:exchange-fixture"
+        crossing = self._crossing_receipt(destination)
+        schema = json.loads(CROSSING_SCHEMA.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(crossing)
+        receipt = self._hindsight_to_memos(
+            destination_domain_refs=(destination,),
+            crossing_receipt=crossing,
+            crossing_receipt_ref="boundary-crossing:fixture-001",
+        )
+        self.assertEqual("boundary-crossing:fixture-001", receipt.crossing_receipt_ref)
+        self.assertEqual((DOMAIN,), receipt.source_domain_refs)
+        self.assertEqual((destination,), receipt.destination_domain_refs)
+        self.assertEqual("none", receipt.authority_effect)
+
+    def test_crossing_receipt_domain_or_content_drift_is_rejected(self) -> None:
+        destination = "memory-domain:shared:exchange-fixture"
+        crossing = self._crossing_receipt(destination)
+        crossing["destination_domain_refs"] = ["memory-domain:wrong"]
+        with self.assertRaisesRegex(ResourceExchangeError, "destination domains"):
+            self._hindsight_to_memos(
+                destination_domain_refs=(destination,),
+                crossing_receipt=crossing,
+                crossing_receipt_ref="boundary-crossing:fixture-001",
+            )
+
+        crossing = self._crossing_receipt(destination)
+        crossing["representation"]["content_ref"] = "sha256:" + "0" * 64
+        with self.assertRaisesRegex(ResourceExchangeError, "content reference"):
+            self._hindsight_to_memos(
+                destination_domain_refs=(destination,),
+                crossing_receipt=crossing,
+                crossing_receipt_ref="boundary-crossing:fixture-001",
+            )
+
+    def _hindsight_to_memos(self, **overrides):
+        args = dict(
+            snapshot=self.snapshot,
+            source_component=self.hindsight_component,
+            source_qualification=self.hindsight_qualification,
+            source_binding=self.hindsight_binding,
+            target_component=self.memos_component,
+            target_qualification=self.memos_qualification,
+            target_binding=self.memos_binding,
+            target_readback=CONTENT,
+            destination_domain_refs=(DOMAIN,),
+            source_retained=True,
+            crossing_receipt=None,
+            crossing_receipt_ref="",
+            destructive_cutover=False,
+        )
+        args.update(overrides)
+        return prove_resource_exchange(**args)
+
+    def _crossing_receipt(self, destination: str) -> dict:
+        return {
+            "schema_version": "1.0.0",
+            "receipt_id": "boundary-crossing:fixture-001",
+            "operation": "copy",
+            "source_domain_refs": [DOMAIN],
+            "destination_domain_refs": [destination],
+            "actor": "agent:test",
+            "principal": "principal:test",
+            "purpose": "federated-resource-exchange-test",
+            "representation": {
+                "kind": self.snapshot.representation_kind,
+                "content_ref": self.snapshot.content_digest,
+                "privacy_minimized": False,
+            },
+            "source_refs": [LOGICAL_ID],
+            "requested_consequence": "copy resource without source deletion",
+            "pama_disposition": "allow",
+            "authority_refs": ["authority:test-boundary-crossing"],
+            "policy_refs": ["policy:test-boundary-crossing"],
+            "policy_version": "test-v1",
+            "provenance_refs": list(PROVENANCE),
+            "outcome": "committed",
+            "before_scope_refs": [DOMAIN],
+            "after_scope_refs": [destination],
+            "timestamp": "2026-08-31T00:00:00Z",
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/schemas/resource-exchange-receipt.schema.json
+++ b/schemas/resource-exchange-receipt.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MythologIQ-Labs-LLC/agent-memory/schemas/resource-exchange-receipt.schema.json",
+  "title": "Agent Memory Federated Resource Exchange Receipt",
+  "description": "Non-authoritative evidence that one logical resource was copied between two independently qualified resource-memory providers with exact target readback equality. Cross-domain authority remains represented by the canonical ADR-022 boundary-crossing receipt.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "exchange_id",
+    "snapshot_digest",
+    "logical_resource_id",
+    "representation_kind",
+    "content_digest",
+    "source_domain_refs",
+    "destination_domain_refs",
+    "provenance_refs",
+    "source_provider",
+    "target_provider",
+    "source_qualification_digest",
+    "target_qualification_digest",
+    "requirement_digest",
+    "target_readback_digest",
+    "source_retained",
+    "destructive_cutover",
+    "crossing_receipt_ref",
+    "outcome",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "exchange_id": { "type": "string", "pattern": "^resource-exchange:[0-9a-f]{64}$" },
+    "snapshot_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "logical_resource_id": { "type": "string", "minLength": 1 },
+    "representation_kind": { "type": "string", "minLength": 1 },
+    "content_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "source_domain_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "destination_domain_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "provenance_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "source_provider": { "$ref": "#/$defs/providerBinding" },
+    "target_provider": { "$ref": "#/$defs/providerBinding" },
+    "source_qualification_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "target_qualification_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "requirement_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "target_readback_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "source_retained": { "const": true },
+    "destructive_cutover": { "const": false },
+    "crossing_receipt_ref": {
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        { "type": "null" }
+      ]
+    },
+    "outcome": { "const": "copied_verified" },
+    "authority_effect": { "const": "none" }
+  },
+  "$defs": {
+    "providerBinding": {
+      "type": "object",
+      "required": ["component_id", "component_version", "native_resource_id"],
+      "properties": {
+        "component_id": { "type": "string", "minLength": 1 },
+        "component_version": { "type": "string", "minLength": 1 },
+        "native_resource_id": { "type": "string", "minLength": 1 },
+        "runtime_ref": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Closes #358.

## Summary

Implements the first bounded `federated_memory_exchange` path over the two independently qualified external `resource_artifact_memory@1.0` providers:

- Hindsight v0.9.0;
- `@memtensor/memos-local-plugin@2.0.17`.

The slice preserves #276's `no_new_algebra` decision. It does not consolidate the providers into one physical store or introduce a second lifecycle/authority model.

## Exchange contract

Adds a provider-neutral logical resource snapshot and a non-authoritative exchange receipt binding:

- Agent Memory logical resource identity;
- exact content and SHA-256 digest;
- representation kind;
- source and destination isolation-domain references;
- provenance references;
- exact source/target provider component and provider-native IDs;
- current v1.2 qualification applicability digests;
- common resource-memory requirement digest;
- exact target direct-readback digest;
- observed source retention;
- `destructive_cutover: false`;
- `authority_effect: none`.

Provider-native IDs remain mappings only and cannot replace logical identity.

## ADR-022 composition

Same-domain copies need no new crossing authority. Domain-changing exchange requires an already-committed canonical `boundary-crossing-receipt` whose domains, logical resource reference, representation, content digest, outcome, and allowing PAMA disposition match the exchange.

The new exchange layer consumes that receipt. It does not mint, weaken, or redefine boundary-crossing authority.

## Exact runtime evidence

The dedicated exact-head workflow installs both pinned providers and proves both directions in one isolated job.

### Hindsight -> MemOS

Source Hindsight document is direct-read before copy, copied into a distinct MemOS stable trace, target is direct-read, then the Hindsight source is direct-read again. All three byte strings must match.

### MemOS -> Hindsight

Source MemOS trace is direct-read, copied into a distinct Hindsight document, target is direct-read, then the same MemOS SQLite home is reopened and the source is direct-read again. All three byte strings must match.

No source object is deleted in either direction.

## Qualification/evidence boundary

The MemOS #357 passing qualification is persisted alongside the existing Hindsight #353 snapshot. Exchange reuses the existing real provider substitution gate before copy evidence can be accepted. Stale/tampered/legacy/non-runtime qualification evidence therefore fails closed.

## Adversarial coverage

Tests reject:

- target byte mismatch;
- provider-native ID laundering into logical identity;
- missing provenance;
- comparator-only runtime rights;
- provider version drift;
- source deletion or destructive-cutover claims;
- cross-domain copy without a boundary receipt;
- crossing receipt domain/content mismatch.

## Non-goals

No third provider, replication daemon, continuous synchronization, destructive migration, source deletion, conflict-resolution protocol, richer semantic memory transfer, automatic scope promotion, or new logical-state algebra is introduced.

## Validation

Required repository `validate` plus the dedicated `Federated Resource Exchange` workflow must pass on the exact PR head before merge.