### PR TITLE
fix: honor attestation-only external verification at commit

### DIFF
--- a/docs/44-public-api-contract.md
+++ b/docs/44-public-api-contract.md
@@ -58,10 +58,15 @@ The decision projection carries `outcome`, `permitted_actions`, `prohibited_acti
 
 ## What `commit` forwards and what the adapter does with it
 
-`commit` and `forget` forward both `evidence` and `attestation` unchanged (DoD 20, asserted by `reference/tests/test_api_dod20.py` through a recording adapter). The adapter's two seams differ in what they do with an attestation alone:
+`commit` and `forget` forward both `evidence` and `attestation` unchanged (DoD 20, asserted by `reference/tests/test_api_dod20.py` through a recording adapter). The adapter's proposal evaluation, commit, and delete seams use the same three-way authority selection:
 
-- `governed_delete` selects three ways: evidence (with optional attestation) -> qualified-evidence discharge; attestation alone -> external-verification discharge; else the base evaluation.
-- `commit_proposal` selects two ways: evidence -> qualified-evidence discharge (the attestation is passed along); else the base evaluation. **An attestation without evidence is ignored there.** `approve` uses the three-way selection (`GovernedMemoryAdapter.evaluate_proposal`), so a consumer can see a critical correction discharge at `approve` and then park at `commit` unless evidence accompanies the attestation. This asymmetry is pre-existing, pinned by `test_commit_attestation_only_is_ignored_by_the_adapter_today`, and raised as a follow-up rather than changed here: aligning `commit_proposal` is a behaviour change to a seam 48 files call.
+- evidence present, with an optional attestation -> qualified-evidence evaluation through the adapter-owned verifier registry;
+- no evidence and an attestation present -> external-verification evaluation;
+- neither -> base evaluation.
+
+The attestation-only path is intentionally narrow. `policy.evaluate_with_external_verification` changes only a base `require_external_verification` outcome; a medium-risk correction that requires qualified review evidence remains `require_review` even when an attestation is supplied. Binding, self-verification, authority-kind, and risk-ceiling checks remain in the shared evaluator.
+
+Issue #395 corrected the former `commit_proposal` asymmetry in which `approve` and `governed_delete` honored an attestation alone while commit accepted the parameter and ignored it. This is an implementation correction to the already-sanctioned ADR-037 step 4b-2 entry-point channel, not a new envelope or signature, so the public contract remains `1.2.0`.
 
 ## Action authority and execution evidence (contract `1.2.0`, ADR-038)
 

--- a/reference/agentmem_ref/runtime/adapter.py
+++ b/reference/agentmem_ref/runtime/adapter.py
@@ -188,10 +188,10 @@ class GovernedMemoryAdapter:
     ) -> policy.Decision:
         """Evaluate without writing, through this adapter's own verifier registry.
 
-        Sprint 4a (LD5): the public ``approve`` stage. The selection mirrors
-        ``governed_delete``: qualified evidence (with an optional attestation),
-        else an attestation alone, else the base evaluation. ``commit_proposal``
-        keeps its own two-way selection; see the public contract document.
+        Sprint 4a (LD5): the public ``approve`` stage. Qualified evidence (with
+        an optional attestation) uses the evidence path; an attestation alone
+        uses external verification; otherwise the base evaluation runs. The
+        governed commit and delete paths use the same selection.
         """
         if evidence:
             from ..core.evidence_qualification import group_by_dependence
@@ -224,9 +224,13 @@ class GovernedMemoryAdapter:
         ADR-037's sequencing principle forbids.
 
         `evidence` is optional and defaults to None, so a caller that supplies
-        none behaves exactly as before -- it simply parks where it used to
-        discharge on assertion. Supplying evidence routes through
-        `policy.evaluate_with_qualified_evidence`, which enforces R5's ladder.
+        none behaves exactly as before unless it supplies an `attestation` for
+        an existing external-verification authority path. Supplying evidence
+        routes through `policy.evaluate_with_qualified_evidence`, which enforces
+        R5's ladder. Supplying only an attestation routes through
+        `policy.evaluate_with_external_verification`; that evaluator changes
+        only `require_external_verification` outcomes and leaves ordinary
+        `require_review` parked.
 
         **There is deliberately no `verifiers=` parameter.** Verifier trust is
         held by this adapter's `verifier_registry`, configured by the host that
@@ -257,6 +261,8 @@ class GovernedMemoryAdapter:
                 ),
                 attestation=attestation,
             )
+        elif attestation is not None:
+            decision = policy.evaluate_with_external_verification(proposal, attestation)
         else:
             decision = policy.evaluate(proposal)
         authorize_event = self._event(

--- a/reference/tests/test_api_surface.py
+++ b/reference/tests/test_api_surface.py
@@ -98,11 +98,41 @@ class PublicSurface(unittest.TestCase):
         self.assertTrue(committed["committed"]); self.assertEqual(committed["receipt"]["decision_outcome"], policy.ALLOW_WITH_LEDGER)
         self.assertEqual(self.memory.state_version(TARGET), 2)
 
-    def test_commit_attestation_only_is_ignored_by_the_adapter_today(self):
-        # commit_proposal's selection is two-way (evidence or base evaluation); an attestation alone
-        # does not reach evaluate_with_external_verification there. Pinned so the follow-up has a red test.
-        result = surface.commit(self.memory, _correction("critical"), "release branch main", attestation=_attestation())
-        self.assertFalse(result["committed"]); self.assertEqual(result["outcome"], policy.REQUIRE_EXTERNAL_VERIFICATION)
+    def test_commit_attestation_only_discharges_external_verification_at_critical(self):
+        result = surface.commit(
+            self.memory,
+            _correction("critical"),
+            "release branch main",
+            attestation=_attestation(),
+        )
+        self.assertTrue(result["committed"])
+        self.assertEqual(result["outcome"], policy.ALLOW_WITH_LEDGER)
+        self.assertEqual(result["decision"]["review_discharge"], "verified")
+        self.assertEqual(self.memory.state_version(TARGET), 2)
+
+    def test_commit_attestation_only_does_not_discharge_require_review(self):
+        result = surface.commit(
+            self.memory,
+            _correction("medium"),
+            "release branch main",
+            attestation=_attestation(),
+        )
+        self.assertFalse(result["committed"])
+        self.assertEqual(result["outcome"], policy.REQUIRE_REVIEW)
+        self.assertEqual(result["decision"]["review_discharge"], "")
+        self.assertEqual(self.memory.state_version(TARGET), 1)
+
+    def test_commit_attestation_only_still_enforces_proposal_binding(self):
+        result = surface.commit(
+            self.memory,
+            _correction("critical"),
+            "release branch main",
+            attestation=_attestation("proposal:wrong"),
+        )
+        self.assertFalse(result["committed"])
+        self.assertEqual(result["outcome"], policy.REQUIRE_EXTERNAL_VERIFICATION)
+        self.assertIn("attestation_not_bound_to_proposal", result["decision"]["reasons"])
+        self.assertEqual(self.memory.state_version(TARGET), 1)
 
     def test_recall_returns_candidates_and_admissions(self):
         fact = self.memory.current_fact_uuid(TARGET)


### PR DESCRIPTION
## Problem

Issue #395 identified a lifecycle contradiction: `approve` and `governed_delete` honored an attestation supplied without qualified evidence, while `commit_proposal` accepted the same parameter and silently ignored it unless `evidence` was also present. A critical correction could therefore discharge `require_external_verification` at approval and park at commit with the same unchanged authority input.

## Decision

Align `commit_proposal` with the already-sanctioned ADR-037 step 4b-2 entry-point channel and the existing `evaluate_proposal` / `governed_delete` semantics:

- evidence present -> qualified-evidence evaluator, optional attestation forwarded;
- attestation only -> external-verification evaluator;
- neither -> base evaluator.

This does not broaden attestations into review evidence. `evaluate_with_external_verification` only discharges `require_external_verification`; ordinary `require_review` remains parked.

## Verification added

- critical attestation-only correction commits with `review_discharge=verified`;
- medium attestation-only correction still parks at `require_review`;
- an attestation bound to the wrong proposal still fails closed with `attestation_not_bound_to_proposal`.

The public envelope/signature is unchanged, so contract version remains 1.2.0.

Closes #395 when merged and validated.