### PR TITLE
fix: restore sys.modules after DashClaw provider import check

### DIFF
--- a/examples/cloudflare-dashclaw-provider/prepare.py
+++ b/examples/cloudflare-dashclaw-provider/prepare.py
@@ -90,7 +90,30 @@ def _write_package(target: Path) -> dict[str, dict[str, str]]:
     return manifest
 
 
+def _is_agentmem_module(module_name: str) -> bool:
+    return module_name == "agentmem_ref" or module_name.startswith("agentmem_ref.")
+
+
 def _import_check(root: Path) -> None:
+    """Import the prepared portable copies, then leave `sys.modules` as found.
+
+    The prepared copies must not linger in `sys.modules` — they shadow the
+    canonical package. But evicting every `agentmem_ref` module without putting
+    the originals back is not neutral either: any caller that already holds a
+    reference to a canonical function keeps the *old* module's globals, while a
+    later `mock.patch("agentmem_ref.x.y")` re-imports and patches a *new* module
+    object. The patch then targets something the running code never consults.
+
+    That is not hypothetical. Run in one process with the rest of the suite, the
+    purge made five `test_temporal_trust` cases fail: they patch
+    `agentmem_ref.temporal_trust.public_key_digest`, the patch landed on a fresh
+    module, and the stale bound function called the real digest with a dummy key.
+
+    So snapshot what was loaded, and restore it afterwards.
+    """
+    preserved = {
+        name: module for name, module in sys.modules.items() if _is_agentmem_module(name)
+    }
     sys.path.insert(0, str(root))
     try:
         for module_name in (
@@ -103,8 +126,9 @@ def _import_check(root: Path) -> None:
     finally:
         sys.path.remove(str(root))
         for module_name in list(sys.modules):
-            if module_name == "agentmem_ref" or module_name.startswith("agentmem_ref."):
+            if _is_agentmem_module(module_name):
                 sys.modules.pop(module_name, None)
+        sys.modules.update(preserved)
 
 
 def main() -> None:

--- a/reference/tests/test_dashclaw_cloudflare_packaging.py
+++ b/reference/tests/test_dashclaw_cloudflare_packaging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -38,6 +39,58 @@ class DashClawCloudflarePackagingTests(unittest.TestCase):
             prepare._import_check(root)
 
         self.assertEqual(prepared_manifest, manifest)
+
+    def test_import_check_leaves_canonical_modules_as_it_found_them(self) -> None:
+        """Regression: the prepared copies must not evict the canonical package.
+
+        `_import_check` previously purged every `agentmem_ref` module from
+        `sys.modules` without restoring it. Because this test sorts before
+        `test_temporal_trust`, a later `mock.patch("agentmem_ref.temporal_trust.
+        public_key_digest")` re-imported a fresh module and patched that, while
+        the already-bound `evaluate_attestation_trust` still closed over the old
+        module's globals -- so the real digest ran against a dummy key and five
+        cases failed with `public_key must be Ed25519PublicKey`.
+
+        Module *identity* is the invariant, not merely presence.
+        """
+        import agentmem_ref.temporal_trust as canonical_trust
+        import agentmem_ref.policy as canonical_policy
+
+        prepare = _load_prepare_module()
+        before = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == "agentmem_ref" or name.startswith("agentmem_ref.")
+        }
+
+        with tempfile.TemporaryDirectory(prefix="dashclaw-cf-restore-") as temp:
+            root = Path(temp)
+            prepare._write_package(root / "agentmem_ref")
+            prepare._import_check(root)
+
+        for name, module in before.items():
+            self.assertIn(name, sys.modules, f"{name} was evicted by _import_check")
+            self.assertIs(sys.modules[name], module, f"{name} identity changed")
+
+        self.assertIs(sys.modules["agentmem_ref.temporal_trust"], canonical_trust)
+        self.assertIs(sys.modules["agentmem_ref.policy"], canonical_policy)
+        self.assertNotIn(str(root), sys.path)
+
+    def test_patching_still_works_after_import_check(self) -> None:
+        """The end-to-end shape of the failure, without depending on test order."""
+        from unittest.mock import patch
+
+        import agentmem_ref.temporal_trust as trust
+
+        prepare = _load_prepare_module()
+        with tempfile.TemporaryDirectory(prefix="dashclaw-cf-patch-") as temp:
+            root = Path(temp)
+            prepare._write_package(root / "agentmem_ref")
+            prepare._import_check(root)
+
+        sentinel = "sha256:" + "ab" * 32
+        with patch("agentmem_ref.temporal_trust.public_key_digest", return_value=sentinel):
+            self.assertEqual(trust.public_key_digest(object()), sentinel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the five `test_temporal_trust` failures seen in the broad validate lane during #372. **Causality established, not assumed.**

## Root cause

`examples/cloudflare-dashclaw-provider/prepare.py` `_import_check` purged every `agentmem_ref` module from `sys.modules` without restoring them. `test_dashclaw_cloudflare_packaging` sorts before `test_temporal_trust`, so afterwards `mock.patch("agentmem_ref.temporal_trust.public_key_digest")` re-imported a fresh module and patched *that*, while the already-bound `evaluate_attestation_trust` still closed over the original module's globals. The real digest then ran against the test's dummy key.

The dedicated DashClaw lane stayed green because it never runs both modules in one process.

## Evidence

| | Result |
|---|---|
| `tests.test_temporal_trust` alone | 6 OK |
| `test_dashclaw_cloudflare_packaging` + `test_temporal_trust` | **5 errors** |
| Workflow history | `a22e330` (immediately prior) **success**; `d11b4d5`, `2bc56b8` (both #372) **failure** |
| cryptography 50.0.0 in isolation | temporal_trust **passes** — not a dependency issue |
| #372 file list | touches no temporal-trust file and no dependency pin |

## Fix

Snapshot loaded `agentmem_ref` modules before the check; restore after. Prepared copies are still evicted so they cannot shadow the canonical package.

## Not touched

No DashClaw contract semantics. PAMA, authority resolution, governed commit, provider projection, memory mutation, approval binding, state snapshots, evidence/receipts all unchanged. Canonical source digests identical — verified by `prepare.py --check`.

## Tests

Both regression tests verified to **fail against the unfixed `prepare.py`** (`AssertionError: 'agentmem_ref.policy' not found`). One asserts module *identity*, not mere presence — presence alone would not have caught this.

Full suite **951 tests, 0 failures, 19 skipped** (was 949 with 5 errors). DashClaw modules **28 OK**. 58 schemas, 64 fixtures validate.