### PR TITLE
Add minimal Cloudflare transport for DashClaw live conformance

### DIFF
--- a/.github/workflows/dashclaw-external-verdict.yml
+++ b/.github/workflows/dashclaw-external-verdict.yml
@@ -4,13 +4,17 @@ on:
   pull_request:
     paths:
       - "reference/agentmem_ref/dashclaw_external_verdict.py"
+      - "reference/agentmem_ref/dashclaw_authority.py"
       - "reference/agentmem_ref/dashclaw_governed_commit.py"
       - "reference/run_dashclaw_provider.py"
       - "reference/run_dashclaw_external_verdict.py"
       - "reference/tests/test_dashclaw_external_verdict.py"
       - "reference/tests/test_dashclaw_project_authority.py"
       - "reference/tests/test_dashclaw_target_scope_recovery.py"
+      - "reference/tests/test_dashclaw_cloudflare_packaging.py"
+      - "examples/cloudflare-dashclaw-provider/**"
       - "docs/programs/runtime-evidence/dashclaw-external-verdict.md"
+      - "docs/programs/runtime-evidence/dashclaw-live-cloudflare-conformance-plan.md"
       - ".github/workflows/dashclaw-external-verdict.yml"
   workflow_dispatch:
 
@@ -43,9 +47,12 @@ jobs:
         run: |
           python -m py_compile \
             reference/agentmem_ref/dashclaw_external_verdict.py \
+            reference/agentmem_ref/dashclaw_authority.py \
             reference/agentmem_ref/dashclaw_governed_commit.py \
             reference/run_dashclaw_provider.py \
-            reference/run_dashclaw_external_verdict.py
+            reference/run_dashclaw_external_verdict.py \
+            examples/cloudflare-dashclaw-provider/prepare.py \
+            examples/cloudflare-dashclaw-provider/src/entry.py
 
       - name: Run provider contract and adversarial tests
         env:
@@ -54,7 +61,19 @@ jobs:
           python -m unittest \
             reference/tests/test_dashclaw_external_verdict.py \
             reference/tests/test_dashclaw_project_authority.py \
-            reference/tests/test_dashclaw_target_scope_recovery.py
+            reference/tests/test_dashclaw_target_scope_recovery.py \
+            reference/tests/test_dashclaw_cloudflare_packaging.py
+
+      - name: Verify portable Cloudflare provider source preparation
+        run: python examples/cloudflare-dashclaw-provider/prepare.py --check
+
+      - name: Dry-run Cloudflare Python Worker bundle
+        run: |
+          python -m pip install --disable-pip-version-check uv
+          python examples/cloudflare-dashclaw-provider/prepare.py
+          cd examples/cloudflare-dashclaw-provider
+          uvx --from workers-py pywrangler deploy --dry-run --outdir dist
+          test -d dist
 
       - name: Execute governed durable-memory workload
         env:

--- a/examples/cloudflare-dashclaw-provider/.gitignore
+++ b/examples/cloudflare-dashclaw-provider/.gitignore
@@ -1,0 +1,5 @@
+src/agentmem_ref/
+dist/
+.dev.vars
+.env
+*.local.json

--- a/examples/cloudflare-dashclaw-provider/README.md
+++ b/examples/cloudflare-dashclaw-provider/README.md
@@ -1,0 +1,290 @@
+# DashClaw Cloudflare Provider Proving Example
+
+Status: **test-only / live conformance transport**
+
+Tracking: [Agent Memory #361](https://github.com/MythologIQ-Labs-LLC/agent-memory/issues/361) · [DashClaw #219](https://github.com/ucsandman/DashClaw/issues/219)
+
+This example exposes the already-tested Agent Memory/PAMA DashClaw external-verdict provider through one minimal public Cloudflare Python Worker.
+
+It is deliberately **not** a production Agent Memory service. It exposes no mutation endpoint, persists no state, and has no R2, D1, Durable Object, Workflow, Queue, Cron, Workers AI, AGT, AgentTrust, QOR, Qortara Governance, or Qortara SDLC dependency.
+
+## Authority boundary
+
+```text
+DashClaw v5.32.0 guard
+    |
+    | external-verdict v1 / public HTTPS
+    v
+agent-memory-dashclaw-provider-proving
+    |
+    +-- bearer verification
+    +-- DashClaw v1 request validation
+    +-- exact input_identity echo
+    +-- project-scoped trusted test authority
+    +-- canonical Agent Memory/PAMA evaluation
+    |
+    v
+allow | escalate | deny
+```
+
+The Worker is decision projection only:
+
+```text
+provider decision != Agent Memory execution
+DashClaw approval != standing Agent Memory authority
+```
+
+Any actual permitted/approved mutation still goes through the ordinary Agent Memory governed commit path and independently revalidates authority, PAMA, current state, and approval binding.
+
+## Why Python Worker
+
+Agent Memory's reference PAMA/provider implementation is Python and stdlib-only at the decision boundary. Cloudflare Python Workers execute CPython semantics through Pyodide, so this proving transport can run the canonical provider logic rather than creating a second JavaScript PAMA implementation.
+
+`prepare.py` copies the exact canonical sources from `reference/agentmem_ref/` into the generated Worker source tree and records SHA-256 identities. The only packaging transformation makes the stateful `GovernedMemoryAdapter` import type-checking-only. Provider behavior is otherwise unchanged.
+
+The generated `src/agentmem_ref/` directory is ignored by Git and must not become another manually maintained implementation.
+
+## Hard account safety boundary
+
+Before **any remote Cloudflare mutation**, inventory the intended account from an authorized Cloudflare-capable environment.
+
+Classify and protect at least:
+
+```text
+PROTECTED PRODUCTION
+  Empty Flagon Inn
+  Celestara
+  all related Workers, routes, domains, secrets and storage
+
+PRESERVED PROVING INFRASTRUCTURE
+  QOR / AGT / AgentTrust proving Workers
+  Qortara Governance / SDLC proving services
+  proving R2 buckets, Workflows, Durable Objects, Service Bindings and evidence
+
+THIS ISSUE OWNS ONLY
+  agent-memory-dashclaw-provider-proving
+```
+
+Do not delete, rename, replace, rebind, reroute, rotate secrets for, or otherwise mutate unrelated resources while performing this run.
+
+No plan upgrade or Cloudflare spend is authorized by #361. Stop if deployment tooling requests either.
+
+## Local preparation
+
+From this directory:
+
+```bash
+python prepare.py --check
+python prepare.py
+```
+
+`--check` performs the packaging/importability check in a temporary directory and leaves the working tree unchanged. The normal command writes the generated provider package under `src/agentmem_ref/` and prints the canonical/prepared source hashes.
+
+## Provider configuration secret
+
+The Worker has one encrypted Cloudflare secret:
+
+```text
+DASHCLAW_PROVIDER_CONFIG
+```
+
+Its JSON value contains both the bearer credential and the exact reference-only authority grants for the test workload:
+
+```json
+{
+  "bearer_token": "<high-entropy-test-token>",
+  "authority": {
+    "grants": [
+      {
+        "org_id": "<dashclaw-test-org-id>",
+        "agent_id": "<dashclaw-test-agent-id>",
+        "isolation_domain_refs": ["project:fixture"],
+        "evidence_ref": "operator-configured:dashclaw-live-conformance"
+      }
+    ]
+  }
+}
+```
+
+Do not commit the populated value. Keep it in a local ignored file or pipe it directly to Wrangler when provisioning the secret.
+
+The project-scoped resolver requires an exact `project_ref`; authenticated DashClaw org/agent identity alone does not become organization-wide memory mutation authority.
+
+## Dry-run before account mutation
+
+Cloudflare Python Workers are deployed with `pywrangler`. Use an isolated invocation rather than the repository root dependency set:
+
+```bash
+uvx --from workers-py pywrangler deploy --dry-run --outdir dist
+```
+
+Before proceeding, inspect the output and confirm all of the following:
+
+- Worker name is exactly `agent-memory-dashclaw-provider-proving`;
+- the endpoint uses `workers.dev`; no custom route or DNS change is proposed;
+- no R2/D1/DO/Workflow/Queue/Cron/Workers-AI/service binding appears;
+- the bundle is comfortably within the current free-plan size limit;
+- only the intended Worker is being prepared;
+- no plan/billing change is requested.
+
+If any condition is false, stop and update #361 rather than improvising around it.
+
+## Remote deployment sequence
+
+Only after the account inventory and dry run are clean:
+
+1. Confirm the account remains on the intended Cloudflare Workers Free plan.
+2. Confirm the Worker name does not collide with an existing service.
+3. Provision `DASHCLAW_PROVIDER_CONFIG` on this Worker only.
+4. Deploy `agent-memory-dashclaw-provider-proving`.
+5. Record the deployment identity and source revision in #361.
+6. Verify no unrelated Cloudflare resource changed.
+
+Do not add a scheduled trigger. This endpoint should receive requests only when the integration test deliberately calls it.
+
+## DashClaw configuration
+
+Use current DashClaw **v5.32.0** for the live run. The maintainer confirmed that the external-verdict wire contract, applicability filter, and posture handling remain unchanged from the previously tested line.
+
+In `/policies`, configure the provider with:
+
+```text
+URL:          https://<worker>.workers.dev/v1/external-verdict
+Bearer token: value matching bearer_token in DASHCLAW_PROVIDER_CONFIG
+Action types: agent_memory.mutation
+Posture:      fail_closed
+Timeout:      within DashClaw's supported 100-5000 ms range
+```
+
+`fail_closed` is intentional for the outage test. Under DashClaw's contract, an unavailable provider then becomes `require_approval`, while the evidence remains explicitly `external unavailable` rather than fabricating an Agent Memory verdict.
+
+## Live acceptance sequence
+
+### 1. Connection test
+
+Use DashClaw's **Test provider** control.
+
+Expected:
+
+```text
+action_type = dashclaw.connection_test
+provider allow
+exact input_identity echo
+zero Agent Memory mutation state
+```
+
+### 2. Initial governed promotion
+
+```text
+release_branch = release
+operation = promotion
+risk = low
+```
+
+Expected:
+
+```text
+PAMA allow_with_ledger
+-> external allow
+-> DashClaw stricter-wins effective decision
+-> ordinary Agent Memory governed commit
+```
+
+### 3. Correction and approval
+
+```text
+release_branch = main
+operation = correction
+risk = medium
+```
+
+Expected:
+
+```text
+PAMA require_review
+-> external escalate
+-> DashClaw require_approval
+```
+
+Then prove that missing approval, wrong `input_identity`, and self-approval all refuse commit; only exact independent human approval may satisfy the review evidence, after which Agent Memory revalidates PAMA and current state before committing.
+
+### 4. Stale replay
+
+Replay the previously valid correction/approval after state advances.
+
+Expected: Agent Memory refuses the stale mutation. Approval remains evidence, not standing authority.
+
+### 5. Scope/authority attack
+
+Submit the canonical high-authority or foreign-project attack.
+
+Expected:
+
+```text
+external deny
+-> DashClaw block
+-> no Agent Memory substrate mutation
+```
+
+DashClaw confirms external `deny` maps to `block` regardless of local grant or calibration state.
+
+### 6. Provider unavailable
+
+Make only this test provider unavailable for an in-scope mutation while DashClaw is configured `fail_closed`.
+
+Expected:
+
+```text
+external unavailable
+-> fail_closed posture
+-> require_approval
+```
+
+The evidence must say unavailable. It must not say Agent Memory allowed or denied the act.
+
+## Evidence to retain
+
+DashClaw decision chain:
+
+```text
+request_id
+input_identity
+local decision
+external decision
+external status
+effective decision
+provider reason
+provider policy version
+approval reference
+posture
+```
+
+Agent Memory chain:
+
+```text
+proposal_id
+proposal_digest
+content digest
+authority evidence
+PAMA version/outcome
+state snapshot
+approval binding
+commit/refusal
+receipt
+current-memory reference
+later governed recall/admission evidence
+```
+
+Correlate the chains without collapsing their identities.
+
+## Closeout
+
+After DashClaw #219 accepts the run:
+
+- post the correlated result to DashClaw #219 and Agent Memory #361;
+- record any defect, remediation, and retest evidence;
+- retain this source and deployment identity;
+- leave the Worker idle only if there is a near-term #220 conformance use;
+- otherwise disable/remove **only this Worker** according to the recorded account inventory;
+- do not dismantle the parked QOR proving stack;
+- do not touch Empty Flagon Inn or Celestara.

--- a/examples/cloudflare-dashclaw-provider/prepare.py
+++ b/examples/cloudflare-dashclaw-provider/prepare.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Prepare the minimal Python Worker bundle from canonical Agent Memory sources.
+
+The Worker must use the exact Agent Memory/PAMA provider semantics rather than a
+second implementation. This script copies the canonical stdlib-only sources into
+the Worker source tree and applies one packaging-only change: the stateful
+``GovernedMemoryAdapter`` import becomes type-checking-only so Cloudflare does
+not pull the unrelated runtime dependency graph into a decision-only Worker.
+
+The transformation is deliberately exact-match and fail-closed. If the
+canonical provider import shape changes, this script refuses to prepare a
+bundle until a human reviews the new boundary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = EXAMPLE_DIR.parents[1]
+CANONICAL_DIR = REPO_ROOT / "reference" / "agentmem_ref"
+OUTPUT_DIR = EXAMPLE_DIR / "src" / "agentmem_ref"
+
+SOURCE_FILES = (
+    "policy.py",
+    "dashclaw_external_verdict.py",
+    "dashclaw_authority.py",
+)
+
+_TYPING_IMPORT = "from typing import Any, Callable, Iterable, Mapping\n"
+_PORTABLE_TYPING_IMPORT = "from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping\n"
+_ADAPTER_IMPORT = "from .adapter import GovernedMemoryAdapter\n"
+_PORTABLE_ADAPTER_IMPORT = "if TYPE_CHECKING:\n    from .adapter import GovernedMemoryAdapter\n"
+
+
+def _sha256(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _portable_provider(source: str) -> str:
+    if source.count(_TYPING_IMPORT) != 1:
+        raise RuntimeError("canonical provider typing import changed; review packaging boundary")
+    if source.count(_ADAPTER_IMPORT) != 1:
+        raise RuntimeError("canonical provider adapter import changed; review packaging boundary")
+    source = source.replace(_TYPING_IMPORT, _PORTABLE_TYPING_IMPORT)
+    source = source.replace(_ADAPTER_IMPORT, _PORTABLE_ADAPTER_IMPORT)
+    return source
+
+
+def _render_sources() -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+    rendered: dict[str, str] = {}
+    manifest: dict[str, dict[str, str]] = {}
+
+    for name in SOURCE_FILES:
+        source_path = CANONICAL_DIR / name
+        raw = source_path.read_bytes()
+        text = raw.decode("utf-8")
+        prepared = _portable_provider(text) if name == "dashclaw_external_verdict.py" else text
+        compile(prepared, str(source_path), "exec")
+        rendered[name] = prepared
+        manifest[name] = {
+            "canonical_sha256": _sha256(raw),
+            "prepared_sha256": _sha256(prepared.encode("utf-8")),
+        }
+
+    return rendered, manifest
+
+
+def _write_package(target: Path) -> dict[str, dict[str, str]]:
+    rendered, manifest = _render_sources()
+    shutil.rmtree(target, ignore_errors=True)
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "__init__.py").write_text(
+        '"""Generated minimal Agent Memory provider package for Cloudflare proving."""\n',
+        encoding="utf-8",
+    )
+    for name, content in rendered.items():
+        (target / name).write_text(content, encoding="utf-8")
+    (target / "SOURCE_MANIFEST.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _import_check(root: Path) -> None:
+    sys.path.insert(0, str(root))
+    try:
+        for module_name in (
+            "agentmem_ref.policy",
+            "agentmem_ref.dashclaw_external_verdict",
+            "agentmem_ref.dashclaw_authority",
+        ):
+            sys.modules.pop(module_name, None)
+            importlib.import_module(module_name)
+    finally:
+        sys.path.remove(str(root))
+        for module_name in list(sys.modules):
+            if module_name == "agentmem_ref" or module_name.startswith("agentmem_ref."):
+                sys.modules.pop(module_name, None)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify portable preparation/import without changing the working tree",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        with tempfile.TemporaryDirectory(prefix="agent-memory-dashclaw-cf-") as temp:
+            root = Path(temp)
+            manifest = _write_package(root / "agentmem_ref")
+            _import_check(root)
+    else:
+        manifest = _write_package(OUTPUT_DIR)
+        _import_check(EXAMPLE_DIR / "src")
+
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cloudflare-dashclaw-provider/pyproject.toml
+++ b/examples/cloudflare-dashclaw-provider/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "agent-memory-dashclaw-provider-proving"
+version = "0.0.0"
+description = "Minimal Cloudflare transport for Agent Memory DashClaw live conformance"
+requires-python = ">=3.13"
+dependencies = []
+
+# Run pywrangler through uvx so this proving example does not inherit the
+# repository root's broader reference-runtime dependency set.

--- a/examples/cloudflare-dashclaw-provider/src/entry.py
+++ b/examples/cloudflare-dashclaw-provider/src/entry.py
@@ -1,0 +1,121 @@
+"""Minimal public HTTPS transport for Agent Memory's DashClaw provider.
+
+This Worker exposes decision projection only. It does not mutate Agent Memory,
+persist state, call AGT/AgentTrust/QOR, or use Cloudflare storage/services.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+from urllib.parse import urlparse
+
+from workers import Response, WorkerEntrypoint
+
+from agentmem_ref.dashclaw_authority import ProjectScopedAuthorityResolver
+from agentmem_ref.dashclaw_external_verdict import (
+    DashClawRequestError,
+    StaticAuthorityResolver,
+    evaluate_request,
+)
+
+MAX_BODY_BYTES = 64 * 1024
+CONFIG_ENV = "DASHCLAW_PROVIDER_CONFIG"
+
+
+def _json_response(status: int, payload: dict, *, extra_headers: dict[str, str] | None = None) -> Response:
+    headers = {
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "no-store",
+        "x-content-type-options": "nosniff",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return Response(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")),
+        status=status,
+        headers=headers,
+    )
+
+
+def _load_provider_config(env) -> tuple[str, ProjectScopedAuthorityResolver]:
+    raw = getattr(env, CONFIG_ENV, None)
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("provider config secret missing")
+
+    document = json.loads(raw)
+    if not isinstance(document, dict):
+        raise ValueError("provider config must be an object")
+
+    token = document.get("bearer_token")
+    authority = document.get("authority")
+    if not isinstance(token, str) or not token:
+        raise ValueError("bearer_token must be a non-empty string")
+    if not isinstance(authority, dict):
+        raise ValueError("authority must be an object")
+
+    resolver = ProjectScopedAuthorityResolver(StaticAuthorityResolver.from_document(authority))
+    return token, resolver
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        path = urlparse(request.url).path
+        if path != "/v1/external-verdict":
+            return _json_response(404, {"error": "not_found"})
+
+        if request.method != "POST":
+            return _json_response(405, {"error": "method_not_allowed"}, extra_headers={"allow": "POST"})
+
+        try:
+            token, authority_resolver = _load_provider_config(self.env)
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+            # Configuration errors are availability failures, not policy verdicts.
+            # Keep details out of the public response and let DashClaw apply the
+            # explicitly configured unavailability posture.
+            return _json_response(503, {"error": "provider_not_configured"})
+
+        authorization = request.headers.get("authorization")
+        expected = f"Bearer {token}"
+        if not isinstance(authorization, str) or not hmac.compare_digest(authorization, expected):
+            return _json_response(
+                401,
+                {"error": "unauthorized"},
+                extra_headers={"www-authenticate": "Bearer"},
+            )
+
+        content_length = request.headers.get("content-length")
+        if content_length is not None:
+            try:
+                if int(content_length) > MAX_BODY_BYTES:
+                    return _json_response(413, {"error": "body_too_large"})
+            except (TypeError, ValueError):
+                return _json_response(400, {"error": "invalid_content_length"})
+
+        try:
+            body = await request.text()
+        except Exception:
+            return _json_response(400, {"error": "invalid_body"})
+
+        body_size = len(body.encode("utf-8"))
+        if body_size <= 0:
+            return _json_response(400, {"error": "empty_body"})
+        if body_size > MAX_BODY_BYTES:
+            return _json_response(413, {"error": "body_too_large"})
+
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            return _json_response(400, {"error": "invalid_json"})
+
+        if not isinstance(payload, dict):
+            return _json_response(400, {"error": "request_must_be_object"})
+
+        try:
+            verdict = evaluate_request(payload, authority_resolver)
+        except DashClawRequestError:
+            # Missing/invalid DashClaw identity cannot be answered with a
+            # contract-valid echoed verdict. Non-2xx is the honest result.
+            return _json_response(400, {"error": "invalid_dashclaw_request"})
+
+        return _json_response(200, verdict)

--- a/examples/cloudflare-dashclaw-provider/wrangler.toml
+++ b/examples/cloudflare-dashclaw-provider/wrangler.toml
@@ -1,0 +1,9 @@
+name = "agent-memory-dashclaw-provider-proving"
+main = "src/entry.py"
+compatibility_date = "2026-09-04"
+compatibility_flags = ["python_workers"]
+workers_dev = true
+
+# Deliberately no routes, cron, R2, D1, Durable Objects, Workflows, Queues,
+# Workers AI, service bindings, or other account resources. The sole runtime
+# configuration is the encrypted DASHCLAW_PROVIDER_CONFIG secret.

--- a/reference/agentmem_ref/dashclaw_authority.py
+++ b/reference/agentmem_ref/dashclaw_authority.py
@@ -1,0 +1,34 @@
+"""Pure project-scoped authority wrapper for DashClaw provider integration.
+
+This module keeps the provider-side scope profile independent from the stateful
+Agent Memory commit path. It is intentionally tiny: authenticated DashClaw
+identity is not organization-wide mutation authority, and an exact project
+binding is required before a trusted resolver may authorize the request.
+"""
+
+from __future__ import annotations
+
+from .dashclaw_external_verdict import (
+    AuthorityRequest,
+    AuthorityResolution,
+    AuthorityResolver,
+)
+
+
+class ProjectScopedAuthorityResolver:
+    """Constrain any trusted resolver to the bounded DashClaw project profile."""
+
+    def __init__(self, delegate: AuthorityResolver) -> None:
+        self._delegate = delegate
+
+    def __call__(self, request: AuthorityRequest) -> AuthorityResolution:
+        if not request.project_ref:
+            return AuthorityResolution(authorized=False, reason_code="project_scope_required")
+        if request.scope != request.project_ref:
+            return AuthorityResolution(authorized=False, reason_code="scope_project_mismatch")
+        domains = set(request.isolation_domain_refs)
+        if request.project_ref not in domains:
+            return AuthorityResolution(authorized=False, reason_code="project_isolation_not_bound")
+        if request.task_ref and request.task_ref not in domains:
+            return AuthorityResolution(authorized=False, reason_code="task_isolation_not_bound")
+        return self._delegate(request)

--- a/reference/agentmem_ref/dashclaw_governed_commit.py
+++ b/reference/agentmem_ref/dashclaw_governed_commit.py
@@ -14,9 +14,9 @@ authorized in Project A from correcting a Project B memory merely by naming its
 logical target reference and proposing a Project A replacement.
 
 This #279 profile is intentionally project-scoped. Authenticated organization
-identity is not organization-wide memory mutation authority. The
-``ProjectScopedAuthorityResolver`` therefore refuses requests that omit an exact
-project scope or try to smuggle a task outside the bound isolation domains.
+identity is not organization-wide memory mutation authority. The pure
+``ProjectScopedAuthorityResolver`` is defined separately so provider transports
+can reuse that boundary without importing the stateful commit runtime.
 
 This registry is process-local by design in the current slice. Its restart-safe
 persistence/reconstruction becomes part of #282 rather than being mistaken for
@@ -28,6 +28,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from .adapter import GovernedMemoryAdapter
+from .dashclaw_authority import ProjectScopedAuthorityResolver
 from .dashclaw_external_verdict import (
     AuthorityRequest,
     AuthorityResolution,
@@ -36,25 +37,6 @@ from .dashclaw_external_verdict import (
     BoundMutation,
     commit_bound_mutation,
 )
-
-
-class ProjectScopedAuthorityResolver:
-    """Constrain any trusted resolver to the bounded #279 project profile."""
-
-    def __init__(self, delegate: AuthorityResolver) -> None:
-        self._delegate = delegate
-
-    def __call__(self, request: AuthorityRequest) -> AuthorityResolution:
-        if not request.project_ref:
-            return AuthorityResolution(authorized=False, reason_code="project_scope_required")
-        if request.scope != request.project_ref:
-            return AuthorityResolution(authorized=False, reason_code="scope_project_mismatch")
-        domains = set(request.isolation_domain_refs)
-        if request.project_ref not in domains:
-            return AuthorityResolution(authorized=False, reason_code="project_isolation_not_bound")
-        if request.task_ref and request.task_ref not in domains:
-            return AuthorityResolution(authorized=False, reason_code="task_isolation_not_bound")
-        return self._delegate(request)
 
 
 @dataclass(frozen=True)

--- a/reference/run_dashclaw_provider.py
+++ b/reference/run_dashclaw_provider.py
@@ -20,12 +20,12 @@ import json
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
+from agentmem_ref.dashclaw_authority import ProjectScopedAuthorityResolver
 from agentmem_ref.dashclaw_external_verdict import (
     DashClawRequestError,
     StaticAuthorityResolver,
     evaluate_request,
 )
-from agentmem_ref.dashclaw_governed_commit import ProjectScopedAuthorityResolver
 
 MAX_BODY_BYTES = 64 * 1024
 

--- a/reference/tests/test_dashclaw_cloudflare_packaging.py
+++ b/reference/tests/test_dashclaw_cloudflare_packaging.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PREPARE_PATH = REPO_ROOT / "examples" / "cloudflare-dashclaw-provider" / "prepare.py"
+
+
+def _load_prepare_module():
+    spec = importlib.util.spec_from_file_location("dashclaw_cloudflare_prepare", PREPARE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load Cloudflare prepare module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DashClawCloudflarePackagingTests(unittest.TestCase):
+    def test_prepared_provider_uses_canonical_sources_and_imports_without_runtime_dependencies(self) -> None:
+        prepare = _load_prepare_module()
+        rendered, manifest = prepare._render_sources()
+
+        self.assertEqual(
+            set(rendered),
+            {"policy.py", "dashclaw_external_verdict.py", "dashclaw_authority.py"},
+        )
+        self.assertEqual(set(manifest), set(rendered))
+        self.assertIn("if TYPE_CHECKING:\n    from .adapter import GovernedMemoryAdapter", rendered["dashclaw_external_verdict.py"])
+        self.assertNotIn("\nfrom .adapter import GovernedMemoryAdapter\n", rendered["dashclaw_external_verdict.py"])
+
+        with tempfile.TemporaryDirectory(prefix="dashclaw-cf-test-") as temp:
+            root = Path(temp)
+            prepared_manifest = prepare._write_package(root / "agentmem_ref")
+            prepare._import_check(root)
+
+        self.assertEqual(prepared_manifest, manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the repository-side portion of #361 needed to run the live DashClaw #219 conformance pass without reusing or exposing the parked QOR proving stack.

### What this adds

- isolates the project-scoped DashClaw authority wrapper from the stateful commit runtime;
- preserves existing imports by re-exporting the wrapper from `dashclaw_governed_commit`;
- adds `examples/cloudflare-dashclaw-provider/`, a minimal Cloudflare Python Worker exposing only `POST /v1/external-verdict`;
- uses one encrypted `DASHCLAW_PROVIDER_CONFIG` secret for bearer auth plus exact test-only authority grants;
- adds a deterministic packaging step that copies the canonical Agent Memory/PAMA provider sources into the Worker bundle and records SHA-256 source identities;
- keeps the stateful adapter import type-checking-only in the generated decision-only bundle, avoiding the unrelated runtime dependency graph without creating a second PAMA implementation;
- adds a packaging/importability test and a bounded live-run runbook.

## Cloudflare boundary

This PR performs **no Cloudflare account mutation**.

The Worker configuration intentionally has no R2, D1, Durable Objects, Workflows, Queues, Cron, Workers AI, service bindings, custom routes, or DNS changes. The intended deployed service name is only:

`agent-memory-dashclaw-provider-proving`

Before any remote deployment, #361 requires a fresh account inventory, explicit protection of Empty Flagon Inn / Celestara and the parked QOR proving resources, confirmation of the Workers Free posture, and a dry-run package inspection. No plan upgrade or spend is authorized.

## DashClaw acceptance target

Current DashClaw v5.32.0 is the target. The maintainer confirmed the v1 wire contract, applicability filter, and posture handling are unchanged.

The live run will cover:

1. `dashclaw.connection_test`;
2. promotion -> external `allow`;
3. correction -> external `escalate` -> exact human approval -> governed commit;
4. stale replay refusal;
5. scope/authority attack -> external `deny` -> DashClaw `block`;
6. provider unavailable with DashClaw explicitly configured `fail_closed`.

DashClaw decision evidence remains separate from Agent Memory PAMA/commit/receipt evidence.

Closes no issue by itself. #361 closes only after the real DashClaw traversal and correlated evidence are complete.

Refs: #361, #279, PR #305, ucsandman/DashClaw#219