### PR TITLE
fix: route domain-schema review through ADR-037 authority

### DIFF
--- a/docs/profiles/pama-1-2-domain-schema-compatibility.md
+++ b/docs/profiles/pama-1-2-domain-schema-compatibility.md
@@ -25,6 +25,17 @@ Reference minimum outcomes are:
 
 Existing PAMA dimensions remain controlling. If the same request also widens scope, the existing `scope_expansion` posture still applies. M5 and A5 floors remain unchanged. Estimator confidence does not lower the operation's required outcome.
 
+## Review and verification discharge
+
+PAMA 1.2's operation/version remains valid after ADR-037, but its original caller-asserted review implementation does not. New evaluations use the shared PAMA authority mechanisms:
+
+- `review_satisfied=True` plus arbitrary `approval_refs` is legacy proposal state and does not discharge review;
+- low/medium `require_review` may discharge only through qualified evidence meeting ADR-037's risk/evidence ladder;
+- high/critical `require_external_verification` requires a proposal-bound external attestation satisfying the shared binding, separation, authority-kind, and risk-ceiling checks;
+- a requested scope expansion, M5/A5 floor, self-approval block, missing evidence, or other stricter shared constraint remains controlling.
+
+Historical 1.2.0 decision documents are not rewritten. This is evaluator hardening for new decisions, not a schema-version migration.
+
 Executable evidence:
 
 - `schemas/pama-decision.schema.json`
@@ -34,4 +45,4 @@ Executable evidence:
 - `reference/tests/test_domain_schema_mutation_compatibility.py`
 - `.github/workflows/domain-schema-mutation-contract.yml`
 
-Research source: #226. Implementation: #236.
+Research source: #226. Initial implementation: #236. ADR-037 reconciliation: #401.

--- a/reference/agentmem_ref/memory/domain_schema_mutation.py
+++ b/reference/agentmem_ref/memory/domain_schema_mutation.py
@@ -15,17 +15,9 @@ from ..core import policy, receipts
 DOMAIN_SCHEMA_MUTATION = "domain_schema_mutation"
 PAMA_SCHEMA_VERSION = "1.2.0"
 
-_OUTCOME_ORDER = {
-    policy.ALLOW: 0,
-    policy.ALLOW_WITH_LEDGER: 1,
-    policy.REQUIRE_REVIEW: 2,
-    policy.REQUIRE_EXTERNAL_VERIFICATION: 3,
-    policy.BLOCK: 4,
-}
-
 
 def required_outcome_for_risk(risk_class: str) -> str:
-    """Return the minimum PAMA posture for domain-schema mutation."""
+    """Return the PAMA 1.2 base posture for domain-schema mutation."""
     if risk_class in ("low", "medium"):
         return policy.REQUIRE_REVIEW
     if risk_class in ("high", "critical"):
@@ -33,99 +25,62 @@ def required_outcome_for_risk(risk_class: str) -> str:
     raise ValueError(f"unsupported risk class {risk_class!r}")
 
 
-def _envelope(outcome: str, operation: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    if outcome == policy.REQUIRE_REVIEW:
-        return ("enter_pending_verification", "collect_more_evidence", "defer"), (operation,)
-    if outcome == policy.REQUIRE_EXTERNAL_VERIFICATION:
-        return ("request_external_verification", "collect_more_evidence", "defer"), (operation,)
-    if outcome == policy.BLOCK:
-        return (), (operation, "enter_pending_verification", "request_external_verification")
-    if outcome in (policy.ALLOW, policy.ALLOW_WITH_LEDGER):
-        return (operation, "collect_more_evidence", "defer"), ()
-    raise ValueError(f"unsupported outcome {outcome!r}")
-
-
-def _strictest_decision(
-    current: policy.Decision,
-    minimum_outcome: str,
-    operation: str,
-    reason: str,
-) -> policy.Decision:
-    if _OUTCOME_ORDER[current.outcome] >= _OUTCOME_ORDER[minimum_outcome]:
-        return current
-    permitted, prohibited = _envelope(minimum_outcome, operation)
-    return policy.Decision(
-        outcome=minimum_outcome,
-        permitted_actions=permitted,
-        prohibited_actions=prohibited,
-        reasons=current.reasons + (reason,),
-        policy_version=current.policy_version,
-    )
-
-
-def _scope_expansion_floor(proposal: policy.Proposal) -> policy.Decision:
-    scope_proposal = replace(proposal, operation="scope_expansion", review_satisfied=False)
-    return policy.evaluate(scope_proposal)
-
-
-def _discharge_review(decision: policy.Decision, proposal: policy.Proposal) -> policy.Decision:
-    if decision.outcome not in (policy.REQUIRE_REVIEW, policy.REQUIRE_EXTERNAL_VERIFICATION):
-        return decision
-    if not proposal.review_satisfied:
-        return decision
-    if not proposal.approval_refs or proposal.approves_own_authority:
-        return policy.Decision(
-            outcome=decision.outcome,
-            permitted_actions=decision.permitted_actions,
-            prohibited_actions=decision.prohibited_actions,
-            reasons=decision.reasons + ("review claimed without an external approval record",),
-            policy_version=decision.policy_version,
-        )
-    permitted, prohibited = _envelope(policy.ALLOW_WITH_LEDGER, proposal.operation)
-    return policy.Decision(
-        outcome=policy.ALLOW_WITH_LEDGER,
-        permitted_actions=permitted,
-        prohibited_actions=prohibited,
-        reasons=decision.reasons + (f"review discharged by {list(proposal.approval_refs)}",),
-        policy_version=decision.policy_version,
-    )
-
-
 def evaluate(
     proposal: policy.Proposal,
     *,
     requested_scope_change: str = "",
+    evidence=None,
+    attestation: policy.ExternalVerification | None = None,
+    verifier_registry=None,
 ) -> policy.Decision:
-    """Evaluate a domain-schema mutation while preserving stricter PAMA floors.
+    """Evaluate PAMA 1.2 domain-schema mutation through shared authority logic.
 
-    The generic evaluator first runs with review discharge disabled, preserving
-    actor, target-class, downstream-authority, isolation, reversibility, and
-    evidence constraints. The explicit operation and any scope-expansion floor
-    are then applied. Only after those floors exist may a valid external review
-    discharge the resulting review/verification requirement.
+    The 1.2 profile owns the operation's base risk cell. Shared PAMA owns every
+    authority floor, modifier, and discharge mechanism. This matters because
+    ADR-037 removed caller-asserted ``review_satisfied`` / ``approval_refs`` as
+    an authority path after this profile originally shipped.
+
+    Qualified evidence is grouped through an evaluator-held ``VerifierRegistry``
+    when one is supplied. A bound attestation can discharge only an existing
+    ``require_external_verification`` outcome. With neither, review remains
+    fail-closed and the shared evaluator names the remediation route.
     """
     if proposal.operation != DOMAIN_SCHEMA_MUTATION:
         raise ValueError("domain-schema evaluator requires domain_schema_mutation")
 
-    undecided_review = replace(proposal, review_satisfied=False)
-    decision = policy.evaluate(undecided_review)
-    decision = _strictest_decision(
-        decision,
-        required_outcome_for_risk(proposal.risk_class),
-        proposal.operation,
-        "domain-schema mutation minimum",
+    if requested_scope_change and proposal.requested_scope_change:
+        if requested_scope_change != proposal.requested_scope_change:
+            raise ValueError("requested_scope_change disagrees with proposal")
+    scope_change = requested_scope_change or proposal.requested_scope_change
+    evaluated = (
+        replace(proposal, requested_scope_change=scope_change)
+        if scope_change != proposal.requested_scope_change
+        else proposal
     )
+    base = required_outcome_for_risk(evaluated.risk_class)
 
-    if requested_scope_change:
-        scope_decision = _scope_expansion_floor(undecided_review)
-        decision = _strictest_decision(
-            decision,
-            scope_decision.outcome,
-            proposal.operation,
-            "scope-expansion floor preserved",
+    if evidence:
+        from ..core.evidence_qualification import group_by_dependence
+
+        return policy.evaluate_with_qualified_evidence(
+            evaluated,
+            group_by_dependence(
+                evidence,
+                verifiers=(verifier_registry.as_mapping() if verifier_registry else None),
+            ),
+            base_outcome=base,
+            attestation=attestation,
         )
-
-    return _discharge_review(decision, proposal)
+    if attestation is not None:
+        return policy.evaluate_with_external_verification(
+            evaluated,
+            attestation,
+            base_outcome=base,
+        )
+    return policy.evaluate_with_base_outcome(
+        evaluated,
+        base_outcome=base,
+    )
 
 
 def build_pama_decision(
@@ -172,8 +127,9 @@ def build_pama_decision(
             "decision_receipt_ref": receipt_ref,
         },
     }
-    if requested_scope_change:
-        document["mutation"]["requested_scope_change"] = requested_scope_change
+    scope_change = requested_scope_change or proposal.requested_scope_change
+    if scope_change:
+        document["mutation"]["requested_scope_change"] = scope_change
     if proposal.tenant_ref:
         document["target"]["tenant_ref"] = proposal.tenant_ref
     if proposal.purpose:

--- a/reference/tests/_maintenance_run_cases.py
+++ b/reference/tests/_maintenance_run_cases.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.qualified_fixtures import corpus_for, registry_for, rule
+
 from agentmem_ref import domain_schema_mutation as dsm
 from agentmem_ref import policy, receipts
 from agentmem_ref.maintenance_run_state import seal
@@ -27,6 +29,11 @@ def pama_decision(
     purpose: str = "memory maintenance",
     reviewed: bool = False,
 ):
+    # `reviewed` predates ADR-037. For the PAMA 1.2 domain-schema positive
+    # fixture it now means "the evaluator has qualifying transition evidence",
+    # not "the caller set review_satisfied plus an approval string". Other
+    # historical operation fixtures retain their existing shape.
+    legacy_review_assertion = reviewed and operation != dsm.DOMAIN_SCHEMA_MUTATION
     proposal = policy.Proposal(
         proposal_id=f"maintenance:{operation}:{risk}:{tenant}",
         actor_id="agent:maintenance",
@@ -41,8 +48,8 @@ def pama_decision(
         reversibility="versioned_revocable",
         risk_class=risk,
         evidence_refs=("evidence:source-a",),
-        approval_refs=("approval:independent",) if reviewed else (),
-        review_satisfied=reviewed,
+        approval_refs=("approval:independent",) if legacy_review_assertion else (),
+        review_satisfied=legacy_review_assertion,
         tenant_ref=tenant,
         purpose=purpose,
         isolation_domain_refs=(f"{tenant}/project-a",),
@@ -50,7 +57,27 @@ def pama_decision(
         project_ref="project-a",
     )
     if operation == dsm.DOMAIN_SCHEMA_MUTATION:
-        decision = dsm.evaluate(proposal)
+        if reviewed:
+            corpus = corpus_for(rule(
+                rule_id="rule:maintenance-domain-schema",
+                target=proposal.target_reference,
+                criterion="maintenance-domain-schema-transition",
+                from_state="v1",
+                to_values=("v2",),
+            ))
+            evidence = corpus.evidence_for(
+                target_reference=proposal.target_reference,
+                criterion="maintenance-domain-schema-transition",
+                pre_state="v1",
+                proposed_value="v2",
+            )
+            decision = dsm.evaluate(
+                proposal,
+                evidence=evidence,
+                verifier_registry=registry_for(corpus),
+            )
+        else:
+            decision = dsm.evaluate(proposal)
         document = dsm.build_pama_decision(
             proposal,
             decision,

--- a/reference/tests/test_domain_schema_mutation_policy.py
+++ b/reference/tests/test_domain_schema_mutation_policy.py
@@ -2,6 +2,8 @@
 
 import unittest
 
+from tests.qualified_fixtures import corpus_for, registry_for, rule
+
 from agentmem_ref import domain_schema_mutation as dsm
 from agentmem_ref import policy
 
@@ -18,6 +20,32 @@ def make_proposal(risk="medium", target=policy.M3, authority=policy.A3, evidence
         state_snapshot="snapshot:model:v4", tenant_ref="tenant-a", purpose="ontology evolution",
         isolation_domain_refs=("tenant-a/project-a",), required_isolation_domain_refs=("tenant-a/project-a",),
         project_ref="project-a",
+    )
+
+
+def transition_evidence(proposal):
+    corpus = corpus_for(rule(
+        rule_id="rule:domain-schema-transition",
+        target=proposal.target_reference,
+        criterion="domain-schema-transition",
+        from_state="v4",
+        to_values=("v5",),
+    ))
+    evidence = corpus.evidence_for(
+        target_reference=proposal.target_reference,
+        criterion="domain-schema-transition",
+        pre_state="v4",
+        proposed_value="v5",
+    )
+    return evidence, registry_for(corpus)
+
+
+def attestation(proposal, *, proposal_id=None, principal="human:schema-owner"):
+    return policy.ExternalVerification(
+        bound_proposal_id=proposal_id or proposal.proposal_id,
+        verifier_principal_id=principal,
+        authority_kind=policy.HUMAN_CONFIRMATION,
+        max_risk_class="critical",
     )
 
 
@@ -44,10 +72,54 @@ class DomainSchemaMutationPolicyTests(unittest.TestCase):
         governance = dsm.evaluate(make_proposal(risk="low", target=policy.M5, authority=policy.A5))
         self.assertEqual(governance.outcome, policy.REQUIRE_EXTERNAL_VERIFICATION)
 
-    def test_review_discharges_only_after_floors(self):
-        result = dsm.evaluate(make_proposal(risk="high", reviewed=True, approvals=("approval:independent",)))
+    def test_asserted_review_no_longer_discharges_medium_or_high(self):
+        medium = dsm.evaluate(make_proposal(risk="medium", reviewed=True, approvals=("approval:independent",)))
+        self.assertEqual(medium.outcome, policy.REQUIRE_REVIEW)
+        self.assertIn(policy.REVIEW_REQUIRES_QUALIFIED_EVIDENCE, medium.reasons)
+
+        high = dsm.evaluate(make_proposal(risk="high", reviewed=True, approvals=("approval:independent",)))
+        self.assertEqual(high.outcome, policy.REQUIRE_EXTERNAL_VERIFICATION)
+        self.assertIn("external_verification_requires_attestation", high.reasons)
+
+    def test_medium_qualified_transition_evidence_discharges_review(self):
+        proposal = make_proposal(risk="medium")
+        evidence, registry = transition_evidence(proposal)
+        result = dsm.evaluate(proposal, evidence=evidence, verifier_registry=registry)
         self.assertEqual(result.outcome, policy.ALLOW_WITH_LEDGER)
         self.assertIn(dsm.DOMAIN_SCHEMA_MUTATION, result.permitted_actions)
+        self.assertEqual(result.discharge_authority, policy.DELEGATED_POLICY)
+
+    def test_high_bound_human_attestation_discharges_external_verification(self):
+        proposal = make_proposal(risk="high")
+        result = dsm.evaluate(proposal, attestation=attestation(proposal))
+        self.assertEqual(result.outcome, policy.ALLOW_WITH_LEDGER)
+        self.assertEqual(result.review_discharge, "verified")
+        self.assertIn(dsm.DOMAIN_SCHEMA_MUTATION, result.permitted_actions)
+
+    def test_high_attestation_still_enforces_binding_and_separation(self):
+        proposal = make_proposal(risk="high")
+        wrong = dsm.evaluate(
+            proposal,
+            attestation=attestation(proposal, proposal_id="schema:other"),
+        )
+        self.assertEqual(wrong.outcome, policy.REQUIRE_EXTERNAL_VERIFICATION)
+        self.assertIn("attestation_not_bound_to_proposal", wrong.reasons)
+
+        self_verified = dsm.evaluate(
+            proposal,
+            attestation=attestation(proposal, principal=proposal.actor_id),
+        )
+        self.assertEqual(self_verified.outcome, policy.REQUIRE_EXTERNAL_VERIFICATION)
+        self.assertIn("attestation_self_verified", self_verified.reasons)
+
+    def test_scope_change_argument_cannot_disagree_with_proposal(self):
+        proposal = make_proposal(risk="high")
+        proposal = policy.replace(proposal, requested_scope_change="project -> tenant") if hasattr(policy, "replace") else proposal
+        # Proposal does not expose a helper; construct the disagreement directly.
+        if not proposal.requested_scope_change:
+            proposal = policy.Proposal(**{**proposal.__dict__, "requested_scope_change": "project -> tenant"})
+        with self.assertRaisesRegex(ValueError, "requested_scope_change disagrees"):
+            dsm.evaluate(proposal, requested_scope_change="project -> global")
 
 
 if __name__ == "__main__":

--- a/reference/tests/test_domain_schema_mutation_policy.py
+++ b/reference/tests/test_domain_schema_mutation_policy.py
@@ -1,5 +1,6 @@
 """Focused policy cases for PAMA 1.2 domain-schema mutation."""
 
+from dataclasses import replace
 import unittest
 
 from tests.qualified_fixtures import corpus_for, registry_for, rule
@@ -113,11 +114,7 @@ class DomainSchemaMutationPolicyTests(unittest.TestCase):
         self.assertIn("attestation_self_verified", self_verified.reasons)
 
     def test_scope_change_argument_cannot_disagree_with_proposal(self):
-        proposal = make_proposal(risk="high")
-        proposal = policy.replace(proposal, requested_scope_change="project -> tenant") if hasattr(policy, "replace") else proposal
-        # Proposal does not expose a helper; construct the disagreement directly.
-        if not proposal.requested_scope_change:
-            proposal = policy.Proposal(**{**proposal.__dict__, "requested_scope_change": "project -> tenant"})
+        proposal = replace(make_proposal(risk="high"), requested_scope_change="project -> tenant")
         with self.assertRaisesRegex(ValueError, "requested_scope_change disagrees"):
             dsm.evaluate(proposal, requested_scope_change="project -> global")
 


### PR DESCRIPTION
## Problem

Issue #401 found that the specialized PAMA 1.2 `domain_schema_mutation` evaluator still had its own pre-ADR-037 `_discharge_review()` implementation. Caller-set `review_satisfied=True` plus non-empty `approval_refs` could therefore turn a high-risk schema mutation directly into `allow_with_ledger`, even though the shared evaluator has removed that assertion authority path.

## Correction

- removes the duplicate local review-discharge implementation;
- preserves PAMA 1.2's explicit risk cells as the base outcome;
- routes all floors/modifiers and discharge behavior through shared PAMA;
- adds qualified-evidence and proposal-bound attestation channels so fail-closed review is not a dead end;
- preserves scope-expansion, M5/A5, self-approval, evidence, and other shared constraints;
- rejects disagreement between a separately supplied `requested_scope_change` and the proposal's bound value;
- keeps historical 1.2.0 decision documents valid. This changes evaluation of new decisions, not the schema version.

## Adversarial controls

- asserted medium review stays `require_review`;
- asserted high review stays `require_external_verification`;
- qualified transition evidence can discharge medium review through an evaluator-held registry;
- bound human confirmation can discharge high external verification;
- wrong-proposal and self-verifying attestations still fail closed;
- estimator confidence and missing evidence do not weaken posture;
- scope/governance floors remain strict.

Closes #401 when merged and validated.