### PR TITLE
docs: correct doctrine 43 on Code Reality Graph ownership and in-repo memory implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,32 @@ Retrieval does not answer:
 
 ---
 
+## Ownership: contracts are Agent Memory's, implementations live here
+
+Read this before mapping any component to any external product.
+
+**Agent Memory owns the architectural contracts.** A provider may be named as the initial or candidate implementation of one. That naming is an implementation mapping, never a transfer of ownership, naming, or authority.
+
+| Contract | Owner | Initial implementation | Status |
+|---|---|---|---|
+| Reality Graphs / Code Reality Graph | **Agent Memory** | CodeGenome | declared ([ADR-035](docs/adr/ADR-035-agent-memory-is-a-governed-cognitive-framework.md), [ownership map](docs/39-implementation-ownership-map.md)) |
+| Lifecycle Engine | **Agent Memory** | EvolveAI proposer, COREFORGE Vault committer | declared, contested |
+| Evidence and Provenance | **Agent Memory** | CodeGenome, FailSafe receipts, COREFORGE ledgers | declared, contested |
+| Saturation and Decay | **Agent Memory** | EvolveAI | declared |
+
+So a Code Reality Graph derived from CodeGenome is an **Agent Memory artifact under an Agent Memory name**, developed in a modular structure in this repository. It is not a CodeGenome export that Agent Memory consumes.
+
+**Functional memory implementations reside in this repository.** Epistemic belief, procedural/skill, predictive/counterfactual, and conditional memory influence are governed reference implementations here, not integrations pointed elsewhere. See [substrate inventory & maturity](docs/43-substrate-inventory-and-maturity.md) for what exists, where it lives, and how mature it is.
+
+Two failure modes this section exists to prevent, both of which have happened:
+
+- Reading "CodeGenome implements the Code Reality Graph" as "the Code Reality Graph is CodeGenome's". The ownership map says the opposite.
+- Reading "no qualification artifact exists" as "the decision has not been made". Maturity and ownership are independent axes; a contract can be owned and named while its implementation is still `declared`.
+
+Mapping a component to a role **does not promote its capability maturity** and does not make its internal ontology canonical ([`docs/01-layer-model.md`](docs/01-layer-model.md)).
+
+---
+
 ## Native doctrine: Proportional Adaptive Mutation Authority
 
 **Proportional Adaptive Mutation Authority (PAMA) is native Agent Memory doctrine authored by Kevin R. Knapp.** It is not an external dependency, related-product import, or source-registry item.

--- a/docs/43-substrate-inventory-and-maturity.md
+++ b/docs/43-substrate-inventory-and-maturity.md
@@ -32,6 +32,22 @@ Verified by enumerating classes implementing the full `TemporalGraphPort` surfac
 
 **No other substrate exists in this repository.** Any additional substrate is prospective work, not an implementation with a location.
 
+---
+
+## 2b. First-party memory implementations
+
+**Correction.** The first draft of this document scoped itself to `TemporalGraphPort` implementations and so answered "which substrates exist" while missing "which functional memory implementations exist". Those are not the same question, and the second is the more useful one. Agent Memory carries a family of governed memory implementations in-repo today:
+
+| Implementation | Location | What it is |
+|---|---|---|
+| Epistemic belief memory | `reference/agentmem_ref/epistemic_memory.py` | Bounded `epistemic_belief_memory` runtime surface, Capability Contract v3 |
+| Procedural / skill memory | `reference/agentmem_ref/procedural_memory.py` | ADR-034 vertical slice; a skill is bounded JSON metadata plus human-readable procedure, not a specialized skill store |
+| Predictive / counterfactual memory | `reference/agentmem_ref/predictive_memory.py` | Bounded `predictive_counterfactual_memory` surface, Capability Contract v3 |
+| Conditional memory influence | `reference/agentmem_ref/conditional_memory_influence.py` | Vendor-neutral admission evidence for model-internal conditional memory |
+| Code-graph qualification | `reference/agentmem_ref/code_graph_qualification.py` | Provider-neutral CodeGenome/Graphify normalizer (#300) |
+
+These are **memory implementations**, not substrates: they sit above `TemporalGraphPort` and use a substrate for persistence. A substrate is where facts live; a memory implementation is a governed surface with its own contract, lifecycle, and admission semantics.
+
 ### Maturity ladder
 
 Schema-enforced in `schemas/component-capability-qualification.schema.json`:
@@ -68,11 +84,18 @@ Each of these is real and each lives somewhere — just not as a substrate. This
 
 ### Code Reality Graph
 
-An **architectural role** in the layer model (`docs/01-layer-model.md:48`, `docs/11-component-architecture.md:41`).
+**Agent Memory owns this contract. That is a decided and accepted position, not an open question.**
 
-**CodeGenome** is the *proposed* first-party implementation of the role (`docs/11:77`). `docs/01:71` is explicit that the mapping "does not promote any capability maturity and does not make either provider's internal ontology canonical."
+- `docs/39-implementation-ownership-map.md:28` — *"Reality Graphs | **Agent Memory contract**; CodeGenome candidate implementation | Runtime Memory | declared"*
+- `ADR-035` (**Accepted**) `:272` — *"CodeGenome is the initial first-party implementation of the Code Reality Graph"*, and `:661` — mapped *"without promoting its domain ontology to universal memory semantics"*
 
-**Maturity: role is doctrine-defined; no implementation is qualified in this repository.** There is no CodeGenome code, capability declaration, or qualification artifact here.
+So the ownership split is settled: **Agent Memory owns the contract and the naming; CodeGenome is the initial implementation of it.** A Code Reality Graph derived from CodeGenome is an Agent Memory artifact under an Agent Memory name, not a CodeGenome export.
+
+**Status: `declared`** — the contract is owned and the implementation candidate is named; no qualification artifact has been earned yet.
+
+**What exists here now**: `reference/agentmem_ref/code_graph_qualification.py` is a provider-neutral CodeGenome/Graphify qualification normalizer (issue #300). It preserves provider-native outputs as separate artifacts and normalizes only the shared factual surface, and its docstring states it "cannot grant Agent Memory authority". Profiles live at `docs/programs/memory-modules/codegenome-multicapability-profile.md` and `codegenome-scope-residue-closeout.md`.
+
+**What does not exist here**: a named, Agent-Memory-owned Code Reality Graph *module*. See §6.
 
 External equivalents: code-property-graph and code-knowledge-graph tooling (Sourcegraph SCIP, Glean, CodeQL's database). None is qualified against a capability contract here.
 
@@ -100,13 +123,33 @@ External equivalents: pgvector, Supabase, Timescale for temporal workloads. Any 
 
 ---
 
-## 5. Summary — what actually exists
+## 5. Structural finding — there is no modular structure to own a named module
+
+`reference/agentmem_ref/` contains **122 modules and zero subdirectories**. It is entirely flat.
+
+That is the concrete obstacle to the stated intent that a derived Code Reality Graph be "Agent Memory owned and named within a modular structure". There is no package boundary for a named memory module to occupy, so every implementation — epistemic, procedural, predictive, conditional, code-graph qualification — sits in the same undifferentiated namespace as `receipts`, `policy`, and 100+ comparator, harness, and evidence-emitter modules.
+
+The ownership decision (§4, Code Reality Graph) is settled and documented. The **structure to express it is not built**. Those are different gaps and only the second is open:
+
+| | State |
+|---|---|
+| Agent Memory owns the Code Reality Graph contract | **decided**, ADR-035 Accepted + `docs/39:28` |
+| CodeGenome named as initial implementation | **decided**, same sources |
+| Named Agent-Memory-owned Code Reality Graph module | **not built** |
+| Modular package structure to hold it | **not built** — `agentmem_ref/` is flat |
+
+This interacts directly with [#362](https://github.com/MythologIQ-Labs-LLC/agent-memory/issues/362) (no public consumer API): a module structure and a public surface are the same design conversation, and Sprint 4's boundary freeze is where both belong.
+
+---
+
+## 6. Summary — what actually exists
 
 | | Count | At what maturity |
 |---|---|---|
 | First-party substrates | **2** | one reference implementation, one `declared` |
+| First-party memory implementations | **5** | in-repo, above the substrate layer (§2b) |
 | Qualified external components | **2** | both `evidence_proven`, both `authority_effect: none` |
-| Architectural roles with no implementation here | 1 (Code Reality Graph) | doctrine-defined |
+| Contracts Agent Memory owns whose module is not yet built | 1 (Code Reality Graph) | **ownership decided**; module and structure open |
 | Capability families with no declaration here | 1 (GraphRAG) | doctrine-defined |
 | Persistence mechanisms named as examples | 4+ (Markdown, files, Postgres/SQLite, object stores, event logs) | not substrates |
 
@@ -114,6 +157,6 @@ External equivalents: pgvector, Supabase, Timescale for temporal workloads. Any 
 
 ---
 
-## 6. Maintenance
+## 7. Maintenance
 
 Update in the same change that adds a substrate, declares a capability, or lands a qualification artifact. A substrate added without a row here is a `docs/GOVERNANCE_INDEX.md` Tier 1 drift bug.

--- a/docs/GOVERNANCE_INDEX.md
+++ b/docs/GOVERNANCE_INDEX.md
@@ -31,7 +31,7 @@ MUST be current at every cycle close. Drift signal: wrong version / wrong state 
 | Shadow Genome | `docs/SHADOW_GENOME.md` | 5 entries, 4 resolved |
 | Process Shadow Genome | `docs/PROCESS_SHADOW_GENOME.md` | append-only JSONL of process events (capability shortfalls, gate skips, overrides) |
 | Changelog | `CHANGELOG.md` | **absent** (GAP-REL-01, Sprint 8); register here when created |
-| README | `README.md` | Conformance badge spec-scoped (Sprint 1); installable-distribution section added (Loop 7) |
+| README | `README.md` | Conformance badge spec-scoped (Sprint 1); installable distribution (Loop 7); **ownership section** — contracts are Agent Memory's, implementations live here (2026-09-04) |
 | Roadmap events | `.qor/roadmaps/agent-memory-1_0-completion/events.jsonl` | 32 events; 7 frontier nodes open |
 
 ## Tier 2 — Doctrine & Policy


### PR DESCRIPTION
Corrects two errors in doctrine 43 as first written.

**Ownership was presented as open. It is decided.** ADR-035 is Accepted and `docs/39:28` records *"Reality Graphs | Agent Memory contract; CodeGenome candidate implementation"*. Agent Memory owns the contract and the naming; CodeGenome is the initial implementation. A derived Code Reality Graph is an Agent Memory artifact under an Agent Memory name.

**The document missed the in-repo memory implementations.** It scoped to `TemporalGraphPort` and so answered "which substrates exist" rather than "which functional memory implementations exist". Five already live here: epistemic belief, procedural/skill, predictive/counterfactual, conditional memory influence, and code-graph qualification.

**New structural finding.** `reference/agentmem_ref/` is 122 modules with zero subdirectories. The ownership decision is settled; the modular structure to express it is not built. Same design conversation as #362.