### PR TITLE
ADR-037 step 2: evidence qualification and dependence lineage

### DIFF
--- a/docs/FEATURE_INDEX.md
+++ b/docs/FEATURE_INDEX.md
@@ -7,8 +7,8 @@ Single canonical cross-reference of every user-touchable feature in Agent Memory
 
 ## Coverage Summary
 
-- Total entries: **12**
-- **Verified**: 12
+- Total entries: **13**
+- **Verified**: 13
 - **Unverified**: 0
 - **N/A (operator-justified)**: 0
 
@@ -30,6 +30,7 @@ Single canonical cross-reference of every user-touchable feature in Agent Memory
 | FX010 | Reusable grant evaluation verifies against an independently-held ratification record | `reference/agentmem_ref/reusable_grants.py` `RatificationRegistry`, `grant_body_digest`, `evaluate_reusable_grant` | `docs/plan-sprint2e-ratification-anchor.md` LD1-LD5 | `reference/tests/test_ratification_anchor.py` | verified | api | GAP-SEC-04 grant path. Implements the operator's option-C decision; option D retained as a labelled profile. Defeats the recompute attack that beat a digest-only fix. No schema modified |
 | FX011 | External verification is dischargeable only through a proposal-bound attestation, never by assertion | `reference/agentmem_ref/policy.py` `ExternalVerification`, `evaluate_with_external_verification`, `_apply_review` cap; `decision_overwrite.py`; `structural_mutation.py`; `adapter.py` `governed_delete` | `docs/33-pama-decision-table.md` "Discharging a decision"; `docs/plan-sprint2f-verified-discharge.md` | `reference/tests/test_verified_discharge.py` | verified | api | GAP-ARCH-04 external-verification leg. Attestation is caller-constructed and therefore forgeable; unforgeability is open work |
 | FX012 | A refused proposal is parked with its decision, its remediation route, and its correlation identity, emitting schema-valid evidence | `reference/agentmem_ref/pending_verification.py` `ParkedProposal`, `PendingVerificationRegistry.park` | `docs/adr/ADR-037-fail-closed-review-requires-a-remediation-path.md` sections 3 and 5; `docs/plan-sprint2g-parked-verification.md` LD1-LD7 | `reference/tests/test_pending_verification.py` | verified | api | ADR-037 **step 1 of 4**. 20 tests. Parks only `require_review` and `require_external_verification`; refuses `allow` (nothing was refused) and `block` (its envelope names `enter_pending_verification` as prohibited, so the record could never resume). Retains the whole `Proposal` so step 3 can re-evaluate and apply the staleness guard. No `resume` method exists. Steps 2-4 not built; `_apply_review` untouched |
+| FX013 | Evidence carries a derived checkability class and binding status, and correlated items collapse into lineage-derived dependence groups | `reference/agentmem_ref/evidence_qualification.py` `qualify`, `group_by_dependence`, `DependenceAnalysis` | `docs/adr/ADR-037-fail-closed-review-requires-a-remediation-path.md` R2, R3; `docs/plan-sprint2h-evidence-qualification.md` LD1-LD9 | `reference/tests/test_evidence_qualification.py` | verified | api | ADR-037 **step 2 of 4**. 28 tests. Class is derived from which bindings are present -- `EvidenceItem` has no class field, so the claim cannot be expressed. Three lineage relations (`derived_from`, shared `failure_domain`, identical `(method, method_version, inputs)`); a declaration may only merge groups, never split one. **Bindings are caller-supplied strings: presence is not verification, `asserted` is the default because no verifier has run, and this cycle does NOT close the caller-asserted pattern** -- same residual class as FX011. `refuted` is a distinct third status so a failed check never reads as an unmade one. Named `qualification_class`, not `evidence_class`, which `derivation_currentness` owns for an orthogonal axis. Steps 3-4 not built; `policy.py` untouched |
 
 ---
 

--- a/docs/GOVERNANCE_INDEX.md
+++ b/docs/GOVERNANCE_INDEX.md
@@ -84,6 +84,8 @@ Live for plan duration; archived at substantiate. Drift signal: plan shipped but
 | Sprint 2f research brief | `docs/research-brief-sprint2f-verified-discharge-2026-09-04.md` | sprint2f-verified-discharge |
 | Sprint 2g plan | `docs/plan-sprint2g-parked-verification.md` | sprint2g-parked-verification |
 | Sprint 2g research brief | `docs/research-brief-sprint2g-parked-verification-2026-09-04.md` | sprint2g-parked-verification |
+| Sprint 2h plan | `docs/plan-sprint2h-evidence-qualification.md` | sprint2h-evidence-qualification |
+| Sprint 2h research brief | `docs/research-brief-sprint2h-evidence-qualification-2026-09-05.md` | sprint2h-evidence-qualification |
 
 ## Tier 5 — Reference Material
 

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -897,3 +897,118 @@ precedent.
 
 Audit: VETO, VETO, PASS -- attempts 1-3 of 5. Grounds V1-V4 closed and recorded.
 Review Boundary: staged, not committed.
+---
+
+### Entry #19: SESSION SEAL - Phase 10 (Sprint 2h evidence qualification)
+
+**Entry ID**: `e2c500fff592`
+**Content Hash**: `2555d59b5c3826708f6bb77c53bc438a5b4f84dc1a9a335f534b9d1e59ce305d`
+**Previous Hash**: `07bde207e78cc97268e85c782f55d407fc30030349d190132224a9a656230a58`
+**Chain Hash**: `23d71557eeb046ad071585e3a20a2edc4c39b7c8a7b4460febf725ac98b968f5`
+**Timestamp**: 2026-09-05T01:10:00-04:00
+**Phase**: SUBSTANTIATE
+**Author**: Judge
+**Risk Grade**: L2
+**Verdict**: PASS
+**Session**: 2026-09-05T0045-37f432
+**Plan**: docs/plan-sprint2h-evidence-qualification.md (iteration 4)
+**SSDF Practices**: PO.1.4, PS.2.1, PW.1.1, PW.7.2
+
+**Merkle Seal** (SHA256 over `git write-tree` of the staged index 87eb6a6c9dbca6cf801163f7de191329b0db3846):
+`7d281120671c481a5560ec115ebeb55ff71ec3c5528aaa823cec96a2d88d28ed`
+
+**Scope**: ADR-037 implementation **step 2 of 4**, and only step 2. R2 and R3
+made computable. Resumption (step 3) and fail-closed conversion (step 4) are not
+built. `policy.py` is unmodified, verified by empty diff; `PendingVerificationRegistry`
+is not imported, asserted over the module's parsed import statements.
+
+**The gap this closes, measured**: `policy._apply_modifiers:252` was the shared
+evaluator's entire treatment of evidence -- `if not proposal.evidence_refs`. On
+`semantic/write/low/reversible`, `(" ",)` and `("i-said-so",)` and ten copies of
+one reference all cleared M-EVID exactly as `("receipt://sha256:deadbeef",)` did.
+Evidence was a truthiness check on a tuple. This is the **sixth** control found
+implemented in one module and absent from the shared evaluator.
+
+**Reality = Promise**: two new files, five documentation updates, no existing
+module modified, no schema modified. No UNPLANNED changes.
+
+**Definition of Done**: 16 of 16 PASS. Test count 971 -> 999 (+28), 0 failures,
+7 skipped, under the pinned `cryptography==50.0.1`. Validators clean (58 schemas,
+64 fixtures).
+
+**Negative control**: six mutations, each caught, control restored green --
+`artifact_bound` requiring only one binding; a failing verifier collapsing to
+`asserted`; relation 3 removed; groups counted at their strongest status rather
+than weakest; estimator groups counted as directly satisfying; a named-but-unheld
+verifier trusted.
+
+**Decision**: audit VETOed twice, on five grounds, and the first was the most
+important thing this cycle produced.
+
+*V1* -- the plan claimed that deriving a class from present bindings was "the
+direct answer" to the caller-asserted defect found six times. It is not. The
+bindings are themselves caller-supplied strings: `digest="deadbeef"` with
+`verifier="trust-me"` classifies `artifact_bound` with nothing checked. That is
+the same defect with more fields to fill in, and shipping it under a closure
+claim would have been worse than not claiming it. The repository had already
+solved this shape twice -- `ratification_evidence_verified`/`_asserted` (Loop 6)
+and `review_discharge` recording `asserted`/`verified` (Loop 7) -- and the plan
+had ignored both. Classification now carries a binding status, and **the claim
+is narrowed to what the work supports**: evidence stops being an opaque string
+and becomes a typed, ranked claim that names its own verifier. The
+caller-asserted pattern remains open.
+
+*V2* -- the stated algorithm (union-find over `derived_from` and shared
+`failure_domain`) could not satisfy its own DoD 9. Two runs of one deterministic
+procedure share no derivation edge and need declare no failure domain, so they
+would have reported as two independent groups -- precisely the laundering R2
+names by name. A third relation, identical `(method, method_version, inputs)`,
+is the mechanism. DoD 9 now also asserts the absence of the other two relations
+so the test cannot pass by accident.
+
+*V3* -- ADR-037 §4 (`collect_more_evidence` must state what would discharge
+*this* proposal) was owned by **no step** of the ADR's own four-step order. It is
+now assigned to step 3, with the reason: it needs a risk class, and step 2
+refuses one so it cannot return a sufficiency verdict. The ADR is amended.
+
+*V4* -- introducing a verifier introduced a state the plan had not: a verifier
+that runs and **fails**. Two statuses meant the obvious implementation was
+`"verified" if passed else "asserted"`, making "nobody has checked this digest"
+and "somebody checked it and it did not match" the same state. The second is a
+refutation, and collapsing it lets a proposer whose artifact failed keep
+re-presenting it as merely unchecked. `refuted` is a distinct third status that
+never collapses into `asserted`. Neither prior precedent carried a third state,
+because neither runs a verifier that can fail -- this was new to the repository,
+not a repeated oversight.
+
+*V5* -- Loop 8's V1 shape returned. The result broke groups down by class only,
+so a group holding an `asserted` artifact and one holding a `verified` artifact
+were indistinguishable -- collapsing the very distinction V1 had just
+introduced, and forcing step 4 to reach past the result and re-derive the
+grouping. `DependenceAnalysis` now counts by (class rank x binding status), and
+DoD 10 answers step 4's actual question from the result alone.
+
+**Audit conditions on the PASS**: C1, counting discipline -- a group counts at
+its **weakest** status, so a group holding a `verified` and a `refuted` item is
+never counted as verified and is reported among the refuted-carrying groups; and
+no total mixes `unqualified` groups with qualifying ones, because ten distinct
+bare strings legitimately form ten groups and qualify nothing. C2, FX013's index
+note carries the narrowed claim including the residual, on the FX011 precedent.
+Both satisfied.
+
+**Naming, found in research before it was spent**: `EVIDENCE_CLASSES` was already
+taken. `derivation_currentness.py:26` uses it for polarity and role -- ordinary,
+negative, adversarial, correction, incident -- with two schema consumers. R3
+ranks checkability, an orthogonal axis. The module says `qualification_class`.
+Discovering this after step 4 would have been an expensive rename across a
+schema surface.
+
+**Recorded, not acted on**: `reusable_grants` establishes independence by
+`source_ref` identity plus a caller-asserted `independent_adjudication` boolean,
+which R2 says is not sufficient on its own. R4 fences that module off -- it
+governs reusable authority from historical precedent and must not be generalized
+-- so the tension is recorded rather than resolved. `_eligible_human_precedents`
+dedupes correctly via `by_source.setdefault`; there is no defect to fix there.
+
+Audit: VETO, VETO, PASS -- attempts 1-3 of 5. Grounds V1-V5 closed and recorded.
+Review Boundary: staged, not committed.

--- a/docs/SYSTEM_STATE.md
+++ b/docs/SYSTEM_STATE.md
@@ -4,13 +4,13 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Last Updated** | 2026-09-04T23:59:00-04:00 |
+| **Last Updated** | 2026-09-05T01:10:00-04:00 |
 | **Updated By** | Judge |
-| **Phase** | SUBSTANTIATED (Sprint 2g parked verification, ADR-037 step 1 of 4) |
-| **Iteration** | 8 |
-| **Session Seal** | Entry #18 (session 2026-09-04T2347-39681d) |
+| **Phase** | SUBSTANTIATED (Sprint 2h evidence qualification, ADR-037 step 2 of 4) |
+| **Iteration** | 9 |
+| **Session Seal** | Entry #19 (session 2026-09-05T0045-37f432) |
 
-Snapshot refreshed at the Sprint 2g seal (Loop 8). Genesis values came from the `/qor-deep-audit` reconnaissance (see `docs/RESEARCH_BRIEF.md`); deltas through Loops 2-8 are measured from the sealed tree, with the suite run under the pinned `cryptography==50.0.1` the repo declares -- not the ambient interpreter.
+Snapshot refreshed at the Sprint 2h seal (Loop 9). Genesis values came from the `/qor-deep-audit` reconnaissance (see `docs/RESEARCH_BRIEF.md`); deltas through Loops 2-8 are measured from the sealed tree, with the suite run under the pinned `cryptography==50.0.1` the repo declares -- not the ambient interpreter.
 
 ---
 
@@ -34,7 +34,7 @@ agent-memory/
 |   |-- run_*.py               68 evidence emitters
 |   |-- native/                1 Rust driver
 |   |-- policies/, fixtures/ (15 JSON), testdata/
-|   `-- tests/                 129 test files, 971 tests
+|   `-- tests/                 130 test files, 999 tests
 |-- integrations/
 |   |-- agent-memory-runtime/  JS, 1 source + 1 test, private
 |   `-- hermes-agent-memory/   Python, 10 modules, 6 tests
@@ -51,7 +51,7 @@ agent-memory/
 | Metric | Value |
 |--------|-------|
 | Total Source Files | 121 (`reference/agentmem_ref`) + 68 emitters + 12 scripts + 11 integration modules |
-| Total Test Files | 129 (`reference/tests`) + 6 (hermes) + 1 (JS) |
+| Total Test Files | 130 (`reference/tests`) + 6 (hermes) + 1 (JS) |
 | Total Lines of Code | 60,376 under `reference/` |
 | Average File Size | ~300 lines (`agentmem_ref`) |
 | Max File Size | 733 lines (file: `reference/agentmem_ref/runtime_config.py`) |
@@ -119,7 +119,7 @@ Pre-existing at genesis. Any new file under `/qor-plan` must meet the razor.
 
 | Component | Test File | Exists | Passing |
 |-----------|-----------|--------|---------|
-| Reference runtime (all) | `reference/tests/` (129 files) | OK | 971 pass / 0 fail / 7 skip under pinned `cryptography==50.0.1`; CI green on `main` |
+| Reference runtime (all) | `reference/tests/` (130 files) | OK | 999 pass / 0 fail / 7 skip under pinned `cryptography==50.0.1`; CI green on `main` |
 | Cedar digest pin | `reference/tests/test_cedar_policy_comparator.py:71` | OK | FAIL on Windows checkouts (GAP-RT-02) |
 | Third-party version pins | `test_agent_manifest_correlation.py:151`, `test_trace_action_evidence.py:118` | OK | FAIL unless env matches requirements (GAP-RT-03) |
 | Graphiti substrate | `reference/tests/test_graphiti_substrate.py` | OK | SKIPPED (7) without graphiti/kuzu (GAP-RT-07) |
@@ -156,7 +156,7 @@ Sprint 1 install correctness (branch `feat/agent-memory-genesis`, staged, uncomm
 | Merkle Chain | VALID | Entries #1-#8; Entry #6 hashes recomputed once for a verdict-line format fix (recorded in-entry) |
 | Blueprint Sync | SYNCED | File tree and Dependencies table updated at Sprint 1 |
 | Section 4 Compliance | VIOLATIONS (pre-existing) | New code clean; 58 file + 175 function pre-existing overages (GAP-RT-04, Sprint 11) |
-| Test Status | PASS | 971 run, 0 fail, 7 skipped (Graphiti/kuzu absent) under the pinned `cryptography==50.0.1`; fresh-venv wheel smoke exit 0 |
+| Test Status | PASS | 999 run, 0 fail, 7 skipped (Graphiti/kuzu absent) under the pinned `cryptography==50.0.1`; fresh-venv wheel smoke exit 0 |
 
 ---
 

--- a/docs/adr/ADR-037-fail-closed-review-requires-a-remediation-path.md
+++ b/docs/adr/ADR-037-fail-closed-review-requires-a-remediation-path.md
@@ -148,8 +148,8 @@ The principal still needs qualifying evidence and valid scope/risk authority. Re
 The gate does not close until the first three exist. This ordering is part of the decision.
 
 1. **Parked proposal state** — `enter_pending_verification` as a real, resumable, evidence-emitting outcome. **DONE** (Loop 8, ledger entry #18): `reference/agentmem_ref/pending_verification.py`.
-2. **Evidence qualification and dependence lineage** — R2 and R3 made computable, including dependence-group collapse. *Next.*
-3. **Governed resumption and re-evaluation** — evaluator-owned, policy re-evaluated from scratch, staleness applied.
+2. **Evidence qualification and dependence lineage** — R2 and R3 made computable, including dependence-group collapse. **DONE** (Loop 9, ledger entry #19): `reference/agentmem_ref/evidence_qualification.py`.
+3. **Governed resumption and re-evaluation** — evaluator-owned, policy re-evaluated from scratch, staleness applied. **Also owns §4** (see below). *Next.*
 4. **Fail-closed `require_review`** — convert the 51 caller sites.
 
 **What step 1 settled, so steps 2–3 do not re-litigate it.** Two questions surfaced in audit and were decided:
@@ -158,6 +158,12 @@ The gate does not close until the first three exist. This ordering is part of th
 - **What the record retains.** The whole `Proposal`, not an identity summary. Step 3 must re-evaluate from scratch and `policy.evaluate` takes a `Proposal`; retaining it is also what carries `state_snapshot` forward so the staleness guard can be applied at resumption. The record shape is therefore fixed and step 3 does not reshape it.
 
 The registry has **no** `resume` method — not a stub, not one raising. Step 3 adds it, and step 3 is gated on step 2.
+
+**What step 2 settled.**
+
+- **§4 belongs to step 3.** As written, this ADR's four-step order named no owner for §4 (`collect_more_evidence` must state which criteria are unmet, what class satisfies each, and what independence bar applies at this risk class). It is not step 2's: computing "what independence bar applies at this risk class" needs a risk class, and the qualification module deliberately refuses one so it cannot return a sufficiency verdict. It lands in **step 3**, which already re-evaluates against a risk class and already holds the parked record that would carry the message. Recorded here so the requirement is owned rather than falling between four cycles that each correctly declared it out of scope.
+- **Qualification is derived, and it is not yet verification.** A class comes from which bindings an item carries, never from a claim it makes. But the bindings are themselves caller-supplied strings, so every class pairs with a binding status: `asserted` (nobody has checked), `verified` (a verifier in the evaluator's registry ran and passed), `refuted` (it ran and failed). `refuted` is distinct on purpose — collapsing it into `asserted` would make a failed check indistinguishable from an unmade one. **This does not close the caller-asserted-input pattern**; it makes evidence a typed claim that names its own verifier.
+- **Independence is three relations, not two.** Derivation edges and shared failure domains are both insufficient alone: two runs of one deterministic procedure share neither, and R2 says in as many words that they are one evidence item. Identical `(method, method_version, inputs)` is the third relation. A declared failure domain may only **merge** groups, never split one — the constrained party can weaken its own independence claim and never strengthen it.
 
 Do not flip the gate before 1–3 exist. A control whose remediation path does not yet work is a halt, and the pressure it creates becomes a workaround that outlives it.
 

--- a/docs/plan-sprint2h-evidence-qualification.md
+++ b/docs/plan-sprint2h-evidence-qualification.md
@@ -1,0 +1,161 @@
+# Plan: Sprint 2h — evidence qualification and dependence lineage
+
+**change_class**: feature
+**Risk Grade**: L2
+**Session**: 2026-09-05T0045-37f432
+**Research**: `docs/research-brief-sprint2h-evidence-qualification-2026-09-05.md`
+**Iteration**: 4 (audit attempt 3: PASS with binding conditions C1, C2)
+**Implements**: ADR-037 implementation order, **step 2 of 4**
+
+## Objective
+
+Make R2 and R3 computable: give an evidence item a checkability class, and collapse correlated items into dependence groups derived from lineage rather than from a label. Nothing consumes either result this cycle.
+
+## Boundaries
+
+**In scope**: a new `reference/agentmem_ref/evidence_qualification.py`, and its tests.
+
+**Explicitly out of scope:**
+
+| Step | Status here |
+|---|---|
+| 3. Governed resumption | **not built.** Nothing here discharges or resumes a parked proposal |
+| 4. Fail-closed `require_review` | **not built.** `policy.py` unmodified, verified by empty diff |
+
+The temptation this cycle is not resumption — it is wiring the qualifier into `policy.evaluate` to fix the M-EVID truthiness check, which looks like two lines. **Those two lines are step 4.** They convert all 51 sites at once with no resumption path built. `PendingVerificationRegistry` is likewise not imported: connecting qualification to parking is step 3's work.
+
+## Design decisions
+
+**LD1 — `qualification_class`, never `evidence_class`.**
+`derivation_currentness.py:26` already owns `EVIDENCE_CLASSES` for polarity and role — ordinary, negative, adversarial, correction, incident — with two schema consumers. R3 ranks *checkability*, an orthogonal axis. Reusing the name would silently merge two axes that ADR-037's "four variables, kept distinct" section exists to keep apart.
+
+**LD2 — A class is derived from which bindings are present, never accepted from the caller.**
+This is the whole point of the cycle. The three R3 classes are distinguished by what an item binds:
+
+| Class | Required bindings | Standing |
+|---|---|---|
+| `artifact_bound` | `artifact_ref` + `digest` + `verifier` | satisfies directly |
+| `reproducible_procedure` | `inputs` + `method` + `method_version` + `result` + `verifier` | satisfies directly |
+| `calibrated_estimator` | `estimator_id` + `estimator_version` + `calibration_ref` | contributes only |
+
+An item is classified by what it actually carries. A caller cannot declare itself `artifact_bound`; it can only supply a digest and a verifier.
+
+**That is not verification, and this plan will not claim it is (audit V1).** All three bindings are caller-supplied strings; `digest="deadbeef"` with `verifier="trust-me"` classifies `artifact_bound` with nothing checked. Presence of a binding raises the cost and names a verifier so the claim becomes checkable *by someone later* — it does not make the claim true.
+
+So classification carries a **binding status** alongside the class, following the two precedents the repository already set for exactly this shape:
+
+- Loop 6, `reusable_grants.py:434,441` — `ratification_evidence_verified` vs `ratification_evidence_asserted`
+- Loop 7, `policy.py:320` — `review_discharge` records `asserted` or `verified`
+
+| Status | Meaning |
+|---|---|
+| `asserted` | the bindings are present; **no verifier has been run** |
+| `verified` | a verifier was executed against this item and **passed** |
+| `refuted` | a verifier was executed and **failed** (audit V4) |
+
+`refuted` is not optional bookkeeping. Without it the obvious implementation is `"verified" if passed else "asserted"`, which makes "nobody has checked this digest" and "somebody checked this digest and it did not match" the same state. The second is a **refutation** — the most valuable thing the system will ever learn about that item — and collapsing it lets a proposer whose artifact failed keep re-presenting it as merely unchecked. `refuted` must never collapse into `asserted`.
+
+**The verifier registry is held by the evaluator, not the proposer**, on the `RatificationRegistry` precedent from Loop 6. A proposal *names* a verifier; it does not supply one. With no registry, everything is `asserted` — which is the honest reading of a system where nothing has been checked yet.
+
+The class says what kind of claim this is. The status says whether anyone checked, and what happened when they did. **The honest claim for this cycle is that evidence stops being an opaque string and becomes a typed, ranked claim that names its own verifier** — real progress toward step 4, and not a closure of the caller-asserted pattern, which remains open until a verifier actually runs.
+
+**LD3 — An item that binds nothing qualifying is `unqualified`, and that is a fourth state, not an error.**
+The evidence in the wild today is bare strings (F1). Classification must have somewhere to put them that is neither a crash nor a free pass. `unqualified` names them so step 4 can later see how much of the corpus is opinion.
+
+**LD4 — Dependence grouping is derived from lineage; a declared failure domain may only merge.**
+Union-find over **three** relations (audit V2):
+
+1. `derived_from` edges — an item derived from another shares its group.
+2. Shared declared `failure_domain` — distinct roots that can fail together (the syndicated-report case).
+3. **Identical `(method, method_version, inputs)`** — the same deterministic procedure run twice.
+
+Relation 3 was missing in iteration 1, and without it LD6 and DoD 9 could not be satisfied: a repeated deterministic check has no `derived_from` edge to its own earlier run and need share no declared failure domain, so it would have reported as **two** independent groups — precisely the laundering R2 names. The fix is the algorithm, not a special case in the test.
+
+A declaration can put two items in one group; it can never assert that two lineage-connected items are in different groups. The asymmetry is what makes accepting the declaration safe — the constrained party can only weaken its own independence claim, never strengthen it.
+
+**LD5 — The result counts groups by class *and* status, and refuses to report a row count as corroboration.**
+Carrying `autonomous_maintenance_harness`'s `row_count_is_not_corroboration` property into a form the evaluator could use. The returned type exposes independent **group** count; the item count is never presented as a strength.
+
+**The breakdown is two-dimensional (audit V5).** A class-only breakdown cannot answer step 4's actual question — *how many independent groups carry directly-satisfying evidence that was actually verified?* — because a group holding one `asserted` `artifact_bound` item and one holding a `verified` one would be indistinguishable, collapsing the very distinction LD2 introduces. Step 4 would then have to reach past the result and re-derive the grouping, which is the reshaping cost that VETOed Loop 8 twice.
+
+So `DependenceAnalysis` reports group counts by (class rank × binding status). **Counts, not verdicts** — LD7 still forbids the verdict; this supplies what a verdict would need.
+
+**Counting discipline (audit C1).** Two edges both fail toward overstating evidence, so both are pinned:
+
+- **A group's counted status is the weakest disposition it carries, not the strongest.** A group holding one `verified` and one `refuted` item is internally contradictory; counting it as verified would hide the refutation, reintroducing V4's harm one level up after V4 closed it at the item level. Groups containing any `refuted` item are reported separately. This module does not adjudicate the contradiction — it must simply not conceal it.
+- **No single field mixes `unqualified` groups into a qualifying total.** Ten *distinct* bare strings legitimately form ten groups. A headline "10 independent groups" would then be true and misleading in precisely the way §2b names: *raising the count does not raise the class.* LD5 already refuses to present the item count as a strength; the same refusal extends to the group count.
+
+**LD6 — Repetition of one deterministic procedure is one item, not two.**
+R2 states this in as many words: "a second deterministic reproduction of the same test is validation of one evidence item, not a second evidence item." Two `reproducible_procedure` items with identical `method`, `method_version`, and `inputs` are the same check run twice, and LD4 relation 3 is the mechanism that collapses them — derived, not declared.
+
+**LD7 — No method returns a decision, an outcome, or a permission.**
+The same discipline as LD6 in Loop 8, and for the same reason. This module reports *what evidence is*; it never reports what may therefore happen. There is no `discharges`, no `sufficient_for`, no risk-class parameter — accepting a risk class would invite returning a verdict against it, and that verdict is step 4's.
+
+**LD9 — ADR-037 §4 is recorded as step 3's, not silently dropped (audit V3).**
+§4 requires `collect_more_evidence` to state which criteria are unmet, what class satisfies each, and what independence bar applies at this risk class. No step in the ADR's four-step order names an owner for it, which is how a requirement gets lost between four cycles that each correctly declare it out of scope.
+
+It is **not** this cycle's: it needs a risk class, and LD7 refuses one on purpose. It lands in **step 3**, where resumption already re-evaluates against a risk class and already holds the parked record that would carry the message. Recorded here so the ADR can be amended to say so.
+
+**LD8 — `calibrated_estimator` is marked as never-sole, structurally.**
+R3: an estimator "must never be the sole basis for discharging `require_review`". The result therefore reports the qualifying (direct-satisfying) groups separately from the contributing ones, so a caller cannot reach "one estimator is enough" without deliberately reading past the distinction.
+
+## Affected files
+
+| File | Change |
+|---|---|
+| `reference/agentmem_ref/evidence_qualification.py` | **new** — `EvidenceItem`, `Qualification`, `DependenceAnalysis`, `qualify`, `group_by_dependence` |
+| `reference/tests/test_evidence_qualification.py` | **new** |
+
+No existing file is modified. Nothing calls this yet, by design.
+
+## Feature Inventory Touches
+
+| ID | Feature | Disposition |
+|---|---|---|
+| FX013 | Evidence carries a derived checkability class and binding status, and correlated items collapse into lineage-derived dependence groups | NEW |
+
+**FX013's index note must carry the narrowed claim (audit C2).** The feature index is where a claim outlives the cycle that made it, and FX011 sets the precedent by recording its own residual. The note states that classification is derived from bindings present, that `asserted` is the default because no verifier has run, and that **this cycle does not close the caller-asserted pattern**. Six prior instances make an unqualified claim here actively harmful to the next reader.
+
+## Definition of Done
+
+1. `artifact_bound` is derived only when `artifact_ref`, `digest`, and `verifier` are all present; missing any one drops the item to `unqualified`, asserted per-binding.
+2. `reproducible_procedure` requires all of `inputs`, `method`, `method_version`, `result`, `verifier` — asserted per-binding (LD2).
+3. `calibrated_estimator` requires `estimator_id`, `estimator_version`, `calibration_ref`.
+4. **A caller cannot declare its own class.** An item carrying `qualification_class="artifact_bound"` as an input field and no digest classifies `unqualified`.
+4b. **Binding status is `asserted` unless a verifier actually ran** (audit V1). Bindings present with no registry classify with the correct class and status `asserted`; a passing verifier yields `verified`.
+4c. **A failing verifier yields `refuted`, never `asserted`** (audit V4). Asserted as a distinct third state, and asserted that `refuted` is not equal to `asserted`, because `"verified" if passed else "asserted"` is the implementation this DoD exists to fail.
+4d. The registry is supplied by the evaluator, not carried on the item: an item naming a verifier absent from the registry stays `asserted`, and cannot reach `verified` by naming it.
+5. A bare string reference (`"i-said-so"`, `" "`) classifies `unqualified` without raising (LD3).
+6. Two items linked by `derived_from` land in one dependence group, whatever their declarations say.
+7. Two items with distinct roots and a shared declared `failure_domain` land in one group (the syndicated-report case).
+8. **A declaration cannot split a lineage-connected pair.** Two items joined by `derived_from` and given different `failure_domain` values remain in one group — merge-only asymmetry (LD4).
+9. Two `reproducible_procedure` items with identical `method`, `method_version`, and `inputs` land in one group **with no `derived_from` edge and no shared declared `failure_domain` between them** (LD4 relation 3, LD6, R2's "second deterministic reproduction"). Stated this way so the test cannot pass by accident through relation 1 or 2.
+10. The result reports independent group count, and breaks groups down by **class rank and binding status together** (LD5, LD8, audit V5). Asserted by answering step 4's question directly from the result: the count of independent groups carrying `verified` directly-satisfying evidence, with no reach into the raw items and no re-derivation of the grouping.
+11. Ten copies of one reference yield **one** group, and the result exposes no field that presents the row count as corroboration.
+12. **The module exposes no method returning a decision, outcome, permission, or sufficiency verdict**, asserted over the public surface (LD7).
+13. **All 971 prior tests pass**, and `policy.py` is unmodified — verified by empty diff, since step 4 is explicitly not in this cycle.
+14. `validate_schemas.py` and `validate_fixtures.py fixtures` clean; no schema file modified.
+15. **A group's counted status is its weakest** (audit C1): a group holding a `verified` and a `refuted` item is not counted as verified, and is reported among the refuted-carrying groups.
+16. **No reported total mixes `unqualified` groups with qualifying ones** (audit C1). Ten distinct bare strings produce ten groups and zero qualifying groups, asserted together.
+
+## CI Commands
+
+```
+python -m unittest discover -s reference/tests -t reference
+python scripts/validate_schemas.py
+python scripts/validate_fixtures.py fixtures
+```
+
+## CI Coverage Exemptions
+
+No workflow path filter covers a new unreferenced module. DoD 13 runs the full suite, which is the coverage that matters for a module nothing calls yet — the same disposition as Loop 8.
+
+## Rollback
+
+Delete both new files. Nothing else changes.
+
+## Next
+
+`/qor-implement`. Audit attempt 3 returned PASS with binding conditions C1 (counting discipline: a group counts at its weakest status; no total mixes `unqualified` groups with qualifying ones) and C2 (FX013 carries LD2's narrowed claim, not the ambitious one), both folded into LD5, the Feature Inventory section, and DoD 15-16.
+
+Attempts 1 and 2 vetoed on V1-V5: presence of a binding is not verification (V1); the stated algorithm could not satisfy DoD 9 (V2); ADR-037 §4 was unassigned across all four steps (V3); a failing verifier had no state and would have collapsed into `asserted` (V4); the result could not answer step 4's question without reshaping (V5). All five are discharged in this iteration.

--- a/docs/research-brief-sprint2h-evidence-qualification-2026-09-05.md
+++ b/docs/research-brief-sprint2h-evidence-qualification-2026-09-05.md
@@ -1,0 +1,100 @@
+# Research Brief: Sprint 2h — evidence qualification and dependence lineage
+
+**Date**: 2026-09-05
+**Analyst**: The Qor-logic Analyst
+**Program**: ADR-035 build-toward, research-led `/qor-enterprise-auto-dev`. Loop 9.
+**Implements**: ADR-037 implementation order **step 2 of 4**, and only step 2.
+
+## 1. Scope, stated first because the order is part of the decision
+
+Step 1 landed in entry #18: a refusal now parks with its decision and its route. It cannot yet be resumed, because resumption requires knowing whether arriving evidence *qualifies* — which is this step.
+
+**This cycle builds step 2 only**: R2 and R3 made computable.
+
+| Step | Status here |
+|---|---|
+| 1. Parked proposal state | **done**, entry #18 |
+| 2. Evidence qualification and dependence lineage | **this cycle** |
+| 3. Governed resumption | **not built.** Nothing here discharges or resumes a parked proposal |
+| 4. Fail-closed `require_review` | **not built.** `_apply_review` untouched; `policy.py` unmodified |
+
+The temptation this time is different from last cycle's. It is not to build resumption — it is to *wire the qualifier into `policy.evaluate`* while the vocabulary is in hand, because M-EVID is visibly weak (F1) and the fix looks like a two-line change. That two-line change **is step 4**. It converts every one of the 51 sites at once, with no resumption path built. The gate does not flip before step 3 exists.
+
+## 2. The gap, measured
+
+`policy._apply_modifiers:252` is the shared evaluator's **entire** treatment of evidence:
+
+```python
+if not proposal.evidence_refs:
+    outcome = _strictest(outcome, REQUIRE_REVIEW)
+    reasons.append("M-EVID: no evidence references supplied")
+```
+
+Measured on `semantic/write/low/reversible`:
+
+| `evidence_refs` | Outcome | Reasons |
+|---|---|---|
+| `()` | `require_review` | `M-EVID: no evidence references supplied` |
+| `("i-said-so",)` | `require_review` | `()` |
+| `(" ",)` | `require_review` | `()` |
+| `("same",) * 10` | `require_review` | `()` |
+| `("receipt://sha256:deadbeef",)` | `require_review` | `()` |
+
+A single space clears the evidence modifier exactly as a content-addressed receipt does, and ten copies of one reference are "evidence supplied". **Evidence is currently a truthiness check on a tuple.** R3's ranking exists as doctrine and has no computable form anywhere in the evaluator.
+
+This is the **sixth** control this program has found implemented in one module and absent from the shared evaluator, after derived self-approval, verified/unverified provenance, the ratification registry, version derivation, and the `DurableDecisionRegistry` lifecycle.
+
+## 3. The estimator leg is half-enforced
+
+`estimator_refs`, `estimator_versions`, and `confidence` are recorded on `Proposal` and **never read** by the evaluator. Measured: confidence `0.99` and `0.01` produce identical decisions, identical reasons, identical envelopes.
+
+That is correct for the half of R3 that says an estimator must never *become* authority — `policy.py:8` and the `authority_laundering_harness` checks `confidence_does_not_change_outcome` / `confidence_has_no_authority` hold it.
+
+It leaves the other half unenforced. R3 also says a calibrated estimator "must **never** be the sole basis for discharging `require_review`". Since evidence is an opaque string tuple, **an estimate placed in `evidence_refs` is indistinguishable from an artifact-bound receipt** — measured, the two proposals compare equal. The prohibition is unenforceable while evidence has no class.
+
+## 4. Dependence grouping exists, and is caller-asserted
+
+`autonomous_maintenance_harness._group_probabilities:33-56` collapses a dependence group before cross-group fusion, asserting `row_count_is_not_corroboration`. It is the right idea and the only implementation.
+
+It groups by `signal["dependence_group"]` — **a caller-supplied string**. The harness's own docstring is candid that the reducer is a fixture convenience. Nothing verifies that two signals in *different* groups are actually independent.
+
+**Building step 2 on an asserted group label would reproduce the exact defect this program has now found six times**: a control whose input is asserted by the party it constrains. It is the same shape as `approves_own_authority`, `review_satisfied`, and `ratification_evidence_present`.
+
+**The lineage needed to derive grouping is already in the fixtures.** `autonomous-maintenance-scenarios.json` carries `root_ref` and `derived_from` alongside the label, and two distinct grouping mechanisms appear in the data:
+
+- **Derivation lineage** — `derived:summary-a` with `derived_from: ["root:a"]` shares a group with `root:a`. Computable from the refs.
+- **Shared failure domain** — `root:news-a` and `root:news-b` are distinct roots that share `syndicated-report`. *Not* computable from derivation; it must be declared.
+
+So grouping must be **derived from lineage, with declared failure domains as an additional merge input** — and where a caller's grouping disagrees with what lineage shows, lineage must win. A declaration may only ever *merge* groups (assert more dependence), never *split* them (assert more independence). That asymmetry is what makes the input safe to accept: the party being constrained can only make its own claim weaker.
+
+## 5. Name collision, found before it was spent
+
+`derivation_currentness.py:26` already defines:
+
+```python
+EVIDENCE_CLASSES = {"ordinary", "negative", "adversarial", "correction", "incident"}
+```
+
+That is **polarity and role** — what the evidence says. R3's ranking is **checkability** — how strongly it can be verified. Two orthogonal axes, and `evidence_class` is already taken for the first, in a schema (`derivation-currentness-evaluation.schema.json:45`) and a second consumer (`precedent-candidate-retrieval.schema.json:58`).
+
+Step 2 must not reuse the name. `qualification` / `qualification_class` keeps the axes distinct and leaves the existing vocabulary alone.
+
+## 6. What must not be generalized
+
+`reusable_grants` establishes independence by `source_ref` identity plus a caller-asserted `independent_adjudication` boolean, and requires `minimum_independent_human_evidence >= 2`.
+
+R4 rules that this has a **different job** — creating reusable authority from historical precedent, followed by a separate ratification transition — and "must not be generalized into a two-approver requirement for ordinary review". `_eligible_human_precedents` does dedupe correctly by `source_ref` (`by_source.setdefault`), so there is no defect to fix. **Do not touch it, and do not import its threshold.**
+
+Noted for the record: its independence test is by source identity, which R2 says is not sufficient on its own. That is a live tension inside a module R4 has fenced off, so it is recorded here rather than acted on.
+
+## 7. Blast radius
+
+Near zero, deliberately, and for the same reason as step 1: a new module that nothing calls. `policy.py` is not modified — verified by empty diff at the end of the cycle, as in Loop 8. The 51 assertion sites keep working unchanged.
+
+## 8. Risk grade
+
+**L2.** New isolated module, no existing caller, no schema change, no policy path modified. Not L1 because the qualification vocabulary and the grouping algorithm are what steps 3 and 4 build on, and a wrong shape here is expensive later — the same reasoning that graded step 1, and step 1's audit proved it right twice.
+
+## 9. Next
+
+`/qor-plan`.

--- a/reference/agentmem_ref/evidence_qualification.py
+++ b/reference/agentmem_ref/evidence_qualification.py
@@ -1,0 +1,342 @@
+"""Evidence qualification and dependence lineage: ADR-037 step 2 of 4.
+
+The shared evaluator's entire treatment of evidence today is one truthiness
+check (``policy._apply_modifiers``)::
+
+    if not proposal.evidence_refs:
+        outcome = _strictest(outcome, REQUIRE_REVIEW)
+
+So ``(" ",)`` clears the evidence modifier exactly as a content-addressed
+receipt does, and ten copies of one reference are "evidence supplied". ADR-037
+R2 and R3 say what evidence must actually be; this module makes that
+computable. Nothing consumes it yet.
+
+Out of scope, because ADR-037 fixes the order:
+
+  step 3  governed resumption -- ``PendingVerificationRegistry`` is not imported
+  step 4  fail-closed ``require_review`` -- ``policy.py`` is not modified
+
+The temptation here is not resumption. It is wiring ``qualify`` into
+``_apply_modifiers`` to fix that truthiness check, which is genuinely two lines.
+**Those two lines are step 4**: they convert all 51 assertion sites at once,
+with no resumption path built.
+
+What this module does NOT claim
+-------------------------------
+
+Bindings are caller-supplied strings. ``digest="deadbeef"`` with
+``verifier="trust-me"`` classifies as ``ARTIFACT_BOUND`` with nothing checked.
+Presence of a binding raises the cost and names a verifier, so the claim becomes
+checkable *by someone later*; it does not make the claim true.
+
+That is why a class is always paired with a **binding status**, on the
+precedent this repository already set twice -- ``ratification_evidence_verified``
+vs ``_asserted`` (Loop 6) and ``review_discharge`` recording ``asserted`` vs
+``verified`` (Loop 7):
+
+    asserted  bindings present, no verifier has run       (the default)
+    verified  a verifier ran against this item and passed
+    refuted   a verifier ran and FAILED
+
+``refuted`` is not bookkeeping. Without it the obvious implementation is
+``"verified" if passed else "asserted"``, which makes "nobody checked this
+digest" and "somebody checked it and it did not match" the same state. The
+second is a refutation, and collapsing it lets a proposer whose artifact failed
+keep re-presenting it as merely unchecked.
+
+The honest claim for this module is therefore narrow and real: **evidence stops
+being an opaque string and becomes a typed, ranked claim that names its own
+verifier.** The caller-asserted pattern is not closed here.
+
+Naming
+------
+
+``EVIDENCE_CLASSES`` is already taken. ``derivation_currentness`` uses it for
+polarity and role -- ordinary, negative, adversarial, correction, incident --
+with two schema consumers. R3 ranks *checkability*, an orthogonal axis, so this
+module says ``qualification_class``. Merging the two axes is exactly what
+ADR-037's "four variables, kept distinct" section exists to prevent.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Mapping
+
+# --- R3: qualification classes, ranked by checkability ----------------------
+
+ARTIFACT_BOUND = "artifact_bound"
+REPRODUCIBLE_PROCEDURE = "reproducible_procedure"
+CALIBRATED_ESTIMATOR = "calibrated_estimator"
+UNQUALIFIED = "unqualified"
+
+#: Classes that satisfy an evidence criterion directly (R3).
+DIRECTLY_SATISFYING = (ARTIFACT_BOUND, REPRODUCIBLE_PROCEDURE)
+
+#: May contribute under explicit policy; never authority, never a sole basis.
+CONTRIBUTING = (CALIBRATED_ESTIMATOR,)
+
+# --- Binding status ---------------------------------------------------------
+
+ASSERTED = "asserted"
+VERIFIED = "verified"
+REFUTED = "refuted"
+
+#: Ordered weakest-first. A dependence group counts at the weakest disposition
+#: it carries, so a group holding a refuted item is never counted as verified.
+_STATUS_RANK = {REFUTED: 0, ASSERTED: 1, VERIFIED: 2}
+
+#: Bindings each class requires. A class is derived from what is present.
+_REQUIRED_BINDINGS: dict[str, tuple[str, ...]] = {
+    ARTIFACT_BOUND: ("artifact_ref", "digest", "verifier"),
+    REPRODUCIBLE_PROCEDURE: ("inputs", "method", "method_version", "result", "verifier"),
+    CALIBRATED_ESTIMATOR: ("estimator_id", "estimator_version", "calibration_ref"),
+}
+
+#: Checked in rank order so the strongest satisfied class wins.
+_CLASS_ORDER = (ARTIFACT_BOUND, REPRODUCIBLE_PROCEDURE, CALIBRATED_ESTIMATOR)
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    """One evidence reference and whatever it binds.
+
+    Every binding is optional and every binding is caller-supplied. The class
+    is derived from which are present; it is never read from the item.
+    """
+
+    ref: str
+
+    # artifact-bound
+    artifact_ref: str = ""
+    digest: str = ""
+
+    # reproducible procedure
+    inputs: str = ""
+    method: str = ""
+    method_version: str = ""
+    result: str = ""
+
+    # either of the above
+    verifier: str = ""
+
+    # calibrated estimator
+    estimator_id: str = ""
+    estimator_version: str = ""
+    calibration_ref: str = ""
+
+    # lineage
+    derived_from: tuple[str, ...] = ()
+    failure_domain: str = ""
+
+    def _binds(self, name: str) -> bool:
+        return bool(str(getattr(self, name, "")).strip())
+
+
+@dataclass(frozen=True)
+class Qualification:
+    """What an item is, and whether anyone checked."""
+
+    ref: str
+    qualification_class: str
+    binding_status: str
+    missing_bindings: tuple[str, ...] = ()
+
+    @property
+    def directly_satisfying(self) -> bool:
+        return self.qualification_class in DIRECTLY_SATISFYING
+
+
+def qualify(
+    item: EvidenceItem,
+    *,
+    verifiers: Mapping[str, Callable[[EvidenceItem], bool]] | None = None,
+) -> Qualification:
+    """Derive an item's class from its bindings, and its status from a verifier.
+
+    ``verifiers`` is the evaluator's registry, on the ``RatificationRegistry``
+    precedent: a proposal *names* a verifier, it does not supply one. With no
+    registry -- or with a name absent from it -- the status is ``asserted``.
+    An item cannot reach ``verified`` by naming a verifier nobody holds.
+    """
+    qualification_class = UNQUALIFIED
+    missing: tuple[str, ...] = ()
+    for candidate in _CLASS_ORDER:
+        required = _REQUIRED_BINDINGS[candidate]
+        absent = tuple(name for name in required if not item._binds(name))
+        if not absent:
+            qualification_class = candidate
+            missing = ()
+            break
+        if not missing or len(absent) < len(missing):
+            missing = absent
+
+    if qualification_class == UNQUALIFIED:
+        # Nothing qualifying was bound: an opinion held at arm's length. Not an
+        # error -- the corpus is full of these today, and step 4 needs to be
+        # able to count them rather than crash on them.
+        return Qualification(item.ref, UNQUALIFIED, ASSERTED, missing)
+
+    status = ASSERTED
+    if verifiers and item.verifier and item.verifier in verifiers:
+        status = VERIFIED if verifiers[item.verifier](item) else REFUTED
+    return Qualification(item.ref, qualification_class, status)
+
+
+# --- R2: dependence lineage -------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DependenceAnalysis:
+    """Groups, counted by class rank and binding status together.
+
+    Counts, never verdicts. Step 4 decides what is sufficient; this reports
+    what there is, in the shape that decision needs, so step 4 need not reach
+    past this result and re-derive the grouping.
+    """
+
+    groups: tuple[tuple[str, ...], ...]
+    #: (qualification_class, binding_status) -> number of groups
+    group_counts: Mapping[tuple[str, str], int]
+    refuted_groups: tuple[tuple[str, ...], ...]
+
+    @property
+    def independent_group_count(self) -> int:
+        """Total groups, INCLUDING unqualified ones.
+
+        Deliberately not a measure of strength: ten distinct bare strings make
+        ten groups and qualify nothing. Use :meth:`qualifying_group_count`,
+        which is the number this is repeatedly mistaken for.
+        """
+        return len(self.groups)
+
+    def qualifying_group_count(self, *, status: str = VERIFIED) -> int:
+        """Groups whose evidence directly satisfies, at ``status`` or better.
+
+        This answers step 4's actual question -- how many independent groups
+        carry directly-satisfying evidence that was actually verified -- from
+        the result alone.
+        """
+        floor = _STATUS_RANK[status]
+        return sum(
+            count
+            for (klass, group_status), count in self.group_counts.items()
+            if klass in DIRECTLY_SATISFYING and _STATUS_RANK[group_status] >= floor
+        )
+
+    def contributing_group_count(self, *, status: str = VERIFIED) -> int:
+        """Estimator-only groups. R3: may contribute, never a sole basis."""
+        floor = _STATUS_RANK[status]
+        return sum(
+            count
+            for (klass, group_status), count in self.group_counts.items()
+            if klass in CONTRIBUTING and _STATUS_RANK[group_status] >= floor
+        )
+
+
+class _Union:
+    def __init__(self) -> None:
+        self._parent: dict[str, str] = {}
+
+    def add(self, key: str) -> None:
+        self._parent.setdefault(key, key)
+
+    def find(self, key: str) -> str:
+        self.add(key)
+        while self._parent[key] != key:
+            self._parent[key] = self._parent[self._parent[key]]
+            key = self._parent[key]
+        return key
+
+    def union(self, left: str, right: str) -> None:
+        a, b = self.find(left), self.find(right)
+        if a != b:
+            self._parent[b] = a
+
+
+def group_by_dependence(
+    items: Iterable[EvidenceItem],
+    *,
+    verifiers: Mapping[str, Callable[[EvidenceItem], bool]] | None = None,
+) -> DependenceAnalysis:
+    """Collapse correlated items into dependence groups, derived from lineage.
+
+    Three relations, jointly necessary -- dropping any one leaves a laundering
+    route open:
+
+    1. ``derived_from`` -- an item derived from another shares its group.
+    2. Shared declared ``failure_domain`` -- distinct roots that fail together
+       (the syndicated-report case), which derivation cannot compute.
+    3. Identical ``(method, method_version, inputs)`` -- the same deterministic
+       procedure run twice. R2: "a second deterministic reproduction of the
+       same test is validation of one evidence item, not a second evidence
+       item." Such a pair shares no derivation edge and need declare no failure
+       domain, so relations 1 and 2 would report it as two independent groups.
+
+    A declared ``failure_domain`` may only ever **merge** groups, never split
+    one. That asymmetry is what makes accepting the declaration safe: the party
+    being constrained can weaken its own independence claim and never
+    strengthen it.
+    """
+    items = list(items)
+    union = _Union()
+    by_ref: dict[str, EvidenceItem] = {}
+    for item in items:
+        union.add(item.ref)
+        by_ref[item.ref] = item
+
+    domains: dict[str, str] = {}
+    procedures: dict[tuple[str, str, str], str] = {}
+    for item in items:
+        for parent in item.derived_from:  # relation 1
+            if parent in by_ref:
+                union.union(parent, item.ref)
+        if item.failure_domain:  # relation 2 -- merge only
+            key = item.failure_domain
+            if key in domains:
+                union.union(domains[key], item.ref)
+            else:
+                domains[key] = item.ref
+        if item.method and item.method_version and item.inputs:  # relation 3
+            signature = (item.method, item.method_version, item.inputs)
+            if signature in procedures:
+                union.union(procedures[signature], item.ref)
+            else:
+                procedures[signature] = item.ref
+
+    clustered: dict[str, list[str]] = {}
+    for item in items:
+        clustered.setdefault(union.find(item.ref), []).append(item.ref)
+
+    qualifications = {item.ref: qualify(item, verifiers=verifiers) for item in items}
+
+    groups: list[tuple[str, ...]] = []
+    refuted: list[tuple[str, ...]] = []
+    counts: dict[tuple[str, str], int] = {}
+    for refs in clustered.values():
+        group = tuple(refs)
+        groups.append(group)
+        members = [qualifications[ref] for ref in refs]
+        # The group's class is the strongest evidence it holds; its status is
+        # the WEAKEST disposition it carries. A group holding one verified and
+        # one refuted item is internally contradictory -- counting it as
+        # verified would hide the refutation, reintroducing at group level the
+        # collapse `refuted` exists to prevent at item level. This module does
+        # not adjudicate the contradiction; it must not conceal it.
+        best_class = UNQUALIFIED
+        for candidate in _CLASS_ORDER:
+            if any(m.qualification_class == candidate for m in members):
+                best_class = candidate
+                break
+        weakest = min(members, key=lambda m: _STATUS_RANK[m.binding_status]).binding_status
+        counts[(best_class, weakest)] = counts.get((best_class, weakest), 0) + 1
+        if any(m.binding_status == REFUTED for m in members):
+            refuted.append(group)
+
+    return DependenceAnalysis(
+        groups=tuple(groups),
+        group_counts=counts,
+        refuted_groups=tuple(refuted),
+    )

--- a/reference/tests/test_evidence_qualification.py
+++ b/reference/tests/test_evidence_qualification.py
@@ -1,0 +1,355 @@
+"""ADR-037 step 2: evidence gets a class it cannot claim, and a lineage it cannot escape.
+
+Written against the plausible wrong implementation. That one reads a
+``qualification_class`` field off the item, treats a failing verifier as merely
+unverified, groups by a declared label, and reports one flattering total. Each
+has a test here that fails.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmem_ref.evidence_qualification import (
+    ARTIFACT_BOUND,
+    ASSERTED,
+    CALIBRATED_ESTIMATOR,
+    REFUTED,
+    REPRODUCIBLE_PROCEDURE,
+    UNQUALIFIED,
+    VERIFIED,
+    DependenceAnalysis,
+    EvidenceItem,
+    group_by_dependence,
+    qualify,
+)
+
+
+def _artifact(ref="a", **kw):
+    base = dict(artifact_ref="art://x", digest="sha256:abc", verifier="digest-check")
+    base.update(kw)
+    return EvidenceItem(ref=ref, **base)
+
+
+def _procedure(ref="p", **kw):
+    base = dict(
+        inputs="in-1", method="pytest", method_version="8.0", result="pass",
+        verifier="rerun",
+    )
+    base.update(kw)
+    return EvidenceItem(ref=ref, **base)
+
+
+def _estimator(ref="e", **kw):
+    base = dict(
+        estimator_id="model-x", estimator_version="v1", calibration_ref="cal://2026-09"
+    )
+    base.update(kw)
+    return EvidenceItem(ref=ref, **base)
+
+
+class ClassIsDerivedFromBindings(unittest.TestCase):
+    """DoD 1-4 -- R3's ranking, computed from what an item carries."""
+
+    def test_artifact_bound_requires_all_three_bindings(self):
+        self.assertEqual(qualify(_artifact()).qualification_class, ARTIFACT_BOUND)
+        for dropped in ("artifact_ref", "digest", "verifier"):
+            item = _artifact(**{dropped: ""})
+            q = qualify(item)
+            self.assertNotEqual(
+                q.qualification_class, ARTIFACT_BOUND, f"{dropped} must be required"
+            )
+            self.assertIn(dropped, q.missing_bindings)
+
+    def test_reproducible_procedure_requires_all_five_bindings(self):
+        self.assertEqual(
+            qualify(_procedure()).qualification_class, REPRODUCIBLE_PROCEDURE
+        )
+        for dropped in ("inputs", "method", "method_version", "result", "verifier"):
+            q = qualify(_procedure(**{dropped: ""}))
+            self.assertNotEqual(q.qualification_class, REPRODUCIBLE_PROCEDURE)
+            self.assertIn(dropped, q.missing_bindings)
+
+    def test_calibrated_estimator_requires_its_three_bindings(self):
+        self.assertEqual(
+            qualify(_estimator()).qualification_class, CALIBRATED_ESTIMATOR
+        )
+        for dropped in ("estimator_id", "estimator_version", "calibration_ref"):
+            q = qualify(_estimator(**{dropped: ""}))
+            self.assertNotEqual(q.qualification_class, CALIBRATED_ESTIMATOR)
+
+    def test_a_caller_cannot_declare_its_own_class(self):
+        """DoD 4. This is the test that separates this cycle from six prior defects.
+
+        ``EvidenceItem`` has no ``qualification_class`` field at all, so the
+        claim cannot even be expressed -- the strongest form of the guarantee.
+        """
+        self.assertNotIn("qualification_class", EvidenceItem.__dataclass_fields__)
+        with self.assertRaises(TypeError):
+            EvidenceItem(ref="x", qualification_class=ARTIFACT_BOUND)
+        # And the empty claim, made the only way it can be, still fails.
+        self.assertEqual(
+            qualify(EvidenceItem(ref=ARTIFACT_BOUND)).qualification_class, UNQUALIFIED
+        )
+
+    def test_bare_strings_are_unqualified_not_an_error(self):
+        """DoD 5, LD3. The corpus is full of these; step 4 must be able to count them."""
+        for ref in ("i-said-so", " ", "receipt-ish"):
+            q = qualify(EvidenceItem(ref=ref))
+            self.assertEqual(q.qualification_class, UNQUALIFIED)
+            self.assertFalse(q.directly_satisfying)
+
+
+class BindingStatusSaysWhetherAnyoneChecked(unittest.TestCase):
+    """DoD 4b-4d -- audit V1 and V4."""
+
+    def test_default_is_asserted_because_no_verifier_has_run(self):
+        q = qualify(_artifact())
+        self.assertEqual(q.qualification_class, ARTIFACT_BOUND)
+        self.assertEqual(q.binding_status, ASSERTED)
+
+    def test_passing_verifier_yields_verified(self):
+        q = qualify(_artifact(), verifiers={"digest-check": lambda item: True})
+        self.assertEqual(q.binding_status, VERIFIED)
+
+    def test_failing_verifier_yields_refuted_never_asserted(self):
+        """DoD 4c / audit V4.
+
+        ``"verified" if passed else "asserted"`` is the implementation this
+        test exists to fail. It would make "nobody checked this digest" and
+        "somebody checked it and it did not match" the same state, letting a
+        proposer whose artifact failed keep re-presenting it as unchecked.
+        """
+        q = qualify(_artifact(), verifiers={"digest-check": lambda item: False})
+        self.assertEqual(q.binding_status, REFUTED)
+        self.assertNotEqual(q.binding_status, ASSERTED)
+
+    def test_naming_a_verifier_nobody_holds_stays_asserted(self):
+        """DoD 4d. The registry is the evaluator's; naming is not holding."""
+        q = qualify(_artifact(verifier="my-own-rubber-stamp"), verifiers={})
+        self.assertEqual(q.binding_status, ASSERTED)
+        q2 = qualify(
+            _artifact(verifier="my-own-rubber-stamp"),
+            verifiers={"digest-check": lambda item: True},
+        )
+        self.assertEqual(q2.binding_status, ASSERTED)
+
+    def test_unqualified_item_cannot_be_verified_into_standing(self):
+        q = qualify(
+            EvidenceItem(ref="opinion", verifier="digest-check"),
+            verifiers={"digest-check": lambda item: True},
+        )
+        self.assertEqual(q.qualification_class, UNQUALIFIED)
+
+
+class DependenceIsDerivedFromLineage(unittest.TestCase):
+    """DoD 6-9 -- R2's three relations."""
+
+    def test_relation_1_derived_from_joins(self):
+        root = _artifact("root")
+        derived = _artifact("summary", derived_from=("root",))
+        analysis = group_by_dependence([root, derived])
+        self.assertEqual(analysis.independent_group_count, 1)
+
+    def test_relation_2_shared_failure_domain_joins_distinct_roots(self):
+        """The syndicated-report case: derivation cannot compute this one."""
+        a = _artifact("news-a", failure_domain="syndicated-report")
+        b = _artifact("news-b", failure_domain="syndicated-report")
+        self.assertEqual(group_by_dependence([a, b]).independent_group_count, 1)
+
+    def test_relation_3_identical_procedure_run_twice_is_one_item(self):
+        """DoD 9 / R2's second deterministic reproduction.
+
+        Asserted with no ``derived_from`` edge and no shared ``failure_domain``,
+        so the test cannot pass through relation 1 or 2. Under the two-relation
+        algorithm this reported two independent groups -- the laundering R2
+        names by name.
+        """
+        first = _procedure("run-1")
+        second = _procedure("run-2")
+        self.assertEqual(first.derived_from, ())
+        self.assertEqual(second.derived_from, ())
+        self.assertEqual(first.failure_domain, "")
+        self.assertEqual(second.failure_domain, "")
+        self.assertEqual(group_by_dependence([first, second]).independent_group_count, 1)
+
+    def test_differing_procedure_version_is_two_groups(self):
+        """The negative control for relation 3: it must not over-merge."""
+        first = _procedure("run-1")
+        second = _procedure("run-2", method_version="9.0")
+        self.assertEqual(group_by_dependence([first, second]).independent_group_count, 2)
+
+    def test_a_declaration_cannot_split_a_lineage_connected_pair(self):
+        """DoD 8, LD4. Merge-only asymmetry, tested against a hostile declaration."""
+        root = _artifact("root", failure_domain="domain-a")
+        derived = _artifact("summary", derived_from=("root",), failure_domain="domain-b")
+        self.assertEqual(group_by_dependence([root, derived]).independent_group_count, 1)
+
+    def test_genuinely_independent_items_stay_separate(self):
+        a = _artifact("a")
+        b = _procedure("b")
+        self.assertEqual(group_by_dependence([a, b]).independent_group_count, 2)
+
+
+class CountingDiscipline(unittest.TestCase):
+    """DoD 10, 11, 15, 16 -- audit C1. Every edge fails toward overstating."""
+
+    def test_ten_copies_of_one_reference_are_one_group(self):
+        """DoD 11. Row count is not corroboration."""
+        items = [_artifact("same", derived_from=("same",)) for _ in range(10)]
+        # Same ref repeated: they are literally one item, ten times.
+        self.assertEqual(group_by_dependence(items).independent_group_count, 1)
+
+    def test_answering_step_4s_question_from_the_result_alone(self):
+        """DoD 10 / audit V5.
+
+        How many independent groups carry directly-satisfying evidence that was
+        actually verified? Answered without reaching into the raw items and
+        without re-deriving the grouping.
+        """
+        verifiers = {"digest-check": lambda item: True, "rerun": lambda item: True}
+        analysis = group_by_dependence(
+            [_artifact("a"), _procedure("p"), _estimator("e")], verifiers=verifiers
+        )
+        self.assertEqual(analysis.qualifying_group_count(status=VERIFIED), 2)
+        self.assertEqual(analysis.contributing_group_count(status=VERIFIED), 0)
+        self.assertEqual(analysis.independent_group_count, 3)
+
+    def test_asserted_and_verified_groups_are_distinguishable(self):
+        """The distinction LD2 introduces must survive into the counts."""
+        unchecked = group_by_dependence([_artifact("a")])
+        checked = group_by_dependence(
+            [_artifact("a")], verifiers={"digest-check": lambda item: True}
+        )
+        self.assertEqual(unchecked.qualifying_group_count(status=VERIFIED), 0)
+        self.assertEqual(checked.qualifying_group_count(status=VERIFIED), 1)
+        self.assertEqual(unchecked.qualifying_group_count(status=ASSERTED), 1)
+
+    def test_a_group_counts_at_its_weakest_status(self):
+        """DoD 15 / audit C1.
+
+        A group holding one verified and one refuted item is internally
+        contradictory. Counting it as verified would hide the refutation --
+        reintroducing at group level the collapse ``refuted`` prevents at item
+        level.
+        """
+        good = _artifact("good", failure_domain="shared")
+        bad = _artifact("bad", verifier="strict", failure_domain="shared")
+        analysis = group_by_dependence(
+            [good, bad],
+            verifiers={"digest-check": lambda item: True, "strict": lambda item: False},
+        )
+        self.assertEqual(analysis.independent_group_count, 1)
+        self.assertEqual(analysis.qualifying_group_count(status=VERIFIED), 0)
+        self.assertEqual(len(analysis.refuted_groups), 1)
+
+    def test_no_total_mixes_unqualified_groups_with_qualifying_ones(self):
+        """DoD 16 / audit C1. Raising the count does not raise the class."""
+        opinions = [EvidenceItem(ref=f"opinion-{n}") for n in range(10)]
+        analysis = group_by_dependence(opinions)
+        self.assertEqual(analysis.independent_group_count, 10)
+        self.assertEqual(analysis.qualifying_group_count(status=ASSERTED), 0)
+        self.assertEqual(analysis.contributing_group_count(status=ASSERTED), 0)
+
+    def test_an_estimator_is_never_counted_as_directly_satisfying(self):
+        """LD8, R3. It may contribute; it is never a sole basis."""
+        analysis = group_by_dependence(
+            [_estimator("e1"), _estimator("e2", failure_domain="d")],
+            verifiers={"digest-check": lambda item: True},
+        )
+        self.assertEqual(analysis.qualifying_group_count(status=ASSERTED), 0)
+        self.assertGreaterEqual(analysis.contributing_group_count(status=ASSERTED), 1)
+
+
+class ReportsWhatEvidenceIsNeverWhatMayHappen(unittest.TestCase):
+    """DoD 12, LD7. Step 4's verdict must not arrive early."""
+
+    _FORBIDDEN = (
+        "discharges", "sufficient", "sufficient_for", "decide", "decision",
+        "outcome", "permit", "permitted", "authorize", "approve", "allow",
+        "evaluate", "risk_class", "resume",
+    )
+
+    def test_module_exposes_no_verdict_returning_surface(self):
+        import agentmem_ref.evidence_qualification as module
+
+        public = {n for n in dir(module) if not n.startswith("_")}
+        for forbidden in self._FORBIDDEN:
+            self.assertNotIn(forbidden, public)
+
+    def test_analysis_exposes_counts_not_verdicts(self):
+        analysis = group_by_dependence([_artifact("a")])
+        surface = {n for n in dir(analysis) if not n.startswith("_")}
+        self.assertEqual(
+            surface,
+            {"groups", "group_counts", "refuted_groups", "independent_group_count",
+             "qualifying_group_count", "contributing_group_count"},
+        )
+        for forbidden in self._FORBIDDEN:
+            self.assertNotIn(forbidden, surface)
+
+    def test_no_function_accepts_a_risk_class(self):
+        """Accepting one invites returning a verdict against it."""
+        import inspect
+
+        for func in (qualify, group_by_dependence):
+            self.assertNotIn("risk_class", inspect.signature(func).parameters)
+
+    def test_qualification_reports_no_permission(self):
+        q = qualify(_artifact())
+        surface = {n for n in dir(q) if not n.startswith("_")}
+        self.assertEqual(
+            surface,
+            {"ref", "qualification_class", "binding_status", "missing_bindings",
+             "directly_satisfying"},
+        )
+
+    def test_pending_verification_is_not_imported(self):
+        """Connecting qualification to parking is step 3's work.
+
+        Checked over the module's actual import statements rather than its
+        text, so the docstring may say what is deliberately absent.
+        """
+        import ast
+        import inspect
+
+        import agentmem_ref.evidence_qualification as module
+
+        imported: set[str] = set()
+        for node in ast.walk(ast.parse(inspect.getsource(module))):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.add(node.module or "")
+                imported.update(alias.name for alias in node.names)
+
+        self.assertNotIn("pending_verification", imported)
+        self.assertNotIn("PendingVerificationRegistry", imported)
+        self.assertNotIn("policy", imported)
+
+
+class NameAxesStayDistinct(unittest.TestCase):
+    """LD1 -- the collision found in research, before it was spent."""
+
+    def test_does_not_redefine_the_existing_evidence_classes_vocabulary(self):
+        from agentmem_ref import derivation_currentness, evidence_qualification
+
+        self.assertEqual(
+            derivation_currentness.EVIDENCE_CLASSES,
+            {"ordinary", "negative", "adversarial", "correction", "incident"},
+        )
+        self.assertFalse(hasattr(evidence_qualification, "EVIDENCE_CLASSES"))
+        self.assertFalse(hasattr(evidence_qualification, "evidence_class"))
+        self.assertIn(
+            "qualification_class", Qualification_fields()
+        )
+
+
+def Qualification_fields():
+    from agentmem_ref.evidence_qualification import Qualification
+
+    return Qualification.__dataclass_fields__
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements **step 2 of 4** of the ADR-037 implementation order, and only step 2.

## The gap, measured

`policy._apply_modifiers:252` was the shared evaluator's **entire** treatment of evidence:

```python
if not proposal.evidence_refs:
    outcome = _strictest(outcome, REQUIRE_REVIEW)
```

Measured on `semantic/write/low/reversible`:

| `evidence_refs` | Outcome | Reasons |
|---|---|---|
| `()` | `require_review` | `M-EVID: no evidence references supplied` |
| `("i-said-so",)` | `require_review` | `()` |
| `(" ",)` | `require_review` | `()` |
| `("same",) * 10` | `require_review` | `()` |
| `("receipt://sha256:deadbeef",)` | `require_review` | `()` |

A single space cleared the evidence modifier exactly as a content-addressed receipt did. This is the **sixth** control found implemented in one module and absent from the shared evaluator.

## What this builds

**R3 — a class derived from bindings, never claimed.** `EvidenceItem` has no `qualification_class` field, so the claim cannot be expressed. `artifact_bound` needs `artifact_ref` + `digest` + `verifier`; `reproducible_procedure` needs `inputs` + `method` + `method_version` + `result` + `verifier`; `calibrated_estimator` needs `estimator_id` + `estimator_version` + `calibration_ref`. Anything else is `unqualified` — a state, not an error, because step 4 must be able to count how much of the existing corpus is opinion.

**R2 — independence is three relations, not two.** `derived_from` edges; shared declared `failure_domain` (distinct roots that fail together); and identical `(method, method_version, inputs)`. The third is load-bearing: two runs of one deterministic procedure share no derivation edge and need declare no failure domain, and R2 says in as many words that they are **one** evidence item. A declared failure domain may only **merge** groups, never split one — the constrained party can weaken its own independence claim and never strengthen it.

## What this does not claim

The bindings are themselves caller-supplied strings. `digest="deadbeef"` with `verifier="trust-me"` classifies `artifact_bound` with nothing checked. So every class pairs with a binding status, on the two precedents this repo already set (`ratification_evidence_verified`/`_asserted`, and `review_discharge`):

| Status | Meaning |
|---|---|
| `asserted` | bindings present, **no verifier has run** — the default |
| `verified` | a verifier in the evaluator's registry ran and **passed** |
| `refuted` | a verifier ran and **failed** |

`refuted` is distinct on purpose: `"verified" if passed else "asserted"` would make "nobody checked this digest" and "somebody checked it and it did not match" the same state, letting a proposer whose artifact failed keep re-presenting it as merely unchecked.

**This does not close the caller-asserted-input pattern.** The honest claim is narrower and still real: evidence stops being an opaque string and becomes a typed, ranked claim that names its own verifier. FX013 records the residual, on the FX011 precedent.

## Not built

| Step | Status |
|---|---|
| 3. Governed resumption | not built — `PendingVerificationRegistry` is not imported, asserted over parsed imports |
| 4. Fail-closed `require_review` | not built — `policy.py` unmodified, verified by empty diff |

Wiring `qualify` into `_apply_modifiers` is genuinely two lines. Those two lines are step 4: they convert all 51 sites at once with no resumption path built.

## Verification

- **999 tests pass, 0 failures, 7 skipped** (971 + 28), under the pinned `cryptography==50.0.1`.
- Validators clean: 58 schemas, 64 fixtures. No schema modified.
- **Negative control**: six mutations each caught — `artifact_bound` needing only one binding; a failing verifier collapsing to `asserted`; relation 3 removed; groups counted at strongest rather than weakest status; estimator groups counted as directly satisfying; a named-but-unheld verifier trusted.

## Governance

Audit VETOed twice across five grounds. The first mattered most: the plan claimed deriving a class from present bindings was "the direct answer" to the six-times defect. It is not — it is the same defect with more fields to fill in, and the repo had already solved this shape twice while the plan ignored both precedents. The claim was narrowed rather than the work inflated.

V2: the stated algorithm could not satisfy its own DoD 9. V3: **ADR-037 §4 was owned by no step** of the ADR's own four-step order — now assigned to step 3, with the reason, and the ADR amended. V4: a verifier that runs and fails had no state. V5: Loop 8's V1 shape returned — the result couldn't answer step 4's question without reshaping.

PASS carried two binding conditions, both satisfied: a group counts at its **weakest** status so a refutation is never absorbed, and no total mixes `unqualified` groups with qualifying ones (ten distinct bare strings make ten groups and qualify nothing — *raising the count does not raise the class*).

Sealed as META_LEDGER entry #19 (`e2c500fff592`); chain verifies clean through #19.

**Found in research before it was spent**: `EVIDENCE_CLASSES` was already taken — `derivation_currentness` uses it for polarity and role, with two schema consumers. R3 ranks checkability, an orthogonal axis. Hence `qualification_class`. Discovering that after step 4 would have been an expensive rename across a schema surface.

**Recorded, not acted on**: `reusable_grants` establishes independence by `source_ref` identity plus a caller-asserted boolean, which R2 says is not sufficient alone. R4 fences that module off, so the tension is recorded rather than resolved.
