### PR TITLE
ADR-037 step 1: park refused proposals with their remediation route

### DIFF
--- a/docs/FEATURE_INDEX.md
+++ b/docs/FEATURE_INDEX.md
@@ -7,8 +7,8 @@ Single canonical cross-reference of every user-touchable feature in Agent Memory
 
 ## Coverage Summary
 
-- Total entries: **11**
-- **Verified**: 11
+- Total entries: **12**
+- **Verified**: 12
 - **Unverified**: 0
 - **N/A (operator-justified)**: 0
 
@@ -29,6 +29,7 @@ Single canonical cross-reference of every user-touchable feature in Agent Memory
 | FX009 | Review discharge derives self-approval from identity and records what the discharge rested on (now produces `verified`, Loop 7) | `reference/agentmem_ref/policy.py` `_apply_modifiers`, `evaluate_with_base_outcome`; `Decision.review_discharge` | `docs/plan-sprint2d-derived-authority.md` LD1-LD4 | `reference/tests/test_derived_authority.py` | verified | api | GAP-ARCH-04 self-approval leg only -- gap remains OPEN. Generalizes `decision_overwrite.py:171` and `enforcement_evidence.py:61-80`. Reaches `crossing.py` via `policy.evaluate` |
 | FX010 | Reusable grant evaluation verifies against an independently-held ratification record | `reference/agentmem_ref/reusable_grants.py` `RatificationRegistry`, `grant_body_digest`, `evaluate_reusable_grant` | `docs/plan-sprint2e-ratification-anchor.md` LD1-LD5 | `reference/tests/test_ratification_anchor.py` | verified | api | GAP-SEC-04 grant path. Implements the operator's option-C decision; option D retained as a labelled profile. Defeats the recompute attack that beat a digest-only fix. No schema modified |
 | FX011 | External verification is dischargeable only through a proposal-bound attestation, never by assertion | `reference/agentmem_ref/policy.py` `ExternalVerification`, `evaluate_with_external_verification`, `_apply_review` cap; `decision_overwrite.py`; `structural_mutation.py`; `adapter.py` `governed_delete` | `docs/33-pama-decision-table.md` "Discharging a decision"; `docs/plan-sprint2f-verified-discharge.md` | `reference/tests/test_verified_discharge.py` | verified | api | GAP-ARCH-04 external-verification leg. Attestation is caller-constructed and therefore forgeable; unforgeability is open work |
+| FX012 | A refused proposal is parked with its decision, its remediation route, and its correlation identity, emitting schema-valid evidence | `reference/agentmem_ref/pending_verification.py` `ParkedProposal`, `PendingVerificationRegistry.park` | `docs/adr/ADR-037-fail-closed-review-requires-a-remediation-path.md` sections 3 and 5; `docs/plan-sprint2g-parked-verification.md` LD1-LD7 | `reference/tests/test_pending_verification.py` | verified | api | ADR-037 **step 1 of 4**. 20 tests. Parks only `require_review` and `require_external_verification`; refuses `allow` (nothing was refused) and `block` (its envelope names `enter_pending_verification` as prohibited, so the record could never resume). Retains the whole `Proposal` so step 3 can re-evaluate and apply the staleness guard. No `resume` method exists. Steps 2-4 not built; `_apply_review` untouched |
 
 ---
 

--- a/docs/GOVERNANCE_INDEX.md
+++ b/docs/GOVERNANCE_INDEX.md
@@ -82,6 +82,8 @@ Live for plan duration; archived at substantiate. Drift signal: plan shipped but
 | Sprint 2e research brief | `docs/research-brief-sprint2e-ratification-anchor-2026-09-04.md` | sprint2e-ratification-anchor |
 | Sprint 2f plan | `docs/plan-sprint2f-verified-discharge.md` | sprint2f-verified-discharge |
 | Sprint 2f research brief | `docs/research-brief-sprint2f-verified-discharge-2026-09-04.md` | sprint2f-verified-discharge |
+| Sprint 2g plan | `docs/plan-sprint2g-parked-verification.md` | sprint2g-parked-verification |
+| Sprint 2g research brief | `docs/research-brief-sprint2g-parked-verification-2026-09-04.md` | sprint2g-parked-verification |
 
 ## Tier 5 — Reference Material
 

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -801,3 +801,99 @@ gains the installable-distribution path Sprint 1 delivered but never documented.
 
 Review Boundary: staged, not committed. Prior work is committed at `fe7724e` and
 `97721dc`.
+---
+
+### Entry #18: SESSION SEAL - Phase 9 (Sprint 2g parked verification)
+
+**Entry ID**: `3961f7d97ed9`
+**Content Hash**: `f67fd881819b614be4ecbb8ecbac7815c6849cc581ac87315bc4072c4ef033de`
+**Previous Hash**: `2fd54bae86d94ca781390dadbeed36954306c40cb803bbaf4253858694d12929`
+**Chain Hash**: `07bde207e78cc97268e85c782f55d407fc30030349d190132224a9a656230a58`
+**Timestamp**: 2026-09-04T23:59:00-04:00
+**Phase**: SUBSTANTIATE
+**Author**: Judge
+**Risk Grade**: L2
+**Verdict**: PASS
+**Session**: 2026-09-04T2347-39681d
+**Plan**: docs/plan-sprint2g-parked-verification.md (iteration 4)
+**SSDF Practices**: PO.1.4, PS.2.1, PW.1.1, PW.7.2
+
+**Merkle Seal** (SHA256 over `git write-tree` of the staged index 2f7f6177dea169708ed15365f27c86fb46e32cbd):
+`e3cecc621ff23efb0120b202d7ec0a39cd74d8cd54867a70ba09e2196a80aa8a`
+
+**Scope**: ADR-037 implementation **step 1 of 4**, and only step 1. The operator
+fixed a rigid order -- parked state, then evidence qualification, then governed
+resumption, then fail-closed conversion of the 51 caller sites -- and directed
+that the gate not flip before the first three exist. Steps 2-4 are not built.
+`policy._apply_review` is unmodified, verified by empty diff. Assertion still
+discharges `require_review` after this cycle, deliberately.
+
+**Reality = Promise**: two new files, four documentation updates, no existing
+module modified, no schema modified. No UNPLANNED changes.
+
+**Definition of Done**: 11 of 11 PASS.
+| # | Item | Result |
+|---|---|---|
+| 1 | Park records the `Proposal`, decision, correlation, `parked_at`, `policy_version` | PASS |
+| 1b | Retained proposal re-evaluates to the recorded decision | PASS -- `policy.evaluate(record.proposal) == record.decision` |
+| 1c | `state_snapshot` rides along for the staleness guard | PASS |
+| 2 | `permitted_actions` equals the decision's, per outcome | PASS -- asserted by equality, never a literal |
+| 3 | One schema-valid event; modeled fields top-level | PASS -- absence from `payload` asserted |
+| 4 | Duplicate park raises; first record intact | PASS |
+| 5 | `allow` and `allow_with_ledger` refused | PASS |
+| 6 | `require_external_verification` parks with its own route | PASS |
+| 7 | `block` refused | PASS -- prohibition asserted from the decision |
+| 8/9 | No method discharges or permits; `resume` absent, not stubbed | PASS |
+| 10 | Full suite; `_apply_review` unmodified | PASS -- 971 pass / 0 fail / 7 skip; `policy.py` diff empty |
+| 11 | Validators clean, no schema modified | PASS -- 58 schemas, 64 fixtures, exit 0 |
+
+**Test count**: 951 -> 971 (+20). Run under the pinned `cryptography==50.0.1` the
+repository declares, not the ambient interpreter's 48.0.0.
+
+**Negative control**: five mutations, each caught, control restored green --
+park accepting `block`; the route hardcoded to `enter_pending_verification`;
+a `resume` stub raising `NotImplementedError`; `correlation_id` demoted into
+`payload`; duplicate park overwriting instead of raising.
+
+**Decision**: audit VETOed twice, on four grounds, and every one was a design
+correction rather than wording.
+
+*V1* -- the planned record held identity fields only (`proposal_id`, `actor_id`,
+`target_reference`, `operation`, `risk_class`). `policy.evaluate` takes a
+`Proposal` of 28 fields, and the floors and modifiers read `target_class`,
+`downstream_authority`, `reversibility`, `evidence_refs`, and the isolation-domain
+fields. Step 3 could not have re-evaluated from that summary, so it would have had
+to reshape the record -- the exact cost this cycle existed to avoid. The record now
+retains the `Proposal`.
+
+*V2* -- the plan parked `block` and treated its empty `permitted_actions` as a
+feature. `_envelope` names `enter_pending_verification` in the **prohibited** set
+for `block`. Parking one contradicts the envelope being recorded and produces a
+record no evidence can ever discharge: permanent parked residue charged against
+retention. `block` is now refused, on the same footing as `allow` but for the
+opposite reason -- `allow` had no refusal to record, `block` has no route out.
+
+*V3* -- staleness had no anchor. Fixed by V1: `state_snapshot` is a `Proposal`
+field, so it is recorded as a reason rather than acquired by luck.
+
+*V4* -- DoD 2 and DoD 6 could not both be satisfied. Measured: `require_review`
+permits `enter_pending_verification`; `require_external_verification` permits
+`request_external_verification` instead. The danger was not the failing test but
+the fix an implementer reaches for -- hardcoding the review route to make DoD 2
+pass, which is the caller-asserted-input defect this program has now found four
+times. The envelope has three states, not two: permitted, unlisted, prohibited.
+
+**Audit conditions on the PASS**: C1, modeled event fields (`correlation_id`,
+`policy_version`, `state_snapshot`) take their modeled top-level home rather than
+`payload` -- legal either way, but a modeled field buried in `payload` is invisible
+to any consumer joining on it. C2, parked records have no eviction path in this
+cycle and retention belongs to #363, recorded as a deferral rather than left to be
+discovered. Both satisfied.
+
+**Known limitation, disclosed**: `decision_overwrite._event` places
+`state_snapshot` inside `payload`, the placement C1 rules against. It is
+pre-existing, out of this cycle's scope, and named here so it is not later read as
+precedent.
+
+Audit: VETO, VETO, PASS -- attempts 1-3 of 5. Grounds V1-V4 closed and recorded.
+Review Boundary: staged, not committed.

--- a/docs/SYSTEM_STATE.md
+++ b/docs/SYSTEM_STATE.md
@@ -4,13 +4,13 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Last Updated** | 2026-09-02T01:30:00-04:00 |
+| **Last Updated** | 2026-09-04T23:59:00-04:00 |
 | **Updated By** | Judge |
-| **Phase** | SUBSTANTIATED (Sprint 1 install correctness) |
-| **Iteration** | 1 |
-| **Session Seal** | Entry #8 (session 2026-09-02T0158-2a109f) |
+| **Phase** | SUBSTANTIATED (Sprint 2g parked verification, ADR-037 step 1 of 4) |
+| **Iteration** | 8 |
+| **Session Seal** | Entry #18 (session 2026-09-04T2347-39681d) |
 
-Snapshot refreshed at the Sprint 1 seal. Genesis values came from the `/qor-deep-audit` reconnaissance (see `docs/RESEARCH_BRIEF.md`); Sprint 1 deltas are measured from the sealed tree.
+Snapshot refreshed at the Sprint 2g seal (Loop 8). Genesis values came from the `/qor-deep-audit` reconnaissance (see `docs/RESEARCH_BRIEF.md`); deltas through Loops 2-8 are measured from the sealed tree, with the suite run under the pinned `cryptography==50.0.1` the repo declares -- not the ambient interpreter.
 
 ---
 
@@ -34,7 +34,7 @@ agent-memory/
 |   |-- run_*.py               68 evidence emitters
 |   |-- native/                1 Rust driver
 |   |-- policies/, fixtures/ (15 JSON), testdata/
-|   `-- tests/                 113 test files, 861 tests
+|   `-- tests/                 129 test files, 971 tests
 |-- integrations/
 |   |-- agent-memory-runtime/  JS, 1 source + 1 test, private
 |   `-- hermes-agent-memory/   Python, 10 modules, 6 tests
@@ -51,7 +51,7 @@ agent-memory/
 | Metric | Value |
 |--------|-------|
 | Total Source Files | 121 (`reference/agentmem_ref`) + 68 emitters + 12 scripts + 11 integration modules |
-| Total Test Files | 113 (`reference/tests`) + 6 (hermes) + 1 (JS) |
+| Total Test Files | 129 (`reference/tests`) + 6 (hermes) + 1 (JS) |
 | Total Lines of Code | 60,376 under `reference/` |
 | Average File Size | ~300 lines (`agentmem_ref`) |
 | Max File Size | 733 lines (file: `reference/agentmem_ref/runtime_config.py`) |
@@ -119,7 +119,7 @@ Pre-existing at genesis. Any new file under `/qor-plan` must meet the razor.
 
 | Component | Test File | Exists | Passing |
 |-----------|-----------|--------|---------|
-| Reference runtime (all) | `reference/tests/` (113 files) | OK | 851 pass / 3 fail / 7 skip locally; CI green on `main` |
+| Reference runtime (all) | `reference/tests/` (129 files) | OK | 971 pass / 0 fail / 7 skip under pinned `cryptography==50.0.1`; CI green on `main` |
 | Cedar digest pin | `reference/tests/test_cedar_policy_comparator.py:71` | OK | FAIL on Windows checkouts (GAP-RT-02) |
 | Third-party version pins | `test_agent_manifest_correlation.py:151`, `test_trace_action_evidence.py:118` | OK | FAIL unless env matches requirements (GAP-RT-03) |
 | Graphiti substrate | `reference/tests/test_graphiti_substrate.py` | OK | SKIPPED (7) without graphiti/kuzu (GAP-RT-07) |
@@ -156,7 +156,7 @@ Sprint 1 install correctness (branch `feat/agent-memory-genesis`, staged, uncomm
 | Merkle Chain | VALID | Entries #1-#8; Entry #6 hashes recomputed once for a verdict-line format fix (recorded in-entry) |
 | Blueprint Sync | SYNCED | File tree and Dependencies table updated at Sprint 1 |
 | Section 4 Compliance | VIOLATIONS (pre-existing) | New code clean; 58 file + 175 function pre-existing overages (GAP-RT-04, Sprint 11) |
-| Test Status | PASS | 868 run, 0 fail, 9 skipped locally (7 Graphiti absent, 2 pin tests by design); fresh-venv wheel smoke exit 0 |
+| Test Status | PASS | 971 run, 0 fail, 7 skipped (Graphiti/kuzu absent) under the pinned `cryptography==50.0.1`; fresh-venv wheel smoke exit 0 |
 
 ---
 

--- a/docs/adr/ADR-037-fail-closed-review-requires-a-remediation-path.md
+++ b/docs/adr/ADR-037-fail-closed-review-requires-a-remediation-path.md
@@ -147,10 +147,17 @@ The principal still needs qualifying evidence and valid scope/risk authority. Re
 
 The gate does not close until the first three exist. This ordering is part of the decision.
 
-1. **Parked proposal state** — `enter_pending_verification` as a real, resumable, evidence-emitting outcome.
-2. **Evidence qualification and dependence lineage** — R2 and R3 made computable, including dependence-group collapse.
+1. **Parked proposal state** — `enter_pending_verification` as a real, resumable, evidence-emitting outcome. **DONE** (Loop 8, ledger entry #18): `reference/agentmem_ref/pending_verification.py`.
+2. **Evidence qualification and dependence lineage** — R2 and R3 made computable, including dependence-group collapse. *Next.*
 3. **Governed resumption and re-evaluation** — evaluator-owned, policy re-evaluated from scratch, staleness applied.
 4. **Fail-closed `require_review`** — convert the 51 caller sites.
+
+**What step 1 settled, so steps 2–3 do not re-litigate it.** Two questions surfaced in audit and were decided:
+
+- **Which outcomes park.** Only `require_review` and `require_external_verification` — refusals that granted a route. `allow`/`allow_with_ledger` are refused because nothing was refused; `block` is refused because `_envelope` names `enter_pending_verification` in its *prohibited* set, so parking one would contradict the recorded envelope and create a record no evidence could ever discharge.
+- **What the record retains.** The whole `Proposal`, not an identity summary. Step 3 must re-evaluate from scratch and `policy.evaluate` takes a `Proposal`; retaining it is also what carries `state_snapshot` forward so the staleness guard can be applied at resumption. The record shape is therefore fixed and step 3 does not reshape it.
+
+The registry has **no** `resume` method — not a stub, not one raising. Step 3 adds it, and step 3 is gated on step 2.
 
 Do not flip the gate before 1–3 exist. A control whose remediation path does not yet work is a halt, and the pressure it creates becomes a workaround that outlives it.
 

--- a/docs/plan-sprint2g-parked-verification.md
+++ b/docs/plan-sprint2g-parked-verification.md
@@ -1,0 +1,132 @@
+# Plan: Sprint 2g — parked verification state
+
+**change_class**: feature
+**Risk Grade**: L2
+**Session**: 2026-09-04T2347-39681d
+**Research**: `docs/research-brief-sprint2g-parked-verification-2026-09-04.md`
+**Iteration**: 4 (audit attempt 3: PASS with binding conditions C1, C2)
+**Implements**: ADR-037 implementation order, **step 1 of 4**
+
+## Objective
+
+Make `enter_pending_verification` a real, recorded, evidence-emitting outcome, so a proposal that cannot discharge has somewhere to go instead of failing silently.
+
+## Boundaries
+
+**In scope**: a new `reference/agentmem_ref/pending_verification.py`, and its tests.
+
+**Explicitly out of scope — the ordering is the decision, per ADR-037:**
+
+| Step | Status here |
+|---|---|
+| 2. Evidence qualification and dependence lineage | **not built.** No dependence-group logic, no evidential-class ranking |
+| 3. Governed resumption | **not built.** Nothing in this cycle discharges a parked proposal |
+| 4. Fail-closed `require_review` | **not built.** `_apply_review` untouched; assertion still discharges after this cycle, by design |
+
+The temptation is to add resumption while the lifecycle is in hand. A half-built resumption is worse than none, because it would let a proposal leave the parked state without the qualification machinery that decides whether it should.
+
+## Design decisions
+
+**LD1 — A new module, not the adapter.**
+`PendingVerificationRegistry` lives in its own module, following the `DurableDecisionRegistry` precedent. Putting it on `GovernedMemoryAdapter` would widen a surface that #362 is going to re-shape, and would make every adapter consumer carry it before anything uses it.
+
+**LD2 — Park refuses duplicates rather than overwriting.**
+`park()` raises on a `proposal_id` already parked. Append-oriented, matching both `DurableDecisionRegistry.propose` and Loop 6's `RatificationRegistry`. A silent overwrite would let a second attempt erase the evidence of the first — the failure shape Loop 4's falsified tombstone had.
+
+**LD3 — Parking emits a schema-valid audit event, using the schema's modeled fields (audit C1).**
+`memory.pending_verification`, validated against `memory-audit-event.schema.json`. Legal because `event_type` is an open string.
+
+The schema models `correlation_id`, `policy_version`, `state_snapshot`, `actor`, and `component` as **top-level properties**, so those go top-level. Only detail the schema does not model goes under `payload` (`proposal_id`, `outcome`, `reasons`, `permitted_actions`, `parked_at`) — the placement Loop 3 established for `memory.recall`.
+
+Putting a modeled field in `payload` is schema-legal and wrong: it is invisible to any consumer joining on the modeled field, which defeats the reason DoD 1 records `correlation_id` at all.
+
+**Retention (audit C2).** Parked records now hold full `Proposal` objects, which carry `tenant_ref`, `purpose`, `actor_id`, and `project_ref`. There is **no eviction path in this cycle**; retention and eviction belong to #363 (production state). This is a recorded deferral, not an oversight — the larger surface is the price of step 3 being able to re-evaluate at all.
+
+**LD4 — The record retains the `Proposal` itself, not a summary of it (audit V1).**
+
+Iteration 1 recorded identity fields only. That cannot support step 3. `policy.evaluate` takes a `Proposal`, and ADR-037 §5 requires resumption to re-evaluate policy from scratch — `target_class` and `downstream_authority` drive `_apply_floors`; `reversibility`, `evidence_refs`, and the isolation-domain fields drive `_apply_modifiers`. None is recoverable from an identity summary, so step 3 would have had to reshape this record, which is the cost this cycle exists to avoid.
+
+The record therefore holds: the `Proposal`, the `Decision`, `correlation_id`, `parked_at`, and `policy_version`.
+
+**This also anchors staleness (audit V3).** `state_snapshot` is a `Proposal` field, so retaining the proposal is what lets resumption apply the entry-#14 staleness guard and detect that the world moved while the proposal sat parked. That is the specific risk parking introduces, since parking is by definition a delay. Recorded here as a reason rather than acquired by luck.
+
+It also records `permitted_actions` **copied from the decision, never restated** (audit V4). The route differs by outcome, and hardcoding one would reintroduce the caller-asserted-input defect this program has found four times.
+
+**LD5 — No schema for the record itself.**
+The parked record is an internal dataclass. Adding a schema is a public contract addition belonging to Sprint 4's boundary freeze (#362). The *evidence* is schema-valid; the *type* is not frozen. This mirrors Loop 3 adding defaulted fields to `AdmissionResult` rather than schema-backing it.
+
+**LD6 — A parked proposal carries no authority, and the type must make that hard to misread.**
+ADR-037 §5. The registry exposes no method that returns a permission, discharges a decision, or mutates the parked decision. `resume` does not exist in this cycle — not as a stub, not as `NotImplementedError`. A stub is an invitation; its absence is a statement.
+
+**LD7 — Park only outcomes that have a remediation route: refuse both `allow` and `block` (audit V2).**
+
+`park()` raises for `allow`, `allow_with_ledger`, **and `block`**.
+
+Refusing `allow` is straightforward: parking a permitted proposal manufactures a governance record for an event that did not occur — the defect class of Loop 4's D5, where deleting a nonexistent fact still wrote a tombstone.
+
+Refusing `block` is the correction. `_envelope` (`policy.py:290`) returns empty permitted actions for `block` **and explicitly prohibits `enter_pending_verification`**. The policy states a blocked proposal may not enter pending verification, so parking one contradicts the very envelope the record would be preserving. It would also create a record that can never leave the parked state — no evidence discharges an absorbing `block` — producing permanent residue charged against retention (#363) for a proposal policy said may not park.
+
+**The envelope has three states, not two (audit V4).** Measured across all five outcomes:
+
+| Outcome | `permitted_actions` | `enter_pending_verification` | Parks? |
+|---|---|---|---|
+| `allow` / `allow_with_ledger` | `(operation, 'collect_more_evidence', 'defer')` | unlisted | **no** — nothing was refused |
+| `require_review` | `('enter_pending_verification', 'collect_more_evidence', 'defer')` | **permitted** | **yes** — the envelope authorizes parking by name |
+| `require_external_verification` | `('request_external_verification', 'collect_more_evidence', 'defer')` | unlisted | **yes** — refused with a route, but the route is `request_external_verification` |
+| `block` | `()` | **prohibited** | **no** — the envelope forbids it by name |
+
+Parking is for refusals **with** a route, and the record carries whichever route the decision actually granted. `block` is the only outcome whose envelope names `enter_pending_verification` as prohibited, which is what makes refusing it a contradiction rather than a preference.
+
+## Affected files
+
+| File | Change |
+|---|---|
+| `reference/agentmem_ref/pending_verification.py` | **new** — `ParkedProposal`, `PendingVerificationRegistry` |
+| `reference/tests/test_pending_verification.py` | **new** |
+
+No existing file is modified. Nothing calls this yet, by design.
+
+## Feature Inventory Touches
+
+| ID | Feature | Disposition |
+|---|---|---|
+| FX012 | A refused proposal can be parked with its decision, unmet criteria, and remediation routes, emitting schema-valid evidence | NEW |
+
+## Definition of Done
+
+1. Parking a `require_review` decision records the **`Proposal` itself**, the decision, `correlation_id`, `parked_at`, and `policy_version`, and returns the parked record.
+1b. **The retained proposal is sufficient to re-evaluate**: `policy.evaluate(record.proposal)` reproduces the recorded decision exactly. Asserted directly, because this is what step 3 depends on and an identity-summary record would fail it (audit V1).
+1c. The retained proposal carries `state_snapshot`, so resumption can apply the staleness guard (audit V3).
+2. **The record's `permitted_actions` equals the decision's, per outcome** — asserted by equality against `decision.permitted_actions`, never against a literal (audit V4):
+   - `require_review` → `('enter_pending_verification', 'collect_more_evidence', 'defer')`
+   - `require_external_verification` → `('request_external_verification', 'collect_more_evidence', 'defer')`
+   Asserting a fixed tuple for both is the failure this DoD exists to prevent.
+3. Parking emits exactly one event per park; it validates against `memory-audit-event.schema.json`; `event_type` is `memory.pending_verification`. **`correlation_id`, `policy_version`, and `state_snapshot` are top-level; unmodeled detail is under `payload`** (audit C1). Asserted by reading the top-level keys, so a regression into `payload` fails.
+4. Parking the same `proposal_id` twice raises, and the first record is unchanged.
+5. Parking an `allow_with_ledger` or `allow` decision raises — a permitted proposal cannot be parked (LD7).
+6. `require_external_verification` parks as well as `require_review`; both are refusals with routes, and the parked record shows the *different* route each was granted (DoD 2).
+7. **Parking a `block` decision raises.** `_envelope` prohibits `enter_pending_verification` for `block`, so parking one would contradict the recorded envelope and create a record that can never resume (audit V2). Asserted with the prohibition quoted, so the reason survives the test.
+8. **The registry exposes no method that discharges, resumes, or returns a permission.** Asserted over the public surface, so step 3 cannot arrive by accident (LD6).
+9. `resume` is absent from the public surface — not present-and-raising (LD6).
+10. **All 951 prior tests pass**, and `_apply_review` is unmodified — verified by diff, since step 4 is explicitly not in this cycle.
+11. `validate_schemas.py` and `validate_fixtures.py fixtures` clean; no schema file modified.
+
+## CI Commands
+
+```
+python -m unittest discover -s reference/tests -t reference
+python scripts/validate_schemas.py
+python scripts/validate_fixtures.py fixtures
+```
+
+## CI Coverage Exemptions
+
+No workflow path filter covers a new unreferenced module, so no evidence lane is triggered by it specifically. DoD 10 runs the full suite, which is the coverage that matters for a module nothing calls yet.
+
+## Rollback
+
+Delete both new files. Nothing else changes.
+
+## Next
+
+`/qor-implement`. Audit attempt 3 returned PASS with binding conditions C1 (modeled event fields top-level) and C2 (retention deferral recorded), both folded into LD3 above and DoD 3. Attempts 1 and 2 vetoed on V1-V4; all four are discharged in this iteration.

--- a/docs/research-brief-sprint2g-parked-verification-2026-09-04.md
+++ b/docs/research-brief-sprint2g-parked-verification-2026-09-04.md
@@ -1,0 +1,76 @@
+# Research Brief: Sprint 2g — parked verification state
+
+**Date**: 2026-09-04
+**Analyst**: The Qor-logic Analyst
+**Program**: ADR-035 build-toward, research-led `/qor-enterprise-auto-dev`. Loop 8.
+**Implements**: ADR-037 implementation order **step 1 of 4**, and only step 1.
+
+## 1. Scope, stated first because the order is part of the decision
+
+ADR-037 fixes a rigid order: parked state → evidence qualification and dependence lineage → governed resumption → fail-closed conversion of the 51 callers. **This cycle builds step 1 only.**
+
+Explicitly out of scope, and not to be smuggled in because they are adjacent:
+
+- **Evidence qualification** (R2/R3, step 2). No dependence-group logic, no evidential-class ranking.
+- **Resumption** (step 3). Nothing in this cycle may resume a parked proposal. The parked record is written and read; it is not discharged.
+- **Fail-closed conversion** (step 4). `_apply_review` is untouched. Assertion still discharges `require_review` after this cycle, by design.
+
+The temptation is to build resumption while the lifecycle is in hand. ADR-037's ordering exists because a half-built resumption is worse than none: it would let a proposal leave the parked state without the qualification machinery that decides whether it should.
+
+## 2. What exists to generalize
+
+`decision_overwrite.DurableDecisionRegistry` carries the whole lifecycle already (`:127-141`):
+
+```python
+def propose(self, proposal: OverwriteProposal) -> OverwriteResult:
+    if proposal.proposal_id in self._proposals:
+        raise ValueError(f"overwrite proposal already exists: {proposal.proposal_id}")
+    self._validate_proposal_shape(proposal)
+    event = self._event("memory.decision_overwrite_proposed", proposal, self._now(), status=PENDING)
+    result = OverwriteResult(proposal=proposal, status=PENDING, events=[event])
+    self._proposals[proposal.proposal_id] = result
+    self.events.append(event)
+    return result
+```
+
+Four properties worth carrying over exactly:
+
+1. **Duplicate proposal ids are refused**, not overwritten — parking is append-oriented like the ratification registry.
+2. **Parking emits an event.** It is a governed outcome with evidence, not a silent failure return.
+3. **The record holds the decision**, so a later reader knows what was refused and why, without re-deriving it.
+4. **Status is explicit** and gates the later transition (`commit` refuses anything not `PENDING`).
+
+This is the fifth control this program has found implemented in one module and absent from the shared evaluator, after derived self-approval, verified/unverified provenance, the ratification registry, and the version-derivation constant.
+
+## 3. What the parked record must carry
+
+From ADR-037 §3: the decision, its unmet criteria, and its correlation identity.
+
+- `proposal_id`, `actor_id`, `target_reference`, `operation`, `risk_class` — identity of what was refused
+- the `Decision` — `outcome`, `reasons`, `permitted_actions`, `review_discharge`
+- `correlation_id` — so the parked record joins the same evidence chain as the attempt
+- `parked_at`, `policy_version` — when, and under what policy
+
+**`permitted_actions` is the remediation route, and it already exists.** `_envelope` returns `("enter_pending_verification", "collect_more_evidence", "defer")` for `REQUIRE_REVIEW`. Recording it on the parked record means the actor is told what it may do, from the same structure that decided it may not proceed.
+
+## 4. Contract-surface findings
+
+**The audit event needs no schema change.** `memory-audit-event.schema.json` constrains `event_type` only as `{"type": "string"}`, so `memory.pending_verification` is legal. It sets `additionalProperties: False`, so the record detail goes under `payload` (`additionalProperties: true`) — the same placement Loop 3 established for `memory.recall`. Existing event types follow a `memory.<verb>` convention, including three from the decision-overwrite lifecycle.
+
+**The parked record itself must not get a schema this cycle.** Adding one is a public contract addition, which belongs to Sprint 4's boundary freeze (#362). The record stays an internal dataclass; the *evidence* it emits is schema-valid. This mirrors Loop 3's decision to add defaulted fields to `AdmissionResult` rather than schema-back it.
+
+**A new module, not the adapter.** `PendingVerificationRegistry` in its own module follows the `DurableDecisionRegistry` precedent and avoids widening `GovernedMemoryAdapter`, which #362 will re-shape.
+
+## 5. Blast radius: near zero, deliberately
+
+Nothing calls the parked state yet. It is opt-in until step 4 flips the gate. So this cycle adds a module and its tests and changes no existing caller — which is what makes it a safe first step and why the order puts it first.
+
+`_apply_review` is not touched, so the 51 assertion sites keep working unchanged.
+
+## 6. Risk grade
+
+**L2.** New isolated module, no existing caller, no schema change, no policy path modified. It is not L1 because the record shape it establishes is what steps 2–4 build on, and a wrong shape here is expensive later.
+
+## 7. Next
+
+`/qor-plan`.

--- a/reference/agentmem_ref/pending_verification.py
+++ b/reference/agentmem_ref/pending_verification.py
@@ -1,0 +1,202 @@
+"""Parked verification state: ADR-037 implementation, step 1 of 4.
+
+A proposal that policy refuses is not, today, recorded anywhere. The refusal
+returns and the attempt evaporates. ADR-037 holds that fail-closed cannot mean
+a dead end under full automation -- a refusal must leave behind a record that
+names what was refused, why, and which route out remains open.
+
+This module builds that record and nothing else.
+
+What it deliberately does NOT do, because ADR-037 fixes the order:
+
+  step 2  evidence qualification and dependence lineage -- not here
+  step 3  governed resumption -- **nothing in this module discharges a park**
+  step 4  fail-closed ``require_review`` -- ``policy._apply_review`` is untouched
+
+There is no ``resume``. Not as a stub, not raising ``NotImplementedError``.
+A stub is an invitation; its absence is a statement. A parked proposal carries
+no authority, and the type is shaped so that misreading it as authority takes
+deliberate effort rather than a moment's inattention (ADR-037 section 5).
+
+Parking is for refusals **with a route**. The envelope has three states, and
+only the middle band parks::
+
+    allow / allow_with_ledger    nothing was refused                   refuse
+    require_review               enter_pending_verification permitted  park
+    require_external_verificat.  request_external_verification granted park
+    block                        enter_pending_verification PROHIBITED refuse
+
+The two ends are refused for different reasons. Parking a permitted proposal
+would manufacture a governance record for an event that did not occur. Parking
+a blocked one would contradict the envelope being recorded -- ``_envelope``
+names ``enter_pending_verification`` in the *prohibited* set for ``block`` --
+and would create a record that can never leave the parked state, since no
+evidence discharges an absorbing block.
+
+The record retains the whole ``Proposal``, not a summary of it. Step 3 must
+re-evaluate policy from scratch, ``policy.evaluate`` takes a ``Proposal``, and
+the floors and modifiers read fields no identity summary preserves. Retaining
+the proposal is also what carries ``state_snapshot`` forward, so resumption can
+apply the staleness guard -- the specific risk parking introduces, since
+parking is by definition a delay.
+
+Parked records have no eviction path in this cycle. Retention belongs to #363.
+
+Stdlib apart from the canonical schema validation reached through ``receipts``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable
+
+from . import policy, receipts
+
+#: Outcomes that park. Both are refusals that granted a route out.
+PARKABLE = (policy.REQUIRE_REVIEW, policy.REQUIRE_EXTERNAL_VERIFICATION)
+
+#: Refused because nothing was refused -- there is no remediation to record.
+_PERMITTED_OUTCOMES = (policy.ALLOW, policy.ALLOW_WITH_LEDGER)
+
+EVENT_TYPE = "memory.pending_verification"
+COMPONENT = "pending-verification-registry"
+
+
+@dataclass(frozen=True)
+class ParkedProposal:
+    """A refusal preserved with its decision, its route, and its identity.
+
+    Frozen, and it exposes no method. It is evidence of a refusal, not a
+    handle for undoing one. ``decision`` is the refusal verbatim; nothing
+    here restates or narrows it.
+    """
+
+    proposal: policy.Proposal
+    decision: policy.Decision
+    correlation_id: str
+    parked_at: str
+    policy_version: str
+
+    @property
+    def proposal_id(self) -> str:
+        return self.proposal.proposal_id
+
+    @property
+    def permitted_actions(self) -> tuple[str, ...]:
+        """The route out, taken from the decision rather than restated.
+
+        The route differs by outcome -- ``enter_pending_verification`` for
+        ``require_review``, ``request_external_verification`` for
+        ``require_external_verification``. Deriving it from the decision is
+        what keeps this from becoming another caller-asserted input.
+        """
+        return self.decision.permitted_actions
+
+
+class PendingVerificationRegistry:
+    """Records refusals that have somewhere to go. Discharges nothing.
+
+    The public surface is deliberately three methods: ``park``, ``get``, and
+    ``parked``. None returns a permission, mutates a decision, or advances a
+    lifecycle. Adding one that does is step 3's work, and step 3 is gated on
+    step 2 existing.
+    """
+
+    def __init__(self, *, now: Callable[[], datetime] | None = None) -> None:
+        self._parked: dict[str, ParkedProposal] = {}
+        self._now = now or (lambda: datetime.now(timezone.utc))
+        self._event_counter = 0
+        self.events: list[dict] = []
+
+    def park(
+        self,
+        proposal: policy.Proposal,
+        decision: policy.Decision,
+        *,
+        correlation_id: str | None = None,
+    ) -> ParkedProposal:
+        """Record a refusal that granted a route out.
+
+        Raises on a permitted outcome, on ``block``, and on a duplicate
+        ``proposal_id``. Emits exactly one schema-valid audit event.
+        """
+        outcome = decision.outcome
+        if outcome in _PERMITTED_OUTCOMES:
+            raise ValueError(
+                f"refusing to park proposal {proposal.proposal_id!r}: outcome is "
+                f"{outcome!r}, which permitted the operation. Parking a permitted "
+                "proposal would manufacture a governance record for a refusal "
+                "that did not happen."
+            )
+        if outcome == policy.BLOCK:
+            raise ValueError(
+                f"refusing to park proposal {proposal.proposal_id!r}: outcome is "
+                "'block', whose envelope names 'enter_pending_verification' in the "
+                "prohibited set. Parking it would contradict the recorded envelope "
+                "and create a record that can never be resumed, because no evidence "
+                "discharges a block."
+            )
+        if outcome not in PARKABLE:
+            raise ValueError(
+                f"refusing to park proposal {proposal.proposal_id!r}: unrecognised "
+                f"outcome {outcome!r} is not one of {PARKABLE}."
+            )
+        if proposal.proposal_id in self._parked:
+            raise ValueError(
+                f"proposal already parked: {proposal.proposal_id!r}. Parking is "
+                "append-oriented; overwriting would erase the evidence of the "
+                "first refusal."
+            )
+
+        parked_at = self._now().isoformat().replace("+00:00", "Z")
+        record = ParkedProposal(
+            proposal=proposal,
+            decision=decision,
+            correlation_id=correlation_id or proposal.proposal_id,
+            parked_at=parked_at,
+            policy_version=decision.policy_version,
+        )
+        self._parked[proposal.proposal_id] = record
+        self._emit(record)
+        return record
+
+    def get(self, proposal_id: str) -> ParkedProposal | None:
+        """The parked record, or None. Reading does not discharge."""
+        return self._parked.get(proposal_id)
+
+    def parked(self) -> tuple[ParkedProposal, ...]:
+        """Every parked record, in park order."""
+        return tuple(self._parked.values())
+
+    def _emit(self, record: ParkedProposal) -> None:
+        self._event_counter += 1
+        # Fields the audit-event schema models get their modeled home. Burying
+        # correlation_id in payload validates and is still wrong: it is then
+        # invisible to any consumer joining on the modeled field, which is the
+        # entire reason the record carries it.
+        document = {
+            "schema_version": "1.0.0",
+            "event_id": f"pending-verification-event:{self._event_counter}",
+            "event_type": EVENT_TYPE,
+            "event_version": "1.0.0",
+            "timestamp": record.parked_at,
+            "component": COMPONENT,
+            "memory_id": record.proposal.target_reference,
+            "actor": record.proposal.actor_id,
+            "correlation_id": record.correlation_id,
+            "policy_version": record.policy_version,
+            "state_snapshot": record.proposal.state_snapshot,
+            "payload": {
+                "proposal_id": record.proposal_id,
+                "outcome": record.decision.outcome,
+                "reasons": list(record.decision.reasons),
+                "permitted_actions": list(record.decision.permitted_actions),
+                "prohibited_actions": list(record.decision.prohibited_actions),
+                "operation": record.proposal.operation,
+                "risk_class": record.proposal.risk_class,
+                "parked_at": record.parked_at,
+            },
+        }
+        receipts.validate("memory-audit-event.schema.json", document)
+        self.events.append(document)

--- a/reference/tests/test_pending_verification.py
+++ b/reference/tests/test_pending_verification.py
@@ -1,0 +1,360 @@
+"""ADR-037 step 1: a refusal is parked with its route, and nothing more.
+
+These tests are written against the plausible *wrong* implementation as much as
+the intended one. The wrong implementation parks anything that is not an allow,
+hardcodes ``enter_pending_verification`` as "the" remediation route, and grows a
+``resume`` stub because the lifecycle felt incomplete without one. Each of those
+has a test here that fails.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from agentmem_ref import policy, receipts
+from agentmem_ref.pending_verification import (
+    EVENT_TYPE,
+    PARKABLE,
+    ParkedProposal,
+    PendingVerificationRegistry,
+)
+
+_BASE = dict(
+    charter_version="v1",
+    target_class="semantic",
+    scope="project",
+    operation="write",
+    current_strength=0.1,
+    proposed_strength=0.2,
+    downstream_authority=False,
+    evidence_refs=("evidence-1",),
+)
+
+
+def _proposal(proposal_id: str, **overrides) -> policy.Proposal:
+    kwargs = dict(
+        _BASE,
+        proposal_id=proposal_id,
+        actor_id="actor-1",
+        target_reference="memory-1",
+        reversibility="reversible",
+        risk_class="low",
+    )
+    kwargs.update(overrides)
+    return policy.Proposal(**kwargs)
+
+
+def _review_proposal(proposal_id: str = "prop-review", **overrides) -> policy.Proposal:
+    """semantic/write/low/reversible -> require_review (measured, not assumed)."""
+    return _proposal(proposal_id, **overrides)
+
+
+def _external_proposal(proposal_id: str = "prop-external") -> policy.Proposal:
+    """semantic/write/high/irreversible -> require_external_verification."""
+    return _proposal(proposal_id, risk_class="high", reversibility="irreversible")
+
+
+def _fixed_clock():
+    return lambda: datetime(2026, 9, 4, 23, 59, 0, tzinfo=timezone.utc)
+
+
+class ParkedRecordShape(unittest.TestCase):
+    """DoD 1, 1b, 1c -- the record must be able to carry step 3."""
+
+    def test_park_records_the_decision_and_its_identity(self):
+        proposal = _review_proposal()
+        decision = policy.evaluate(proposal)
+        registry = PendingVerificationRegistry(now=_fixed_clock())
+
+        record = registry.park(proposal, decision, correlation_id="corr-1")
+
+        self.assertEqual(record.proposal, proposal)
+        self.assertEqual(record.decision, decision)
+        self.assertEqual(record.correlation_id, "corr-1")
+        self.assertEqual(record.policy_version, decision.policy_version)
+        self.assertEqual(record.parked_at, "2026-09-04T23:59:00Z")
+        self.assertEqual(registry.get("prop-review"), record)
+
+    def test_retained_proposal_is_sufficient_to_re_evaluate(self):
+        """DoD 1b. This is the whole reason the record holds a Proposal.
+
+        An identity-summary record -- proposal_id, actor_id, target_reference,
+        operation, risk_class -- cannot reach ``policy.evaluate`` at all, so
+        step 3 would have had to reshape the record. Asserting re-evaluation
+        here is what stops that from being discovered two cycles later.
+        """
+        proposal = _review_proposal()
+        decision = policy.evaluate(proposal)
+        registry = PendingVerificationRegistry()
+
+        record = registry.park(proposal, decision)
+
+        self.assertEqual(policy.evaluate(record.proposal), record.decision)
+
+    def test_retained_proposal_carries_the_staleness_anchor(self):
+        """DoD 1c. Resumption must be able to tell whether the world moved."""
+        proposal = _review_proposal(state_snapshot="state-v7")
+        registry = PendingVerificationRegistry()
+
+        record = registry.park(proposal, policy.evaluate(proposal))
+
+        self.assertEqual(record.proposal.state_snapshot, "state-v7")
+
+
+class RemediationRouteIsTakenNotRestated(unittest.TestCase):
+    """DoD 2 and 6 -- the route differs by outcome and comes from the decision."""
+
+    def test_review_route_is_enter_pending_verification(self):
+        proposal = _review_proposal()
+        decision = policy.evaluate(proposal)
+        self.assertEqual(decision.outcome, policy.REQUIRE_REVIEW)
+
+        record = PendingVerificationRegistry().park(proposal, decision)
+
+        self.assertEqual(record.permitted_actions, decision.permitted_actions)
+        self.assertEqual(
+            record.permitted_actions,
+            ("enter_pending_verification", "collect_more_evidence", "defer"),
+        )
+
+    def test_external_verification_route_is_a_different_route(self):
+        """The route is ``request_external_verification``, NOT parking's own name.
+
+        An implementation that hardcodes ``enter_pending_verification`` to make
+        the review case pass fails here. That hardcoding is the caller-asserted
+        input defect this program has now found four times.
+        """
+        proposal = _external_proposal()
+        decision = policy.evaluate(proposal)
+        self.assertEqual(decision.outcome, policy.REQUIRE_EXTERNAL_VERIFICATION)
+
+        record = PendingVerificationRegistry().park(proposal, decision)
+
+        self.assertEqual(record.permitted_actions, decision.permitted_actions)
+        self.assertEqual(
+            record.permitted_actions,
+            ("request_external_verification", "collect_more_evidence", "defer"),
+        )
+        self.assertNotIn("enter_pending_verification", record.permitted_actions)
+
+    def test_both_parkable_outcomes_park(self):
+        registry = PendingVerificationRegistry()
+        for proposal in (_review_proposal(), _external_proposal()):
+            decision = policy.evaluate(proposal)
+            self.assertIn(decision.outcome, PARKABLE)
+            registry.park(proposal, decision)
+        self.assertEqual(len(registry.parked()), 2)
+
+
+class ParkingEmitsEvidence(unittest.TestCase):
+    """DoD 3 -- schema-valid, and the modeled fields get their modeled home."""
+
+    def test_exactly_one_schema_valid_event_per_park(self):
+        proposal = _review_proposal()
+        registry = PendingVerificationRegistry(now=_fixed_clock())
+
+        registry.park(proposal, policy.evaluate(proposal), correlation_id="corr-9")
+
+        self.assertEqual(len(registry.events), 1)
+        event = registry.events[0]
+        receipts.validate("memory-audit-event.schema.json", event)
+        self.assertEqual(event["event_type"], EVENT_TYPE)
+        self.assertEqual(event["event_type"], "memory.pending_verification")
+
+    def test_modeled_governance_fields_are_top_level_not_payload(self):
+        """Audit condition C1.
+
+        Putting ``correlation_id`` in ``payload`` validates against the schema
+        and is still wrong: it becomes invisible to any consumer joining on the
+        modeled field, defeating the reason the record carries it. Asserting
+        absence from ``payload`` is what makes a regression fail rather than
+        silently degrade the evidence.
+        """
+        proposal = _review_proposal(state_snapshot="state-v3")
+        registry = PendingVerificationRegistry()
+
+        registry.park(proposal, policy.evaluate(proposal), correlation_id="corr-3")
+        event = registry.events[0]
+
+        self.assertEqual(event["correlation_id"], "corr-3")
+        self.assertEqual(event["policy_version"], policy.evaluate(proposal).policy_version)
+        self.assertEqual(event["state_snapshot"], "state-v3")
+        self.assertEqual(event["actor"], "actor-1")
+        self.assertEqual(event["memory_id"], "memory-1")
+
+        for modeled in ("correlation_id", "policy_version", "state_snapshot", "actor"):
+            self.assertNotIn(modeled, event["payload"], f"{modeled} belongs top-level")
+
+    def test_payload_carries_the_detail_the_schema_does_not_model(self):
+        proposal = _review_proposal()
+        registry = PendingVerificationRegistry()
+        decision = policy.evaluate(proposal)
+
+        registry.park(proposal, decision)
+        payload = registry.events[0]["payload"]
+
+        self.assertEqual(payload["proposal_id"], "prop-review")
+        self.assertEqual(payload["outcome"], policy.REQUIRE_REVIEW)
+        self.assertEqual(payload["permitted_actions"], list(decision.permitted_actions))
+        self.assertEqual(payload["prohibited_actions"], list(decision.prohibited_actions))
+        self.assertIn("parked_at", payload)
+
+    def test_correlation_id_defaults_to_the_proposal_id(self):
+        proposal = _review_proposal()
+        registry = PendingVerificationRegistry()
+
+        record = registry.park(proposal, policy.evaluate(proposal))
+
+        self.assertEqual(record.correlation_id, "prop-review")
+
+
+class ParkRefusals(unittest.TestCase):
+    """DoD 4, 5, 7 -- what must not be parked, and why."""
+
+    def test_duplicate_park_raises_and_leaves_the_first_record_intact(self):
+        proposal = _review_proposal()
+        decision = policy.evaluate(proposal)
+        registry = PendingVerificationRegistry(now=_fixed_clock())
+        first = registry.park(proposal, decision, correlation_id="first")
+
+        with self.assertRaises(ValueError) as ctx:
+            registry.park(proposal, decision, correlation_id="second")
+
+        self.assertIn("already parked", str(ctx.exception))
+        self.assertEqual(registry.get("prop-review"), first)
+        self.assertEqual(registry.get("prop-review").correlation_id, "first")
+        self.assertEqual(len(registry.events), 1)
+
+    def test_permitted_outcomes_cannot_be_parked(self):
+        """A permitted proposal has nothing to remediate."""
+        proposal = _proposal("prop-allow", operation="score_adjustment")
+        decision = policy.evaluate(proposal)
+        self.assertEqual(decision.outcome, policy.ALLOW_WITH_LEDGER)
+        registry = PendingVerificationRegistry()
+
+        with self.assertRaises(ValueError) as ctx:
+            registry.park(proposal, decision)
+
+        self.assertIn("permitted the operation", str(ctx.exception))
+        self.assertEqual(registry.parked(), ())
+        self.assertEqual(registry.events, [])
+
+    def test_plain_allow_cannot_be_parked(self):
+        proposal = _review_proposal("prop-plain-allow")
+        allowed = policy.Decision(
+            outcome=policy.ALLOW,
+            permitted_actions=("write", "collect_more_evidence", "defer"),
+            prohibited_actions=(),
+            reasons=(),
+            policy_version="ref-p1",
+        )
+        registry = PendingVerificationRegistry()
+
+        with self.assertRaises(ValueError):
+            registry.park(proposal, allowed)
+
+        self.assertEqual(registry.parked(), ())
+
+    def test_block_cannot_be_parked_because_its_envelope_prohibits_it(self):
+        """DoD 7 / audit V2.
+
+        ``_envelope`` names ``enter_pending_verification`` in the *prohibited*
+        set for ``block``. Parking one would contradict the very envelope the
+        record preserves, and would create a record that can never resume,
+        because no evidence discharges an absorbing block -- permanent parked
+        residue charged against retention (#363).
+        """
+        proposal = _proposal(
+            "prop-block", operation="score_adjustment", risk_class="critical"
+        )
+        decision = policy.evaluate(proposal)
+        self.assertEqual(decision.outcome, policy.BLOCK)
+        self.assertIn("enter_pending_verification", decision.prohibited_actions)
+        self.assertEqual(decision.permitted_actions, ())
+        registry = PendingVerificationRegistry()
+
+        with self.assertRaises(ValueError) as ctx:
+            registry.park(proposal, decision)
+
+        message = str(ctx.exception)
+        self.assertIn("prohibited", message)
+        self.assertIn("can never be resumed", message)
+        self.assertEqual(registry.parked(), ())
+        self.assertEqual(registry.events, [])
+
+    def test_parkable_set_matches_the_outcomes_with_a_route(self):
+        self.assertEqual(
+            PARKABLE, (policy.REQUIRE_REVIEW, policy.REQUIRE_EXTERNAL_VERIFICATION)
+        )
+
+
+class ParkedProposalCarriesNoAuthority(unittest.TestCase):
+    """DoD 8, 9 -- LD6. Step 3 must not arrive by accident."""
+
+    _FORBIDDEN = (
+        "resume",
+        "discharge",
+        "approve",
+        "commit",
+        "unpark",
+        "release",
+        "grant",
+        "permit",
+        "authorize",
+        "satisfy",
+        "verify",
+    )
+
+    def test_registry_exposes_no_method_that_discharges_or_permits(self):
+        # Introspect an instance, not the class: a discharge method added as an
+        # instance attribute would be invisible to dir() on the class.
+        surface = {n for n in dir(PendingVerificationRegistry()) if not n.startswith("_")}
+        self.assertEqual(surface, {"park", "get", "parked", "events"})
+        for forbidden in self._FORBIDDEN:
+            self.assertNotIn(forbidden, surface)
+
+    def test_resume_is_absent_not_stubbed(self):
+        """A stub is an invitation; its absence is a statement.
+
+        ``NotImplementedError`` would still put ``resume`` on the surface, where
+        the next reader treats it as scheduled rather than gated on step 2.
+        """
+        self.assertFalse(hasattr(PendingVerificationRegistry, "resume"))
+        self.assertFalse(hasattr(ParkedProposal, "resume"))
+
+    def test_parked_record_exposes_no_mutator(self):
+        proposal = _review_proposal()
+        record = PendingVerificationRegistry().park(proposal, policy.evaluate(proposal))
+        surface = {n for n in dir(record) if not n.startswith("_")}
+        self.assertEqual(
+            surface,
+            {"proposal", "decision", "correlation_id", "parked_at",
+             "policy_version", "proposal_id", "permitted_actions"},
+        )
+        for forbidden in self._FORBIDDEN:
+            self.assertNotIn(forbidden, surface)
+
+    def test_parked_record_is_frozen(self):
+        proposal = _review_proposal()
+        record = PendingVerificationRegistry().park(proposal, policy.evaluate(proposal))
+        with self.assertRaises(Exception):
+            record.decision = policy.evaluate(_external_proposal())
+
+    def test_reading_a_parked_record_does_not_discharge_it(self):
+        proposal = _review_proposal()
+        registry = PendingVerificationRegistry()
+        registry.park(proposal, policy.evaluate(proposal))
+
+        registry.get("prop-review")
+        registry.parked()
+
+        self.assertEqual(len(registry.parked()), 1)
+        self.assertEqual(len(registry.events), 1)
+        self.assertEqual(
+            registry.get("prop-review").decision.outcome, policy.REQUIRE_REVIEW
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements **step 1 of 4** of the ADR-037 implementation order, and only step 1.

A proposal that policy refuses is recorded nowhere today — the refusal returns and the attempt evaporates. ADR-037 holds that under full automation fail-closed cannot mean a dead end: a refusal must leave behind a record naming what was refused, why, and which route out remains open.

## What this does not do

The ordering is part of the decision, so the temptation to build resumption while the lifecycle is in hand is declined here.

| Step | Status |
|---|---|
| 1. Parked proposal state | **this PR** |
| 2. Evidence qualification and dependence lineage | not built |
| 3. Governed resumption | not built — nothing here discharges a park |
| 4. Fail-closed `require_review` | not built — `_apply_review` unmodified, verified by empty diff |

Assertion still discharges `require_review` after this PR, deliberately. The gate does not flip until steps 1–3 exist.

## Two design points settled under audit

**Parking is for refusals with a route, and the envelope has three states rather than two.** Measured across all five outcomes:

| Outcome | `permitted_actions` | `enter_pending_verification` | Parks? |
|---|---|---|---|
| `allow` / `allow_with_ledger` | `(operation, …)` | unlisted | no — nothing was refused |
| `require_review` | `('enter_pending_verification', …)` | **permitted** | yes |
| `require_external_verification` | `('request_external_verification', …)` | unlisted | yes, by a *different* route |
| `block` | `()` | **prohibited** | no |

`block` is refused because `_envelope` names `enter_pending_verification` in its prohibited set — parking one would contradict the envelope being recorded and produce a record no evidence could ever discharge, leaving permanent residue charged against retention (#363). `allow` is refused for the opposite reason: nothing was refused, so there is nothing to remediate.

**The record retains the whole `Proposal`, not an identity summary.** Step 3 must re-evaluate policy from scratch; `policy.evaluate` takes a `Proposal`, and the floors and modifiers read `target_class`, `downstream_authority`, `reversibility`, `evidence_refs`, and the isolation-domain fields — none recoverable from a summary. Retaining it also carries `state_snapshot` forward so resumption can apply the staleness guard, which is the specific risk parking introduces, since parking is a delay by definition.

There is no `resume` method — not even one raising `NotImplementedError`. A stub is an invitation; its absence is a statement.

## Verification

- **971 tests pass, 0 failures, 7 skipped** (951 + 20 new), run under the pinned `cryptography==50.0.1` the repository declares rather than the ambient interpreter.
- `validate_schemas.py` exit 0 (58 schemas); `validate_fixtures.py` exit 0 (64 fixtures). No schema modified.
- `policy.py` diff empty — step 4 is not smuggled into step 1.
- **Negative control**: five mutations each caught, control restored green — park accepting `block`; the route hardcoded to `enter_pending_verification`; a `resume` stub; `correlation_id` demoted into `payload`; duplicate park overwriting instead of raising.

## Governance

Audit VETOed twice across four grounds before PASS, each a design correction rather than wording: the record could not have supported step 3 (V1); parking `block` created unresumable records (V2); staleness had no anchor (V3); and DoD 2 and DoD 6 were mutually unsatisfiable, whose tempting fix was to hardcode the review route — the caller-asserted-input defect this program has now found four times (V4).

PASS carried two binding conditions, both satisfied: modeled event fields (`correlation_id`, `policy_version`, `state_snapshot`) take their top-level home rather than `payload`, and the absence of an eviction path is recorded as a deferral to #363 rather than left to be discovered.

Sealed as META_LEDGER entry #18 (`3961f7d97ed9`); chain verifies clean through #18.

**Disclosed, out of scope**: `decision_overwrite._event` places `state_snapshot` inside `payload`, the placement condition C1 rules against. Pre-existing; named so it is not later read as precedent.
